### PR TITLE
fix: 修复 Claude Code 额度 statusLine 命令

### DIFF
--- a/bin/setup-claude-statusline.cjs
+++ b/bin/setup-claude-statusline.cjs
@@ -6,7 +6,7 @@ const os = require("node:os");
 const path = require("node:path");
 
 const settingsPath = path.join(homeDir(), ".claude", "settings.json");
-const command = process.platform === "win32" ? "agent-session-search-claude-statusline.cmd" : "agent-session-search-claude-statusline";
+const command = statuslineCommand();
 
 try {
   const settings = readSettings(settingsPath);
@@ -34,6 +34,14 @@ function readSettings(filePath) {
 
 function homeDir() {
   return process.env.AGENT_SESSION_SEARCH_TEST_HOME || os.homedir();
+}
+
+function statuslineCommand() {
+  const localScript = path.join(__dirname, "claude-statusline-snapshot.cjs");
+  if (fs.existsSync(localScript)) {
+    return process.platform === "win32" ? `node "${localScript}"` : `"${localScript}"`;
+  }
+  return process.platform === "win32" ? "agent-session-search-claude-statusline.cmd" : "agent-session-search-claude-statusline";
 }
 
 function writeJsonAtomic(filePath, value) {

--- a/src/core/quota.test.ts
+++ b/src/core/quota.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -110,6 +110,74 @@ describe("usage quota loader", () => {
         expect.objectContaining({ key: "five_hour", label: "5h", usedPercent: 10, remainingPercent: 90 }),
         expect.objectContaining({ key: "seven_day", label: "7d", usedPercent: 45, remainingPercent: 55 }),
       ]);
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("repairs a missing Claude Code statusLine when loading a stale local snapshot", () => {
+    const homeDir = makeHome();
+    try {
+      writeJson(path.join(homeDir, ".claude", "settings.json"), { env: {} });
+      writeJson(path.join(homeDir, ".claude", "statusline-snapshot.json"), {
+        source: "agent-session-search-statusline",
+        updated_at: "2026-05-31T12:00:00.000Z",
+        rate_limits: {
+          five_hour: { used_percentage: 10, resets_at: 1_807_000_000 },
+        },
+      });
+
+      const card = loadClaudeQuotaCard({ now: NOW, homeDir, env: {} });
+
+      expect(card.status).toBe("supported");
+      const settings = JSON.parse(readFileSync(path.join(homeDir, ".claude", "settings.json"), "utf8")) as {
+        statusLine?: { command?: string };
+      };
+      expect(settings.statusLine?.command).toContain("claude-statusline-snapshot.cjs");
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("repairs an existing Claude Code statusLine that points at an unavailable global bin", () => {
+    const homeDir = makeHome();
+    try {
+      writeJson(path.join(homeDir, ".claude", "settings.json"), {
+        statusLine: { type: "command", command: "agent-session-search-claude-statusline" },
+      });
+      writeJson(path.join(homeDir, ".claude", "statusline-snapshot.json"), {
+        source: "agent-session-search-statusline",
+        updated_at: "2026-05-31T12:00:00.000Z",
+        rate_limits: {
+          five_hour: { used_percentage: 10, resets_at: 1_807_000_000 },
+        },
+      });
+
+      const card = loadClaudeQuotaCard({ now: NOW, homeDir, env: { PATH: "/usr/bin:/bin" } });
+
+      expect(card.status).toBe("supported");
+      const settings = JSON.parse(readFileSync(path.join(homeDir, ".claude", "settings.json"), "utf8")) as {
+        statusLine?: { command?: string };
+      };
+      expect(settings.statusLine?.command).toContain("claude-statusline-snapshot.cjs");
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("installs the Claude Code statusLine when no quota snapshot exists yet", () => {
+    const homeDir = makeHome();
+    try {
+      writeJson(path.join(homeDir, ".claude", "settings.json"), { env: {} });
+
+      const card = loadClaudeQuotaCard({ now: NOW, homeDir, env: {} });
+
+      expect(card.status).toBe("not_configured");
+      expect(card.detail).toContain("Restart Claude Code");
+      const settings = JSON.parse(readFileSync(path.join(homeDir, ".claude", "settings.json"), "utf8")) as {
+        statusLine?: { command?: string };
+      };
+      expect(settings.statusLine?.command).toContain("claude-statusline-snapshot.cjs");
     } finally {
       rmSync(homeDir, { recursive: true, force: true });
     }

--- a/src/core/quota.ts
+++ b/src/core/quota.ts
@@ -1,11 +1,12 @@
 import { execFile } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import http from "node:http";
 import https from "node:https";
 import net from "node:net";
 import { homedir } from "node:os";
 import path from "node:path";
 import tls from "node:tls";
+import { fileURLToPath } from "node:url";
 import type { UsageQuota, UsageQuotaCard, UsageQuotaSnapshot } from "./types";
 
 const CODEX_USAGE_PRIMARY_URL = "https://chatgpt.com/backend-api/wham/usage";
@@ -15,6 +16,8 @@ const HTTP_BODY_LIMIT = 64 * 1024;
 const QUOTA_FIVE_HOUR = "five_hour";
 const QUOTA_SEVEN_DAY = "seven_day";
 const QUOTA_CODE_REVIEW = "code_review";
+const CLAUDE_STATUSLINE_SCRIPT_BASENAME = "claude-statusline-snapshot.cjs";
+const CLAUDE_STATUSLINE_BIN_NAME = "agent-session-search-claude-statusline";
 
 interface QuotaLoadOptions {
   now?: Date;
@@ -170,8 +173,19 @@ export async function loadCodexQuotaCard(options: UsageQuotaLoadOptions = {}): P
 export function loadClaudeQuotaCard(options: QuotaLoadOptions = {}): UsageQuotaCard {
   const now = options.now ?? new Date();
   const card = baseQuotaCard("claude-code", "Claude Code", "Install a Claude Code statusline bridge that writes ~/.claude/statusline-snapshot.json.");
+  const bridgeStatus = ensureClaudeStatuslineBridge(options);
   const statuslinePath = firstExistingFile(claudeStatuslineCandidates(options));
-  if (!statuslinePath) return card;
+  if (!statuslinePath) {
+    return {
+      ...card,
+      detail:
+        bridgeStatus === "installed"
+          ? "Claude Code statusline bridge installed. Restart Claude Code, then run one request to generate quota data."
+          : bridgeStatus === "conflict"
+            ? "Claude Code has a different statusLine configured, so Agent-Session-Search cannot generate quota data automatically."
+            : card.detail,
+    };
+  }
 
   let raw: ClaudeStatuslineFile;
   try {
@@ -202,6 +216,79 @@ export function loadClaudeQuotaCard(options: QuotaLoadOptions = {}): UsageQuotaC
       : "Claude statusline file has no quota data.";
   }
   return next;
+}
+
+type ClaudeStatuslineBridgeStatus = "installed" | "already" | "conflict" | "error" | "skipped";
+
+function ensureClaudeStatuslineBridge(options: QuotaLoadOptions): ClaudeStatuslineBridgeStatus {
+  const home = getHomeDir(options);
+  if (!home) return "skipped";
+  const settingsPath = path.join(home, ".claude", "settings.json");
+  const command = buildClaudeStatuslineCommand();
+
+  let settings: Record<string, unknown> = {};
+  if (existsSync(settingsPath)) {
+    try {
+      const raw = readFileSync(settingsPath, "utf8");
+      if (raw.trim()) {
+        const parsed = JSON.parse(raw) as unknown;
+        if (!isPlainObject(parsed)) return "error";
+        settings = parsed;
+      }
+    } catch {
+      return "error";
+    }
+  }
+
+  const existing = settings.statusLine;
+  if (existing !== undefined && existing !== null) {
+    const existingCommand = isPlainObject(existing) && typeof existing.command === "string" ? existing.command : "";
+    if (!isOurClaudeStatuslineCommand(existingCommand)) return "conflict";
+    if (existingCommand === command) return "already";
+  }
+
+  settings.statusLine = { type: "command", command };
+  try {
+    mkdirSync(path.dirname(settingsPath), { recursive: true });
+    writeJsonAtomic(settingsPath, settings);
+    return "installed";
+  } catch {
+    return "error";
+  }
+}
+
+function buildClaudeStatuslineCommand(): string {
+  const scriptPath = localClaudeStatuslineScriptPath();
+  if (scriptPath) {
+    return process.platform === "win32" ? `node "${scriptPath}"` : `"${scriptPath}"`;
+  }
+  return process.platform === "win32" ? `${CLAUDE_STATUSLINE_BIN_NAME}.cmd` : CLAUDE_STATUSLINE_BIN_NAME;
+}
+
+function localClaudeStatuslineScriptPath(): string | null {
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.resolve(moduleDir, "../../bin", CLAUDE_STATUSLINE_SCRIPT_BASENAME),
+    path.resolve(process.cwd(), "bin", CLAUDE_STATUSLINE_SCRIPT_BASENAME),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function isOurClaudeStatuslineCommand(command: string): boolean {
+  return command.includes(CLAUDE_STATUSLINE_SCRIPT_BASENAME) || command.includes(CLAUDE_STATUSLINE_BIN_NAME);
+}
+
+function writeJsonAtomic(filePath: string, value: unknown): void {
+  const tmpPath = `${filePath}.${process.pid}.tmp`;
+  writeFileSync(tmpPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  renameSync(tmpPath, filePath);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Object.prototype.toString.call(value) === "[object Object]";
 }
 
 function baseQuotaCard(provider: UsageQuotaCard["provider"], displayName: string, detail: string): UsageQuotaCard {

--- a/src/core/setup-claude-statusline.test.ts
+++ b/src/core/setup-claude-statusline.test.ts
@@ -28,12 +28,9 @@ describe("Claude statusline setup", () => {
         theme: "dark",
         statusLine: {
           type: "command",
-          command:
-            process.platform === "win32"
-              ? "agent-session-search-claude-statusline.cmd"
-              : "agent-session-search-claude-statusline",
         },
       });
+      expect((settings.statusLine as { command?: string }).command).toContain("claude-statusline-snapshot.cjs");
     } finally {
       rmSync(homeDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## 变更内容
- 在加载 Claude Code 额度时，自动修复缺失或失效的 Agent-Session-Search statusLine 配置。
- 优先写入当前 checkout 内的 `bin/claude-statusline-snapshot.cjs` 绝对路径，避免依赖全局 npm bin 是否在 Claude Code 的 PATH 中。
- 同步更新手动 setup 脚本，并补充缺失 statusLine、旧快照、全局命令不可用等场景的回归测试。
