### PR TITLE
fix: CodeBuddy 会话标题默认显示 code

### DIFF
--- a/src/core/format-adapters.test.ts
+++ b/src/core/format-adapters.test.ts
@@ -63,6 +63,35 @@ describe("format adapters", () => {
     });
   });
 
+  it("skips the CodeBuddy CLI bootstrap 'code' root message", () => {
+    // The CLI injects a root user message whose text is the literal launch
+    // keyword "code"; it must not become the session title.
+    expect(
+      codebuddyAdapter.parseLine({
+        type: "message",
+        role: "user",
+        timestamp: 1_780_321_278_404,
+        content: [{ type: "input_text", text: "code" }],
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps a real later message that happens to say 'code'", () => {
+    expect(
+      codebuddyAdapter.parseLine({
+        type: "message",
+        role: "user",
+        parentId: "root-1",
+        timestamp: 1_780_321_303_135,
+        content: [{ type: "input_text", text: "code" }],
+      }),
+    ).toEqual({
+      role: "user",
+      content: "code",
+      timestamp: new Date(1_780_321_303_135).toISOString(),
+    });
+  });
+
   it("filters injected user-role noise while keeping short real replies", () => {
     expect(isMeaningfulUserMessage("<environment_context>cwd=/tmp</environment_context>")).toBe(false);
     expect(isMeaningfulUserMessage("# AGENTS.md instructions")).toBe(false);

--- a/src/core/format-adapters.ts
+++ b/src/core/format-adapters.ts
@@ -89,6 +89,12 @@ export const codebuddyAdapter: FormatAdapter = {
     const content = extractTextBlocks(line.content);
     if (!content) return null;
 
+    // The CodeBuddy CLI injects a root user message whose text is the literal
+    // launch keyword "code". It is not a real prompt, so drop it (otherwise it
+    // becomes every session's title). Only the root message (no parentId) is
+    // filtered, so a genuine later "code" reply is preserved.
+    if (line.role === "user" && line.parentId == null && content.trim() === "code") return null;
+
     return {
       role: line.role,
       content,


### PR DESCRIPTION
## 问题
所有 CodeBuddy CLI 会话的默认标题都是 `code`，看不出会话内容。

## 根因
CodeBuddy CLI 在每个会话开头注入一条**根 user 消息（无 `parentId`），内容字面就是 `code`**（等同 CLI 启动关键字，不是真实提问）。标题取“首个有意义的 user 消息”，而 `isMeaningfulUserMessage("code")` 返回 `true`，于是这条引导消息成了每个会话的标题。

## 改动
在 `codebuddyAdapter.parseLine` 精确跳过该引导消息：仅当 `role === "user"` 且**无 `parentId`** 且内容 trim 后恰为 `code` 时丢弃。只过滤根引导消息，会话中途用户真的发送 `code` 仍会保留（已加测试覆盖）。

修复后真实数据中标题不再是 `code`：有真实提问的会话显示其首个问题；只有引导消息的空会话回落到 `Untitled Session`。

## 备注
存在一个更小的相关情况：少数会话首个动作是用户输错的 slash 命令（如 `/mdoel`），修复后标题会显示该命令。这超出本次范围，未在此 PR 处理。