### PR TITLE
新增默认终端恢复快捷键

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -161,6 +161,16 @@ export function App(): ReactElement {
       // Leave list navigation alone while an overlay or menu is in front.
       if (detail || dialog || deleteTagName || contextMenu) return;
 
+      if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+        event.preventDefault();
+        if (actionStatus?.kind === "running" || !selectedKey) return;
+        const session = results.find((item) => item.sessionKey === selectedKey);
+        if (session) {
+          void runAction("Opening terminal", () => window.sessionSearch.resumeSession(session.sessionKey), "Resume command sent to terminal.");
+        }
+        return;
+      }
+
       if (event.key === "ArrowDown" || event.key === "ArrowUp") {
         if (results.length === 0) return;
         event.preventDefault();
@@ -189,7 +199,7 @@ export function App(): ReactElement {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [results, selectedKey, detail, dialog, deleteTagName, contextMenu]);
+  }, [results, selectedKey, detail, dialog, deleteTagName, contextMenu, actionStatus]);
 
   useEffect(() => {
     if (!selectedKey) return;
@@ -423,12 +433,15 @@ export function App(): ReactElement {
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               onKeyDown={(event) => {
-                if (event.key === "Enter" && selected) void openDetail(selected);
+                if (!event.metaKey && !event.ctrlKey && event.key === "Enter" && selected) void openDetail(selected);
               }}
               placeholder={searchPlaceholder}
               autoFocus
             />
             <span className="kbd-hint">⌘K</span>
+            <span className="kbd-hint" title="Resume selected session in the default terminal">
+              ⌘↵
+            </span>
           </div>
           {selectedProject ? (
             <button className="chip clear" onClick={() => setProjectPath(undefined)} title={selectedProject.path}>


### PR DESCRIPTION
## 变更内容

- 在主界面新增 `Cmd/Ctrl + Enter` 快捷键。
- 快捷键会对当前高亮选中的会话执行默认终端 Resume。
- 搜索框内的普通 `Enter` 仍然保持打开会话详情。
- 详情面板、弹窗、右键菜单打开时不会触发该快捷键，避免误操作。
- 搜索框右侧新增 `⌘↵` 快捷键提示。

## 说明

该快捷键复用现有默认终端恢复逻辑，不影响 iTerm 专用入口。
