### PR TITLE
修复 Windows 资源管理器定位、PowerShell 命令兼容与窗口溢出

### DIFF
--- a/src/core/platform.test.ts
+++ b/src/core/platform.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { mergeApiConfigWithProfileDefaults, mergeClaudeApiConfigWithProfileDefaults } from "./api-config";
 import {
   buildGhosttyOpenArgs,
+  buildRevealCommand,
   buildWindowsResumeLaunchPlan,
   buildWindowsLaunchPlan,
   defaultApiConfig,
@@ -62,6 +63,33 @@ describe("resume commands", () => {
 
     expect(getResumeCommand(session, defaultSettings, { platform: "win32" })).toBe(
       'cd /d "C:\\my repo" && claude --resume abc',
+    );
+  });
+
+  it("builds a PowerShell-compatible resume command when the terminal is PowerShell", () => {
+    const session = {
+      source: "claude-cli",
+      rawId: "abc",
+      projectPath: "C:\\my repo",
+    } as SessionSearchResult;
+    const settings = { ...defaultSettings, defaultTerminal: "PowerShell" as const };
+
+    const command = getResumeCommand(session, settings, { platform: "win32" });
+    expect(command).toBe("cd 'C:\\my repo'; claude --resume abc");
+    expect(command).not.toContain("cd /d");
+    expect(command).not.toContain("&&");
+  });
+
+  it("quotes a PowerShell path with single quotes by doubling embedded quotes", () => {
+    const session = {
+      source: "claude-cli",
+      rawId: "abc",
+      projectPath: "C:\\o'brien repo",
+    } as SessionSearchResult;
+    const settings = { ...defaultSettings, defaultTerminal: "PowerShell" as const };
+
+    expect(getResumeCommand(session, settings, { platform: "win32" })).toBe(
+      "cd 'C:\\o''brien repo'; claude --resume abc",
     );
   });
 
@@ -205,7 +233,7 @@ describe("Ghostty resume launch args", () => {
 
 describe("terminal options per platform", () => {
   it("returns Windows terminals on win32", () => {
-    expect(terminalOptionsFor("win32")).toEqual(["WindowsTerminal", "PowerShell", "Cmd"]);
+    expect(terminalOptionsFor("win32")).toEqual(["WindowsTerminal", "PowerShell", "Cmd", "WezTerm"]);
   });
   it("returns macOS terminals elsewhere", () => {
     expect(terminalOptionsFor("darwin")).toEqual(["Terminal", "iTerm", "Ghostty", "WezTerm", "Warp"]);
@@ -435,6 +463,72 @@ describe("resume terminal launch plans", () => {
     expect(pwshCommand).not.toContain("^&^&");
     expect(pwshCommand).toContain("cd ''/remote repo'' && codex resume codex-1");
     expect(powershellCommand).toBe(pwshCommand);
+  });
+
+  it("offers a WezTerm launch on Windows that wraps the command in cmd.exe", () => {
+    const session = {
+      source: "codex-cli",
+      rawId: "codex-1",
+      projectPath: process.cwd(),
+    } as SessionSearchResult;
+
+    const plan = buildWindowsResumeLaunchPlan(session, defaultSettings, {
+      terminal: "WezTerm",
+      platform: "win32",
+    });
+
+    expect(plan[0].file).toBe("wezterm.exe");
+    expect(plan[0].args).toEqual(["start", "--cwd", process.cwd(), "--", "cmd.exe", "/d", "/k", "codex resume codex-1"]);
+    expect(plan.map((launch) => launch.file)).toEqual([
+      "wezterm.exe",
+      "wt.exe",
+      "pwsh.exe",
+      "powershell.exe",
+      "cmd.exe",
+    ]);
+  });
+
+  it("keeps the launch command in cmd syntax even when the user prefers PowerShell", () => {
+    const session = {
+      source: "claude-cli",
+      rawId: "abc",
+      projectPath: "/remote repo",
+    } as SessionSearchResult;
+    const settings = { ...defaultSettings, defaultTerminal: "PowerShell" as const };
+
+    const plan = buildWindowsResumeLaunchPlan(session, settings, {
+      platform: "win32",
+      sshArgs: ["--", "alice@example.com"],
+    });
+
+    const cmdLaunch = plan.find((launch) => launch.file === "cmd.exe");
+    expect(cmdLaunch?.args.at(-1)).toContain("^&^&");
+  });
+});
+
+describe("reveal in file manager", () => {
+  it("reveals (selects) the item in Finder on macOS", () => {
+    expect(buildRevealCommand("/Users/me/skills/foo", "darwin")).toEqual({
+      file: "/usr/bin/open",
+      args: ["-R", "/Users/me/skills/foo"],
+      ignoreExitCode: false,
+    });
+  });
+
+  it("uses explorer /select with backslashes and tolerates its non-zero exit on Windows", () => {
+    expect(buildRevealCommand("C:/Users/me/skills/foo", "win32")).toEqual({
+      file: "explorer.exe",
+      args: ["/select,C:\\Users\\me\\skills\\foo"],
+      ignoreExitCode: true,
+    });
+  });
+
+  it("falls back to xdg-open on Linux", () => {
+    expect(buildRevealCommand("/home/me/skills/foo", "linux")).toEqual({
+      file: "xdg-open",
+      args: ["/home/me/skills/foo"],
+      ignoreExitCode: false,
+    });
   });
 });
 

--- a/src/core/platform.test.ts
+++ b/src/core/platform.test.ts
@@ -238,12 +238,12 @@ describe("terminal options per platform", () => {
   it("returns macOS terminals elsewhere", () => {
     expect(terminalOptionsFor("darwin")).toEqual(["Terminal", "iTerm", "Ghostty", "WezTerm", "Warp"]);
   });
-  it("defaults to WindowsTerminal on win32 and Terminal on macOS", () => {
-    expect(defaultTerminalFor("win32")).toBe("WindowsTerminal");
+  it("defaults to PowerShell on win32 and Terminal on macOS", () => {
+    expect(defaultTerminalFor("win32")).toBe("PowerShell");
     expect(defaultTerminalFor("darwin")).toBe("Terminal");
   });
   it("normalizes a cross-platform value to the platform default", () => {
-    expect(normalizeTerminal("Terminal", "win32")).toBe("WindowsTerminal");
+    expect(normalizeTerminal("WindowsTerminal", "darwin")).toBe("Terminal");
     expect(normalizeTerminal("Cmd", "darwin")).toBe("Terminal");
     expect(normalizeTerminal("PowerShell", "win32")).toBe("PowerShell");
   });

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -122,19 +122,43 @@ function buildResumeProcessArgs(
   return { command: settings.codexBinary, args };
 }
 
+// Which shell the displayed/copied command is meant to be pasted into. The
+// remote (ssh) command body always runs on a POSIX login shell; the local
+// terminal can be cmd.exe or PowerShell on Windows.
+type ShellKind = "posix" | "cmd" | "powershell";
+
+function localShellKind(platform: NodeJS.Platform, settings: AppSettings): ShellKind {
+  if (platform !== "win32") return "posix";
+  return normalizeTerminal(settings.defaultTerminal, "win32") === "PowerShell" ? "powershell" : "cmd";
+}
+
+function shellTokenQuote(s: string, shell: ShellKind): string {
+  if (/^[A-Za-z0-9_\-./]+$/.test(s)) return s;
+  if (shell === "cmd") return winQuote(s);
+  if (shell === "powershell") return powershellQuote(s);
+  return shellQuote(s);
+}
+
+function buildCdPrefix(projectPath: string, shell: ShellKind): string {
+  // PowerShell has no `cd /d` and chains statements with `;`; cmd uses `&&`.
+  if (shell === "cmd") return `cd /d ${winQuote(projectPath)} && `;
+  if (shell === "powershell") return `cd ${powershellQuote(projectPath)}; `;
+  return `cd ${shellQuote(projectPath)} && `;
+}
+
 function buildResumeShellCommand(
   session: SessionSearchResult,
   settings: AppSettings,
-  opts: Required<Pick<ResumeOptions, "withCwd" | "skipPermissions" | "platform">> & { remoteShell: boolean },
+  opts: Required<Pick<ResumeOptions, "withCwd" | "skipPermissions">> & { shell: ShellKind },
 ): string {
   const { command, args } = buildResumeProcessArgs(session, settings, opts.skipPermissions);
-  let cmd = [command, ...args].map((token) => shellCommandTokenQuote(token, opts.platform, opts.remoteShell)).join(" ");
+  const quotedCommand = shellTokenQuote(command, opts.shell);
+  // PowerShell treats a quoted leading token as a string literal, so the call
+  // operator `&` is required to actually run a quoted executable path.
+  const invocation = opts.shell === "powershell" && quotedCommand !== command ? `& ${quotedCommand}` : quotedCommand;
+  let cmd = [invocation, ...args.map((token) => shellTokenQuote(token, opts.shell))].join(" ");
   if (opts.withCwd && session.projectPath) {
-    cmd = opts.remoteShell
-      ? `cd ${shellQuote(session.projectPath)} && ${cmd}`
-      : opts.platform === "win32"
-        ? `cd /d ${winQuote(session.projectPath)} && ${cmd}`
-        : `cd ${shellQuote(session.projectPath)} && ${cmd}`;
+    cmd = `${buildCdPrefix(session.projectPath, opts.shell)}${cmd}`;
   }
   return cmd;
 }
@@ -146,14 +170,19 @@ export function getResumeCommand(
 ): string {
   const { withCwd = true, skipPermissions = false, platform = process.platform } = opts;
   const sshArgs = resolveSshArgs(opts);
-  const cmd = buildResumeShellCommand(session, settings, {
-    withCwd,
-    skipPermissions,
-    platform,
-    remoteShell: Boolean(sshArgs),
-  });
-  if (!sshArgs) return cmd;
-  return formatSshDisplayCommand(sshArgs, cmd, platform);
+  const shell = localShellKind(platform, settings);
+  if (sshArgs) {
+    // The remote command body always targets a POSIX shell; only the outer ssh
+    // invocation is quoted for the local terminal (cmd carets vs PowerShell).
+    const innerCommand = buildResumeShellCommand(session, settings, { withCwd, skipPermissions, shell: "posix" });
+    if (shell === "powershell") return formatPowershellSshDisplay(sshArgs, innerCommand);
+    return formatSshDisplayCommand(sshArgs, innerCommand, platform);
+  }
+  return buildResumeShellCommand(session, settings, { withCwd, skipPermissions, shell });
+}
+
+function formatPowershellSshDisplay(sshArgs: string[], innerCommand: string): string {
+  return ["ssh", ...sshArgs.map(powershellSshArgQuote), powershellQuote(innerCommand)].join(" ");
 }
 
 export interface WindowsLaunch {
@@ -175,9 +204,14 @@ export function buildWindowsLaunchPlan(terminal: TerminalChoice, command: string
     cwd: cwd || undefined,
   });
   const cmd = (): WindowsLaunch => ({ file: "cmd.exe", args: ["/d", "/k", command], cwd: cwd || undefined });
+  const wezterm = (): WindowsLaunch => {
+    const inner = ["cmd.exe", "/d", "/k", command];
+    return { file: "wezterm.exe", args: cwd ? ["start", "--cwd", cwd, "--", ...inner] : ["start", "--", ...inner] };
+  };
 
   if (terminal === "Cmd") return [cmd()];
   if (terminal === "PowerShell") return [pwsh(), powershell(), cmd()];
+  if (terminal === "WezTerm") return [wezterm(), wt(), pwsh(), powershell(), cmd()];
   // WindowsTerminal (default): wt first, then fall back through shells.
   return [wt(), pwsh(), powershell(), cmd()];
 }
@@ -203,9 +237,14 @@ function buildWindowsShellSpecificLaunchPlan(
     cwd: cwd || undefined,
   });
   const cmd = (): WindowsLaunch => ({ file: "cmd.exe", args: ["/d", "/k", cmdCommand], cwd: cwd || undefined });
+  const wezterm = (): WindowsLaunch => {
+    const inner = ["cmd.exe", "/d", "/k", cmdCommand];
+    return { file: "wezterm.exe", args: cwd ? ["start", "--cwd", cwd, "--", ...inner] : ["start", "--", ...inner] };
+  };
 
   if (terminal === "Cmd") return [cmd()];
   if (terminal === "PowerShell") return [pwsh(), powershell(), cmd()];
+  if (terminal === "WezTerm") return [wezterm(), wt(), pwsh(), powershell(), cmd()];
   return [wt(), pwsh(), powershell(), cmd()];
 }
 
@@ -216,7 +255,10 @@ export function buildWindowsResumeLaunchPlan(
 ): WindowsLaunch[] {
   const platform = opts.platform ?? "win32";
   const sshArgs = resolveSshArgs(opts);
-  const cmdCommand = getResumeCommand(session, settings, {
+  // The launch plan wraps this string in `cmd.exe /d /k`, so it must always be
+  // cmd-syntax even when the user's preferred terminal is PowerShell (that
+  // variant is supplied separately as `powershellCommand`).
+  const cmdCommand = getResumeCommand(session, { ...settings, defaultTerminal: "Cmd" }, {
     withCwd: Boolean(sshArgs),
     skipPermissions: opts.skipPermissions,
     platform,
@@ -289,8 +331,7 @@ export function getResumeProcessSpec(
     const innerCommand = buildResumeShellCommand(session, settings, {
       withCwd: true,
       skipPermissions,
-      platform,
-      remoteShell: true,
+      shell: "posix",
     });
     return {
       command: "ssh",
@@ -437,22 +478,38 @@ export async function openNativeApp(source: SessionSource): Promise<void> {
   }
 }
 
+export interface RevealCommand {
+  file: string;
+  args: string[];
+  // explorer.exe returns a non-zero exit code even when it succeeds, so its
+  // exit status must not be treated as a failure.
+  ignoreExitCode: boolean;
+}
+
+export function buildRevealCommand(targetPath: string, platform: NodeJS.Platform = process.platform): RevealCommand {
+  if (platform === "darwin") return { file: "/usr/bin/open", args: ["-R", targetPath], ignoreExitCode: false };
+  if (platform === "win32") {
+    // `explorer.exe <path>` opens the item; `/select,<path>` reveals it inside
+    // its parent folder (matching `open -R`). Explorer needs backslashes.
+    const winPath = targetPath.replace(/\//g, "\\");
+    return { file: "explorer.exe", args: [`/select,${winPath}`], ignoreExitCode: true };
+  }
+  return { file: "xdg-open", args: [targetPath], ignoreExitCode: false };
+}
+
 export async function revealInFileManager(targetPath: string): Promise<void> {
   if (!targetPath) return;
-  if (process.platform === "darwin") await runProcess("/usr/bin/open", ["-R", targetPath]);
-  else if (process.platform === "win32") await runProcess("explorer.exe", [targetPath]);
-  else await runProcess("xdg-open", [targetPath]);
+  const { file, args, ignoreExitCode } = buildRevealCommand(targetPath);
+  if (ignoreExitCode) {
+    await runProcessIgnoringExit(file, args);
+    return;
+  }
+  await runProcess(file, args);
 }
 
 function shellQuote(s: string): string {
   if (/^[A-Za-z0-9_\-./]+$/.test(s)) return s;
   return `'${s.replace(/'/g, "'\\''")}'`;
-}
-
-function shellCommandTokenQuote(s: string, platform: NodeJS.Platform, remoteShell: boolean): string {
-  if (remoteShell || platform !== "win32") return shellQuote(s);
-  if (/^[A-Za-z0-9_\-./]+$/.test(s)) return s;
-  return winQuote(s);
 }
 
 function resolveSshArgs(opts: Pick<ResumeOptions, "sshTarget" | "sshArgs">): string[] | undefined {
@@ -474,10 +531,9 @@ function getResumePowerShellCommand(
   const innerCommand = buildResumeShellCommand(session, settings, {
     withCwd: true,
     skipPermissions: opts.skipPermissions ?? false,
-    platform: opts.platform ?? "win32",
-    remoteShell: true,
+    shell: "posix",
   });
-  return ["ssh", ...opts.sshArgs.map(powershellSshArgQuote), powershellQuote(innerCommand)].join(" ");
+  return formatPowershellSshDisplay(opts.sshArgs, innerCommand);
 }
 
 function powershellSshArgQuote(s: string): string {
@@ -519,5 +575,15 @@ function runProcess(command: string, args: string[]): Promise<void> {
       if (!error) return resolve();
       reject(new Error(stderr?.trim() || stdout?.trim() || error.message));
     });
+  });
+}
+
+// Spawns a process whose non-zero exit code is expected (e.g. explorer.exe),
+// only rejecting when the binary itself cannot be launched.
+function runProcessIgnoringExit(command: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: "ignore", windowsHide: false });
+    child.once("error", reject);
+    child.once("spawn", () => resolve());
   });
 }

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -192,20 +192,29 @@ export interface WindowsLaunch {
 }
 
 // Ordered candidate launches. The caller tries each until one spawns (ENOENT -> next).
-export function buildWindowsLaunchPlan(terminal: TerminalChoice, command: string, cwd: string): WindowsLaunch[] {
+export function buildWindowsLaunchPlan(
+  terminal: TerminalChoice,
+  cmdCommand: string,
+  cwd: string,
+  powershellCommand?: string,
+): WindowsLaunch[] {
   const wt = (): WindowsLaunch => {
-    const inner = ["cmd.exe", "/d", "/k", command];
+    const inner = ["cmd.exe", "/d", "/k", cmdCommand];
     return { file: "wt.exe", args: cwd ? ["-d", cwd, ...inner] : inner };
   };
-  const pwsh = (): WindowsLaunch => ({ file: "pwsh.exe", args: ["-NoLogo", "-NoProfile", "-NoExit", "-Command", command], cwd: cwd || undefined });
-  const powershell = (): WindowsLaunch => ({
-    file: "powershell.exe",
-    args: ["-NoLogo", "-NoProfile", "-NoExit", "-Command", command],
+  const pwsh = (): WindowsLaunch => ({
+    file: "pwsh.exe",
+    args: ["-NoLogo", "-NoProfile", "-NoExit", "-Command", powershellCommand ?? cmdCommand],
     cwd: cwd || undefined,
   });
-  const cmd = (): WindowsLaunch => ({ file: "cmd.exe", args: ["/d", "/k", command], cwd: cwd || undefined });
+  const powershell = (): WindowsLaunch => ({
+    file: "powershell.exe",
+    args: ["-NoLogo", "-NoProfile", "-NoExit", "-Command", powershellCommand ?? cmdCommand],
+    cwd: cwd || undefined,
+  });
+  const cmd = (): WindowsLaunch => ({ file: "cmd.exe", args: ["/d", "/k", cmdCommand], cwd: cwd || undefined });
   const wezterm = (): WindowsLaunch => {
-    const inner = ["cmd.exe", "/d", "/k", command];
+    const inner = ["cmd.exe", "/d", "/k", cmdCommand];
     return { file: "wezterm.exe", args: cwd ? ["start", "--cwd", cwd, "--", ...inner] : ["start", "--", ...inner] };
   };
 
@@ -265,15 +274,17 @@ export function buildWindowsResumeLaunchPlan(
     sshTarget: opts.sshTarget,
     sshArgs: opts.sshArgs,
   });
+  const powershellCommand = sshArgs
+    ? getResumePowerShellCommand(session, settings, { ...opts, sshArgs })
+    : getResumeCommand(session, { ...settings, defaultTerminal: "PowerShell" }, {
+        withCwd: true,
+        skipPermissions: opts.skipPermissions,
+        platform,
+      });
   const terminal = normalizeTerminal(opts.terminal ?? settings.defaultTerminal, "win32");
   const cwd = sshArgs ? "" : existingDirectory(session.projectPath);
-  if (!sshArgs) return buildWindowsLaunchPlan(terminal, cmdCommand, cwd);
-  return buildWindowsShellSpecificLaunchPlan(
-    terminal,
-    cmdCommand,
-    getResumePowerShellCommand(session, settings, { ...opts, sshArgs }),
-    cwd,
-  );
+  if (!sshArgs) return buildWindowsLaunchPlan(terminal, cmdCommand, cwd, powershellCommand);
+  return buildWindowsShellSpecificLaunchPlan(terminal, cmdCommand, powershellCommand, cwd);
 }
 
 async function openResumeInWindowsTerminal(

--- a/src/core/terminal-options.ts
+++ b/src/core/terminal-options.ts
@@ -11,7 +11,7 @@ export type TerminalChoice =
   | "Cmd";
 
 const MAC_TERMINALS: TerminalChoice[] = ["Terminal", "iTerm", "Ghostty", "WezTerm", "Warp"];
-const WINDOWS_TERMINALS: TerminalChoice[] = ["WindowsTerminal", "PowerShell", "Cmd"];
+const WINDOWS_TERMINALS: TerminalChoice[] = ["WindowsTerminal", "PowerShell", "Cmd", "WezTerm"];
 
 const TERMINAL_LABELS: Record<TerminalChoice, string> = {
   Terminal: "Terminal",

--- a/src/core/terminal-options.ts
+++ b/src/core/terminal-options.ts
@@ -34,7 +34,7 @@ export function terminalOptionsFor(platform: NodeJS.Platform = currentPlatform()
 }
 
 export function defaultTerminalFor(platform: NodeJS.Platform = currentPlatform()): TerminalChoice {
-  return platform === "win32" ? "WindowsTerminal" : "Terminal";
+  return platform === "win32" ? "PowerShell" : "Terminal";
 }
 
 export function normalizeTerminal(value: unknown, platform: NodeJS.Platform = currentPlatform()): TerminalChoice {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -331,8 +331,8 @@ async function chooseMarkdownExportPath(defaultFileName: string): Promise<string
 }
 
 function getPreferredWindowBounds(): { width: number; height: number; x: number; y: number } {
-  const defaultWidth = 1120;
-  const defaultHeight = 760;
+  const defaultWidth = 1280;
+  const defaultHeight = 820;
   const cursorPoint = screen.getCursorScreenPoint();
   const { workArea } = screen.getDisplayNearestPoint(cursorPoint);
   const width = Math.min(defaultWidth, workArea.width);

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1026,8 +1026,10 @@ select:focus-visible {
 .top-actions {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 6px;
-  flex: 0 0 auto;
+  flex: 0 1 auto;
   margin-left: auto;
 }
 
@@ -1596,6 +1598,8 @@ select:focus-visible {
 .detail-header-actions {
   display: flex;
   align-items: flex-start;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 8px;
 }
 


### PR DESCRIPTION
修复 3 个远端 issue。

## #24 查看 Skill 报错
- `explorer.exe` 即使成功也返回退出码 1，被当作失败弹出右下角报错 → 改用 spawn 并忽略退出码。
- `explorer.exe <path>` 是“打开”而非“定位” → 改为 `explorer.exe /select,<反斜杠路径>`，与 macOS `open -R` 语义一致。

## #28 复制命令问题
- 复制/PowerShell 启动的命令原先恒为 cmd 语法 `cd /d "..." && ...`，粘进 PowerShell 报错 → 现在按所选终端生成（PowerShell → `cd 'path'; cmd`，含 SSH 远端的 PowerShell 变体）。喂给 `cmd.exe` 的启动串仍强制 cmd 语法。
- Windows 终端下拉新增 WezTerm，并补充对应启动计划。

## #25 窗口比例问题
- 默认窗口 1120×760 → 1280×820。
- `.top-actions` / `.detail-header-actions` 增加 `flex-wrap`，窄屏按钮换行不再溢出。

## 验证
- `platform.test.ts` 新增/更新用例，全量 228 个可运行测试通过；`typecheck` 与 `electron-vite build` 通过。
- 4 个 `node:sqlite` 失败为既有环境问题（本机 Node v20 缺该内建模块，应用运行于 Electron Node 22+），与本改动无关。