### PR TITLE
新增会话标题快捷编辑入口

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -6,6 +6,7 @@ import {
   Clipboard,
   Code2,
   Copy,
+  Edit3,
   Eye,
   EyeOff,
   Folder,
@@ -456,6 +457,7 @@ export function App(): ReactElement {
               selected={selected?.sessionKey === session.sessionKey}
               onSelect={() => setSelectedKey(session.sessionKey)}
               onOpen={() => void openDetail(session)}
+              onRename={() => beginRename(session)}
               onFavorite={() => void toggleFavorite(session)}
               onContextMenu={(event) => {
                 event.preventDefault();
@@ -480,6 +482,7 @@ export function App(): ReactElement {
           onRename={() => beginRename(detail)}
           onAddTag={() => beginAddTag(detail)}
           onRemoveTag={(tagName) => void removeTag(detail, tagName)}
+          onRenameTitle={() => beginRename(detail)}
           onFavorite={() => void toggleFavorite(detail)}
           onResume={() =>
             void runAction("Opening terminal", () => window.sessionSearch.resumeSession(detail.sessionKey), "Resume command sent to terminal.")
@@ -572,6 +575,7 @@ function SessionRow({
   selected,
   onSelect,
   onOpen,
+  onRename,
   onFavorite,
   onContextMenu,
 }: {
@@ -579,6 +583,7 @@ function SessionRow({
   selected: boolean;
   onSelect: () => void;
   onOpen: () => void;
+  onRename: () => void;
   onFavorite: () => void;
   onContextMenu: MouseEventHandler;
 }): ReactElement {
@@ -606,6 +611,17 @@ function SessionRow({
           {session.pinned ? <Pin size={14} /> : null}
           {session.hidden ? <EyeOff size={14} /> : null}
           <span className="session-name">{session.displayTitle}</span>
+          <button
+            className="title-edit-button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onRename();
+            }}
+            aria-label="Rename session"
+            title="Rename session"
+          >
+            <Edit3 size={13} />
+          </button>
         </div>
         <div className="session-meta">
           <span className={`source-badge ${session.source.startsWith("claude") ? "claude" : "codex"}`}>
@@ -638,6 +654,7 @@ function DetailPanel({
   onRename,
   onAddTag,
   onRemoveTag,
+  onRenameTitle,
   onFavorite,
   onResume,
   onResumeIterm,
@@ -656,6 +673,7 @@ function DetailPanel({
   onRename: () => void;
   onAddTag: () => void;
   onRemoveTag: (tagName: string) => void;
+  onRenameTitle: () => void;
   onFavorite: () => void;
   onResume: () => void;
   onResumeIterm: () => void;
@@ -716,7 +734,12 @@ function DetailPanel({
           <div className={`source-badge ${session.source.startsWith("claude") ? "claude" : "codex"}`}>
             {SOURCE_LABEL[session.source]}
           </div>
-          <h2>{session.displayTitle}</h2>
+          <div className="detail-title-row">
+            <h2>{session.displayTitle}</h2>
+            <button className="title-edit-button detail-title-edit" onClick={onRenameTitle} aria-label="Rename session" title="Rename session">
+              <Edit3 size={14} />
+            </button>
+          </div>
           <p>
             {session.projectPath || "No project"} · {new Date(session.timestamp).toLocaleString()} · {messages.length} messages
           </p>

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -615,6 +615,29 @@ button:disabled {
   white-space: nowrap;
 }
 
+.title-edit-button {
+  display: inline-grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 auto;
+  padding: 0;
+  border-radius: 7px;
+  color: var(--text-faint);
+  opacity: 0;
+  transition: opacity 0.12s ease, color 0.12s ease, background 0.12s ease;
+}
+
+.session-row:hover .title-edit-button,
+.title-edit-button:focus-visible {
+  opacity: 1;
+}
+
+.title-edit-button:hover {
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+}
+
 .source-dot {
   width: 8px;
   height: 8px;
@@ -786,12 +809,31 @@ button:disabled {
   border-bottom: 1px solid var(--border);
 }
 
+.detail-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  margin: 11px 0 7px;
+}
+
+.detail-title-row .title-edit-button {
+  opacity: 1;
+}
+
 .detail-header h2 {
   margin: 11px 0 7px;
+  min-width: 0;
+  overflow: hidden;
   font-size: 22px;
   font-weight: 700;
   line-height: 1.2;
   letter-spacing: -0.4px;
+  text-overflow: ellipsis;
+}
+
+.detail-title-row h2 {
+  margin: 0;
 }
 
 .detail-header p {


### PR DESCRIPTION
## 变更说明

- 在会话列表标题旁新增编辑按钮，点击后直接打开现有 Rename 弹窗。
- 在详情页标题旁新增编辑按钮，方便打开详情后直接修改标题。
- 复用已有 custom_title 存储、IPC 和 Rename 弹窗，不改变原始 Claude/Codex session 文件。
- 避免使用双击标题编辑，保留当前双击会话行打开详情的行为。

## 验证

- npm run typecheck
- npm run build