### PR TITLE
新增收藏会话功能

### DIFF
--- a/src/core/session-store.test.ts
+++ b/src/core/session-store.test.ts
@@ -41,11 +41,12 @@ describe("SessionStore", () => {
     expect(results[0].matchSnippet).toContain("refresh token");
   });
 
-  it("keeps custom title, tags, pinned, and hidden state separate from reindexing", () => {
+  it("keeps custom title, tags, favorite, pinned, and hidden state separate from reindexing", () => {
     const store = createInMemoryStore();
     store.upsertIndexedSession(sampleSession(), messages);
     store.setCustomTitle("codex:abc", "Auth bug");
     store.addTag("codex:abc", "backend");
+    store.setFavorited("codex:abc", true);
     store.setPinned("codex:abc", true);
     store.setHidden("codex:abc", true);
 
@@ -55,10 +56,25 @@ describe("SessionStore", () => {
     expect(hidden[0]).toMatchObject({
       customTitle: "Auth bug",
       displayTitle: "Auth bug",
+      favorited: true,
       pinned: true,
       hidden: true,
       tags: ["backend"],
     });
+  });
+
+  it("filters favorite sessions while excluding hidden sessions", () => {
+    const store = createInMemoryStore();
+    store.upsertIndexedSession(sampleSession({ sessionKey: "codex:fav", rawId: "fav" }), messages);
+    store.upsertIndexedSession(sampleSession({ sessionKey: "codex:plain", rawId: "plain" }), messages);
+    store.upsertIndexedSession(sampleSession({ sessionKey: "codex:hidden-fav", rawId: "hidden-fav" }), messages);
+
+    store.setFavorited("codex:fav", true);
+    store.setFavorited("codex:hidden-fav", true);
+    store.setHidden("codex:hidden-fav", true);
+
+    expect(store.searchSessions({ visibility: "favorites" }).map((session) => session.sessionKey)).toEqual(["codex:fav"]);
+    expect(store.searchSessions({ visibility: "hidden" }).map((session) => session.sessionKey)).toEqual(["codex:hidden-fav"]);
   });
 
   it("does not search tag names from the text search box, but supports explicit tag filtering", () => {

--- a/src/core/session-store.ts
+++ b/src/core/session-store.ts
@@ -25,6 +25,7 @@ interface SessionRow {
   pr_url: string | null;
   pr_number: number | null;
   custom_title: string | null;
+  favorited: 0 | 1;
   pinned: 0 | 1;
   hidden: 0 | 1;
   last_opened_at: number | null;
@@ -96,6 +97,10 @@ export class SessionStore {
 
   setPinned(sessionKey: string, pinned: boolean): void {
     this.db.prepare("UPDATE sessions SET pinned = ? WHERE session_key = ?").run(pinned ? 1 : 0, sessionKey);
+  }
+
+  setFavorited(sessionKey: string, favorited: boolean): void {
+    this.db.prepare("UPDATE sessions SET favorited = ? WHERE session_key = ?").run(favorited ? 1 : 0, sessionKey);
   }
 
   setHidden(sessionKey: string, hidden: boolean): void {
@@ -259,6 +264,7 @@ export class SessionStore {
         pr_url TEXT,
         pr_number INTEGER,
         custom_title TEXT,
+        favorited INTEGER NOT NULL DEFAULT 0,
         pinned INTEGER NOT NULL DEFAULT 0,
         hidden INTEGER NOT NULL DEFAULT 0,
         last_opened_at INTEGER,
@@ -298,6 +304,14 @@ export class SessionStore {
         tokenize = 'unicode61'
       );
     `);
+    this.addColumnIfMissing("sessions", "favorited", "INTEGER NOT NULL DEFAULT 0");
+  }
+
+  private addColumnIfMissing(tableName: string, columnName: string, definition: string): void {
+    const columns = this.db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>;
+    if (!columns.some((column) => column.name === columnName)) {
+      this.db.exec(`ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${definition}`);
+    }
   }
 
   private refreshFtsForSession(sessionKey: string): void {
@@ -336,6 +350,7 @@ export class SessionStore {
   private getCandidateRows(options: SearchOptions): SessionRow[] {
     const rows = this.db.prepare("SELECT * FROM sessions").all() as SessionRow[];
     if (options.visibility === "hidden") return rows.filter((row) => row.hidden === 1);
+    if (options.visibility === "favorites") return rows.filter((row) => row.hidden === 0 && row.favorited === 1);
     if (options.visibility === "pinned") return rows.filter((row) => row.hidden === 0 && row.pinned === 1);
     return rows.filter((row) => row.hidden === 0);
   }
@@ -432,6 +447,7 @@ export class SessionStore {
       prNumber: row.pr_number,
       customTitle: row.custom_title,
       displayTitle,
+      favorited: row.favorited === 1,
       pinned: row.pinned === 1,
       hidden: row.hidden === 1,
       tags,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -34,7 +34,7 @@ export interface SearchOptions {
   tag?: string;
   projectPath?: string;
   source?: SessionSource | "claude" | "codex" | "all";
-  visibility?: "default" | "hidden" | "pinned";
+  visibility?: "default" | "favorites" | "hidden" | "pinned";
   sortBy?: SessionSortBy;
   limit?: number;
 }
@@ -48,6 +48,7 @@ export interface ProjectSummary {
 export interface SessionSearchResult extends IndexedSession {
   customTitle: string | null;
   displayTitle: string;
+  favorited: boolean;
   pinned: boolean;
   hidden: boolean;
   tags: string[];

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -246,6 +246,7 @@ function registerIpc(): void {
   ipcMain.handle("tag:add", (_event, sessionKey: string, tagName: string) => store.addTag(sessionKey, tagName));
   ipcMain.handle("tag:remove", (_event, sessionKey: string, tagName: string) => store.removeTag(sessionKey, tagName));
   ipcMain.handle("tag:delete", (_event, tagName: string) => store.deleteTag(tagName));
+  ipcMain.handle("favorite:set", (_event, sessionKey: string, favorited: boolean) => store.setFavorited(sessionKey, favorited));
   ipcMain.handle("pin:set", (_event, sessionKey: string, pinned: boolean) => store.setPinned(sessionKey, pinned));
   ipcMain.handle("hide:set", (_event, sessionKey: string, hidden: boolean) => store.setHidden(sessionKey, hidden));
   ipcMain.handle("index:refresh", () => runIndexSync());

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -14,6 +14,7 @@ const api = {
   addTag: (sessionKey: string, tagName: string): Promise<void> => ipcRenderer.invoke("tag:add", sessionKey, tagName),
   removeTag: (sessionKey: string, tagName: string): Promise<void> => ipcRenderer.invoke("tag:remove", sessionKey, tagName),
   deleteTag: (tagName: string): Promise<void> => ipcRenderer.invoke("tag:delete", tagName),
+  setFavorited: (sessionKey: string, favorited: boolean): Promise<void> => ipcRenderer.invoke("favorite:set", sessionKey, favorited),
   setPinned: (sessionKey: string, pinned: boolean): Promise<void> => ipcRenderer.invoke("pin:set", sessionKey, pinned),
   setHidden: (sessionKey: string, hidden: boolean): Promise<void> => ipcRenderer.invoke("hide:set", sessionKey, hidden),
   refreshIndex: (): Promise<IndexStatus> => ipcRenderer.invoke("index:refresh"),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -15,6 +15,7 @@ import {
   Play,
   RefreshCw,
   Search,
+  Star,
   Tag,
   Terminal,
   Trash2,
@@ -47,7 +48,7 @@ const SORT_OPTIONS: Array<{ label: string; value: SessionSortBy }> = [
   { label: "Updated", value: "updated" },
 ];
 
-type ViewMode = "default" | "pinned" | "hidden";
+type ViewMode = "default" | "favorites" | "pinned" | "hidden";
 const INITIAL_MESSAGE_LIMIT = 20;
 const MESSAGE_PAGE_SIZE = 80;
 
@@ -271,6 +272,11 @@ export function App(): ReactElement {
     await refreshAfterAction();
   }
 
+  async function toggleFavorite(session: SessionSearchResult): Promise<void> {
+    await window.sessionSearch.setFavorited(session.sessionKey, !session.favorited);
+    await refreshAfterAction();
+  }
+
   async function deleteTagGlobally(tagName: string): Promise<void> {
     await window.sessionSearch.deleteTag(tagName);
     setDeleteTagName(null);
@@ -330,10 +336,16 @@ export function App(): ReactElement {
           <button className={visibility === "default" ? "active" : ""} onClick={() => setVisibility("default")}>
             All
           </button>
+          <button className={visibility === "favorites" ? "active" : ""} onClick={() => setVisibility("favorites")}>
+            <Star size={14} />
+            Favorites
+          </button>
           <button className={visibility === "pinned" ? "active" : ""} onClick={() => setVisibility("pinned")}>
+            <Pin size={14} />
             Pinned
           </button>
           <button className={visibility === "hidden" ? "active" : ""} onClick={() => setVisibility("hidden")}>
+            <EyeOff size={14} />
             Hidden
           </button>
         </nav>
@@ -444,6 +456,7 @@ export function App(): ReactElement {
               selected={selected?.sessionKey === session.sessionKey}
               onSelect={() => setSelectedKey(session.sessionKey)}
               onOpen={() => void openDetail(session)}
+              onFavorite={() => void toggleFavorite(session)}
               onContextMenu={(event) => {
                 event.preventDefault();
                 setSelectedKey(session.sessionKey);
@@ -467,6 +480,7 @@ export function App(): ReactElement {
           onRename={() => beginRename(detail)}
           onAddTag={() => beginAddTag(detail)}
           onRemoveTag={(tagName) => void removeTag(detail, tagName)}
+          onFavorite={() => void toggleFavorite(detail)}
           onResume={() =>
             void runAction("Opening terminal", () => window.sessionSearch.resumeSession(detail.sessionKey), "Resume command sent to terminal.")
           }
@@ -488,6 +502,13 @@ export function App(): ReactElement {
           state={contextMenu}
           onRename={() => beginRename(contextMenu.session)}
           onAddTag={() => beginAddTag(contextMenu.session)}
+          onFavorite={() =>
+            void runAction(
+              contextMenu.session.favorited ? "Removing favorite" : "Adding favorite",
+              () => window.sessionSearch.setFavorited(contextMenu.session.sessionKey, !contextMenu.session.favorited),
+              contextMenu.session.favorited ? "Removed from favorites." : "Added to favorites.",
+            )
+          }
           onPin={() =>
             void runAction("Updating pin", () => window.sessionSearch.setPinned(contextMenu.session.sessionKey, !contextMenu.session.pinned), "Pin updated.")
           }
@@ -545,12 +566,14 @@ function SessionRow({
   selected,
   onSelect,
   onOpen,
+  onFavorite,
   onContextMenu,
 }: {
   session: SessionSearchResult;
   selected: boolean;
   onSelect: () => void;
   onOpen: () => void;
+  onFavorite: () => void;
   onContextMenu: MouseEventHandler;
 }): ReactElement {
   return (
@@ -563,9 +586,20 @@ function SessionRow({
       <div className="session-main">
         <div className="session-title">
           <span className={`source-dot ${session.source.startsWith("claude") ? "claude" : "codex"}`} />
+          <button
+            className={`favorite-button ${session.favorited ? "active" : ""}`}
+            onClick={(event) => {
+              event.stopPropagation();
+              onFavorite();
+            }}
+            aria-label={session.favorited ? "Remove from favorites" : "Add to favorites"}
+            title={session.favorited ? "Remove from favorites" : "Add to favorites"}
+          >
+            <Star size={14} fill={session.favorited ? "currentColor" : "none"} />
+          </button>
           {session.pinned ? <Pin size={14} /> : null}
           {session.hidden ? <EyeOff size={14} /> : null}
-          <span>{session.displayTitle}</span>
+          <span className="session-name">{session.displayTitle}</span>
         </div>
         <div className="session-meta">
           <span className={`source-badge ${session.source.startsWith("claude") ? "claude" : "codex"}`}>
@@ -598,6 +632,7 @@ function DetailPanel({
   onRename,
   onAddTag,
   onRemoveTag,
+  onFavorite,
   onResume,
   onCopyResume,
   onCopyMarkdown,
@@ -614,6 +649,7 @@ function DetailPanel({
   onRename: () => void;
   onAddTag: () => void;
   onRemoveTag: (tagName: string) => void;
+  onFavorite: () => void;
   onResume: () => void;
   onCopyResume: () => void;
   onCopyMarkdown: () => void;
@@ -677,9 +713,19 @@ function DetailPanel({
             {session.projectPath || "No project"} · {new Date(session.timestamp).toLocaleString()} · {messages.length} messages
           </p>
         </div>
-        <button className="icon-button" onClick={onClose} aria-label="Close">
-          <X size={17} />
-        </button>
+        <div className="detail-header-actions">
+          <button
+            className={`icon-button favorite-button ${session.favorited ? "active" : ""}`}
+            onClick={onFavorite}
+            aria-label={session.favorited ? "Remove from favorites" : "Add to favorites"}
+            title={session.favorited ? "Remove from favorites" : "Add to favorites"}
+          >
+            <Star size={17} fill={session.favorited ? "currentColor" : "none"} />
+          </button>
+          <button className="icon-button" onClick={onClose} aria-label="Close">
+            <X size={17} />
+          </button>
+        </div>
       </div>
       <div className="detail-actions">
         <button onClick={onResume} disabled={actionRunning}>
@@ -758,6 +804,7 @@ function ContextMenu({
   state,
   onRename,
   onAddTag,
+  onFavorite,
   onPin,
   onHide,
   onResume,
@@ -770,6 +817,7 @@ function ContextMenu({
   state: ContextMenuState;
   onRename: () => void;
   onAddTag: () => void;
+  onFavorite: () => void;
   onPin: () => void;
   onHide: () => void;
   onResume: () => void;
@@ -786,6 +834,10 @@ function ContextMenu({
       </button>
       <button onClick={onAddTag}>
         <Tag size={14} /> Add Tag
+      </button>
+      <button onClick={onFavorite}>
+        <Star size={14} fill={state.session.favorited ? "currentColor" : "none"} />{" "}
+        {state.session.favorited ? "Unfavorite" : "Favorite"}
       </button>
       <button onClick={onPin}>{state.session.pinned ? <PinOff size={14} /> : <Pin size={14} />} {state.session.pinned ? "Unpin" : "Pin"}</button>
       <button onClick={onHide}>

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -609,7 +609,7 @@ button:disabled {
   color: var(--accent);
 }
 
-.session-title span:last-child {
+.session-name {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -804,6 +804,12 @@ button:disabled {
   white-space: nowrap;
 }
 
+.detail-header-actions {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
 .icon-button {
   display: inline-grid;
   place-items: center;
@@ -820,6 +826,36 @@ button:disabled {
   border-color: var(--border-strong);
   color: var(--text);
   background: rgba(255, 255, 255, 0.07);
+}
+
+.favorite-button {
+  display: inline-grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 auto;
+  padding: 0;
+  border-radius: 7px;
+  color: var(--text-faint);
+  transition: color 0.12s ease, background 0.12s ease, border-color 0.12s ease;
+}
+
+.favorite-button:hover {
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+}
+
+.favorite-button.active {
+  color: var(--accent-bright);
+}
+
+.icon-button.favorite-button {
+  width: 32px;
+  height: 32px;
+}
+
+.session-title .favorite-button svg {
+  color: currentColor;
 }
 
 .detail-actions {


### PR DESCRIPTION
## 变更说明

- 新增会话收藏状态，作为本地应用 metadata 存储，不修改原始 Claude/Codex session 文件。
- 侧边栏新增 Favorites 视图，用于集中查看已收藏且未隐藏的会话。
- 会话列表行、详情面板头部和右键菜单新增收藏/取消收藏入口，使用五角星图标展示状态。
- Pinned 和 Hidden 入口补充对应图标，使侧边栏状态筛选视觉保持一致。
- 补充收藏状态持久化和 Favorites 过滤逻辑测试。

## 验证

- npm test
- npm run typecheck
- npm run build