### PR TITLE
fix: 补全 Claude 插件 skill 扫描并修正 roots 顶部间距

### DIFF
--- a/src/core/skill-manager.test.ts
+++ b/src/core/skill-manager.test.ts
@@ -63,6 +63,46 @@ describe("skill manager", () => {
     fs.rmSync(homeDir, { recursive: true, force: true });
   });
 
+  it("includes Claude Code plugin skills from installed_plugins.json", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-skills-plugins-"));
+    const pluginsDir = path.join(homeDir, ".claude", "plugins");
+    const superpowersInstall = path.join(pluginsDir, "cache", "official", "superpowers", "5.1.0");
+    const docsInstall = path.join(pluginsDir, "cache", "official", "document-skills", "abc123");
+    writeSkill(
+      path.join(superpowersInstall, "skills"),
+      "brainstorming",
+      ["---", "name: brainstorming", "description: Explore intent before building", "---", "", "# Brainstorm"].join("\n"),
+    );
+    writeSkill(
+      path.join(docsInstall, "skills"),
+      "pdf",
+      ["---", "name: pdf", "description: Work with PDF files", "---", "", "# PDF"].join("\n"),
+    );
+    fs.writeFileSync(
+      path.join(pluginsDir, "installed_plugins.json"),
+      JSON.stringify({
+        version: 2,
+        plugins: {
+          "superpowers@official": [{ scope: "user", installPath: superpowersInstall }],
+          "document-skills@official": [{ scope: "user", installPath: docsInstall }],
+        },
+      }),
+      "utf8",
+    );
+
+    const snapshot = listInstalledSkills({ homeDir, codexHome: path.join(homeDir, ".codex"), projectDirs: [] });
+
+    expect(snapshot.skills.map((skill) => ({ name: skill.name, agent: skill.agent, source: skill.source }))).toEqual([
+      { name: "brainstorming", agent: "claude", source: "claude-plugin" },
+      { name: "pdf", agent: "claude", source: "claude-plugin" },
+    ]);
+    expect(snapshot.roots).toEqual(
+      expect.arrayContaining([expect.objectContaining({ source: "claude-plugin", exists: true, skillCount: 2 })]),
+    );
+
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
   it("falls back to directory names and reports missing roots", () => {
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-skills-fallback-"));
     const codexHome = path.join(homeDir, ".codex");

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 export type SkillAgent = "codex" | "claude";
-export type SkillSource = "codex-user" | "codex-system" | "codex-shared" | "claude-user" | "claude-project";
+export type SkillSource = "codex-user" | "codex-system" | "codex-shared" | "claude-user" | "claude-project" | "claude-plugin";
 
 export interface InstalledSkill {
   id: string;
@@ -36,6 +36,7 @@ export interface SkillManagerOptions {
   homeDir?: string;
   codexHome?: string;
   projectDirs?: string[];
+  claudePluginsDir?: string;
 }
 
 interface SkillRootConfig {
@@ -74,11 +75,56 @@ export function listInstalledSkills(options: SkillManagerOptions = {}): Installe
     skills.push(...rootSkills);
   }
 
+  const pluginsDir = options.claudePluginsDir || path.join(homeDir, ".claude", "plugins");
+  const pluginRoots = collectClaudePluginRoots(pluginsDir);
+  const pluginSkills: InstalledSkill[] = [];
+  for (const root of pluginRoots) {
+    pluginSkills.push(...readSkillsFromRoot(root));
+  }
+  rootStatuses.push({
+    agent: "claude",
+    source: "claude-plugin",
+    path: pluginsDir,
+    exists: fs.existsSync(path.join(pluginsDir, "installed_plugins.json")),
+    skillCount: dedupeSkills(pluginSkills).length,
+  });
+  skills.push(...pluginSkills);
+
   return {
     skills: dedupeSkills(skills).sort((a, b) => a.name.localeCompare(b.name) || a.source.localeCompare(b.source) || a.path.localeCompare(b.path)),
     roots: rootStatuses,
     scannedAt: Date.now(),
   };
+}
+
+function collectClaudePluginRoots(pluginsDir: string): SkillRootConfig[] {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(path.join(pluginsDir, "installed_plugins.json"), "utf8");
+  } catch {
+    return [];
+  }
+
+  let parsed: { plugins?: Record<string, Array<{ installPath?: string }>> };
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+
+  const plugins = parsed.plugins;
+  if (!plugins || typeof plugins !== "object") return [];
+
+  const roots: SkillRootConfig[] = [];
+  for (const installs of Object.values(plugins)) {
+    if (!Array.isArray(installs)) continue;
+    for (const install of installs) {
+      const installPath = install?.installPath;
+      if (typeof installPath !== "string" || !installPath) continue;
+      roots.push({ agent: "claude", source: "claude-plugin", path: path.join(installPath, "skills") });
+    }
+  }
+  return roots;
 }
 
 function readSkillsFromRoot(root: SkillRootConfig): InstalledSkill[] {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import type { CSSProperties, MouseEventHandler, ReactElement } from "react";
+import type { CSSProperties, KeyboardEvent as ReactKeyboardEvent, MouseEventHandler, ReactElement } from "react";
 import {
   AppWindow,
   Archive,
@@ -1322,6 +1322,7 @@ function SkillsDialog({
     null;
   const codexCount = snapshot.skills.filter((skill) => skill.agent === "codex").length;
   const claudeCount = snapshot.skills.filter((skill) => skill.agent === "claude").length;
+  const activeItemRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     if (!filteredSkills.length) {
@@ -1331,9 +1332,23 @@ function SkillsDialog({
     if (!selectedSkillId || !filteredSkills.some((skill) => skill.id === selectedSkillId)) setSelectedSkillId(filteredSkills[0].id);
   }, [filteredSkills, selectedSkillId]);
 
+  useEffect(() => {
+    activeItemRef.current?.scrollIntoView({ block: "nearest" });
+  }, [selectedSkill?.id]);
+
+  const handleListKeyDown = (event: ReactKeyboardEvent) => {
+    if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+    if (!filteredSkills.length) return;
+    event.preventDefault();
+    const currentIndex = filteredSkills.findIndex((skill) => skill.id === selectedSkill?.id);
+    const delta = event.key === "ArrowDown" ? 1 : -1;
+    const nextIndex = Math.min(filteredSkills.length - 1, Math.max(0, (currentIndex < 0 ? 0 : currentIndex) + delta));
+    setSelectedSkillId(filteredSkills[nextIndex].id);
+  };
+
   return (
     <div className="dialog-backdrop" onMouseDown={onClose}>
-      <section className="command-dialog skills-dialog" onMouseDown={(event) => event.stopPropagation()}>
+      <section className="command-dialog skills-dialog" onMouseDown={(event) => event.stopPropagation()} onKeyDown={handleListKeyDown}>
         <div className="dialog-title">
           <span>{l("Skills", "Skills 管理")}</span>
           <span className="skills-dialog-count">
@@ -1379,6 +1394,7 @@ function SkillsDialog({
               ? filteredSkills.map((skill) => (
                   <button
                     key={skill.id}
+                    ref={selectedSkill?.id === skill.id ? activeItemRef : undefined}
                     type="button"
                     className={`skill-item ${selectedSkill?.id === skill.id ? "active" : ""}`}
                     onClick={() => setSelectedSkillId(skill.id)}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1456,6 +1456,7 @@ function skillSourceUiLabel(source: SkillSource, language: LanguageMode): string
   if (source === "codex-shared") return localize(language, "Shared", "共享");
   if (source === "codex-system") return localize(language, "Codex System", "Codex 系统");
   if (source === "claude-project") return localize(language, "Project", "项目");
+  if (source === "claude-plugin") return localize(language, "Claude Plugin", "Claude 插件");
   return skillSourceLabel(source);
 }
 

--- a/src/renderer/src/skill-manager.ts
+++ b/src/renderer/src/skill-manager.ts
@@ -12,6 +12,7 @@ export function skillSourceLabel(source: SkillSource): string {
   if (source === "codex-system") return "Codex System";
   if (source === "codex-shared") return "Shared";
   if (source === "claude-project") return "Project";
+  if (source === "claude-plugin") return "Claude Plugin";
   return "Claude Code";
 }
 

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1874,13 +1874,21 @@ select:focus-visible {
   border-radius: 8px;
   background: var(--panel-bg);
   color: var(--text-muted);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
-.skills-search input {
+.skills-search:focus-within {
+  border-color: var(--accent-line);
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+
+.skills-search input,
+.skills-search input:focus {
   height: 34px;
   padding: 0;
   border: 0;
   border-radius: 0;
+  outline: 0;
   background: transparent;
   box-shadow: none;
 }

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1924,7 +1924,7 @@ select:focus-visible {
   display: flex;
   flex: 0 0 auto;
   gap: 6px;
-  padding: 0 14px 12px;
+  padding: 12px 14px;
   overflow-x: auto;
 }
 
@@ -2060,7 +2060,8 @@ select:focus-visible {
 }
 
 .skill-source-badge.claude-user,
-.skill-source-badge.claude-project {
+.skill-source-badge.claude-project,
+.skill-source-badge.claude-plugin {
   background: var(--claude-badge-bg);
   color: var(--claude-badge-text);
 }


### PR DESCRIPTION
## 背景

围绕右上角 Skills 管理面板的若干问题修复:

1. **Claude Code 的系统 skill 没拉全** —— 原来只扫描 `~/.claude/skills`(用户)和 `<project>/.claude/skills`(项目),完全没有读取插件来源的 skill。而 Claude Code 实际加载的"系统 skill"(superpowers / vercel / document-skills 等)都安装在 `~/.claude/plugins/cache/<市场>/<插件>/<版本>/skills/`。
2. **来源标签行顶着工具栏横线** —— `.skills-roots` 顶部 padding 为 0,导致 "Codex / Codex System" 等标签紧贴上方边框。
3. **搜索框聚焦时出现蓝色竖线** —— 内层 input 命中通用规则 `.command-dialog input:focus`,聚焦时的蓝色 box-shadow 圆环在窄 pill 中被裁切成一条竖线。
4. **Skills 面板里上下键不能切换 skill** —— 全局列表导航在 `skillsOpen` 时被禁用,面板内收不到方向键。

## 改动

- `src/core/skill-manager.ts`:新增 `claude-plugin` 来源;读取 `~/.claude/plugins/installed_plugins.json`,遍历各插件登记的 `installPath/skills`。只取清单中登记为生效的版本,避免 cache 中残留旧版本造成重复,并聚合成单个 root 统计数量。
- `src/renderer/src/skill-manager.ts`、`src/renderer/src/App.tsx`:补充 `claude-plugin` 的来源标签(`Claude Plugin` / `Claude 插件`)。
- `src/renderer/src/styles.css`:`.skills-roots` padding 由 `0 14px 12px` 改为 `12px 14px`;徽章配色复用 Claude 系列;`.skills-search` 聚焦高亮移到外层 `:focus-within`,压掉内层 input 的 outline/box-shadow,与主搜索框一致。
- `src/renderer/src/App.tsx`:Skills 面板支持上下键切换选中 skill —— 在 `SkillsDialog` 内部处理 `ArrowUp`/`ArrowDown`,在过滤后的列表中移动选中项并自动滚动到可视区。
- `src/core/skill-manager.test.ts`:新增插件 skill 扫描的测试用例。