### PR TITLE
fix: CodeBuddy 会话优先使用 ai-title 作为标题

### DIFF
--- a/src/core/session-loader.test.ts
+++ b/src/core/session-loader.test.ts
@@ -445,4 +445,48 @@ describe("CodeBuddy session loading", () => {
 
     fs.rmSync(codeBuddyDir, { recursive: true, force: true });
   });
+
+  it("prefers the CodeBuddy ai-title over slash-command first messages", () => {
+    const codeBuddyDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-codebuddy-title-"));
+    const projectDir = path.join(codeBuddyDir, "projects", "Users-xjx");
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDir, "codebuddy-title.jsonl"),
+      [
+        // Root bootstrap "code" message is dropped, and the first real user
+        // message is a slash command that should NOT become the title.
+        JSON.stringify({
+          id: "root",
+          timestamp: 1_780_321_278_000,
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "code" }],
+          sessionId: "codebuddy-title",
+          cwd: "/repo",
+        }),
+        JSON.stringify({
+          id: "cmd",
+          parentId: "root",
+          timestamp: 1_780_321_278_404,
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "/model" }],
+          sessionId: "codebuddy-title",
+          cwd: "/repo",
+        }),
+        JSON.stringify({
+          type: "ai-title",
+          aiTitle: "Switch the active model",
+          sessionId: "codebuddy-title",
+          cwd: "/repo",
+        }),
+      ].join("\n"),
+    );
+
+    const loaded = loadCodeBuddyCliSessions(codeBuddyDir);
+
+    expect(loaded[0].session.originalTitle).toBe("Switch the active model");
+
+    fs.rmSync(codeBuddyDir, { recursive: true, force: true });
+  });
 });

--- a/src/core/session-loader.ts
+++ b/src/core/session-loader.ts
@@ -372,6 +372,19 @@ function firstCodeBuddySessionMeta(rows: unknown[], fallbackRawId: string): { ra
   return { rawId, projectPath, timestamp };
 }
 
+// CodeBuddy writes its AI-generated session title as a dedicated `ai-title` row
+// (e.g. `{ type: "ai-title", aiTitle: "..." }`). Prefer it over the first user
+// message, which is often a slash command like "/model" that CodeBuddy stores as
+// plain text rather than wrapping in a <command-name> tag we could filter.
+function firstCodeBuddyAiTitle(rows: unknown[]): string {
+  for (const row of rows) {
+    if (!isRecord(row) || row.type !== "ai-title") continue;
+    const title = stringField(row, "aiTitle").trim();
+    if (title) return title;
+  }
+  return "";
+}
+
 export function loadCodexSessionFile(filePath: string, title?: string, updatedAt?: string): LoadedSession | null {
   const rows = readJsonl(filePath);
   if (rows.length === 0) return null;
@@ -612,6 +625,7 @@ export function* loadCodeBuddyCliSessionsIterator(codeBuddyDir = path.join(os.ho
     const tokenEvents = extractCodeBuddyTokenEvents(rows);
     const tokenUsage = tokenUsageFromEvents(tokenEvents);
     const question = firstQuestion(messages);
+    const aiTitle = firstCodeBuddyAiTitle(rows);
 
     yield {
       session: createIndexedSession({
@@ -620,7 +634,7 @@ export function* loadCodeBuddyCliSessionsIterator(codeBuddyDir = path.join(os.ho
         source: "codebuddy-cli",
         projectPath: meta.projectPath,
         filePath,
-        originalTitle: cleanTitle(question) || "Untitled Session",
+        originalTitle: aiTitle || cleanTitle(question) || "Untitled Session",
         firstQuestion: cleanTitle(question),
         timestamp: meta.timestamp,
         tokenUsage,


### PR DESCRIPTION
## 背景
有用户反馈 CodeBuddy 会话解析不对。排查后定位到**标题解析**问题(token 解析、项目路径、数据目录经核对均正常)。

## 问题
CodeBuddy 把斜杠命令(如 `/model`)存成普通文本用户消息,不像 Claude/Codex 会包成 `<command-name>` 标签,所以没被 `isMeaningfulUserMessage` 过滤掉,直接变成了会话标题。同时 CodeBuddy 自己生成的 `ai-title` 行(`aiTitle` 字段)完全没被使用。

## 修复
新增 `firstCodeBuddyAiTitle()`,解析 `ai-title` 行`,与 Codex 用 `thread_name` 索引标题的逻辑保持一致。`firstQuestion` 字段仍保留真实首条用户消息。

## 一并核实(本 PR 未改动)
- **Token 解析**:`readCodeBuddyUsage` 读 camelCase `inputTokens`/`outputTokens` + `inputTokensDetails[0].cached_tokens`,真实数据核对 math 正确。
- **数据目录**:CLI 会话在 `~/.codebuddy/projects/`(`.codebuddycn` 是 IDE 配置目录,无会话),路径正确。
- **遗留**:`types.ts` 的 `CodeBuddyConversationLine.providerData.usage` 类型仍是旧 snake_case 注解,与运行时不符(仅类型误导,不影响功能),可后续单独清理。Resume 命令(`codebuddy --resume <id>`)的参数正确性待与 CodeBuddy Code CLI `--help` 核对。
