### PR TITLE
fix: 修复 Ghostty 恢复会话不执行命令

### DIFF
--- a/src/core/platform.test.ts
+++ b/src/core/platform.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildGhosttyOpenArgs,
   buildWindowsLaunchPlan,
   defaultApiConfig,
   defaultClaudeApiConfig,
@@ -72,6 +73,28 @@ describe("resume commands", () => {
     expect(getResumeCommand(session, defaultSettings, { platform: "win32", withCwd: false })).toBe(
       "claude --resume abc",
     );
+  });
+});
+
+describe("Ghostty resume launch args", () => {
+  it("runs the resume command via -e and the shell, not the unsupported --initial-command flag", () => {
+    const session = {
+      source: "claude-cli",
+      rawId: "abc",
+      projectPath: "/repo",
+    } as SessionSearchResult;
+    const originalShell = process.env.SHELL;
+    process.env.SHELL = "/bin/zsh";
+    try {
+      const args = buildGhosttyOpenArgs(session, defaultSettings);
+      expect(args.slice(0, 5)).toEqual(["-na", "Ghostty.app", "--args", "-e", "/bin/zsh"]);
+      expect(args[5]).toBe("-ic");
+      expect(args[6]).toBe("cd /repo && claude --resume abc");
+      expect(args.some((arg) => arg.includes("--initial-command"))).toBe(false);
+    } finally {
+      if (originalShell === undefined) delete process.env.SHELL;
+      else process.env.SHELL = originalShell;
+    }
   });
 });
 

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -216,6 +216,15 @@ export function getResumeProcessSpec(
   };
 }
 
+// Ghostty has no `--initial-command` option, so the previous flag was silently
+// ignored and the window opened without resuming. The documented way to run a
+// command is the special `-e <command>` argument; run it through the user's
+// shell so the `cd … &&` chain plus PATH/aliases resolve, mirroring WezTerm.
+export function buildGhosttyOpenArgs(session: SessionSearchResult, settings: AppSettings): string[] {
+  const shell = process.env.SHELL || "/bin/zsh";
+  return ["-na", "Ghostty.app", "--args", "-e", shell, "-ic", getResumeCommand(session, settings, { withCwd: true })];
+}
+
 export async function openResumeInTerminal(session: SessionSearchResult, settings: AppSettings): Promise<void> {
   const command = getResumeCommand(session, settings, { withCwd: true });
   if (process.platform === "win32") {
@@ -256,7 +265,7 @@ end tell`);
   }
 
   if (settings.defaultTerminal === "Ghostty") {
-    await runProcess("/usr/bin/open", ["-na", "Ghostty.app", "--args", `--initial-command=${command}`]);
+    await runProcess("/usr/bin/open", buildGhosttyOpenArgs(session, settings));
     return;
   }
 


### PR DESCRIPTION
## 问题

在 Settings 选 Ghostty 为默认终端后,Resume 会话只打开 Ghostty 窗口、**不执行 resume 命令**。

## 原因

旧实现传的是 `--initial-command=<command>`:

open -na Ghostty.app --args --initial-command=cd /path && claude --resume <id>

但 **Ghostty 根本没有 `--initial-command` 这个配置键**。Ghostty 的 CLI 约定是「所有配置键都能用 `--<key>=<value>` 传」,合法键是 `command` / `working-directory`,运行命令的方式是特殊参数 `-e <command>`。传一个不存在的键会被判为无效(实测 `+show-config --initial-command=foo` 退出码非 0,和乱写的键一样),于是命令被丢弃。

## 修复

改用官方文档说明的 `-e <command>`,并通过用户 shell 运行,让 `cd … &&`、PATH、别名都能正确解析(与现有 WezTerm 分支一致):

open -na Ghostty.app --args -e $SHELL -ic "cd /path && claude --resume <id>"

- 把参数构造抽成纯函数 `buildGhosttyOpenArgs` 并加回归测试(断言走 `-e` + shell,且不含 `--initial-command`)。

## 验证

- 在本机已安装的 Ghostty 上实测:`open -na Ghostty.app --args -e /bin/zsh -ic '<cmd>'` 能真实启动 Ghostty 并执行命令(命令成功写入临时文件)。