### PR TITLE
feat: add remote environment health checks

### DIFF
--- a/src/core/platform.test.ts
+++ b/src/core/platform.test.ts
@@ -54,14 +54,15 @@ describe("resume commands", () => {
     );
   });
 
-  it("builds a cmd-compatible cd prefix on Windows", () => {
+  it("builds a cmd-compatible cd prefix when Windows terminal is Cmd", () => {
     const session = {
       source: "claude-cli",
       rawId: "abc",
       projectPath: "C:\\my repo",
     } as SessionSearchResult;
+    const settings = { ...defaultSettings, defaultTerminal: "Cmd" as const };
 
-    expect(getResumeCommand(session, defaultSettings, { platform: "win32" })).toBe(
+    expect(getResumeCommand(session, settings, { platform: "win32" })).toBe(
       'cd /d "C:\\my repo" && claude --resume abc',
     );
   });
@@ -93,14 +94,15 @@ describe("resume commands", () => {
     );
   });
 
-  it("keeps local Windows non-ssh quoting unchanged for cmd metacharacters", () => {
+  it("keeps local Windows Cmd quoting unchanged for cmd metacharacters", () => {
     const session = {
       source: "claude-cli",
       rawId: "abc",
       projectPath: "C:\\repo %USERNAME% & tools",
     } as SessionSearchResult;
+    const settings = { ...defaultSettings, defaultTerminal: "Cmd" as const };
 
-    expect(getResumeCommand(session, defaultSettings, { platform: "win32" })).toBe(
+    expect(getResumeCommand(session, settings, { platform: "win32" })).toBe(
       'cd /d "C:\\repo %USERNAME% & tools" && claude --resume abc',
     );
   });
@@ -163,8 +165,9 @@ describe("resume commands", () => {
       rawId: "codex-1",
       projectPath: "/repo with spaces",
     } as SessionSearchResult;
+    const settings = { ...defaultSettings, defaultTerminal: "Cmd" as const };
 
-    const command = getResumeCommand(session, defaultSettings, {
+    const command = getResumeCommand(session, settings, {
       platform: "win32",
       sshTarget: "dev@example.com",
     });
@@ -195,8 +198,9 @@ describe("resume commands", () => {
       rawId: "codex %USERNAME% $HOME",
       projectPath: "/repo %USERNAME% $HOME",
     } as SessionSearchResult;
+    const settings = { ...defaultSettings, defaultTerminal: "Cmd" as const };
 
-    const command = getResumeCommand(session, defaultSettings, {
+    const command = getResumeCommand(session, settings, {
       platform: "win32",
       sshTarget: "dev@example.com",
     });

--- a/src/core/remote-health.test.ts
+++ b/src/core/remote-health.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { diagnoseRemoteEnvironment, preflightRemoteSessionResume } from "./remote-health";
+import type { SessionEnvironment, SessionSearchResult } from "./types";
+
+const environment: SessionEnvironment = {
+  id: "ssh-devbox",
+  kind: "ssh",
+  label: "devbox",
+  hostAlias: "devbox",
+  host: null,
+  user: null,
+  port: null,
+  authMode: "none",
+  identityFile: null,
+  enabled: true,
+  syncState: "idle",
+  lastSyncedAt: null,
+  lastError: null,
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+const session = {
+  environmentId: "ssh-devbox",
+  environmentKind: "ssh",
+  filePath: "/home/me/.codex/sessions/session.jsonl",
+  projectPath: "/work/project",
+  source: "codex-cli",
+} as SessionSearchResult;
+
+describe("remote health checks", () => {
+  it("returns structured health checks for ssh connectivity, CLIs, and session directories", async () => {
+    const report = await diagnoseRemoteEnvironment(environment, {
+      runSsh: async (_environment, command) => {
+        expect(command).toMatch(/^bash -lc /);
+        expect(command).toContain("python3 -c");
+        return JSON.stringify({
+          ok: true,
+          home: "/home/me",
+          codexCli: "/usr/local/bin/codex",
+          claudeCli: null,
+          codexSessionsExists: true,
+          codexSessionsReadable: true,
+          claudeProjectsExists: false,
+          claudeProjectsReadable: false,
+        });
+      },
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.checks.map((check) => [check.id, check.status])).toEqual([
+      ["connectivity", "ok"],
+      ["codex-cli", "ok"],
+      ["claude-cli", "warning"],
+      ["codex-sessions", "ok"],
+      ["claude-projects", "warning"],
+    ]);
+    expect(report.summary).toContain("3/5");
+  });
+
+  it("marks connectivity as failed when ssh command fails", async () => {
+    const report = await diagnoseRemoteEnvironment(environment, {
+      runSsh: async () => {
+        throw new Error("Permission denied");
+      },
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.checks[0]).toMatchObject({
+      id: "connectivity",
+      status: "error",
+      message: "Permission denied",
+    });
+  });
+
+  it("fails resume preflight when the remote session file is missing", async () => {
+    const report = await preflightRemoteSessionResume(environment, session, {
+      runSsh: async (_environment, command) => {
+        expect(command).toMatch(/^bash -lc /);
+        expect(command).toContain("python3 -c");
+        expect(command).not.toContain(session.filePath);
+        return JSON.stringify({
+          ok: false,
+          fileExists: false,
+          fileReadable: false,
+          projectExists: true,
+          cliPath: "/usr/local/bin/codex",
+        });
+      },
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.checks).toContainEqual(
+      expect.objectContaining({
+        id: "session-file",
+        status: "error",
+      }),
+    );
+  });
+
+  it("passes resume preflight with a readable session file, existing project, and matching CLI", async () => {
+    const report = await preflightRemoteSessionResume(environment, session, {
+      runSsh: async () =>
+        JSON.stringify({
+          ok: true,
+          fileExists: true,
+          fileReadable: true,
+          projectExists: true,
+          cliPath: "/usr/local/bin/codex",
+        }),
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.checks.map((check) => check.status)).toEqual(["ok", "ok", "ok"]);
+  });
+});

--- a/src/core/remote-health.ts
+++ b/src/core/remote-health.ts
@@ -1,0 +1,228 @@
+import { execFile, type ExecFileOptions } from "node:child_process";
+import { buildRemoteSyncSshArgs, formatRemoteSyncProcessError } from "./remote-sync";
+import type { SessionEnvironment, SessionSearchResult, SessionSource } from "./types";
+
+export type RemoteHealthStatus = "ok" | "warning" | "error";
+
+export interface RemoteHealthCheck {
+  id: string;
+  label: string;
+  status: RemoteHealthStatus;
+  message: string;
+  detail?: string;
+}
+
+export interface RemoteHealthReport {
+  ok: boolean;
+  summary: string;
+  checkedAt: number;
+  checks: RemoteHealthCheck[];
+}
+
+export interface RemoteHealthOptions {
+  runSsh?: (environment: SessionEnvironment, remoteCommand: string) => Promise<string>;
+}
+
+const REMOTE_HEALTH_EXEC_OPTIONS = {
+  maxBuffer: 512 * 1024,
+  timeout: 20_000,
+} satisfies ExecFileOptions;
+
+export async function diagnoseRemoteEnvironment(
+  environment: SessionEnvironment,
+  options: RemoteHealthOptions = {},
+): Promise<RemoteHealthReport> {
+  const runSsh = options.runSsh ?? runHealthSsh;
+  try {
+    const output = await runSsh(environment, buildRemoteHealthCommand());
+    const payload = parseHealthPayload(output);
+    const checks: RemoteHealthCheck[] = [
+      { id: "connectivity", label: "SSH connection", status: "ok", message: `Connected as ${payload.user || "remote user"}.` },
+      cliCheck("codex-cli", "Codex CLI", payload.codexCli),
+      cliCheck("claude-cli", "Claude CLI", payload.claudeCli),
+      directoryCheck("codex-sessions", "Codex sessions", payload.codexSessionsExists, payload.codexSessionsReadable),
+      directoryCheck("claude-projects", "Claude projects", payload.claudeProjectsExists, payload.claudeProjectsReadable),
+    ];
+    return buildReport(checks);
+  } catch (error) {
+    return buildReport([
+      {
+        id: "connectivity",
+        label: "SSH connection",
+        status: "error",
+        message: errorMessage(error),
+      },
+    ]);
+  }
+}
+
+export async function preflightRemoteSessionResume(
+  environment: SessionEnvironment,
+  session: SessionSearchResult,
+  options: RemoteHealthOptions = {},
+): Promise<RemoteHealthReport> {
+  const runSsh = options.runSsh ?? runHealthSsh;
+  try {
+    const output = await runSsh(environment, buildRemoteResumePreflightCommand(session));
+    const payload = parseResumePreflightPayload(output);
+    const cli = cliNameForSource(session.source);
+    const checks: RemoteHealthCheck[] = [
+      sessionFileCheck(payload.fileExists, payload.fileReadable),
+      {
+        id: "project-path",
+        label: "Project path",
+        status: payload.projectExists ? "ok" : "warning",
+        message: payload.projectExists ? "Remote project path exists." : "Remote project path was not found; resume will start without a verified project directory.",
+      },
+      cliCheck("resume-cli", `${cli} CLI`, payload.cliPath),
+    ];
+    return buildReport(checks);
+  } catch (error) {
+    return buildReport([
+      {
+        id: "connectivity",
+        label: "SSH connection",
+        status: "error",
+        message: errorMessage(error),
+      },
+    ]);
+  }
+}
+
+function cliCheck(id: string, label: string, path: unknown): RemoteHealthCheck {
+  if (typeof path === "string" && path) {
+    return { id, label, status: "ok", message: `${label} found.`, detail: path };
+  }
+  return { id, label, status: "warning", message: `${label} was not found on PATH.` };
+}
+
+function directoryCheck(id: string, label: string, exists: unknown, readable: unknown): RemoteHealthCheck {
+  if (exists && readable) return { id, label, status: "ok", message: `${label} directory is readable.` };
+  if (exists) return { id, label, status: "error", message: `${label} directory exists but is not readable.` };
+  return { id, label, status: "warning", message: `${label} directory was not found.` };
+}
+
+function sessionFileCheck(exists: unknown, readable: unknown): RemoteHealthCheck {
+  if (exists && readable) return { id: "session-file", label: "Session file", status: "ok", message: "Remote session file is readable." };
+  if (exists) return { id: "session-file", label: "Session file", status: "error", message: "Remote session file exists but is not readable." };
+  return { id: "session-file", label: "Session file", status: "error", message: "Remote session file was not found." };
+}
+
+function buildReport(checks: RemoteHealthCheck[]): RemoteHealthReport {
+  const okCount = checks.filter((check) => check.status === "ok").length;
+  const warningCount = checks.filter((check) => check.status === "warning").length;
+  const errorCount = checks.filter((check) => check.status === "error").length;
+  const suffix = [
+    warningCount ? `${warningCount} warning${warningCount === 1 ? "" : "s"}` : null,
+    errorCount ? `${errorCount} error${errorCount === 1 ? "" : "s"}` : null,
+  ].filter((part): part is string => Boolean(part));
+  return {
+    ok: errorCount === 0,
+    summary: `${okCount}/${checks.length} checks passed${suffix.length ? `, ${suffix.join(", ")}` : ""}`,
+    checkedAt: Date.now(),
+    checks,
+  };
+}
+
+function cliNameForSource(source: SessionSource): "codex" | "claude" | "codebuddy" {
+  if (source.startsWith("claude")) return "claude";
+  if (source === "codebuddy-cli") return "codebuddy";
+  return "codex";
+}
+
+function buildRemoteHealthCommand(): string {
+  const script = String.raw`import json, os, shutil
+from pathlib import Path
+
+home = Path.home()
+
+def readable(path):
+  try:
+    return path.exists() and os.access(path, os.R_OK)
+  except Exception:
+    return False
+
+codex_sessions = home / ".codex" / "sessions"
+claude_projects = home / ".claude" / "projects"
+print(json.dumps({
+  "ok": True,
+  "home": str(home),
+  "user": os.environ.get("USER") or os.environ.get("USERNAME") or "",
+  "codexCli": shutil.which("codex"),
+  "claudeCli": shutil.which("claude"),
+  "codexSessionsExists": codex_sessions.exists(),
+  "codexSessionsReadable": readable(codex_sessions),
+  "claudeProjectsExists": claude_projects.exists(),
+  "claudeProjectsReadable": readable(claude_projects),
+}, ensure_ascii=False))`;
+  return buildPythonBase64Command(script);
+}
+
+function buildRemoteResumePreflightCommand(session: SessionSearchResult): string {
+  const script = String.raw`import base64, json, os, shutil
+from pathlib import Path
+
+session_file = Path(base64.b64decode("__FILE_B64__").decode("utf-8"))
+project = Path(base64.b64decode("__PROJECT_B64__").decode("utf-8")) if "__PROJECT_B64__" else None
+cli = "__CLI__"
+
+def readable(path):
+  try:
+    return path.exists() and os.access(path, os.R_OK)
+  except Exception:
+    return False
+
+print(json.dumps({
+  "ok": True,
+  "fileExists": session_file.exists(),
+  "fileReadable": readable(session_file),
+  "projectExists": bool(project and project.exists() and project.is_dir()),
+  "cliPath": shutil.which(cli),
+}, ensure_ascii=False))`
+    .replace("__FILE_B64__", Buffer.from(session.filePath, "utf-8").toString("base64"))
+    .replaceAll("__PROJECT_B64__", session.projectPath ? Buffer.from(session.projectPath, "utf-8").toString("base64") : "")
+    .replace("__CLI__", cliNameForSource(session.source));
+  return buildPythonBase64Command(script);
+}
+
+function buildPythonBase64Command(script: string): string {
+  const encoded = Buffer.from(script, "utf-8").toString("base64");
+  const pythonCommand = `python3 -c 'import base64; exec(base64.b64decode("${encoded}").decode("utf-8"))'`;
+  return `bash -lc ${posixShellQuote(pythonCommand)}`;
+}
+
+function posixShellQuote(value: string): string {
+  if (/^[A-Za-z0-9_\-./]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function parseHealthPayload(output: string): Record<string, unknown> {
+  return parseJsonRecord(output, "remote health check");
+}
+
+function parseResumePreflightPayload(output: string): Record<string, unknown> {
+  return parseJsonRecord(output, "remote resume preflight");
+}
+
+function parseJsonRecord(output: string, label: string): Record<string, unknown> {
+  const trimmed = output.trim();
+  if (!trimmed) throw new Error(`${label} returned no output.`);
+  const firstLine = trimmed.split(/\r?\n/, 1)[0] ?? "";
+  const parsed = JSON.parse(firstLine) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error(`${label} returned an invalid payload.`);
+  return parsed as Record<string, unknown>;
+}
+
+async function runHealthSsh(environment: SessionEnvironment, remoteCommand: string): Promise<string> {
+  const args = buildRemoteSyncSshArgs(environment, remoteCommand);
+  return new Promise((resolve, reject) => {
+    execFile("ssh", args, REMOTE_HEALTH_EXEC_OPTIONS, (error, stdout, stderr) => {
+      if (error) reject(new Error(formatRemoteSyncProcessError(error, stdout, stderr)));
+      else resolve(stdout);
+    });
+  });
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -40,6 +40,7 @@ import { loadUsageQuotaSnapshot } from "../core/quota";
 import { focusLiveSessionTerminal } from "../core/session-focus";
 import { loadLiveSessionSnapshot } from "../core/session-activity";
 import { routeResumeSession } from "../core/resume-router";
+import { diagnoseRemoteEnvironment, preflightRemoteSessionResume } from "../core/remote-health";
 import { fetchRemoteSessionFilePayload, syncRemoteEnvironment } from "../core/remote-sync";
 import { loadRemoteSessionDetailPayload } from "../core/remote-session-loader";
 import { RemoteEnvironmentLifecycle } from "../core/remote-environment-lifecycle";
@@ -56,7 +57,13 @@ import { buildSshArgs, readUserSshConfig } from "../core/ssh-config";
 import { AUTO_INDEX_REFRESH_INTERVAL_MS, INITIAL_INDEX_DELAY_MS } from "../core/refresh-policy";
 import { globalShortcutLabel, normalizeGlobalShortcut } from "../core/shortcuts";
 import type { AppSettings, AppSettingsUpdate } from "../core/platform";
-import type { EnvironmentUpsertInput, SearchOptions, SessionSearchResult, SessionStatsOptions } from "../core/types";
+import type {
+  EnvironmentUpsertInput,
+  SearchOptions,
+  SessionEnvironment,
+  SessionSearchResult,
+  SessionStatsOptions,
+} from "../core/types";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PRODUCT_NAME = "Agent-Session-Search";
@@ -293,6 +300,30 @@ function requireSshArgsForRemoteSession(session: SessionSearchResult): string[] 
     throw new Error("SSH environment is not available for this remote session.");
   }
   return sshArgs;
+}
+
+function requireRemoteSshEnvironment(session: SessionSearchResult): SessionEnvironment | null {
+  if (isLocalSession(session)) return null;
+  const environment = store.getEnvironment(session.environmentId);
+  if (!environment || environment.kind !== "ssh") throw new Error("SSH environment is not available for this remote session.");
+  return environment;
+}
+
+function requireSshEnvironment(environmentId: string): SessionEnvironment {
+  const environment = store.getEnvironment(environmentId);
+  if (!environment) throw new Error("SSH environment was not found.");
+  if (environment.kind !== "ssh") throw new Error("Diagnostics are only available for SSH environments.");
+  return environment;
+}
+
+async function ensureRemoteResumePreflight(session: SessionSearchResult): Promise<void> {
+  const environment = requireRemoteSshEnvironment(session);
+  if (!environment) return;
+  const report = await preflightRemoteSessionResume(environment, session);
+  const errors = report.checks.filter((check) => check.status === "error");
+  if (errors.length === 0) return;
+  const detail = errors.map((check) => `${check.label}: ${check.message}`).join("; ");
+  throw new Error(`Remote resume preflight failed: ${detail}`);
 }
 
 async function ensureRemoteSessionDetailsLoaded(sessionKey: string): Promise<void> {
@@ -643,6 +674,9 @@ function registerIpc(): void {
   ipcMain.handle("environment:refresh", (_event, environmentId: string) =>
     ensureRemoteEnvironmentLifecycle().refreshEnvironment(environmentId),
   );
+  ipcMain.handle("environment:diagnose", (_event, environmentId: string) =>
+    diagnoseRemoteEnvironment(requireSshEnvironment(environmentId)),
+  );
   ipcMain.handle("title:set", (_event, sessionKey: string, title: string | null) => store.setCustomTitle(sessionKey, title));
   ipcMain.handle("tag:add", (_event, sessionKey: string, tagName: string) => store.addTag(sessionKey, tagName));
   ipcMain.handle("tag:remove", (_event, sessionKey: string, tagName: string) => store.removeTag(sessionKey, tagName));
@@ -712,6 +746,7 @@ function registerIpc(): void {
     if (!session) return { route: "resume" as const };
     const sshArgs = requireSshArgsForRemoteSession(session);
     if (!isLocalSession(session)) {
+      await ensureRemoteResumePreflight(session);
       await openResumeInTerminal(session, getSettings(), { sshArgs });
       store.markResumed(sessionKey);
       return { route: "resume" as const };
@@ -732,6 +767,7 @@ function registerIpc(): void {
     const session = store.getSession(sessionKey);
     if (!session) return;
     const sshArgs = requireSshArgsForRemoteSession(session);
+    await ensureRemoteResumePreflight(session);
     await openResumeInSpecificTerminal(session, getSettings(), "iTerm", { sshArgs });
     store.markResumed(sessionKey);
   });

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,6 +4,7 @@ import type { ApplyClaudeProfileResult } from "../core/claude-profile";
 import type { ApplyCodexProfileResult } from "../core/codex-profile";
 import type { AppSettings, AppSettingsUpdate } from "../core/platform";
 import type { IndexStatus } from "../core/indexer";
+import type { RemoteHealthReport } from "../core/remote-health";
 import type { ResumeRouteResult } from "../core/resume-router";
 import type { DeleteInstalledSkillResult, InstalledSkillsSnapshot } from "../core/skill-manager";
 import type { SkillUsageRefreshStatus } from "../core/skill-usage";
@@ -42,6 +43,7 @@ const api = {
     ipcRenderer.invoke("environment:save", environment),
   deleteEnvironment: (environmentId: string): Promise<void> => ipcRenderer.invoke("environment:delete", environmentId),
   refreshEnvironment: (environmentId: string): Promise<void> => ipcRenderer.invoke("environment:refresh", environmentId),
+  diagnoseEnvironment: (environmentId: string): Promise<RemoteHealthReport> => ipcRenderer.invoke("environment:diagnose", environmentId),
   setCustomTitle: (sessionKey: string, title: string | null): Promise<void> => ipcRenderer.invoke("title:set", sessionKey, title),
   addTag: (sessionKey: string, tagName: string): Promise<void> => ipcRenderer.invoke("tag:add", sessionKey, tagName),
   removeTag: (sessionKey: string, tagName: string): Promise<void> => ipcRenderer.invoke("tag:remove", sessionKey, tagName),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties, MouseEventHandler, ReactElement } from "react";
 import {
   AppWindow,
   Archive,
+  Activity,
   ChevronDown,
   ChevronRight,
   Clipboard,
@@ -42,6 +43,7 @@ import type { IndexStatus } from "../../core/indexer";
 import { formatRelativeTime } from "../../core/format-session";
 import { QUOTA_REFRESH_INTERVAL_MS } from "../../core/refresh-policy";
 import type { AppSettings, AppSettingsUpdate } from "../../core/platform";
+import type { RemoteHealthReport } from "../../core/remote-health";
 import type { InstalledSkill, InstalledSkillsSnapshot } from "../../core/skill-manager";
 import { globalShortcutOptions } from "../../core/shortcuts";
 import { terminalSelectOptions } from "../../core/terminal-options";
@@ -295,6 +297,8 @@ export function App(): ReactElement {
   const [skillsFeedback, setSkillsFeedback] = useState<SkillsFeedback>(null);
   const [appSettings, setAppSettings] = useState<AppSettings | null>(null);
   const [settingsFeedback, setSettingsFeedback] = useState<SettingsFeedback>(null);
+  const [environmentHealthReports, setEnvironmentHealthReports] = useState<Record<string, RemoteHealthReport>>({});
+  const [diagnosingEnvironmentId, setDiagnosingEnvironmentId] = useState<string | null>(null);
   const [skillHookInstalled, setSkillHookInstalled] = useState<boolean | null>(null);
   const [skillHookBusy, setSkillHookBusy] = useState(false);
   const [pendingPersonalSources, setPendingPersonalSources] = useState<{ claude: boolean; codex: boolean; codebuddy: boolean }>({
@@ -1040,10 +1044,30 @@ export function App(): ReactElement {
     }
   }
 
+  async function diagnoseEnvironment(environment: SessionEnvironment): Promise<void> {
+    if (environment.kind !== "ssh") return;
+    setDiagnosingEnvironmentId(environment.id);
+    setSettingsFeedback({ kind: "running", message: t(`Checking ${environment.label}...`, `正在检查 ${environment.label}...`) });
+    try {
+      const report = await window.sessionSearch.diagnoseEnvironment(environment.id);
+      setEnvironmentHealthReports((current) => ({ ...current, [environment.id]: report }));
+      setSettingsFeedback({ kind: report.ok ? "success" : "error", message: report.summary });
+    } catch (error) {
+      setSettingsFeedback({ kind: "error", message: error instanceof Error ? error.message : String(error) });
+    } finally {
+      setDiagnosingEnvironmentId((current) => (current === environment.id ? null : current));
+    }
+  }
+
   async function deleteEnvironment(environment: SessionEnvironment): Promise<void> {
     setSettingsFeedback({ kind: "running", message: t(`Deleting ${environment.label}...`, `正在删除 ${environment.label}...`) });
     try {
       await window.sessionSearch.deleteEnvironment(environment.id);
+      setEnvironmentHealthReports((current) => {
+        const next = { ...current };
+        delete next[environment.id];
+        return next;
+      });
       if (environmentId === environment.id) setEnvironmentId("all");
       if (projectEnvironmentId === environment.id) clearProjectFilter();
       await reloadEnvironmentData();
@@ -1590,6 +1614,8 @@ export function App(): ReactElement {
         <SettingsDialog
           settings={appSettings}
           environments={environments}
+          environmentHealthReports={environmentHealthReports}
+          diagnosingEnvironmentId={diagnosingEnvironmentId}
           theme={theme}
           language={language}
           feedback={settingsFeedback}
@@ -1602,6 +1628,7 @@ export function App(): ReactElement {
           skillHookBusy={skillHookBusy}
           onSkillHookChange={(enabled) => void toggleSkillUsageHook(enabled)}
           onRefreshEnvironment={(environment) => void refreshEnvironment(environment)}
+          onDiagnoseEnvironment={(environment) => void diagnoseEnvironment(environment)}
           onDeleteEnvironment={(environment) => void deleteEnvironment(environment)}
           onAddSsh={() => setSshDialogOpen(true)}
           onClose={() => setSettingsOpen(false)}
@@ -1959,6 +1986,8 @@ function ContextMenu({
 function SettingsDialog({
   settings,
   environments,
+  environmentHealthReports,
+  diagnosingEnvironmentId,
   theme,
   language,
   feedback,
@@ -1971,12 +2000,15 @@ function SettingsDialog({
   skillHookBusy,
   onSkillHookChange,
   onRefreshEnvironment,
+  onDiagnoseEnvironment,
   onDeleteEnvironment,
   onAddSsh,
   onClose,
 }: {
   settings: AppSettings | null;
   environments: SessionEnvironment[];
+  environmentHealthReports: Record<string, RemoteHealthReport>;
+  diagnosingEnvironmentId: string | null;
   theme: ThemeMode;
   language: LanguageMode;
   feedback: SettingsFeedback;
@@ -1989,6 +2021,7 @@ function SettingsDialog({
   skillHookBusy: boolean;
   onSkillHookChange: (enabled: boolean) => void;
   onRefreshEnvironment: (environment: SessionEnvironment) => void;
+  onDiagnoseEnvironment: (environment: SessionEnvironment) => void;
   onDeleteEnvironment: (environment: SessionEnvironment) => void;
   onAddSsh: () => void;
   onClose: () => void;
@@ -2105,37 +2138,69 @@ function SettingsDialog({
                   </button>
                 </header>
                 <div className="connection-list">
-                  {environments.map((environment) => (
-                    <div key={environment.id} className={`connection-row ${environmentStatus(environment)}`}>
-                      <div className="connection-icon">{environment.kind === "local" ? <Laptop size={15} /> : <Server size={15} />}</div>
-                      <div className="connection-main">
-                        <span className="connection-title">{environment.label}</span>
-                        <span className="connection-target">{environmentTarget(environment, language)}</span>
-                        {environment.lastError ? <span className="connection-error">{environment.lastError}</span> : null}
-                      </div>
-                      <span className="connection-status">{environmentStatusLabel(environment, language)}</span>
-                      {environment.kind === "ssh" ? (
-                        <div className="connection-actions">
-                          <button
-                            className="icon-button"
-                            onClick={() => onRefreshEnvironment(environment)}
-                            title={l("Refresh", "刷新")}
-                            aria-label={l(`Refresh ${environment.label}`, `刷新 ${environment.label}`)}
-                          >
-                            <RefreshCw size={14} />
-                          </button>
-                          <button
-                            className="icon-button danger"
-                            onClick={() => onDeleteEnvironment(environment)}
-                            title={l("Delete", "删除")}
-                            aria-label={l(`Delete ${environment.label}`, `删除 ${environment.label}`)}
-                          >
-                            <Trash2 size={14} />
-                          </button>
+                  {environments.map((environment) => {
+                    const report = environmentHealthReports[environment.id];
+                    const diagnosing = diagnosingEnvironmentId === environment.id;
+                    return (
+                      <div key={environment.id} className={`connection-row ${environmentStatus(environment)} ${report ? "with-diagnostics" : ""}`}>
+                        <div className="connection-icon">{environment.kind === "local" ? <Laptop size={15} /> : <Server size={15} />}</div>
+                        <div className="connection-main">
+                          <span className="connection-title">{environment.label}</span>
+                          <span className="connection-target">{environmentTarget(environment, language)}</span>
+                          {environment.lastError ? <span className="connection-error">{environment.lastError}</span> : null}
                         </div>
-                      ) : null}
-                    </div>
-                  ))}
+                        <span className="connection-status">{environmentStatusLabel(environment, language)}</span>
+                        {environment.kind === "ssh" ? (
+                          <div className="connection-actions">
+                            <button
+                              className="icon-button"
+                              disabled={diagnosing}
+                              onClick={() => onDiagnoseEnvironment(environment)}
+                              title={l("Diagnose", "诊断")}
+                              aria-label={l(`Diagnose ${environment.label}`, `诊断 ${environment.label}`)}
+                            >
+                              <Activity size={14} />
+                            </button>
+                            <button
+                              className="icon-button"
+                              onClick={() => onRefreshEnvironment(environment)}
+                              title={l("Refresh", "刷新")}
+                              aria-label={l(`Refresh ${environment.label}`, `刷新 ${environment.label}`)}
+                            >
+                              <RefreshCw size={14} />
+                            </button>
+                            <button
+                              className="icon-button danger"
+                              onClick={() => onDeleteEnvironment(environment)}
+                              title={l("Delete", "删除")}
+                              aria-label={l(`Delete ${environment.label}`, `删除 ${environment.label}`)}
+                            >
+                              <Trash2 size={14} />
+                            </button>
+                          </div>
+                        ) : null}
+                        {report ? (
+                          <div className="connection-diagnostics">
+                            <div className="connection-diagnostics-head">
+                              <span>{report.summary}</span>
+                              <time>{formatRelativeTime(report.checkedAt)}</time>
+                            </div>
+                            <div className="connection-diagnostic-list">
+                              {report.checks.map((check) => (
+                                <div key={check.id} className={`connection-diagnostic-check ${check.status}`}>
+                                  <span className="connection-diagnostic-dot" />
+                                  <span className="connection-diagnostic-label">{check.label}</span>
+                                  <span className="connection-diagnostic-message" title={check.detail ?? check.message}>
+                                    {check.message}
+                                  </span>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        ) : null}
+                      </div>
+                    );
+                  })}
                 </div>
               </section>
             ) : null}

--- a/src/renderer/src/detail-panel-actions.test.ts
+++ b/src/renderer/src/detail-panel-actions.test.ts
@@ -79,6 +79,7 @@ describe("detail panel actions", () => {
       "environment:save",
       "environment:delete",
       "environment:refresh",
+      "environment:diagnose",
       "environments-updated",
     ]) {
       expect(preloadSource).toContain(channel);
@@ -89,6 +90,7 @@ describe("detail panel actions", () => {
     expect(preloadSource).toContain("saveEnvironment");
     expect(preloadSource).toContain("deleteEnvironment");
     expect(preloadSource).toContain("refreshEnvironment");
+    expect(preloadSource).toContain("diagnoseEnvironment");
     expect(preloadSource).toContain("onEnvironmentsUpdated");
   });
 
@@ -138,5 +140,31 @@ describe("detail panel actions", () => {
       );
     }
     expect(mainHandlerSource("command:copy-resume")).toContain("async (_event, sessionKey: string)");
+  });
+
+  it("preflights remote resume before opening terminals", () => {
+    expect(mainSource).toContain("preflightRemoteSessionResume");
+    expect(mainSource).toContain("ensureRemoteResumePreflight");
+    expect(mainSource).toContain("Remote resume preflight failed:");
+
+    for (const channel of ["command:resume", "command:resume-iterm"]) {
+      const handler = mainHandlerSource(channel);
+      expect(handler).toContain("await ensureRemoteResumePreflight(session)");
+      expect(handler.indexOf("await ensureRemoteResumePreflight(session)")).toBeLessThan(
+        handler.indexOf("openResumeIn"),
+      );
+    }
+    expect(mainHandlerSource("command:copy-resume")).not.toContain("ensureRemoteResumePreflight");
+  });
+
+  it("renders remote environment diagnostics in settings", () => {
+    const settingsDialog = appSource.slice(appSource.indexOf("function SettingsDialog"), appSource.indexOf("function SettingsSection"));
+
+    expect(appSource).toContain("environmentHealthReports");
+    expect(appSource).toContain("diagnosingEnvironmentId");
+    expect(appSource).toContain("window.sessionSearch.diagnoseEnvironment(environment.id)");
+    expect(settingsDialog).toContain("onDiagnoseEnvironment");
+    expect(settingsDialog).toContain("connection-diagnostics");
+    expect(settingsDialog).toContain("connection-diagnostic-check");
   });
 });

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -2616,6 +2616,10 @@ select:focus-visible {
   background: var(--panel-subtle);
 }
 
+.connection-row.with-diagnostics {
+  align-items: start;
+}
+
 .connection-icon {
   display: grid;
   place-items: center;
@@ -2687,6 +2691,90 @@ select:focus-visible {
 .connection-actions .icon-button {
   width: 28px;
   height: 28px;
+}
+
+.connection-actions .icon-button:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.connection-diagnostics {
+  grid-column: 2 / -1;
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.connection-diagnostics-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--text-muted);
+  font-size: 11.5px;
+  font-weight: 650;
+}
+
+.connection-diagnostics-head time {
+  flex: 0 0 auto;
+  color: var(--text-faint);
+  font-weight: 550;
+}
+
+.connection-diagnostic-list {
+  display: grid;
+  gap: 5px;
+}
+
+.connection-diagnostic-check {
+  display: grid;
+  grid-template-columns: 8px minmax(90px, 0.35fr) minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 11.5px;
+}
+
+.connection-diagnostic-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--text-faint);
+}
+
+.connection-diagnostic-check.ok .connection-diagnostic-dot {
+  background: var(--success-text);
+}
+
+.connection-diagnostic-check.warning .connection-diagnostic-dot {
+  background: var(--running-text);
+}
+
+.connection-diagnostic-check.error .connection-diagnostic-dot {
+  background: var(--danger);
+}
+
+.connection-diagnostic-check.error {
+  color: var(--danger);
+}
+
+.connection-diagnostic-label {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-dim);
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.connection-diagnostic-message {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .icon-button.danger:hover {


### PR DESCRIPTION
## Summary
- Add structured SSH remote environment health checks for connectivity, CLI discovery, and session directories.
- Expose diagnostics in Settings > Connections and show inline check results per SSH environment.
- Preflight remote resume actions before opening a terminal so missing files, missing CLIs, or SSH errors fail with clearer messages.

## Test Plan
- npm test
- npm run build
- git diff --check

## Notes
- Health checks run through a login shell (`bash -lc`) so remote CLI detection uses the same PATH users get when logging in manually.