### PR TITLE
feat: 设置中可隐藏 Codex / Claude Code 剩余额度

### DIFF
--- a/docs/superpowers/specs/2026-06-03-hide-quota-design.md
+++ b/docs/superpowers/specs/2026-06-03-hide-quota-design.md
@@ -1,0 +1,75 @@
+# 设计:在设置中可隐藏 Codex / Claude Code 剩余额度
+
+日期:2026-06-03
+分支:`feat/hide-quota`
+
+## 背景与动机
+
+"剩余额度"面板默认同时展示 Codex 和 Claude Code 两张卡。但有的用户只订阅了其中一个,另一个根本没用——空卡 / 报错卡是噪音,Codex 那张还会白跑一次 HTTP 请求。需要在设置里能分别隐藏其中任意一个,默认两个都展示。
+
+## 目标
+
+- 设置中提供两个开关,分别隐藏 Codex / Claude Code 额度。
+- 被隐藏的额度**不加载**(Codex 不发 HTTP、Claude 不读本地文件),也**不在面板渲染**。
+- 默认两者都显示(开关默认关)。
+- 切换开关后额度面板立即反映。
+
+## 非目标
+
+- 不做"自动检测有没有订阅"。是否隐藏完全由用户决定。
+- 不改变额度数据的解析逻辑。
+
+## 方案
+
+数据源头过滤:被隐藏的额度从一开始就不加载、不进 `providers` 数组。(备选"只在 renderer 过滤渲染"会白跑一次加载,排除。)
+
+## 改动详情
+
+### 1. `AppSettings`(`src/core/platform.ts`)
+
+新增两个布尔,默认 `false`:
+
+```ts
+hideCodexQuota: boolean;   // 默认 false(显示)
+hideClaudeQuota: boolean;  // 默认 false(显示)
+```
+
+`defaultSettings` 同步补上 `hideCodexQuota: false` / `hideClaudeQuota: false`。
+
+### 2. `loadUsageQuotaSnapshot`(`src/core/quota.ts`)
+
+`UsageQuotaLoadOptions` 增加可选 `hideCodexQuota?: boolean` / `hideClaudeQuota?: boolean`。
+
+加载逻辑:被隐藏的跳过对应 `loadCodexQuotaCard` / `loadClaudeQuotaCard` 调用;`providers` 只放未隐藏的卡,保持原顺序(codex 在前、claude 在后)。两个都隐藏时 `providers` 为空数组。
+
+### 3. main 进程(`src/main/index.ts`)
+
+`quota:get` 把设置传入:
+
+```ts
+ipcMain.handle("quota:get", () => loadUsageQuotaSnapshot({
+  hideCodexQuota: getSettings().hideCodexQuota,
+  hideClaudeQuota: getSettings().hideClaudeQuota,
+}));
+```
+
+### 4. 设置 UI(`src/renderer/src/App.tsx`)
+
+在设置面板的额度/用量区,沿用现有 `settings-toggle` 复选框样式,加两个:
+
+- 「在剩余额度中隐藏 Codex」/ "Hide Codex usage"
+- 「在剩余额度中隐藏 Claude Code」/ "Hide Claude Code usage"
+
+`onChange` 调 `updateSettings({ hideCodexQuota: ... })`。`updateSettings` 检测到这两个键发生变化时,额外调用一次 `loadQuotas()`,让被隐藏的卡立即消失 / 重新出现。
+
+## 边界情况
+
+- **两个都隐藏**:`providers` 为空 → 复用面板已有空态文案("额度不可用")。可接受。
+
+## 测试
+
+`src/core/quota.test.ts` 新增:
+
+- `hideCodexQuota: true` → `providers` 不含 codex 卡,且传入的 `codexFetcher` 不被调用(证明确实跳过加载)。
+- `hideClaudeQuota: true` → `providers` 不含 claude-code 卡。
+- 都不隐藏(默认)→ 两张卡都在,顺序 codex、claude。

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -29,6 +29,8 @@ export interface AppSettings {
   includeClaudeInternal: boolean;
   includeCodexInternal: boolean;
   includeCodeBuddyCli: boolean;
+  hideCodexQuota: boolean;
+  hideClaudeQuota: boolean;
 }
 
 export const defaultSettings: AppSettings = {
@@ -40,6 +42,8 @@ export const defaultSettings: AppSettings = {
   includeClaudeInternal: false,
   includeCodexInternal: false,
   includeCodeBuddyCli: false,
+  hideCodexQuota: false,
+  hideClaudeQuota: false,
 };
 
 const ITERM_APPLICATION_NAMES = ["iTerm", "iTerm2"];

--- a/src/core/quota.test.ts
+++ b/src/core/quota.test.ts
@@ -131,4 +131,65 @@ describe("usage quota loader", () => {
       rmSync(homeDir, { recursive: true, force: true });
     }
   });
+
+  it("skips loading and omits the Codex card when hidden", async () => {
+    const homeDir = makeHome();
+    try {
+      writeJson(path.join(homeDir, ".codex", "auth.json"), {
+        tokens: { access_token: "codex-access", account_id: "account-1" },
+      });
+      let fetched = false;
+
+      const snapshot = await loadUsageQuotaSnapshot({
+        now: NOW,
+        homeDir,
+        env: {},
+        hideCodexQuota: true,
+        codexFetcher: async () => {
+          fetched = true;
+          return {};
+        },
+      });
+
+      expect(fetched).toBe(false);
+      expect(snapshot.providers.map((provider) => provider.provider)).toEqual(["claude-code"]);
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("omits the Claude Code card when hidden", async () => {
+    const homeDir = makeHome();
+    try {
+      const snapshot = await loadUsageQuotaSnapshot({
+        now: NOW,
+        homeDir,
+        env: {},
+        hideClaudeQuota: true,
+        codexFetcher: async () => ({}),
+      });
+
+      expect(snapshot.providers.map((provider) => provider.provider)).toEqual(["codex"]);
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns an empty provider list when both quotas are hidden", async () => {
+    const homeDir = makeHome();
+    try {
+      const snapshot = await loadUsageQuotaSnapshot({
+        now: NOW,
+        homeDir,
+        env: {},
+        hideCodexQuota: true,
+        hideClaudeQuota: true,
+        codexFetcher: async () => ({}),
+      });
+
+      expect(snapshot.providers).toEqual([]);
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/core/quota.ts
+++ b/src/core/quota.ts
@@ -24,6 +24,8 @@ interface QuotaLoadOptions {
 
 export interface UsageQuotaLoadOptions extends QuotaLoadOptions {
   codexFetcher?: CodexUsageFetcher;
+  hideCodexQuota?: boolean;
+  hideClaudeQuota?: boolean;
 }
 
 export type CodexUsageFetcher = (accessToken: string, accountId: string) => Promise<CodexUsageResponse>;
@@ -91,10 +93,14 @@ interface ClaudeStatuslineQuota {
 
 export async function loadUsageQuotaSnapshot(options: UsageQuotaLoadOptions = {}): Promise<UsageQuotaSnapshot> {
   const now = options.now ?? new Date();
-  const [codex, claudeCode] = await Promise.all([loadCodexQuotaCard({ ...options, now }), Promise.resolve(loadClaudeQuotaCard({ ...options, now }))]);
+  // Hidden providers are skipped at the source: no HTTP/file load and no card.
+  const [codex, claudeCode] = await Promise.all([
+    options.hideCodexQuota ? Promise.resolve(null) : loadCodexQuotaCard({ ...options, now }),
+    options.hideClaudeQuota ? Promise.resolve(null) : Promise.resolve(loadClaudeQuotaCard({ ...options, now })),
+  ]);
   return {
     generatedAt: now.toISOString(),
-    providers: [codex, claudeCode],
+    providers: [codex, claudeCode].filter((card): card is UsageQuotaCard => card !== null),
   };
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -334,7 +334,13 @@ function registerIpc(): void {
   );
   ipcMain.handle("sessions:live", () => loadLiveSessionSnapshot());
   ipcMain.handle("stats:get", (_event, options?: SessionStatsOptions) => store.getStats(options));
-  ipcMain.handle("quota:get", () => loadUsageQuotaSnapshot());
+  ipcMain.handle("quota:get", () => {
+    const settings = getSettings();
+    return loadUsageQuotaSnapshot({
+      hideCodexQuota: settings.hideCodexQuota,
+      hideClaudeQuota: settings.hideClaudeQuota,
+    });
+  });
   ipcMain.handle("tags:list", () => store.listTags());
   ipcMain.handle("projects:list", () => store.listProjects());
   ipcMain.handle("title:set", (_event, sessionKey: string, title: string | null) => store.setCustomTitle(sessionKey, title));

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -15,6 +15,7 @@ import {
   EyeOff,
   Folder,
   FolderOpen,
+  Gauge,
   GitBranch,
   Keyboard,
   Languages,
@@ -678,10 +679,14 @@ export function App(): ReactElement {
     const enablingClaude = next.includeClaudeInternal === true && !appSettings?.includeClaudeInternal;
     const enablingCodex = next.includeCodexInternal === true && !appSettings?.includeCodexInternal;
     const enablingCodeBuddy = next.includeCodeBuddyCli === true && !appSettings?.includeCodeBuddyCli;
+    const quotaVisibilityChanged =
+      ("hideCodexQuota" in next && next.hideCodexQuota !== appSettings?.hideCodexQuota) ||
+      ("hideClaudeQuota" in next && next.hideClaudeQuota !== appSettings?.hideClaudeQuota);
     setSettingsFeedback({ kind: "running", message: t("Saving settings...", "正在保存设置...") });
     try {
       const nextSettings = await window.sessionSearch.setSettings(next);
       setAppSettings(nextSettings);
+      if (quotaVisibilityChanged) void loadQuotas();
 
       if (enablingClaude || enablingCodex || enablingCodeBuddy) {
         // Keep the toggle responsive: scan the personal source in the background
@@ -1654,7 +1659,7 @@ function SettingsDialog({
   const globalShortcut = settings?.globalShortcut ?? (RUNTIME_PLATFORM === "win32" ? "Ctrl+Alt+Space" : "Alt+Space");
   const saving = feedback?.kind === "running";
   const l = (en: string, zh: string) => localize(language, en, zh);
-  const [activeSection, setActiveSection] = useState<"terminal" | "shortcut" | "sources" | "appearance">("terminal");
+  const [activeSection, setActiveSection] = useState<"terminal" | "shortcut" | "sources" | "usage" | "appearance">("terminal");
 
   return (
     <div className="dialog-backdrop" onMouseDown={onClose}>
@@ -1678,6 +1683,10 @@ function SettingsDialog({
             <button className={activeSection === "sources" ? "active" : ""} onClick={() => setActiveSection("sources")}>
               <Folder size={15} />
               <span>{l("Personal sources", "个人来源")}</span>
+            </button>
+            <button className={activeSection === "usage" ? "active" : ""} onClick={() => setActiveSection("usage")}>
+              <Gauge size={15} />
+              <span>{l("Usage limits", "剩余额度")}</span>
             </button>
             <button className={activeSection === "appearance" ? "active" : ""} onClick={() => setActiveSection("appearance")}>
               <Sun size={15} />
@@ -1780,6 +1789,40 @@ function SettingsDialog({
                     checked={Boolean(settings?.includeCodeBuddyCli)}
                     disabled={!settings || saving}
                     onChange={(event) => onSettingsChange({ includeCodeBuddyCli: event.currentTarget.checked })}
+                  />
+                </label>
+              </section>
+            ) : null}
+            {activeSection === "usage" ? (
+              <section className="settings-pane">
+                <header className="settings-pane-head">
+                  <h3>{l("Usage limits", "剩余额度")}</h3>
+                  <p>{l("Hide a provider in the Remaining panel if you do not have that subscription.", "如果没有某个订阅,可在剩余额度面板中隐藏对应来源。")}</p>
+                </header>
+                <label className="settings-field settings-toggle">
+                  <div className="settings-field-text">
+                    <span className="settings-field-title">{l("Hide Codex usage", "隐藏 Codex 额度")}</span>
+                    <span className="settings-field-sub">{l("Skip loading and hide the Codex card.", "不加载并隐藏 Codex 额度卡片。")}</span>
+                  </div>
+                  <input
+                    type="checkbox"
+                    className="switch"
+                    checked={Boolean(settings?.hideCodexQuota)}
+                    disabled={!settings || saving}
+                    onChange={(event) => onSettingsChange({ hideCodexQuota: event.currentTarget.checked })}
+                  />
+                </label>
+                <label className="settings-field settings-toggle">
+                  <div className="settings-field-text">
+                    <span className="settings-field-title">{l("Hide Claude Code usage", "隐藏 Claude Code 额度")}</span>
+                    <span className="settings-field-sub">{l("Skip loading and hide the Claude Code card.", "不加载并隐藏 Claude Code 额度卡片。")}</span>
+                  </div>
+                  <input
+                    type="checkbox"
+                    className="switch"
+                    checked={Boolean(settings?.hideClaudeQuota)}
+                    disabled={!settings || saving}
+                    onChange={(event) => onSettingsChange({ hideClaudeQuota: event.currentTarget.checked })}
                   />
                 </label>
               </section>


### PR DESCRIPTION
## 背景
"剩余额度"面板默认同时展示 Codex 和 Claude Code 两张卡。但有用户只订阅了其中一个,另一个根本没用。

## 改动
设置新增独立的「剩余额度 / Usage limits」分区,提供两个开关:
- 隐藏 Codex 额度
- 隐藏 Claude Code 额度

默认都关(即两个都展示)。被隐藏的额度**从源头跳过加载**(Codex 不发 HTTP、Claude 不读本地文件),也不在面板渲染。切换开关后额度面板立即刷新。

## 实现
- `AppSettings` 新增 `hideCodexQuota` / `hideClaudeQuota`(默认 false);`getSettings` 已用 `defaultSettings` 兜底,老用户自动获得默认值。
- `loadUsageQuotaSnapshot` 接受 `hideCodexQuota?` / `hideClaudeQuota?`,被隐藏的不调用对应 `loadXxxQuotaCard`,`providers` 只放未隐藏的卡。
- main 进程 `quota:get` 把设置传入加载器。
- 设置 UI 新增分区与两个 `settings-toggle` 复选框;`updateSettings` 检测到额度可见性变化时触发 `loadQuotas()`。

