### PR TITLE
按 Git 分支自动标记 Codex，Claude Code 会话

### DIFF
--- a/src/core/session-loader.test.ts
+++ b/src/core/session-loader.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { loadCodexSessionFile, parseCodexSessionMetaLine } from "./session-loader";
+import { loadClaudeCliSessions, loadCodexSessionFile, parseCodexSessionMetaLine } from "./session-loader";
 
 describe("Codex session loading", () => {
   it("extracts id, cwd, originator, first question, and visible messages from a rollout file", () => {
@@ -14,7 +14,7 @@ describe("Codex session loading", () => {
         JSON.stringify({
           type: "session_meta",
           timestamp: "2026-06-01T10:00:00Z",
-          payload: { id: "codex-1", cwd: "/repo", originator: "Codex Desktop" },
+          payload: { id: "codex-1", cwd: "/repo", originator: "Codex Desktop", git: { branch: "feat/session-tags" } },
         }),
         JSON.stringify({
           type: "response_item",
@@ -43,6 +43,7 @@ describe("Codex session loading", () => {
       projectPath: "/repo",
       firstQuestion: "修复登录态失效",
       originalTitle: "修复登录态失效",
+      gitBranch: "feat/session-tags",
     });
     expect(loaded?.messages.map((m) => m.content)).toEqual(["修复登录态失效", "我来检查 auth 逻辑"]);
 
@@ -54,9 +55,9 @@ describe("Codex session loading", () => {
       parseCodexSessionMetaLine({
         type: "session_meta",
         timestamp: "2026-06-01T10:00:00Z",
-        payload: { id: "new-id", cwd: "/new" },
+        payload: { id: "new-id", cwd: "/new", git: { branch: "feat/session-tags" } },
       }),
-    ).toMatchObject({ id: "new-id", projectPath: "/new" });
+    ).toMatchObject({ id: "new-id", projectPath: "/new", gitBranch: "feat/session-tags" });
 
     expect(
       parseCodexSessionMetaLine({
@@ -66,5 +67,47 @@ describe("Codex session loading", () => {
         git: { cwd: "/old" },
       }),
     ).toMatchObject({ id: "old-id", projectPath: "/old" });
+  });
+});
+
+describe("Claude session loading", () => {
+  it("extracts branch metadata from Claude Code jsonl rows", () => {
+    const claudeDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-claude-"));
+    const projectDir = path.join(claudeDir, "projects", "-repo");
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDir, "claude-1.jsonl"),
+      [
+        JSON.stringify({
+          type: "user",
+          timestamp: "2026-06-01T10:00:00Z",
+          cwd: "/repo",
+          sessionId: "claude-1",
+          gitBranch: "feat/claude-tags",
+          message: { role: "user", content: "修复会话列表" },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          timestamp: "2026-06-01T10:01:00Z",
+          cwd: "/repo",
+          sessionId: "claude-1",
+          gitBranch: "feat/claude-tags",
+          message: { role: "assistant", content: "我来处理" },
+        }),
+      ].join("\n"),
+    );
+
+    const loaded = loadClaudeCliSessions(claudeDir);
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].session).toMatchObject({
+      sessionKey: "claude:claude-1",
+      rawId: "claude-1",
+      source: "claude-cli",
+      projectPath: "/repo",
+      gitBranch: "feat/claude-tags",
+    });
+
+    fs.rmSync(claudeDir, { recursive: true, force: true });
   });
 });

--- a/src/core/session-loader.ts
+++ b/src/core/session-loader.ts
@@ -20,6 +20,7 @@ export function parseCodexSessionMetaLine(parsed: CodexConversationLine): {
   id: string;
   projectPath: string;
   ts: number;
+  gitBranch?: string;
   originator?: string;
 } | null {
   if (parsed.type === "session_meta" && parsed.payload?.id) {
@@ -27,6 +28,7 @@ export function parseCodexSessionMetaLine(parsed: CodexConversationLine): {
       id: parsed.payload.id,
       projectPath: parsed.payload.cwd || "",
       ts: parsed.timestamp ? new Date(parsed.timestamp).getTime() : 0,
+      gitBranch: parsed.payload.git?.branch,
       originator: parsed.payload.originator,
     };
   }
@@ -87,6 +89,15 @@ function firstQuestion(messages: SessionMessage[]): string {
   return messages.find((message) => message.role === "user" && isMeaningfulUserMessage(message.content))?.content || "";
 }
 
+function firstClaudeGitBranch(rows: unknown[]): string | null {
+  for (const row of rows) {
+    if (!row || typeof row !== "object" || !("gitBranch" in row)) continue;
+    const branch = (row as ClaudeConversationLine).gitBranch?.trim();
+    if (branch) return branch;
+  }
+  return null;
+}
+
 function createIndexedSession(input: {
   family: "claude" | "codex";
   rawId: string;
@@ -98,6 +109,7 @@ function createIndexedSession(input: {
   timestamp: number;
   prUrl?: string | null;
   prNumber?: number | null;
+  gitBranch?: string | null;
 }): IndexedSession {
   const stat = safeStat(input.filePath);
   return {
@@ -113,6 +125,7 @@ function createIndexedSession(input: {
     fileSize: stat.size,
     prUrl: input.prUrl ?? null,
     prNumber: input.prNumber ?? null,
+    gitBranch: input.gitBranch ?? null,
   };
 }
 
@@ -135,6 +148,7 @@ export function loadCodexSessionFile(filePath: string, title?: string, updatedAt
     originalTitle: title || cleanTitle(question) || "Untitled Session",
     firstQuestion: question ? cleanTitle(question) : "",
     timestamp: updatedAt ? new Date(updatedAt).getTime() : meta.ts,
+    gitBranch: meta.gitBranch,
   });
 
   return { session, messages };
@@ -191,6 +205,7 @@ export function* loadCodexSessionsIterator(codexDir = path.join(os.homedir(), ".
         originalTitle: indexedTitle?.title || cleanTitle(question) || "Untitled Session",
         firstQuestion: question ? cleanTitle(question) : "",
         timestamp: indexedTitle?.updatedAt ? new Date(indexedTitle.updatedAt).getTime() : meta.ts,
+        gitBranch: meta.gitBranch,
       }),
       messages,
     };
@@ -240,6 +255,7 @@ export function* loadClaudeCliSessionsIterator(claudeDir = path.join(os.homedir(
       const embeddedCwd = (rows.find((row) => row && typeof row === "object" && "cwd" in row) as
         | ClaudeConversationLine
         | undefined)?.cwd;
+      const gitBranch = firstClaudeGitBranch(rows);
       yield {
         session: createIndexedSession({
           family: "claude",
@@ -250,6 +266,7 @@ export function* loadClaudeCliSessionsIterator(claudeDir = path.join(os.homedir(
           originalTitle: cleanTitle(question) || "Untitled Session",
           firstQuestion: cleanTitle(question),
           timestamp: index.get(rawId)?.startedAt || 0,
+          gitBranch,
         }),
         messages,
       };
@@ -299,6 +316,7 @@ export function* loadClaudeAppSessionsIterator(
     const messages = extractMessages(rows, "claude");
     const question = firstQuestion(messages);
     const title = appMeta.title && !/^Session\s+\d+$/i.test(appMeta.title) ? appMeta.title : cleanTitle(question);
+    const gitBranch = firstClaudeGitBranch(rows);
     yield {
       session: createIndexedSession({
         family: "claude",
@@ -311,6 +329,7 @@ export function* loadClaudeAppSessionsIterator(
         timestamp: appMeta.lastActivityAt || appMeta.createdAt || 0,
         prUrl: appMeta.prUrl || null,
         prNumber: appMeta.prNumber || null,
+        gitBranch,
       }),
       messages,
     };

--- a/src/core/session-store.test.ts
+++ b/src/core/session-store.test.ts
@@ -86,6 +86,15 @@ describe("SessionStore", () => {
     expect(store.searchSessions({ query: "", tag: "backend" })).toHaveLength(1);
   });
 
+  it("adds a branch tag from indexed Codex metadata", () => {
+    const store = createInMemoryStore();
+
+    store.upsertIndexedSession(sampleSession({ gitBranch: "feat/session-tags" }), messages);
+
+    expect(store.listTags()).toEqual(["branch:feat/session-tags"]);
+    expect(store.searchSessions({ tag: "branch:feat/session-tags" }).map((session) => session.sessionKey)).toEqual(["codex:abc"]);
+  });
+
   it("lists projects with counts and disambiguates duplicate folder names", () => {
     const store = createInMemoryStore();
     store.upsertIndexedSession(

--- a/src/core/session-store.ts
+++ b/src/core/session-store.ts
@@ -84,6 +84,8 @@ export class SessionStore {
       }
 
       this.refreshFtsForSession(session.sessionKey);
+      const branchTag = branchTagName(session.gitBranch);
+      if (branchTag) this.addTagToSession(session.sessionKey, branchTag);
     });
 
     write();
@@ -119,11 +121,7 @@ export class SessionStore {
     const name = tagName.trim();
     if (!name) return;
     const write = this.db.transaction(() => {
-      this.db.prepare("INSERT INTO tags (name) VALUES (?) ON CONFLICT(name) DO NOTHING").run(name);
-      const tag = this.db.prepare("SELECT id FROM tags WHERE name = ?").get(name) as { id: number };
-      this.db
-        .prepare("INSERT INTO session_tags (session_key, tag_id) VALUES (?, ?) ON CONFLICT DO NOTHING")
-        .run(sessionKey, tag.id);
+      this.addTagToSession(sessionKey, name);
     });
     write();
   }
@@ -347,6 +345,16 @@ export class SessionStore {
       .run(tagName);
   }
 
+  private addTagToSession(sessionKey: string, tagName: string): void {
+    const name = tagName.trim();
+    if (!name) return;
+    this.db.prepare("INSERT INTO tags (name) VALUES (?) ON CONFLICT(name) DO NOTHING").run(name);
+    const tag = this.db.prepare("SELECT id FROM tags WHERE name = ?").get(name) as { id: number };
+    this.db
+      .prepare("INSERT INTO session_tags (session_key, tag_id) VALUES (?, ?) ON CONFLICT DO NOTHING")
+      .run(sessionKey, tag.id);
+  }
+
   private getCandidateRows(options: SearchOptions): SessionRow[] {
     const rows = this.db.prepare("SELECT * FROM sessions").all() as SessionRow[];
     if (options.visibility === "hidden") return rows.filter((row) => row.hidden === 1);
@@ -491,6 +499,11 @@ function buildFtsQuery(query: string): string {
     .filter(Boolean)
     .map((token) => `${token}*`)
     .join(" ");
+}
+
+function branchTagName(branch: string | null | undefined): string | null {
+  const normalized = branch?.trim();
+  return normalized ? `branch:${normalized}` : null;
 }
 
 function projectParts(projectPath: string): string[] {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -22,6 +22,7 @@ export interface IndexedSession {
   fileSize: number;
   prUrl: string | null;
   prNumber: number | null;
+  gitBranch?: string | null;
 }
 
 export interface LoadedSession {
@@ -80,6 +81,7 @@ export interface ClaudeConversationLine {
   type: "user" | "assistant" | string;
   timestamp?: string;
   cwd?: string;
+  gitBranch?: string;
   message?: {
     role: "user" | "assistant";
     content?: string | Array<{ type?: string; text?: string }>;
@@ -100,6 +102,11 @@ export interface CodexConversationLine {
     content?: Array<{ type?: string; text?: string }>;
     id?: string;
     cwd?: string;
+    git?: {
+      branch?: string;
+      commit_hash?: string;
+      repository_url?: string;
+    };
     originator?: string;
   };
 }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -11,6 +11,7 @@ import {
   EyeOff,
   Folder,
   FolderOpen,
+  GitBranch,
   Pin,
   PinOff,
   Play,
@@ -52,6 +53,10 @@ const SORT_OPTIONS: Array<{ label: string; value: SessionSortBy }> = [
 type ViewMode = "default" | "favorites" | "pinned" | "hidden";
 const INITIAL_MESSAGE_LIMIT = 20;
 const MESSAGE_PAGE_SIZE = 80;
+
+function isBranchTag(tagName: string): boolean {
+  return tagName.startsWith("branch:");
+}
 
 type ActionStatus = {
   kind: "running" | "success" | "error";
@@ -385,9 +390,12 @@ export function App(): ReactElement {
             All Tags
           </button>
           {tags.map((tagName) => (
-            <div key={tagName} className={`tag-list-row ${tag === tagName ? "active" : ""}`}>
+            <div
+              key={tagName}
+              className={`tag-list-row ${tag === tagName ? "active" : ""} ${isBranchTag(tagName) ? "branch-tag" : ""}`}
+            >
               <button className="tag-filter" onClick={() => setTag(tagName)} title={`Filter by ${tagName}`}>
-                <Tag size={13} />
+                {isBranchTag(tagName) ? <GitBranch size={13} /> : <Tag size={13} />}
                 <span>{tagName}</span>
               </button>
               <button
@@ -636,7 +644,9 @@ function SessionRow({
       </div>
       <div className="row-tags">
         {session.tags.slice(0, 3).map((tagName) => (
-          <span key={tagName}>#{tagName}</span>
+          <span key={tagName} className={isBranchTag(tagName) ? "branch-tag" : undefined}>
+            #{tagName}
+          </span>
         ))}
       </div>
     </article>
@@ -783,7 +793,7 @@ function DetailPanel({
       {actionStatus ? <div className={`action-status ${actionStatus.kind}`}>{actionStatus.message}</div> : null}
       <div className="detail-tags">
         {session.tags.map((tagName) => (
-          <button key={tagName} className="chip" onClick={() => onRemoveTag(tagName)}>
+          <button key={tagName} className={`chip ${isBranchTag(tagName) ? "branch-tag" : ""}`} onClick={() => onRemoveTag(tagName)}>
             #{tagName} ×
           </button>
         ))}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -366,6 +366,24 @@ button:disabled {
   color: var(--text);
 }
 
+.tag-list-row.branch-tag .tag-filter {
+  color: #7dd3fc;
+}
+
+.tag-list-row.branch-tag .tag-filter svg {
+  color: #38bdf8;
+}
+
+.tag-list-row.branch-tag:hover,
+.tag-list-row.branch-tag.active {
+  background: rgba(56, 189, 248, 0.14);
+}
+
+.tag-list-row.branch-tag.active .tag-filter {
+  color: #e0f2fe;
+  font-weight: 650;
+}
+
 .tag-filter span {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -721,6 +739,13 @@ button:disabled {
   font-family: var(--mono);
 }
 
+.row-tags span.branch-tag {
+  border: 1px solid rgba(56, 189, 248, 0.34);
+  background: rgba(14, 165, 233, 0.18);
+  color: #bae6fd;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
 .chip {
   display: inline-flex;
   align-items: center;
@@ -737,6 +762,17 @@ button:disabled {
 
 .chip:hover {
   background: rgba(52, 199, 154, 0.24);
+}
+
+.chip.branch-tag {
+  border: 1px solid rgba(56, 189, 248, 0.36);
+  background: rgba(14, 165, 233, 0.2);
+  color: #bae6fd;
+}
+
+.chip.branch-tag:hover {
+  background: rgba(14, 165, 233, 0.3);
+  color: #e0f2fe;
 }
 
 .chip.clear {


### PR DESCRIPTION
## 变更内容

- 解析 Codex JSONL 中的 `session_meta.payload.git.branch` 字段。
- 解析 Claude Code JSONL 行里的 `gitBranch` 字段，Claude App 关联到 CLI JSONL 时也会复用该分支信息。
- 将分支名保存到索引会话数据中。
- 会话写入索引时，如果存在分支名，自动添加 `branch:<分支名>` 标签，方便后续通过标签查找同一分支产生的会话。
- 没有 Git 分支信息的会话保持原行为，不新增标签。
- 为 `branch:` 标签增加专门的分支图标和更醒目的蓝色样式，避免和普通标签一样偏灰。

