### PR TITLE
fix: CodeBuddy 用量显示为 0

### DIFF
--- a/src/core/session-loader.test.ts
+++ b/src/core/session-loader.test.ts
@@ -340,11 +340,16 @@ describe("CodeBuddy session loading", () => {
           content: [{ type: "output_text", text: "我来处理" }],
           providerData: {
             messageId: "provider-message-1",
+            // Real CodeBuddy shape: camelCase totals where inputTokens already
+            // includes cached, outputTokens already includes reasoning, and the
+            // detail breakdowns are arrays.
             usage: {
-              input_tokens: 120,
-              output_tokens: 30,
-              cached_input_tokens: 10,
-              reasoning_output_tokens: 5,
+              requests: 1,
+              inputTokens: 120,
+              outputTokens: 30,
+              totalTokens: 150,
+              inputTokensDetails: [{ cached_tokens: 10 }],
+              outputTokensDetails: [{ reasoning_tokens: 5 }],
             },
           },
           sessionId: "codebuddy-1",
@@ -364,12 +369,14 @@ describe("CodeBuddy session loading", () => {
       firstQuestion: "接入 CodeBuddy CLI",
       originalTitle: "接入 CodeBuddy CLI",
       timestamp: 1_780_321_278_404,
+      // input split into non-cached (110) + cached (10); output into
+      // non-reasoning (25) + reasoning (5); total matches CodeBuddy's 150.
       tokenUsage: {
-        inputTokens: 120,
-        outputTokens: 30,
+        inputTokens: 110,
+        outputTokens: 25,
         cachedInputTokens: 10,
         reasoningOutputTokens: 5,
-        totalTokens: 165,
+        totalTokens: 150,
       },
     });
     expect(loaded[0].messages.map((message) => message.content)).toEqual(["接入 CodeBuddy CLI", "我来处理"]);
@@ -377,13 +384,64 @@ describe("CodeBuddy session loading", () => {
       {
         dedupeKey: "codebuddy:provider-message-1",
         timestamp: 1_780_321_303_135,
-        inputTokens: 120,
-        outputTokens: 30,
+        inputTokens: 110,
+        outputTokens: 25,
         cachedInputTokens: 10,
         reasoningOutputTokens: 5,
-        totalTokens: 165,
+        totalTokens: 150,
       },
     ]);
+
+    fs.rmSync(codeBuddyDir, { recursive: true, force: true });
+  });
+
+  it("reads token usage from the OpenAI-style rawUsage fallback", () => {
+    const codeBuddyDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-codebuddy-raw-"));
+    const projectDir = path.join(codeBuddyDir, "projects", "Users-xjx");
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDir, "codebuddy-raw.jsonl"),
+      [
+        JSON.stringify({
+          id: "u",
+          timestamp: 1_780_321_278_404,
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "hello" }],
+          sessionId: "codebuddy-raw",
+          cwd: "/repo",
+        }),
+        JSON.stringify({
+          id: "a",
+          timestamp: 1_780_321_303_135,
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "hi" }],
+          providerData: {
+            messageId: "pm-2",
+            rawUsage: {
+              prompt_tokens: 200,
+              completion_tokens: 50,
+              total_tokens: 250,
+              prompt_tokens_details: { cached_tokens: 40 },
+              completion_tokens_details: { reasoning_tokens: 8 },
+            },
+          },
+          sessionId: "codebuddy-raw",
+          cwd: "/repo",
+        }),
+      ].join("\n"),
+    );
+
+    const loaded = loadCodeBuddyCliSessions(codeBuddyDir);
+
+    expect(loaded[0].session.tokenUsage).toEqual({
+      inputTokens: 160,
+      outputTokens: 42,
+      cachedInputTokens: 40,
+      reasoningOutputTokens: 8,
+      totalTokens: 250,
+    });
 
     fs.rmSync(codeBuddyDir, { recursive: true, force: true });
   });

--- a/src/core/session-loader.ts
+++ b/src/core/session-loader.ts
@@ -253,17 +253,13 @@ function extractCodeBuddyTokenEvents(rows: unknown[]): TokenUsageEvent[] {
   rows.forEach((row, index) => {
     if (!isRecord(row) || row.type !== "message" || row.role !== "assistant") return;
     const providerData = objectField(row, "providerData");
-    const usage = objectField(providerData, "usage") || objectField(providerData, "rawUsage");
+    if (!providerData) return;
+
+    const usage = readCodeBuddyUsage(providerData);
     if (!usage) return;
 
-    const cached = numberField(usage, "cache_read_input_tokens") + numberField(usage, "cached_input_tokens");
-    const entry = createTokenUsage(
-      numberField(usage, "input_tokens"),
-      numberField(usage, "output_tokens"),
-      cached,
-      numberField(usage, "reasoning_output_tokens"),
-    );
-    const key = stringField(providerData, "messageId") || stringField(row, "id") || `${index}:${JSON.stringify(usage)}`;
+    const entry = createTokenUsage(usage.inputTokens, usage.outputTokens, usage.cachedInputTokens, usage.reasoningOutputTokens);
+    const key = stringField(providerData, "messageId") || stringField(row, "id") || `${index}:${usage.inputTokens}:${usage.outputTokens}`;
     putTokenEvent(entries, {
       ...entry,
       timestamp: parseTimestampMs(row.timestamp),
@@ -272,6 +268,47 @@ function extractCodeBuddyTokenEvents(rows: unknown[]): TokenUsageEvent[] {
   });
 
   return [...entries.values()];
+}
+
+// CodeBuddy reports OpenAI-style usage: the input/prompt total already includes
+// cached tokens, and the output/completion total already includes reasoning
+// tokens. Split them into the distinct buckets createTokenUsage expects (input
+// excludes cached, output excludes reasoning) so the summed total matches
+// CodeBuddy's own total. Prefer the camelCase `usage` object, falling back to
+// the raw OpenAI `rawUsage` object.
+function readCodeBuddyUsage(providerData: Record<string, unknown>): TokenUsage | null {
+  let totalInput = 0;
+  let totalOutput = 0;
+  let cached = 0;
+  let reasoning = 0;
+
+  const usage = objectField(providerData, "usage");
+  if (usage) {
+    totalInput = numberField(usage, "inputTokens");
+    totalOutput = numberField(usage, "outputTokens");
+    cached = firstDetailNumber(usage.inputTokensDetails, "cached_tokens");
+    reasoning = firstDetailNumber(usage.outputTokensDetails, "reasoning_tokens");
+  }
+
+  const rawUsage = objectField(providerData, "rawUsage");
+  if (!totalInput && !totalOutput && rawUsage) {
+    totalInput = numberField(rawUsage, "prompt_tokens");
+    totalOutput = numberField(rawUsage, "completion_tokens");
+    cached = numberField(objectField(rawUsage, "prompt_tokens_details"), "cached_tokens");
+    reasoning = numberField(objectField(rawUsage, "completion_tokens_details"), "reasoning_tokens");
+  }
+
+  if (!totalInput && !totalOutput) return null;
+
+  return createTokenUsage(Math.max(0, totalInput - cached), Math.max(0, totalOutput - reasoning), cached, reasoning);
+}
+
+// CodeBuddy stores token detail breakdowns as single-element arrays, e.g.
+// `inputTokensDetails: [{ cached_tokens: 19567 }]`. Accept either an array
+// (read the first entry) or a plain object.
+function firstDetailNumber(value: unknown, key: string): number {
+  if (Array.isArray(value)) return numberField(value[0], key);
+  return numberField(value, key);
 }
 
 function firstClaudeGitBranch(rows: unknown[]): string | null {


### PR DESCRIPTION
## 问题
Usage 页里 CodeBuddy CLI 的用量始终显示为 `0`（如 `89 msg · 0`），token 总量没有统计出来。

## 根因
`extractCodeBuddyTokenEvents` 读取的字段名（`providerData.usage.input_tokens / output_tokens`，snake_case）与 CodeBuddy 实际写入的格式不一致：

- 真实 `providerData.usage` 是 camelCase：`{ inputTokens, outputTokens, totalTokens, inputTokensDetails: [{ cached_tokens }], outputTokensDetails: [{ reasoning_tokens }] }`，并另有 OpenAI 风格的 `rawUsage`（`prompt_tokens / completion_tokens / ...`）。
- 由于 `providerData.usage` 对象存在（truthy），代码不会回退到 `rawUsage`，所有数值读成 0，导致 `totalTokens = 0`。
- 原单元测试用的也是虚构的 snake_case 格式，因此代码与测试一起“通过”，但对真实数据全错。

## 改动
- 新增 `readCodeBuddyUsage`：优先解析 camelCase `usage`（含数组形式的 details），回退到 OpenAI 风格 `rawUsage`。
- 按 `createTokenUsage` 的“各桶不重叠”语义拆分：CodeBuddy 的 input 含 cached、output 含 reasoning，故拆成「非缓存输入 + 缓存」「非推理输出 + 推理」，保证合计等于 CodeBuddy 自报总量且不重复计数。
- 单元测试改为真实 CodeBuddy 格式，并补充 `rawUsage` 回退用例。

在本机真实 `~/.codebuddy` 数据上，修复后聚合结果与 CodeBuddy 自报的 `sum(total_tokens)` 完全一致。