### PR TITLE
新增 iTerm 恢复会话入口

### DIFF
--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -43,9 +43,20 @@ export async function openResumeInTerminal(session: SessionSearchResult, setting
   }
 
   if (settings.defaultTerminal === "iTerm") {
-    await runAppleScript(`tell application "iTerm"
+    await runAppleScript(`set wasRunning to application "iTerm" is running
+tell application "iTerm"
   activate
-  if (count of windows) = 0 then create window with default profile
+  if wasRunning then
+    if (count of windows) = 0 then
+      create window with default profile
+    else
+      tell current window
+        create tab with default profile
+      end tell
+    end if
+  else
+    delay 0.3
+  end if
   tell current session of current window
     write text "${escapeAppleScript(command)}"
   end tell
@@ -75,6 +86,14 @@ end tell`);
   activate
   do script "${escapeAppleScript(command)}"
 end tell`);
+}
+
+export async function openResumeInSpecificTerminal(
+  session: SessionSearchResult,
+  settings: AppSettings,
+  terminal: AppSettings["defaultTerminal"],
+): Promise<void> {
+  await openResumeInTerminal(session, { ...settings, defaultTerminal: terminal });
 }
 
 export async function openNativeApp(source: SessionSource): Promise<void> {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,7 +15,14 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { syncDefaultSessionsInBatches, type IndexStatus } from "../core/indexer";
 import { formatSessionMarkdown, formatSessionPlainText } from "../core/format-session";
-import { defaultSettings, getResumeCommand, openNativeApp, openResumeInTerminal, revealInFileManager } from "../core/platform";
+import {
+  defaultSettings,
+  getResumeCommand,
+  openNativeApp,
+  openResumeInSpecificTerminal,
+  openResumeInTerminal,
+  revealInFileManager,
+} from "../core/platform";
 import { SessionStore } from "../core/session-store";
 import type { AppSettings } from "../core/platform";
 import type { SearchOptions } from "../core/types";
@@ -266,6 +273,12 @@ function registerIpc(): void {
     if (!session) return;
     store.markResumed(sessionKey);
     await openResumeInTerminal(session, getSettings());
+  });
+  ipcMain.handle("command:resume-iterm", async (_event, sessionKey: string) => {
+    const session = store.getSession(sessionKey);
+    if (!session) return;
+    store.markResumed(sessionKey);
+    await openResumeInSpecificTerminal(session, getSettings(), "iTerm");
   });
   ipcMain.handle("command:open-app", async (_event, sessionKey: string) => {
     const session = store.getSession(sessionKey);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -23,6 +23,7 @@ const api = {
   setSettings: (settings: Partial<AppSettings>): Promise<AppSettings> => ipcRenderer.invoke("settings:set", settings),
   copyResumeCommand: (sessionKey: string): Promise<void> => ipcRenderer.invoke("command:copy-resume", sessionKey),
   resumeSession: (sessionKey: string): Promise<void> => ipcRenderer.invoke("command:resume", sessionKey),
+  resumeSessionInIterm: (sessionKey: string): Promise<void> => ipcRenderer.invoke("command:resume-iterm", sessionKey),
   openNativeApp: (sessionKey: string): Promise<void> => ipcRenderer.invoke("command:open-app", sessionKey),
   revealSession: (sessionKey: string): Promise<void> => ipcRenderer.invoke("command:reveal", sessionKey),
   copyMarkdown: (sessionKey: string): Promise<void> => ipcRenderer.invoke("command:copy-markdown", sessionKey),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -484,6 +484,9 @@ export function App(): ReactElement {
           onResume={() =>
             void runAction("Opening terminal", () => window.sessionSearch.resumeSession(detail.sessionKey), "Resume command sent to terminal.")
           }
+          onResumeIterm={() =>
+            void runAction("Opening iTerm", () => window.sessionSearch.resumeSessionInIterm(detail.sessionKey), "Resume command sent to iTerm.")
+          }
           onCopyResume={() =>
             void runAction("Copying resume command", () => window.sessionSearch.copyResumeCommand(detail.sessionKey), "Resume command copied.")
           }
@@ -521,6 +524,9 @@ export function App(): ReactElement {
           }
           onResume={() =>
             void runAction("Opening terminal", () => window.sessionSearch.resumeSession(contextMenu.session.sessionKey), "Resume command sent to terminal.")
+          }
+          onResumeIterm={() =>
+            void runAction("Opening iTerm", () => window.sessionSearch.resumeSessionInIterm(contextMenu.session.sessionKey), "Resume command sent to iTerm.")
           }
           onOpenApp={() =>
             void runAction("Opening native app", () => window.sessionSearch.openNativeApp(contextMenu.session.sessionKey), "Native app opened.")
@@ -634,6 +640,7 @@ function DetailPanel({
   onRemoveTag,
   onFavorite,
   onResume,
+  onResumeIterm,
   onCopyResume,
   onCopyMarkdown,
   onCopyPlain,
@@ -651,6 +658,7 @@ function DetailPanel({
   onRemoveTag: (tagName: string) => void;
   onFavorite: () => void;
   onResume: () => void;
+  onResumeIterm: () => void;
   onCopyResume: () => void;
   onCopyMarkdown: () => void;
   onCopyPlain: () => void;
@@ -731,6 +739,9 @@ function DetailPanel({
         <button onClick={onResume} disabled={actionRunning}>
           <Play size={15} /> Resume
         </button>
+        <button onClick={onResumeIterm} disabled={actionRunning}>
+          <Terminal size={15} /> iTerm
+        </button>
         <button onClick={onRename} disabled={actionRunning}>
           <Clipboard size={15} /> Rename
         </button>
@@ -808,6 +819,7 @@ function ContextMenu({
   onPin,
   onHide,
   onResume,
+  onResumeIterm,
   onOpenApp,
   onCopyResume,
   onCopyMarkdown,
@@ -821,6 +833,7 @@ function ContextMenu({
   onPin: () => void;
   onHide: () => void;
   onResume: () => void;
+  onResumeIterm: () => void;
   onOpenApp: () => void;
   onCopyResume: () => void;
   onCopyMarkdown: () => void;
@@ -846,6 +859,9 @@ function ContextMenu({
       <hr />
       <button onClick={onResume}>
         <Play size={14} /> Resume in Terminal
+      </button>
+      <button onClick={onResumeIterm}>
+        <Terminal size={14} /> Resume in iTerm
       </button>
       <button onClick={onOpenApp}>
         <AppWindow size={14} /> Open App


### PR DESCRIPTION
## 变更说明

- 保留现有 Resume / Resume in Terminal 行为，继续使用原来的默认终端逻辑。
- 新增 Resume in iTerm 入口：详情面板增加 iTerm 按钮，右键菜单增加 Resume in iTerm。
- 新增独立 IPC/preload 调用，专门使用 iTerm 打开并恢复当前 session。
- 优化 iTerm AppleScript：iTerm 已运行时优先新建 tab，未运行时启动后再写入 resume 命令。

## 验证

- npm run typecheck
- npm run build