### PR TITLE
fix: 打开会话详情时侧边栏内容横向抖动

### DIFF
--- a/src/renderer/src/style-contract.test.ts
+++ b/src/renderer/src/style-contract.test.ts
@@ -11,4 +11,16 @@ describe("stylesheet theme contract", () => {
     expect(stylesheet).not.toContain("LIGHT WORKBENCH");
     expect(stylesheet).not.toContain("DARK WORKBENCH");
   });
+
+  it("reserves a stable scrollbar gutter on scrollers whose overflow is frozen by the overlay", () => {
+    // Opening the detail overlay toggles `.sidebar`/`.results` to overflow:hidden.
+    // Without a reserved gutter the scrollbar's width is released and the
+    // right-aligned content jumps sideways, so both must keep a stable gutter.
+    const blocks = [...stylesheet.matchAll(/(?:\.sidebar|\.results)\s*\{[^}]*\}/g)].map((m) => m[0]);
+    const scrollers = blocks.filter((block) => /overflow-y:\s*auto/.test(block));
+    expect(scrollers).toHaveLength(2);
+    for (const scroller of scrollers) {
+      expect(scroller).toMatch(/scrollbar-gutter:\s*stable/);
+    }
+  });
 });

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -281,6 +281,7 @@ select:focus-visible {
   margin-top: 40px;
   padding: 0 10px 10px;
   overflow-y: auto;
+  scrollbar-gutter: stable;
   overscroll-behavior: contain;
   background: var(--sidebar-bg);
 }
@@ -1163,6 +1164,7 @@ select:focus-visible {
   gap: 0;
   padding: 0;
   overflow-y: auto;
+  scrollbar-gutter: stable;
   overscroll-behavior: contain;
   border: 1px solid var(--border);
   border-radius: var(--radius);


### PR DESCRIPTION
## 问题
按**空格**打开会话详情(遮罩浮起)时,左侧侧边栏靠右对齐的内容(项目计数、标签删除按钮)会瞬间往右跳一下。

## 根因
打开详情遮罩会给 body 加 `overlay-open` 类,触发:

```css
body.overlay-open .results,
body.overlay-open .sidebar { overflow: hidden; }
```

`.sidebar` / `.results` 平时是 `overflow-y: auto`,内容溢出时右侧有一条 9px 的自定义滚动条占位。切到 `overflow: hidden` 后滚动条消失,释放的 9px 宽度让内容盒变宽回流,靠右内容就整体右移。

## 修复
给这两个滚动容器加 `scrollbar-gutter: stable`,滚动条槽位始终保留,`overflow` 在 `auto ↔ hidden` 之间切换时盒宽不变,横向抖动消除。

## 测试
在 `style-contract.test.ts` 增加样式契约测试,断言两个滚动容器都保留 stable gutter。
