### PR TITLE
Add keyboard shortcuts for session navigation

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -137,11 +137,46 @@ export function App(): ReactElement {
         event.preventDefault();
         searchRef.current?.focus();
         searchRef.current?.select();
+        return;
+      }
+
+      // Leave list navigation alone while an overlay or menu is in front.
+      if (detail || dialog || deleteTagName || contextMenu) return;
+
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        if (results.length === 0) return;
+        event.preventDefault();
+        const currentIndex = results.findIndex((session) => session.sessionKey === selectedKey);
+        const delta = event.key === "ArrowDown" ? 1 : -1;
+        const nextIndex =
+          currentIndex < 0
+            ? delta === 1
+              ? 0
+              : results.length - 1
+            : Math.min(results.length - 1, Math.max(0, currentIndex + delta));
+        setSelectedKey(results[nextIndex].sessionKey);
+        return;
+      }
+
+      if (event.key === " " && selectedKey) {
+        const target = event.target as HTMLElement | null;
+        const tag = target?.tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+        const session = results.find((item) => item.sessionKey === selectedKey);
+        if (session) {
+          event.preventDefault();
+          void openDetail(session);
+        }
       }
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, []);
+  }, [results, selectedKey, detail, dialog, deleteTagName, contextMenu]);
+
+  useEffect(() => {
+    if (!selectedKey) return;
+    document.querySelector(".session-row.selected")?.scrollIntoView({ block: "nearest" });
+  }, [selectedKey]);
 
   const selected = useMemo(
     () => results.find((session) => session.sessionKey === selectedKey) || null,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -625,6 +625,44 @@ function DetailPanel({
     : -1;
   const context = matchIndex >= 0 ? messages.slice(Math.max(0, matchIndex - 1), Math.min(messages.length, matchIndex + 2)) : [];
   const actionRunning = actionStatus?.kind === "running";
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      const el = bodyRef.current;
+      if (!el) return;
+      const target = event.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      const page = el.clientHeight * 0.9;
+      switch (event.key) {
+        case "ArrowDown":
+          el.scrollBy({ top: 64 });
+          break;
+        case "ArrowUp":
+          el.scrollBy({ top: -64 });
+          break;
+        case "PageDown":
+        case " ":
+          el.scrollBy({ top: page });
+          break;
+        case "PageUp":
+          el.scrollBy({ top: -page });
+          break;
+        case "Home":
+          el.scrollTo({ top: 0 });
+          break;
+        case "End":
+          el.scrollTo({ top: el.scrollHeight });
+          break;
+        default:
+          return;
+      }
+      event.preventDefault();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
 
   return (
     <div className="detail-backdrop" onClick={onClose}>
@@ -670,27 +708,29 @@ function DetailPanel({
           </button>
         ))}
       </div>
-      {context.length > 0 ? (
-        <section className="matched">
-          <h3>Matched Context</h3>
-          {context.map((message) => (
+      <div className="detail-body" ref={bodyRef}>
+        {context.length > 0 ? (
+          <section className="matched">
+            <h3>Matched Context</h3>
+            {context.map((message) => (
+              <MessageBlock key={message.index} message={message} query={query} />
+            ))}
+          </section>
+        ) : null}
+        <section className="conversation">
+          <h3>Full Conversation</h3>
+          {loading ? <div className="loading-state">Loading conversation...</div> : null}
+          {!loading && messages.length === 0 ? <div className="loading-state">No visible messages indexed for this session.</div> : null}
+          {messages.map((message) => (
             <MessageBlock key={message.index} message={message} query={query} />
           ))}
+          {!loading && messages.length < session.messageCount ? (
+            <button className="show-more" onClick={onShowMore}>
+              Show {Math.min(MESSAGE_PAGE_SIZE, session.messageCount - messages.length)} more messages
+            </button>
+          ) : null}
         </section>
-      ) : null}
-      <section className="conversation">
-        <h3>Full Conversation</h3>
-        {loading ? <div className="loading-state">Loading conversation...</div> : null}
-        {!loading && messages.length === 0 ? <div className="loading-state">No visible messages indexed for this session.</div> : null}
-        {messages.map((message) => (
-          <MessageBlock key={message.index} message={message} query={query} />
-        ))}
-        {!loading && messages.length < session.messageCount ? (
-          <button className="show-more" onClick={onShowMore}>
-            Show {Math.min(MESSAGE_PAGE_SIZE, session.messageCount - messages.length)} more messages
-          </button>
-        ) : null}
-      </section>
+      </div>
     </aside>
     </div>
   );

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -189,6 +189,11 @@ export function App(): ReactElement {
     document.querySelector(".session-row.selected")?.scrollIntoView({ block: "nearest" });
   }, [selectedKey]);
 
+  useEffect(() => {
+    document.body.classList.toggle("overlay-open", Boolean(detail));
+    return () => document.body.classList.remove("overlay-open");
+  }, [detail]);
+
   const selected = useMemo(
     () => results.find((session) => session.sessionKey === selectedKey) || null,
     [results, selectedKey],

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -131,6 +131,18 @@ export function App(): ReactElement {
     };
   }, [load]);
 
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        searchRef.current?.focus();
+        searchRef.current?.select();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
   const selected = useMemo(
     () => results.find((session) => session.sessionKey === selectedKey) || null,
     [results, selectedKey],

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -140,6 +140,17 @@ export function App(): ReactElement {
         return;
       }
 
+      // Esc backs out of the frontmost layer, one at a time.
+      if (event.key === "Escape") {
+        if (dialog) setDialog(null);
+        else if (deleteTagName) setDeleteTagName(null);
+        else if (contextMenu) setContextMenu(null);
+        else if (detail) setDetail(null);
+        else return;
+        event.preventDefault();
+        return;
+      }
+
       // Leave list navigation alone while an overlay or menu is in front.
       if (detail || dialog || deleteTagName || contextMenu) return;
 

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -467,6 +467,13 @@ button:disabled {
   font-family: var(--mono);
   font-size: 11px;
   color: var(--text-dim);
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.searchbox:focus-within .kbd-hint {
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
+  color: var(--accent-bright);
 }
 
 .result-count {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -910,11 +910,14 @@ button:disabled {
   color: var(--accent);
 }
 
-.conversation {
+.detail-body {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
+}
+
+.conversation {
   padding-bottom: 22px;
 }
 

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1304,3 +1304,11 @@ select {
   background: var(--bg-elevated-2);
   color: var(--text);
 }
+
+/* ============================================================ OVERLAY SCROLL LOCK */
+/* While the detail overlay is open, freeze the background scrollers so the
+   wheel only ever moves the conversation inside the panel. */
+body.overlay-open .results,
+body.overlay-open .sidebar {
+  overflow: hidden;
+}


### PR DESCRIPTION
## 变更说明

- 新增 Cmd/Ctrl+K 快捷键：聚焦并选中搜索框，搜索框聚焦时同步高亮快捷键提示。
- 新增会话列表键盘导航：ArrowUp/ArrowDown 移动当前选中的 session；当焦点不在输入控件内时，Space 打开当前选中 session 的详情。
- 新增 Esc 分层关闭逻辑：优先关闭最前层的弹窗或菜单，顺序为命令弹窗、删除标签确认框、右键菜单、详情面板。
- 调整详情面板滚动结构：将匹配上下文和完整对话放进同一个可滚动 body 区域，打开详情时锁住背景滚动，并支持 Arrow/Page/Home/End 在详情内容内滚动。