### PR TITLE
修复 Claude 用量面板挂载后不再刷新

### DIFF
--- a/src/core/refresh-policy.test.ts
+++ b/src/core/refresh-policy.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { AUTO_INDEX_REFRESH_INTERVAL_MS, INITIAL_INDEX_DELAY_MS } from "./refresh-policy";
+import { AUTO_INDEX_REFRESH_INTERVAL_MS, INITIAL_INDEX_DELAY_MS, QUOTA_REFRESH_INTERVAL_MS } from "./refresh-policy";
 
 describe("refresh policy", () => {
   it("keeps automatic indexing infrequent while still indexing shortly after startup", () => {
     expect(INITIAL_INDEX_DELAY_MS).toBe(750);
     expect(AUTO_INDEX_REFRESH_INTERVAL_MS).toBe(10 * 60 * 1000);
+  });
+
+  it("polls usage quotas often enough to track the statusline snapshot file", () => {
+    expect(QUOTA_REFRESH_INTERVAL_MS).toBe(60 * 1000);
+    expect(QUOTA_REFRESH_INTERVAL_MS).toBeLessThan(AUTO_INDEX_REFRESH_INTERVAL_MS);
   });
 });

--- a/src/core/refresh-policy.ts
+++ b/src/core/refresh-policy.ts
@@ -1,2 +1,6 @@
 export const INITIAL_INDEX_DELAY_MS = 750;
 export const AUTO_INDEX_REFRESH_INTERVAL_MS = 10 * 60 * 1000;
+// The Claude statusline bridge rewrites ~/.claude/statusline-snapshot.json whenever Claude Code
+// renders its statusline, so poll often enough that the quota panel tracks it while the window
+// stays open instead of freezing on the value captured at mount.
+export const QUOTA_REFRESH_INTERVAL_MS = 60 * 1000;

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -37,6 +37,7 @@ import {
 import type { ApiConfig, ClaudeApiConfig } from "../../core/api-config";
 import type { IndexStatus } from "../../core/indexer";
 import { formatRelativeTime } from "../../core/format-session";
+import { QUOTA_REFRESH_INTERVAL_MS } from "../../core/refresh-policy";
 import type { AppSettings, AppSettingsUpdate } from "../../core/platform";
 import type { InstalledSkill, InstalledSkillsSnapshot } from "../../core/skill-manager";
 import { globalShortcutOptions } from "../../core/shortcuts";
@@ -282,13 +283,14 @@ export function App(): ReactElement {
     }
   }, [statsPeriod, t]);
 
-  const loadQuotas = useCallback(async (manual = false) => {
-    setQuotaLoading(true);
-    if (manual) setQuotaFeedback({ kind: "running", message: t("Refreshing usage limits...", "正在刷新额度...") });
+  const loadQuotas = useCallback(async (mode: "initial" | "manual" | "background" = "initial") => {
+    const background = mode === "background";
+    if (!background) setQuotaLoading(true);
+    if (mode === "manual") setQuotaFeedback({ kind: "running", message: t("Refreshing usage limits...", "正在刷新额度...") });
     try {
       const nextQuotas = await window.sessionSearch.getQuotas();
       setQuotas(nextQuotas);
-      if (manual) {
+      if (mode === "manual") {
         const successMessage = t("Usage limits refreshed.", "额度已刷新。");
         setQuotaFeedback({ kind: "success", message: successMessage });
         window.setTimeout(() => {
@@ -296,9 +298,10 @@ export function App(): ReactElement {
         }, 1800);
       }
     } catch (error) {
-      setQuotaFeedback({ kind: "error", message: error instanceof Error ? error.message : String(error) });
+      // Background polls fail silently so a transient read error does not clobber the last good value.
+      if (!background) setQuotaFeedback({ kind: "error", message: error instanceof Error ? error.message : String(error) });
     } finally {
-      setQuotaLoading(false);
+      if (!background) setQuotaLoading(false);
     }
   }, [t]);
 
@@ -370,6 +373,8 @@ export function App(): ReactElement {
 
   useEffect(() => {
     void loadQuotas();
+    const timer = window.setInterval(() => void loadQuotas("background"), QUOTA_REFRESH_INTERVAL_MS);
+    return () => window.clearInterval(timer);
   }, [loadQuotas]);
 
   useEffect(() => {
@@ -974,7 +979,7 @@ export function App(): ReactElement {
           feedback={quotaFeedback}
           expanded={sidebarSections.remaining}
           onToggle={() => toggleSidebarSectionById("remaining")}
-          onRefresh={() => void loadQuotas(true)}
+          onRefresh={() => void loadQuotas("manual")}
           language={language}
         />
 


### PR DESCRIPTION
## 问题

Claude 用量面板打开应用后就不再更新——一直停在挂载那一刻的快照值。

## 根因

`src/renderer/src/App.tsx` 中 `loadQuotas()` 只在组件挂载时调用一次(外加手动刷新 / 额度可见性切换),**没有周期刷新**;对比同文件里 live sessions 有 10s 定时器。而底层 `~/.claude/statusline-snapshot.json` 由 statusline bridge 持续刷新(排查中 `updated_at` 与 `used_percentage` 实时在变),写入端与 `quota.ts` 读取解析均正常。所以只要窗口保持打开,显示值就冻结。

## 改动

- 新增 `QUOTA_REFRESH_INTERVAL_MS`(60s)常量,挂载后定时以 `background` 模式刷新额度
- `loadQuotas` 由 `manual: boolean` 重构为 `initial | manual | background` 三种模式:后台轮询不闪 loading 状态、失败时静默,避免临时读错误覆盖上次正常值
- 补充 `refresh-policy` 测试断言
