### PR TITLE
Add internal session sources with a redesigned settings dialog

### DIFF
--- a/src/core/format-adapters.ts
+++ b/src/core/format-adapters.ts
@@ -78,7 +78,7 @@ export const codexAdapter: FormatAdapter = {
 };
 
 export function getFormatForSource(source: SessionSource): SessionFormat {
-  return source === "claude-cli" || source === "claude-app" ? "claude" : "codex";
+  return source === "claude-cli" || source === "claude-app" || source === "claude-internal" ? "claude" : "codex";
 }
 
 export function getAdapter(sourceOrFormat: SessionSource | SessionFormat): FormatAdapter {

--- a/src/core/format-session.ts
+++ b/src/core/format-session.ts
@@ -3,8 +3,10 @@ import type { IndexedSession, SessionMessage, SessionSearchResult } from "./type
 const SOURCE_LABEL: Record<string, string> = {
   "claude-cli": "Claude Code",
   "claude-app": "Claude App",
+  "claude-internal": "Claude Internal",
   "codex-cli": "Codex CLI",
   "codex-app": "Codex App",
+  "codex-internal": "Codex Internal",
 };
 
 export function formatRelativeTime(ts: number): string {

--- a/src/core/indexer.ts
+++ b/src/core/indexer.ts
@@ -1,4 +1,4 @@
-import { loadDefaultSessions, loadDefaultSessionsIterator } from "./session-loader";
+import { loadDefaultSessions, loadDefaultSessionsIterator, type SessionLoadOptions } from "./session-loader";
 import type { SessionStore } from "./session-store";
 import type { LoadedSession } from "./types";
 
@@ -10,8 +10,8 @@ export interface IndexStatus {
   error: string | null;
 }
 
-export function syncDefaultSessions(store: SessionStore): IndexStatus {
-  const loaded = loadDefaultSessions();
+export function syncDefaultSessions(store: SessionStore, loadOptions: SessionLoadOptions = {}): IndexStatus {
+  const loaded = loadDefaultSessions(loadOptions);
   let indexed = 0;
   for (const item of loaded) {
     store.upsertIndexedSession(item.session, item.messages, item.tokenEvents);
@@ -28,6 +28,7 @@ export function syncDefaultSessions(store: SessionStore): IndexStatus {
 
 export interface BatchIndexOptions {
   batchSize?: number;
+  loadOptions?: SessionLoadOptions;
   onProgress?: (status: IndexStatus) => void;
   yieldToEventLoop?: () => Promise<void>;
 }
@@ -71,5 +72,5 @@ export async function syncLoadedSessionsInBatches(
 }
 
 export function syncDefaultSessionsInBatches(store: SessionStore, options: BatchIndexOptions = {}): Promise<IndexStatus> {
-  return syncLoadedSessionsInBatches(store, loadDefaultSessionsIterator(), options);
+  return syncLoadedSessionsInBatches(store, loadDefaultSessionsIterator(options.loadOptions), options);
 }

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -7,18 +7,22 @@ export interface AppSettings {
   defaultTerminal: "Terminal" | "iTerm" | "Ghostty" | "WezTerm" | "Warp";
   claudeBinary: string;
   codexBinary: string;
+  includeClaudeInternal: boolean;
+  includeCodexInternal: boolean;
 }
 
 export const defaultSettings: AppSettings = {
   defaultTerminal: "Terminal",
   claudeBinary: "claude",
   codexBinary: "codex",
+  includeClaudeInternal: false,
+  includeCodexInternal: false,
 };
 
 const ITERM_APPLICATION_NAMES = ["iTerm", "iTerm2"];
 
 export function sourceFamily(source: SessionSource): "claude" | "codex" {
-  return source === "claude-cli" || source === "claude-app" ? "claude" : "codex";
+  return source === "claude-cli" || source === "claude-app" || source === "claude-internal" ? "claude" : "codex";
 }
 
 export function getResumeCommand(

--- a/src/core/session-loader.test.ts
+++ b/src/core/session-loader.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { loadClaudeCliSessions, loadCodexSessionFile, parseCodexSessionMetaLine } from "./session-loader";
+import { loadClaudeCliSessions, loadCodexSessionFile, loadCodexSessions, parseCodexSessionMetaLine } from "./session-loader";
 
 describe("Codex session loading", () => {
   it("extracts id, cwd, originator, first question, and visible messages from a rollout file", () => {
@@ -138,6 +138,40 @@ describe("Codex session loading", () => {
       }),
     ).toMatchObject({ id: "old-id", projectPath: "/old" });
   });
+
+  it("loads Codex internal sessions with a separate source and session key namespace", () => {
+    const codexDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-codex-internal-"));
+    const sessionDir = path.join(codexDir, "sessions", "2026", "06", "01");
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sessionDir, "rollout.jsonl"),
+      [
+        JSON.stringify({
+          type: "session_meta",
+          timestamp: "2026-06-01T10:00:00Z",
+          payload: { id: "codex-internal-1", cwd: "/internal", git: { branch: "feat/internal" } },
+        }),
+        JSON.stringify({
+          type: "response_item",
+          timestamp: "2026-06-01T10:01:00Z",
+          payload: { type: "message", role: "user", content: [{ type: "input_text", text: "内部会话" }] },
+        }),
+      ].join("\n"),
+    );
+
+    const loaded = loadCodexSessions(codexDir, "codex-internal");
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].session).toMatchObject({
+      sessionKey: "codex-internal:codex-internal-1",
+      rawId: "codex-internal-1",
+      source: "codex-internal",
+      projectPath: "/internal",
+      gitBranch: "feat/internal",
+    });
+
+    fs.rmSync(codexDir, { recursive: true, force: true });
+  });
 });
 
 describe("Claude session loading", () => {
@@ -176,6 +210,38 @@ describe("Claude session loading", () => {
       source: "claude-cli",
       projectPath: "/repo",
       gitBranch: "feat/claude-tags",
+    });
+
+    fs.rmSync(claudeDir, { recursive: true, force: true });
+  });
+
+  it("loads Claude internal sessions with a separate source and session key namespace", () => {
+    const claudeDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-claude-internal-"));
+    const projectDir = path.join(claudeDir, "projects", "-repo");
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDir, "claude-internal-1.jsonl"),
+      [
+        JSON.stringify({
+          type: "user",
+          timestamp: "2026-06-01T10:00:00Z",
+          cwd: "/repo",
+          sessionId: "claude-internal-1",
+          gitBranch: "feat/internal",
+          message: { role: "user", content: "内部 Claude 会话" },
+        }),
+      ].join("\n"),
+    );
+
+    const loaded = loadClaudeCliSessions(claudeDir, "claude-internal");
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].session).toMatchObject({
+      sessionKey: "claude-internal:claude-internal-1",
+      rawId: "claude-internal-1",
+      source: "claude-internal",
+      projectPath: "/repo",
+      gitBranch: "feat/internal",
     });
 
     fs.rmSync(claudeDir, { recursive: true, force: true });

--- a/src/core/session-loader.ts
+++ b/src/core/session-loader.ts
@@ -17,6 +17,13 @@ import type {
 } from "./types";
 
 const CODEX_APP_ORIGINATOR = "Codex Desktop";
+const CLAUDE_INTERNAL_DIR = ".claude-internal";
+const CODEX_INTERNAL_DIR = ".codex-internal";
+
+export interface SessionLoadOptions {
+  includeClaudeInternal?: boolean;
+  includeCodexInternal?: boolean;
+}
 
 function emptyTokenUsage(): TokenUsage {
   return {
@@ -246,7 +253,7 @@ function firstClaudeGitBranch(rows: unknown[]): string | null {
 }
 
 function createIndexedSession(input: {
-  family: "claude" | "codex";
+  keyPrefix: "claude" | "codex" | "claude-internal" | "codex-internal";
   rawId: string;
   source: SessionSource;
   projectPath: string;
@@ -261,7 +268,7 @@ function createIndexedSession(input: {
 }): IndexedSession {
   const stat = safeStat(input.filePath);
   return {
-    sessionKey: `${input.family}:${input.rawId}`,
+    sessionKey: `${input.keyPrefix}:${input.rawId}`,
     rawId: input.rawId,
     source: input.source,
     projectPath: input.projectPath,
@@ -291,7 +298,7 @@ export function loadCodexSessionFile(filePath: string, title?: string, updatedAt
   const question = firstQuestion(messages);
   const source: SessionSource = meta.originator === CODEX_APP_ORIGINATOR ? "codex-app" : "codex-cli";
   const session = createIndexedSession({
-    family: "codex",
+    keyPrefix: "codex",
     rawId: meta.id,
     source,
     projectPath: meta.projectPath,
@@ -323,11 +330,11 @@ function walkJsonlFiles(dir: string): string[] {
   return files;
 }
 
-export function loadCodexSessions(codexDir = path.join(os.homedir(), ".codex")): LoadedSession[] {
-  return [...loadCodexSessionsIterator(codexDir)];
+export function loadCodexSessions(codexDir = path.join(os.homedir(), ".codex"), sourceOverride?: SessionSource): LoadedSession[] {
+  return [...loadCodexSessionsIterator(codexDir, sourceOverride)];
 }
 
-export function* loadCodexSessionsIterator(codexDir = path.join(os.homedir(), ".codex")): Generator<LoadedSession> {
+export function* loadCodexSessionsIterator(codexDir = path.join(os.homedir(), ".codex"), sourceOverride?: SessionSource): Generator<LoadedSession> {
   const sessionsDir = path.join(codexDir, "sessions");
   if (!fs.existsSync(sessionsDir)) return;
 
@@ -348,10 +355,10 @@ export function* loadCodexSessionsIterator(codexDir = path.join(os.homedir(), ".
     const tokenEvents = extractCodexTokenEvents(rows);
     const tokenUsage = tokenUsageFromEvents(tokenEvents);
     const question = firstQuestion(messages);
-    const source: SessionSource = meta.originator === CODEX_APP_ORIGINATOR ? "codex-app" : "codex-cli";
+    const source: SessionSource = sourceOverride || (meta.originator === CODEX_APP_ORIGINATOR ? "codex-app" : "codex-cli");
     yield {
       session: createIndexedSession({
-        family: "codex",
+        keyPrefix: source === "codex-internal" ? "codex-internal" : "codex",
         rawId: meta.id,
         source,
         projectPath: meta.projectPath,
@@ -376,11 +383,11 @@ function loadClaudeMessages(filePath: string): SessionMessage[] {
   return extractMessages(readJsonl(filePath), "claude");
 }
 
-export function loadClaudeCliSessions(claudeDir = path.join(os.homedir(), ".claude")): LoadedSession[] {
-  return [...loadClaudeCliSessionsIterator(claudeDir)];
+export function loadClaudeCliSessions(claudeDir = path.join(os.homedir(), ".claude"), source: SessionSource = "claude-cli"): LoadedSession[] {
+  return [...loadClaudeCliSessionsIterator(claudeDir, source)];
 }
 
-export function* loadClaudeCliSessionsIterator(claudeDir = path.join(os.homedir(), ".claude")): Generator<LoadedSession> {
+export function* loadClaudeCliSessionsIterator(claudeDir = path.join(os.homedir(), ".claude"), source: SessionSource = "claude-cli"): Generator<LoadedSession> {
   const sessionsDir = path.join(claudeDir, "sessions");
   const projectsDir = path.join(claudeDir, "projects");
   if (!fs.existsSync(projectsDir)) return;
@@ -416,9 +423,9 @@ export function* loadClaudeCliSessionsIterator(claudeDir = path.join(os.homedir(
       const gitBranch = firstClaudeGitBranch(rows);
       yield {
         session: createIndexedSession({
-          family: "claude",
+          keyPrefix: source === "claude-internal" ? "claude-internal" : "claude",
           rawId,
-          source: "claude-cli",
+          source,
           projectPath: index.get(rawId)?.cwd || embeddedCwd || "",
           filePath,
           originalTitle: cleanTitle(question) || "Untitled Session",
@@ -481,7 +488,7 @@ export function* loadClaudeAppSessionsIterator(
     const gitBranch = firstClaudeGitBranch(rows);
     yield {
       session: createIndexedSession({
-        family: "claude",
+        keyPrefix: "claude",
         rawId,
         source: "claude-app",
         projectPath: cwd,
@@ -500,12 +507,14 @@ export function* loadClaudeAppSessionsIterator(
   }
 }
 
-export function loadDefaultSessions(): LoadedSession[] {
-  return [...loadDefaultSessionsIterator()];
+export function loadDefaultSessions(options: SessionLoadOptions = {}): LoadedSession[] {
+  return [...loadDefaultSessionsIterator(options)];
 }
 
-export function* loadDefaultSessionsIterator(): Generator<LoadedSession> {
+export function* loadDefaultSessionsIterator(options: SessionLoadOptions = {}): Generator<LoadedSession> {
   yield* loadClaudeCliSessionsIterator();
   yield* loadClaudeAppSessionsIterator();
   yield* loadCodexSessionsIterator();
+  if (options.includeClaudeInternal) yield* loadClaudeCliSessionsIterator(path.join(os.homedir(), CLAUDE_INTERNAL_DIR), "claude-internal");
+  if (options.includeCodexInternal) yield* loadCodexSessionsIterator(path.join(os.homedir(), CODEX_INTERNAL_DIR), "codex-internal");
 }

--- a/src/core/session-store.test.ts
+++ b/src/core/session-store.test.ts
@@ -281,6 +281,36 @@ describe("SessionStore", () => {
     expect(store.searchSessions({ query: "", tag: "backend" })).toHaveLength(1);
   });
 
+  it("keeps internal sources out of the regular Claude and Codex source filters", () => {
+    const store = createInMemoryStore();
+    store.upsertIndexedSession(sampleSession({ sessionKey: "claude:regular", rawId: "regular", source: "claude-cli" }), messages);
+    store.upsertIndexedSession(
+      sampleSession({ sessionKey: "claude-internal:internal", rawId: "internal", source: "claude-internal" }),
+      messages,
+    );
+    store.upsertIndexedSession(sampleSession({ sessionKey: "codex:regular", rawId: "codex-regular", source: "codex-cli" }), messages);
+    store.upsertIndexedSession(
+      sampleSession({ sessionKey: "codex-internal:internal", rawId: "codex-internal", source: "codex-internal" }),
+      messages,
+    );
+
+    expect(store.searchSessions({ source: "claude" }).map((session) => session.source)).toEqual(["claude-cli"]);
+    expect(store.searchSessions({ source: "codex" }).map((session) => session.source)).toEqual(["codex-cli"]);
+    expect(store.searchSessions({ source: "claude-internal" }).map((session) => session.sessionKey)).toEqual(["claude-internal:internal"]);
+    expect(store.searchSessions({ source: "codex-internal" }).map((session) => session.sessionKey)).toEqual(["codex-internal:internal"]);
+  });
+
+  it("deletes indexed sessions by source and removes unused tags", () => {
+    const store = createInMemoryStore();
+    store.upsertIndexedSession(sampleSession({ sessionKey: "claude-internal:one", rawId: "one", source: "claude-internal" }), messages);
+    store.addTag("claude-internal:one", "internal");
+
+    store.deleteSessionsBySource(["claude-internal"]);
+
+    expect(store.searchSessions({ source: "claude-internal" })).toEqual([]);
+    expect(store.listTags()).toEqual([]);
+  });
+
   it("adds a branch tag from indexed Codex metadata", () => {
     const store = createInMemoryStore();
 

--- a/src/core/session-store.ts
+++ b/src/core/session-store.ts
@@ -353,6 +353,17 @@ export class SessionStore {
     clear();
   }
 
+  deleteSessionsBySource(sources: SessionSource[]): void {
+    if (sources.length === 0) return;
+    const placeholders = sources.map(() => "?").join(", ");
+    const remove = this.db.transaction(() => {
+      this.db.prepare(`DELETE FROM session_fts WHERE session_key IN (SELECT session_key FROM sessions WHERE source IN (${placeholders}))`).run(...sources);
+      this.db.prepare(`DELETE FROM sessions WHERE source IN (${placeholders})`).run(...sources);
+      this.deleteUnusedTags();
+    });
+    remove();
+  }
+
   private migrate(): void {
     this.db.pragma("foreign_keys = ON");
     this.db.exec(`
@@ -474,6 +485,21 @@ export class SessionStore {
       `,
       )
       .run(tagName);
+  }
+
+  private deleteUnusedTags(): void {
+    this.db
+      .prepare(
+        `
+        DELETE FROM tags
+        WHERE NOT EXISTS (
+          SELECT 1
+          FROM session_tags
+          WHERE session_tags.tag_id = tags.id
+        )
+      `,
+      )
+      .run();
   }
 
   private addTagToSession(sessionKey: string, tagName: string): void {
@@ -673,8 +699,8 @@ export class SessionStore {
     if (options.tag && !result.tags.includes(options.tag)) return false;
     if (options.projectPath && result.projectPath !== options.projectPath) return false;
     if (options.source && options.source !== "all") {
-      if (options.source === "claude" && !result.source.startsWith("claude-")) return false;
-      else if (options.source === "codex" && !result.source.startsWith("codex-")) return false;
+      if (options.source === "claude" && result.source !== "claude-cli" && result.source !== "claude-app") return false;
+      else if (options.source === "codex" && result.source !== "codex-cli" && result.source !== "codex-app") return false;
       else if (options.source !== "claude" && options.source !== "codex" && result.source !== options.source) return false;
     }
     return true;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,4 +1,4 @@
-export type SessionSource = "claude-cli" | "claude-app" | "codex-cli" | "codex-app";
+export type SessionSource = "claude-cli" | "claude-app" | "claude-internal" | "codex-cli" | "codex-app" | "codex-internal";
 export type SessionFormat = "claude" | "codex";
 export type SessionSortBy = "activity" | "created" | "updated";
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -212,6 +212,10 @@ async function runIndexSync(): Promise<IndexStatus> {
 
   activeIndexRun = syncDefaultSessionsInBatches(store, {
     batchSize: 2,
+    loadOptions: {
+      includeClaudeInternal: getSettings().includeClaudeInternal,
+      includeCodexInternal: getSettings().includeCodexInternal,
+    },
     onProgress: (status) => {
       indexStatus = { ...status, lastIndexedAt: indexStatus.lastIndexedAt };
       mainWindow?.webContents.send("index-status", indexStatus);
@@ -276,8 +280,12 @@ function registerIpc(): void {
   ipcMain.handle("index:status", () => indexStatus);
   ipcMain.handle("settings:get", () => getSettings());
   ipcMain.handle("settings:set", (_event, settings: Partial<AppSettings>) => {
+    const previous = getSettings();
     settingsStore.set({ ...getSettings(), ...settings });
-    return getSettings();
+    const next = getSettings();
+    if (previous.includeClaudeInternal && !next.includeClaudeInternal) store.deleteSessionsBySource(["claude-internal"]);
+    if (previous.includeCodexInternal && !next.includeCodexInternal) store.deleteSessionsBySource(["codex-internal"]);
+    return next;
   });
   ipcMain.handle("command:copy-resume", (_event, sessionKey: string) => {
     const session = store.getSession(sessionKey);

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1198,56 +1198,72 @@ function SettingsDialog({
         <div className="settings-shell">
           <nav className="settings-sidebar" aria-label="Settings sections">
             <button className={activeSection === "terminal" ? "active" : ""} onClick={() => setActiveSection("terminal")}>
-              Default terminal
+              <Terminal size={15} />
+              <span>Default terminal</span>
             </button>
             <button className={activeSection === "sources" ? "active" : ""} onClick={() => setActiveSection("sources")}>
-              Personal sources
+              <Folder size={15} />
+              <span>Personal sources</span>
             </button>
           </nav>
           <div className="settings-content">
             {activeSection === "terminal" ? (
-              <section className="settings-row">
-                <div>
+              <section className="settings-pane">
+                <header className="settings-pane-head">
                   <h3>Default terminal</h3>
-                  <p>Choose which terminal app is used by Resume and the main list shortcut.</p>
+                  <p>Choose which terminal app Resume and the list shortcut use to reopen a session.</p>
+                </header>
+                <div className="settings-field">
+                  <div className="settings-field-text">
+                    <span className="settings-field-title">Terminal app</span>
+                    <span className="settings-field-sub">Applies to Resume and the keyboard shortcut.</span>
+                  </div>
+                  <select
+                    id="default-terminal"
+                    value={defaultTerminal}
+                    disabled={!settings || saving}
+                    onChange={(event) => onDefaultTerminalChange(event.target.value as AppSettings["defaultTerminal"])}
+                  >
+                    {DEFAULT_TERMINAL_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
                 </div>
-                <select
-                  id="default-terminal"
-                  value={defaultTerminal}
-                  disabled={!settings || saving}
-                  onChange={(event) => onDefaultTerminalChange(event.target.value as AppSettings["defaultTerminal"])}
-                >
-                  {DEFAULT_TERMINAL_OPTIONS.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
               </section>
             ) : null}
             {activeSection === "sources" ? (
-              <section className="settings-row">
-                <div>
+              <section className="settings-pane">
+                <header className="settings-pane-head">
                   <h3>Personal sources</h3>
                   <p>Internal sessions stay separate from the normal Claude and Codex filters.</p>
-                </div>
-                <label className="settings-check">
+                </header>
+                <label className="settings-field settings-toggle">
+                  <div className="settings-field-text">
+                    <span className="settings-field-title">Include ~/.claude-internal</span>
+                    <span className="settings-field-sub">Adds a separate Claude Internal source filter.</span>
+                  </div>
                   <input
                     type="checkbox"
+                    className="switch"
                     checked={Boolean(settings?.includeClaudeInternal)}
                     disabled={!settings || saving}
                     onChange={(event) => onSettingsChange({ includeClaudeInternal: event.currentTarget.checked })}
                   />
-                  <span>Include ~/.claude-internal</span>
                 </label>
-                <label className="settings-check">
+                <label className="settings-field settings-toggle">
+                  <div className="settings-field-text">
+                    <span className="settings-field-title">Include ~/.codex-internal</span>
+                    <span className="settings-field-sub">Adds a separate Codex Internal source filter.</span>
+                  </div>
                   <input
                     type="checkbox"
+                    className="switch"
                     checked={Boolean(settings?.includeCodexInternal)}
                     disabled={!settings || saving}
                     onChange={(event) => onSettingsChange({ includeCodexInternal: event.currentTarget.checked })}
                   />
-                  <span>Include ~/.codex-internal</span>
                 </label>
               </section>
             ) : null}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -54,11 +54,13 @@ import { readInitialTheme, THEME_STORAGE_KEY, type ThemeMode } from "./theme";
 const SOURCE_LABEL: Record<SessionSource, string> = {
   "claude-cli": "Claude Code",
   "claude-app": "Claude App",
+  "claude-internal": "Claude Internal",
   "codex-cli": "Codex CLI",
   "codex-app": "Codex App",
+  "codex-internal": "Codex Internal",
 };
 
-const SOURCE_FILTERS: Array<{ label: string; value: SearchOptions["source"] }> = [
+const BASE_SOURCE_FILTERS: Array<{ label: string; value: SearchOptions["source"] }> = [
   { label: "All", value: "all" },
   { label: "Claude", value: "claude" },
   { label: "Codex", value: "codex" },
@@ -67,6 +69,14 @@ const SOURCE_FILTERS: Array<{ label: string; value: SearchOptions["source"] }> =
   { label: "Codex CLI", value: "codex-cli" },
   { label: "Codex App", value: "codex-app" },
 ];
+
+function sourceFilters(settings: AppSettings | null): Array<{ label: string; value: SearchOptions["source"] }> {
+  return [
+    ...BASE_SOURCE_FILTERS,
+    ...(settings?.includeClaudeInternal ? [{ label: "Claude Internal", value: "claude-internal" as const }] : []),
+    ...(settings?.includeCodexInternal ? [{ label: "Codex Internal", value: "codex-internal" as const }] : []),
+  ];
+}
 
 const SORT_OPTIONS: Array<{ label: string; value: SessionSortBy }> = [
   { label: "Latest activity", value: "activity" },
@@ -205,6 +215,11 @@ export function App(): ReactElement {
     void window.sessionSearch.getSettings().then(setAppSettings);
   }, []);
 
+  useEffect(() => {
+    if (source === "claude-internal" && appSettings && !appSettings.includeClaudeInternal) setSource("all");
+    if (source === "codex-internal" && appSettings && !appSettings.includeCodexInternal) setSource("all");
+  }, [source, appSettings]);
+
   useLayoutEffect(() => {
     document.documentElement.dataset.theme = theme;
     window.localStorage.setItem(THEME_STORAGE_KEY, theme);
@@ -304,6 +319,7 @@ export function App(): ReactElement {
     () => results.find((session) => session.sessionKey === selectedKey) || null,
     [results, selectedKey],
   );
+  const visibleSourceFilters = useMemo(() => sourceFilters(appSettings), [appSettings]);
   const selectedProject = useMemo(
     () => projects.find((project) => project.path === projectPath) || null,
     [projects, projectPath],
@@ -434,11 +450,20 @@ export function App(): ReactElement {
   }
 
   async function updateDefaultTerminal(defaultTerminal: AppSettings["defaultTerminal"]): Promise<void> {
+    await updateSettings({ defaultTerminal });
+  }
+
+  async function updateSettings(next: Partial<AppSettings>): Promise<void> {
     setSettingsFeedback({ kind: "running", message: "Saving settings..." });
     try {
-      const nextSettings = await window.sessionSearch.setSettings({ defaultTerminal });
+      const shouldRefreshIndex =
+        (next.includeClaudeInternal === true && !appSettings?.includeClaudeInternal) ||
+        (next.includeCodexInternal === true && !appSettings?.includeCodexInternal);
+      const nextSettings = await window.sessionSearch.setSettings(next);
       setAppSettings(nextSettings);
-      setSettingsFeedback({ kind: "success", message: "Default terminal updated." });
+      if (shouldRefreshIndex) await window.sessionSearch.refreshIndex();
+      await load();
+      setSettingsFeedback({ kind: "success", message: "Settings saved." });
       window.setTimeout(() => {
         setSettingsFeedback((current) => (current?.kind === "success" ? null : current));
       }, 1600);
@@ -527,7 +552,7 @@ export function App(): ReactElement {
         <SidebarSectionHeader title="Sources" expanded={sidebarSections.sources} onToggle={() => toggleSidebarSectionById("sources")} />
         {sidebarSections.sources ? (
           <nav className="nav-group">
-            {SOURCE_FILTERS.map((item) => (
+            {visibleSourceFilters.map((item) => (
               <button key={item.label} className={source === item.value ? "active" : ""} onClick={() => setSource(item.value)}>
                 {item.label}
               </button>
@@ -776,6 +801,7 @@ export function App(): ReactElement {
         <SettingsDialog
           settings={appSettings}
           feedback={settingsFeedback}
+          onSettingsChange={(next) => void updateSettings(next)}
           onDefaultTerminalChange={(terminal) => void updateDefaultTerminal(terminal)}
           onClose={() => setSettingsOpen(false)}
         />
@@ -1146,16 +1172,19 @@ function ContextMenu({
 function SettingsDialog({
   settings,
   feedback,
+  onSettingsChange,
   onDefaultTerminalChange,
   onClose,
 }: {
   settings: AppSettings | null;
   feedback: SettingsFeedback;
+  onSettingsChange: (settings: Partial<AppSettings>) => void;
   onDefaultTerminalChange: (terminal: AppSettings["defaultTerminal"]) => void;
   onClose: () => void;
 }): ReactElement {
   const defaultTerminal = settings?.defaultTerminal ?? "Terminal";
   const saving = feedback?.kind === "running";
+  const [activeSection, setActiveSection] = useState<"terminal" | "sources">("terminal");
 
   return (
     <div className="dialog-backdrop" onMouseDown={onClose}>
@@ -1166,21 +1195,63 @@ function SettingsDialog({
             <X size={16} />
           </button>
         </div>
-        <div className="settings-row">
-          <label htmlFor="default-terminal">Default terminal</label>
-          <select
-            id="default-terminal"
-            value={defaultTerminal}
-            disabled={!settings || saving}
-            onChange={(event) => onDefaultTerminalChange(event.target.value as AppSettings["defaultTerminal"])}
-          >
-            {DEFAULT_TERMINAL_OPTIONS.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-          <p>Used by Resume and the main list shortcut.</p>
+        <div className="settings-shell">
+          <nav className="settings-sidebar" aria-label="Settings sections">
+            <button className={activeSection === "terminal" ? "active" : ""} onClick={() => setActiveSection("terminal")}>
+              Default terminal
+            </button>
+            <button className={activeSection === "sources" ? "active" : ""} onClick={() => setActiveSection("sources")}>
+              Personal sources
+            </button>
+          </nav>
+          <div className="settings-content">
+            {activeSection === "terminal" ? (
+              <section className="settings-row">
+                <div>
+                  <h3>Default terminal</h3>
+                  <p>Choose which terminal app is used by Resume and the main list shortcut.</p>
+                </div>
+                <select
+                  id="default-terminal"
+                  value={defaultTerminal}
+                  disabled={!settings || saving}
+                  onChange={(event) => onDefaultTerminalChange(event.target.value as AppSettings["defaultTerminal"])}
+                >
+                  {DEFAULT_TERMINAL_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </section>
+            ) : null}
+            {activeSection === "sources" ? (
+              <section className="settings-row">
+                <div>
+                  <h3>Personal sources</h3>
+                  <p>Internal sessions stay separate from the normal Claude and Codex filters.</p>
+                </div>
+                <label className="settings-check">
+                  <input
+                    type="checkbox"
+                    checked={Boolean(settings?.includeClaudeInternal)}
+                    disabled={!settings || saving}
+                    onChange={(event) => onSettingsChange({ includeClaudeInternal: event.currentTarget.checked })}
+                  />
+                  <span>Include ~/.claude-internal</span>
+                </label>
+                <label className="settings-check">
+                  <input
+                    type="checkbox"
+                    checked={Boolean(settings?.includeCodexInternal)}
+                    disabled={!settings || saving}
+                    onChange={(event) => onSettingsChange({ includeCodexInternal: event.currentTarget.checked })}
+                  />
+                  <span>Include ~/.codex-internal</span>
+                </label>
+              </section>
+            ) : null}
+          </div>
         </div>
         {feedback ? <div className={`settings-feedback ${feedback.kind}`}>{feedback.message}</div> : null}
       </section>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1304,7 +1304,9 @@ function SettingsDialog({
             ) : null}
           </div>
         </div>
-        {feedback ? <div className={`settings-feedback ${feedback.kind}`}>{feedback.message}</div> : null}
+        <div className={`settings-feedback ${feedback?.kind ?? ""}`} aria-live="polite">
+          {feedback?.message ?? ""}
+        </div>
       </section>
     </div>
   );

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -181,6 +181,7 @@ export function App(): ReactElement {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [appSettings, setAppSettings] = useState<AppSettings | null>(null);
   const [settingsFeedback, setSettingsFeedback] = useState<SettingsFeedback>(null);
+  const [pendingInternal, setPendingInternal] = useState<{ claude: boolean; codex: boolean }>({ claude: false, codex: false });
   const searchRef = useRef<HTMLInputElement>(null);
 
   const load = useCallback(async () => {
@@ -319,7 +320,15 @@ export function App(): ReactElement {
     () => results.find((session) => session.sessionKey === selectedKey) || null,
     [results, selectedKey],
   );
-  const visibleSourceFilters = useMemo(() => sourceFilters(appSettings), [appSettings]);
+  const visibleSourceFilters = useMemo(() => {
+    if (!appSettings) return sourceFilters(null);
+    // Reveal an internal source filter only once its background load has finished.
+    return sourceFilters({
+      ...appSettings,
+      includeClaudeInternal: appSettings.includeClaudeInternal && !pendingInternal.claude,
+      includeCodexInternal: appSettings.includeCodexInternal && !pendingInternal.codex,
+    });
+  }, [appSettings, pendingInternal]);
   const selectedProject = useMemo(
     () => projects.find((project) => project.path === projectPath) || null,
     [projects, projectPath],
@@ -454,14 +463,40 @@ export function App(): ReactElement {
   }
 
   async function updateSettings(next: Partial<AppSettings>): Promise<void> {
+    const enablingClaude = next.includeClaudeInternal === true && !appSettings?.includeClaudeInternal;
+    const enablingCodex = next.includeCodexInternal === true && !appSettings?.includeCodexInternal;
     setSettingsFeedback({ kind: "running", message: "Saving settings..." });
     try {
-      const shouldRefreshIndex =
-        (next.includeClaudeInternal === true && !appSettings?.includeClaudeInternal) ||
-        (next.includeCodexInternal === true && !appSettings?.includeCodexInternal);
       const nextSettings = await window.sessionSearch.setSettings(next);
       setAppSettings(nextSettings);
-      if (shouldRefreshIndex) await window.sessionSearch.refreshIndex();
+
+      if (enablingClaude || enablingCodex) {
+        // Keep the toggle responsive: scan the internal source in the background
+        // and only reveal its sidebar filter once that scan finishes.
+        if (enablingClaude) setPendingInternal((current) => ({ ...current, claude: true }));
+        if (enablingCodex) setPendingInternal((current) => ({ ...current, codex: true }));
+        setSettingsFeedback({ kind: "success", message: "Loading sessions in the background…" });
+        void window.sessionSearch
+          .refreshIndex()
+          .then(async () => {
+            setPendingInternal((current) => ({
+              claude: enablingClaude ? false : current.claude,
+              codex: enablingCodex ? false : current.codex,
+            }));
+            await load();
+            setSettingsFeedback({ kind: "success", message: "Sources ready." });
+            window.setTimeout(() => {
+              setSettingsFeedback((current) => (current?.kind === "success" ? null : current));
+            }, 1600);
+          })
+          .catch((error) => {
+            if (enablingClaude) setPendingInternal((current) => ({ ...current, claude: false }));
+            if (enablingCodex) setPendingInternal((current) => ({ ...current, codex: false }));
+            setSettingsFeedback({ kind: "error", message: error instanceof Error ? error.message : String(error) });
+          });
+        return;
+      }
+
       await load();
       setSettingsFeedback({ kind: "success", message: "Settings saved." });
       window.setTimeout(() => {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1437,35 +1437,37 @@ select:focus-visible {
 }
 
 .settings-dialog {
-  width: min(720px, calc(100vw - 40px));
+  width: min(680px, calc(100vw - 40px));
   padding: 0;
   overflow: hidden;
 }
 
 .settings-dialog .dialog-title {
   margin: 0;
-  padding: 14px 16px;
+  padding: 15px 18px;
   border-bottom: 1px solid var(--border);
 }
 
 .settings-shell {
   display: grid;
-  grid-template-columns: 190px minmax(0, 1fr);
-  min-height: 260px;
+  grid-template-columns: 200px minmax(0, 1fr);
+  min-height: 300px;
 }
 
 .settings-sidebar {
   display: grid;
   align-content: start;
   gap: 2px;
-  padding: 12px 8px;
+  padding: 12px 10px;
   border-right: 1px solid var(--border);
   background: var(--panel-subtle);
 }
 
 .settings-sidebar button {
+  position: relative;
   display: flex;
   align-items: center;
+  gap: 9px;
   min-height: 34px;
   padding: 0 10px;
   border-radius: 8px;
@@ -1473,6 +1475,12 @@ select:focus-visible {
   font-size: 13px;
   font-weight: 600;
   text-align: left;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.settings-sidebar button svg {
+  flex: 0 0 auto;
+  color: var(--text-muted);
 }
 
 .settings-sidebar button:hover {
@@ -1480,71 +1488,161 @@ select:focus-visible {
   color: var(--text);
 }
 
+.settings-sidebar button:hover svg {
+  color: var(--text-dim);
+}
+
 .settings-sidebar button.active {
   background: var(--accent-soft);
   color: var(--accent-bright);
 }
 
+.settings-sidebar button.active svg {
+  color: var(--accent);
+}
+
+.settings-sidebar button.active::before {
+  content: "";
+  position: absolute;
+  left: -10px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 18px;
+  border-radius: 0 3px 3px 0;
+  background: var(--accent);
+}
+
 .settings-content {
-  padding: 18px;
-}
-
-.settings-row {
   display: grid;
-  gap: 12px;
+  align-content: start;
+  gap: 16px;
+  padding: 20px;
 }
 
-.settings-row h3 {
-  margin: 0 0 4px;
+.settings-pane {
+  display: grid;
+  gap: 13px;
+}
+
+.settings-pane-head h3 {
+  margin: 0 0 5px;
   color: var(--text);
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 700;
+  letter-spacing: -0.2px;
 }
 
-.settings-row p {
+.settings-pane-head p {
   margin: 0;
   color: var(--text-muted);
-  font-size: 12px;
-  line-height: 1.45;
+  font-size: 12.5px;
+  line-height: 1.5;
 }
 
-.settings-row .settings-check {
+.settings-field {
   display: flex;
   align-items: center;
-  gap: 9px;
-  min-height: 28px;
-  color: var(--text-dim);
-  font-weight: 500;
+  gap: 14px;
+  padding: 13px 15px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  background: var(--panel-subtle);
 }
 
-.settings-row .settings-check input {
-  width: 15px;
-  height: 15px;
-  accent-color: var(--accent);
+.settings-field-text {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
 }
 
-.settings-row select {
-  width: 100%;
-  height: 38px;
-  padding: 0 10px;
+.settings-field-title {
+  color: var(--text);
+  font-size: 13.5px;
+  font-weight: 600;
+}
+
+.settings-field-sub {
+  color: var(--text-muted);
+  font-size: 11.5px;
+  line-height: 1.4;
+}
+
+.settings-field select {
+  flex: 0 0 auto;
+  min-width: 152px;
+  height: 36px;
+  padding: 0 12px;
   border: 1px solid var(--border-strong);
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   outline: 0;
   background: var(--panel-bg);
   color: var(--text);
-  font-size: 13.5px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
-.settings-row select:focus {
+.settings-field select:focus {
   border-color: var(--accent-line);
   box-shadow: 0 0 0 3px var(--accent-ring);
 }
 
+.settings-toggle {
+  cursor: pointer;
+}
+
+.settings-dialog .switch {
+  flex: 0 0 auto;
+  position: relative;
+  width: 40px;
+  height: 23px;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: var(--border-strong);
+  appearance: none;
+  -webkit-appearance: none;
+  cursor: pointer;
+  transition: background 0.18s ease;
+}
+
+.settings-dialog .switch::before {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 19px;
+  height: 19px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  transition: transform 0.18s cubic-bezier(0.2, 0.7, 0.3, 1);
+}
+
+.settings-dialog .switch:checked {
+  background: var(--accent);
+}
+
+.settings-dialog .switch:checked::before {
+  transform: translateX(17px);
+}
+
+.settings-dialog .switch:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .settings-feedback {
-  min-height: 16px;
-  padding: 0 18px 14px 208px;
+  padding: 12px 20px;
+  border-top: 1px solid var(--border);
   color: var(--text-muted);
   font-size: 12px;
+}
+
+.settings-feedback.running {
+  color: var(--running-text);
 }
 
 .settings-feedback.success {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1437,19 +1437,90 @@ select:focus-visible {
 }
 
 .settings-dialog {
-  width: min(520px, calc(100vw - 40px));
+  width: min(720px, calc(100vw - 40px));
+  padding: 0;
+  overflow: hidden;
+}
+
+.settings-dialog .dialog-title {
+  margin: 0;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.settings-shell {
+  display: grid;
+  grid-template-columns: 190px minmax(0, 1fr);
+  min-height: 260px;
+}
+
+.settings-sidebar {
+  display: grid;
+  align-content: start;
+  gap: 2px;
+  padding: 12px 8px;
+  border-right: 1px solid var(--border);
+  background: var(--panel-subtle);
+}
+
+.settings-sidebar button {
+  display: flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 0 10px;
+  border-radius: 8px;
+  color: var(--text-dim);
+  font-size: 13px;
+  font-weight: 600;
+  text-align: left;
+}
+
+.settings-sidebar button:hover {
+  background: var(--panel-hover);
+  color: var(--text);
+}
+
+.settings-sidebar button.active {
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+}
+
+.settings-content {
+  padding: 18px;
 }
 
 .settings-row {
   display: grid;
-  gap: 8px;
-  padding: 2px 0 4px;
+  gap: 12px;
 }
 
-.settings-row label {
+.settings-row h3 {
+  margin: 0 0 4px;
   color: var(--text);
-  font-size: 13px;
+  font-size: 15px;
   font-weight: 700;
+}
+
+.settings-row p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.settings-row .settings-check {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-height: 28px;
+  color: var(--text-dim);
+  font-weight: 500;
+}
+
+.settings-row .settings-check input {
+  width: 15px;
+  height: 15px;
+  accent-color: var(--accent);
 }
 
 .settings-row select {
@@ -1469,14 +1540,9 @@ select:focus-visible {
   box-shadow: 0 0 0 3px var(--accent-ring);
 }
 
-.settings-row p {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: 12px;
-}
-
 .settings-feedback {
-  margin-top: 12px;
+  min-height: 16px;
+  padding: 0 18px 14px 208px;
   color: var(--text-muted);
   font-size: 12px;
 }

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1635,7 +1635,10 @@ select:focus-visible {
 }
 
 .settings-feedback {
-  padding: 12px 20px;
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0 20px;
   border-top: 1px solid var(--border);
   color: var(--text-muted);
   font-size: 12px;


### PR DESCRIPTION
## 概述
新增 Claude / Codex - internal 会话来源，并把设置界面重做成与主界面一致的风格。

## 功能
- 支持扫描 `~/.claude-internal` 和 `~/.codex-internal` 作为独立来源（`claude-internal` / `codex-internal`），与常规 Claude / Codex 过滤分开。
- 设置中可分别开关两个内部来源；关闭时清除其已索引会话。
- 开启时在侧栏新增对应来源过滤项。

## 设置界面（对齐主界面设计）
- 章节 nav 带图标 + 激活态 accent 左轨，与主侧栏一致。
- 每条设置做成主题化字段卡片（左标题/说明、右控件）。
- 布尔项改为拨动开关（toggle switch）。
- 底部反馈状态栏固定高度，避免出现/消失时弹窗抖动。
- 全部使用共享主题 token，浅色 / 深色自动适配。

## 交互优化
- 开启内部来源不再内联等待整轮重扫（之前会卡顿）：开关即时响应，扫描在后台进行，对应侧栏来源过滤在后台加载完成后才出现。

## 合并
- 已合并最新 main（含 `perf: reduce session search reloads`），采用其 SQL 过滤的 `getCandidateRows` 路径，移除分支上过时的 JS 过滤死代码。

