### PR TITLE
fix: 修复 Codex 与 Claude Code 额度显示

### DIFF
--- a/bin/claude-statusline-snapshot.cjs
+++ b/bin/claude-statusline-snapshot.cjs
@@ -21,7 +21,7 @@ process.stdin.on("data", (chunk) => {
 process.stdin.on("end", () => {
   try {
     const input = stdin.trim() ? JSON.parse(stdin) : {};
-    const snapshot = buildSnapshot(input);
+    const snapshot = buildSnapshot(input, readExistingSnapshot());
     fs.mkdirSync(path.dirname(outputPath), { recursive: true });
     writeJsonAtomic(outputPath, snapshot);
     process.stdout.write(formatStatusline(snapshot));
@@ -32,27 +32,41 @@ process.stdin.on("end", () => {
   }
 });
 
-function buildSnapshot(input) {
+function buildSnapshot(input, previous) {
   const snapshot = {
     source: "agent-session-search-statusline",
     updated_at: new Date().toISOString(),
   };
 
-  const plan = stringField(input, "plan") || stringField(input, "subscription_plan");
+  // Claude Code does not include `plan`/`rate_limits` on every statusLine render (early renders and
+  // some refreshes omit them). Carry the last known values forward so a payload without quota data
+  // does not blank out the panel; quota.ts marks them stale once resets_at passes.
+  const plan = stringField(input, "plan") || stringField(input, "subscription_plan") || stringField(previous, "plan");
   if (plan) snapshot.plan = plan;
 
   const rateLimits = objectField(input, "rate_limits");
-  if (rateLimits) {
-    const fiveHour = normalizeWindow(objectField(rateLimits, "five_hour"));
-    const sevenDay = normalizeWindow(objectField(rateLimits, "seven_day"));
-    if (fiveHour || sevenDay) {
-      snapshot.rate_limits = {};
-      if (fiveHour) snapshot.rate_limits.five_hour = fiveHour;
-      if (sevenDay) snapshot.rate_limits.seven_day = sevenDay;
-    }
+  const fiveHour = normalizeWindow(objectField(rateLimits, "five_hour"));
+  const sevenDay = normalizeWindow(objectField(rateLimits, "seven_day"));
+  const prevRateLimits = objectField(previous, "rate_limits");
+  const five = fiveHour || normalizeWindow(objectField(prevRateLimits, "five_hour"));
+  const seven = sevenDay || normalizeWindow(objectField(prevRateLimits, "seven_day"));
+  if (five || seven) {
+    snapshot.rate_limits = {};
+    if (five) snapshot.rate_limits.five_hour = five;
+    if (seven) snapshot.rate_limits.seven_day = seven;
   }
 
   return snapshot;
+}
+
+function readExistingSnapshot() {
+  try {
+    const raw = fs.readFileSync(outputPath, "utf8");
+    const parsed = raw.trim() ? JSON.parse(raw) : null;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
 }
 
 function normalizeWindow(value) {

--- a/src/core/claude-statusline-snapshot.test.ts
+++ b/src/core/claude-statusline-snapshot.test.ts
@@ -43,4 +43,38 @@ describe("Claude statusline snapshot bridge", () => {
       rmSync(outputPath, { force: true });
     }
   });
+
+  it("carries forward the last known quota when a render omits rate_limits", () => {
+    const outputPath = path.join(tmpdir(), `claude-statusline-${process.pid}-${Date.now()}-carry.json`);
+    const run = (input: unknown): void => {
+      execFileSync(process.execPath, [SCRIPT_PATH], {
+        input: JSON.stringify(input),
+        env: { ...process.env, AGENT_SESSION_SEARCH_CLAUDE_STATUSLINE: outputPath },
+        encoding: "utf8",
+      });
+    };
+    try {
+      // First render carries quota data.
+      run({
+        plan: "max",
+        rate_limits: {
+          five_hour: { used_percentage: 6, resets_at: 1_807_000_000 },
+          seven_day: { used_percentage: 4, resets_at: 1_807_400_000 },
+        },
+      });
+      // A later render omits rate_limits/plan entirely (Claude Code does this intermittently).
+      run({ session_id: "s", model: { id: "opus" } });
+
+      const snapshot = JSON.parse(readFileSync(outputPath, "utf8")) as Record<string, unknown>;
+      expect(snapshot).toMatchObject({
+        plan: "max",
+        rate_limits: {
+          five_hour: { used_percentage: 6, resets_at: 1_807_000_000 },
+          seven_day: { used_percentage: 4, resets_at: 1_807_400_000 },
+        },
+      });
+    } finally {
+      rmSync(outputPath, { force: true });
+    }
+  });
 });

--- a/src/core/quota-proxy.test.ts
+++ b/src/core/quota-proxy.test.ts
@@ -7,7 +7,9 @@ describe("selectProxyUrl", () => {
   it("prefers HTTPS_PROXY then falls back through the env chain", () => {
     expect(selectProxyUrl({ HTTPS_PROXY: "http://a:1" })).toBe("http://a:1");
     expect(selectProxyUrl({ https_proxy: "http://b:2" })).toBe("http://b:2");
-    expect(selectProxyUrl({ ALL_PROXY: "http://c:3" })).toBe("http://c:3");
+    expect(selectProxyUrl({ HTTP_PROXY: "http://c:3" })).toBe("http://c:3");
+    expect(selectProxyUrl({ http_proxy: "http://d:4" })).toBe("http://d:4");
+    expect(selectProxyUrl({ ALL_PROXY: "http://e:5" })).toBe("http://e:5");
   });
 
   it("ignores socks proxies that CONNECT tunneling cannot use", () => {

--- a/src/core/quota.test.ts
+++ b/src/core/quota.test.ts
@@ -59,27 +59,87 @@ describe("usage quota loader", () => {
     }
   });
 
-  it("does not fetch Codex subscription quota for API-key-only auth", async () => {
+  it("parses Codex quota from percent_left when used_percent is absent", async () => {
     const homeDir = makeHome();
     try {
       writeJson(path.join(homeDir, ".codex", "auth.json"), {
-        OPENAI_API_KEY: "sk-test",
+        tokens: { access_token: "codex-access", account_id: "account-1" },
       });
-      let fetched = false;
 
       const card = await loadCodexQuotaCard({
         now: NOW,
         homeDir,
         env: {},
-        codexFetcher: async () => {
-          fetched = true;
-          return {};
-        },
+        codexFetcher: async () => ({
+          plan_type: "pro",
+          rate_limit: {
+            primary_window: { percent_left: 65, reset_at: 1_807_000_000 },
+            secondary_window: { percent_left: 40, reset_at: 1_807_400_000 },
+          },
+        }),
       });
 
-      expect(fetched).toBe(false);
-      expect(card.status).toBe("unsupported_api_key");
-      expect(card.detail).toContain("API key");
+      expect(card.status).toBe("supported");
+      expect(card.plan).toBe("Pro");
+      // percent_left=65 → usedPercent=35, remainingPercent=65
+      expect(card.quotas).toEqual([
+        expect.objectContaining({ key: "five_hour", usedPercent: 35, remainingPercent: 65 }),
+        expect.objectContaining({ key: "seven_day", usedPercent: 60, remainingPercent: 40 }),
+      ]);
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("parses Codex quota from remaining_percent when used_percent is absent", async () => {
+    const homeDir = makeHome();
+    try {
+      writeJson(path.join(homeDir, ".codex", "auth.json"), {
+        tokens: { access_token: "codex-access", account_id: "account-1" },
+      });
+
+      const card = await loadCodexQuotaCard({
+        now: NOW,
+        homeDir,
+        env: {},
+        codexFetcher: async () => ({
+          rate_limit: {
+            primary_window: { remaining_percent: 80, reset_at: 1_807_000_000 },
+          },
+        }),
+      });
+
+      expect(card.status).toBe("supported");
+      // remaining_percent=80 → usedPercent=20, remainingPercent=80
+      expect(card.quotas).toEqual([
+        expect.objectContaining({ key: "five_hour", usedPercent: 20, remainingPercent: 80 }),
+      ]);
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("computes Codex reset time from reset_after_seconds when reset_at is absent", async () => {
+    const homeDir = makeHome();
+    const now = new Date("2026-06-01T12:00:00.000Z");
+    try {
+      writeJson(path.join(homeDir, ".codex", "auth.json"), {
+        tokens: { access_token: "codex-access", account_id: "account-1" },
+      });
+
+      const card = await loadCodexQuotaCard({
+        now,
+        homeDir,
+        env: {},
+        codexFetcher: async () => ({
+          rate_limit: {
+            primary_window: { used_percent: 50, reset_after_seconds: 3600 },
+          },
+        }),
+      });
+
+      expect(card.status).toBe("supported");
+      expect(card.quotas[0].resetsAt).toBe("2026-06-01T13:00:00.000Z");
     } finally {
       rmSync(homeDir, { recursive: true, force: true });
     }
@@ -115,6 +175,30 @@ describe("usage quota loader", () => {
     }
   });
 
+  it("parses Claude Code quota from quotas format with used_percentage field name", () => {
+    const homeDir = makeHome();
+    try {
+      // Some tools (onwatch/kaboo) write used_percentage instead of used_percent
+      writeJson(path.join(homeDir, ".claude", "statusline-snapshot.json"), {
+        source: "onwatch",
+        plan: "pro",
+        quotas: {
+          five_hour: { label: "5h", used_percentage: 30, resets_at: "2027-04-05T13:00:00.000Z" },
+        },
+      });
+
+      const card = loadClaudeQuotaCard({ now: NOW, homeDir, env: {} });
+
+      expect(card.status).toBe("supported");
+      expect(card.plan).toBe("Pro");
+      expect(card.quotas).toEqual([
+        expect.objectContaining({ key: "five_hour", label: "5h", usedPercent: 30, remainingPercent: 70 }),
+      ]);
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
   it("repairs a missing Claude Code statusLine when loading a stale local snapshot", () => {
     const homeDir = makeHome();
     try {
@@ -139,7 +223,7 @@ describe("usage quota loader", () => {
     }
   });
 
-  it("repairs an existing Claude Code statusLine that points at an unavailable global bin", () => {
+  it("does not overwrite an existing Claude Code statusLine that already points to our bridge", () => {
     const homeDir = makeHome();
     try {
       writeJson(path.join(homeDir, ".claude", "settings.json"), {
@@ -157,9 +241,10 @@ describe("usage quota loader", () => {
 
       expect(card.status).toBe("supported");
       const settings = JSON.parse(readFileSync(path.join(homeDir, ".claude", "settings.json"), "utf8")) as {
-        statusLine?: { command?: string };
+        statusLine?: { command?: string; type?: string };
       };
-      expect(settings.statusLine?.command).toContain("claude-statusline-snapshot.cjs");
+      // Should NOT overwrite the existing command—even if the resolved path differs.
+      expect(settings.statusLine?.command).toBe("agent-session-search-claude-statusline");
     } finally {
       rmSync(homeDir, { recursive: true, force: true });
     }
@@ -259,5 +344,360 @@ describe("usage quota loader", () => {
     } finally {
       rmSync(homeDir, { recursive: true, force: true });
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// E2E tests — realistic end-to-end scenarios with both providers
+// ---------------------------------------------------------------------------
+
+describe("quota E2E", () => {
+  it("produces a full snapshot with both providers using real-world response formats", async () => {
+    const homeDir = makeHome();
+    try {
+      // Codex: realistic API response with used_percent in 0-100 scale
+      writeJson(path.join(homeDir, ".codex", "auth.json"), {
+        tokens: { access_token: "codex-token", account_id: "acc-1" },
+      });
+
+      // Claude: snapshot file mimicking our statusline bridge output
+      writeJson(path.join(homeDir, ".claude", "statusline-snapshot.json"), {
+        source: "agent-session-search-statusline",
+        updated_at: "2026-06-01T11:59:00.000Z",
+        plan: "max",
+        rate_limits: {
+          five_hour: { used_percentage: 42, resets_at: 1_807_000_000 },
+          seven_day: { used_percentage: 15, resets_at: 1_807_400_000 },
+        },
+      });
+
+      const snapshot = await loadUsageQuotaSnapshot({
+        now: NOW,
+        homeDir,
+        env: {},
+        codexFetcher: async () => ({
+          plan_type: "pro",
+          rate_limit: {
+            primary_window: { used_percent: 25, reset_at: 1_807_000_000 },
+            secondary_window: { used_percent: 60, reset_at: 1_807_400_000 },
+          },
+        }),
+      });
+
+      // Structure
+      expect(snapshot.generatedAt).toBe(NOW.toISOString());
+      expect(snapshot.providers).toHaveLength(2);
+
+      // Codex card
+      const codexCard = snapshot.providers.find((p) => p.provider === "codex")!;
+      expect(codexCard.status).toBe("supported");
+      expect(codexCard.plan).toBe("Pro");
+      expect(codexCard.quotas).toHaveLength(2);
+      expect(codexCard.quotas[0]).toMatchObject({ key: "five_hour", label: "5h", usedPercent: 25, remainingPercent: 75 });
+      expect(codexCard.quotas[1]).toMatchObject({ key: "seven_day", label: "7d", usedPercent: 60, remainingPercent: 40 });
+
+      // Claude card
+      const claudeCard = snapshot.providers.find((p) => p.provider === "claude-code")!;
+      expect(claudeCard.status).toBe("supported");
+      expect(claudeCard.plan).toBe("Max");
+      expect(claudeCard.quotas).toHaveLength(2);
+      expect(claudeCard.quotas[0]).toMatchObject({ key: "five_hour", label: "5h", usedPercent: 42, remainingPercent: 58 });
+      expect(claudeCard.quotas[1]).toMatchObject({ key: "seven_day", label: "7d", usedPercent: 15, remainingPercent: 85 });
+
+      // Display strings always sum to 100
+      for (const provider of snapshot.providers) {
+        for (const q of provider.quotas) {
+          const used = parseInt(q.usedDisplay, 10);
+          const remaining = parseInt(q.remainingDisplay, 10);
+          expect(used + remaining).toBe(100);
+        }
+      }
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("parses Claude quota from onwatch/kaboo quotas format with percentage suffix", async () => {
+    const homeDir = makeHome();
+    try {
+      writeJson(path.join(homeDir, ".claude", "kaboo-statusline.json"), {
+        source: "kaboo",
+        plan: "pro",
+        quotas: {
+          five_hour: { label: "5h", used_percentage: 18, remaining_percentage: 82, resets_at: "2027-04-05T13:00:00.000Z" },
+          seven_day: { label: "7d", used_percentage: 35, resets_at: "2027-04-10T13:00:00.000Z" },
+        },
+      });
+
+      const card = loadClaudeQuotaCard({ now: NOW, homeDir, env: {} });
+
+      expect(card.status).toBe("supported");
+      expect(card.plan).toBe("Pro");
+      expect(card.source).toBe("kaboo");
+      expect(card.quotas).toHaveLength(2);
+      expect(card.quotas[0]).toMatchObject({ key: "five_hour", usedPercent: 18, remainingPercent: 82 });
+      expect(card.quotas[0].resetsAt).toBe("2027-04-05T13:00:00.000Z");
+      expect(card.quotas[0].stale).toBe(false);
+      // seven_day: only used_percentage provided, remaining computed
+      expect(card.quotas[1]).toMatchObject({ key: "seven_day", usedPercent: 35, remainingPercent: 65 });
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  describe("stale detection", () => {
+    it("marks quota as stale when reset_at is more than 60s in the past", () => {
+      const homeDir = makeHome();
+      try {
+        writeJson(path.join(homeDir, ".claude", "statusline-snapshot.json"), {
+          rate_limits: {
+            five_hour: { used_percentage: 50, resets_at: 1_808_000_000 },
+          },
+        });
+
+        // NOW = 2026-06-01T12:00:00Z, reset_at = 1_808_000_000 ≈ 2027-04-17
+        // That's in the future — should NOT be stale
+        const cardFuture = loadClaudeQuotaCard({ now: NOW, homeDir, env: {} });
+        expect(cardFuture.quotas[0].stale).toBe(false);
+
+        // A reset time 2 minutes ago — should be stale
+        const twoMinAgo = new Date(NOW.getTime() - 120_000);
+        const pastUnix = Math.floor(twoMinAgo.getTime() / 1000);
+        writeJson(path.join(homeDir, ".claude", "statusline-snapshot.json"), {
+          rate_limits: {
+            five_hour: { used_percentage: 50, resets_at: pastUnix },
+          },
+        });
+        const cardPast = loadClaudeQuotaCard({ now: NOW, homeDir, env: {} });
+        expect(cardPast.quotas[0].stale).toBe(true);
+
+        // A reset time 30 seconds ago — within grace period, NOT stale
+        const thirtySecAgo = new Date(NOW.getTime() - 30_000);
+        const graceUnix = Math.floor(thirtySecAgo.getTime() / 1000);
+        writeJson(path.join(homeDir, ".claude", "statusline-snapshot.json"), {
+          rate_limits: {
+            five_hour: { used_percentage: 50, resets_at: graceUnix },
+          },
+        });
+        const cardGrace = loadClaudeQuotaCard({ now: NOW, homeDir, env: {} });
+        expect(cardGrace.quotas[0].stale).toBe(false);
+      } finally {
+        rmSync(homeDir, { recursive: true, force: true });
+      }
+    });
+
+    it("auto-detects staleness from resets_at when quotas format omits the stale field", () => {
+      const homeDir = makeHome();
+      try {
+        const pastIso = new Date(NOW.getTime() - 120_000).toISOString();
+        writeJson(path.join(homeDir, ".claude", "statusline-snapshot.json"), {
+          quotas: {
+            five_hour: { label: "5h", used_percentage: 50, resets_at: pastIso },
+          },
+        });
+
+        const card = loadClaudeQuotaCard({ now: NOW, homeDir, env: {} });
+        expect(card.quotas[0].stale).toBe(true);
+      } finally {
+        rmSync(homeDir, { recursive: true, force: true });
+      }
+    });
+
+    it("preserves stale flag from quotas format", () => {
+      const homeDir = makeHome();
+      try {
+        writeJson(path.join(homeDir, ".claude", "statusline-snapshot.json"), {
+          quotas: {
+            five_hour: { label: "5h", used_percentage: 50, resets_at: "2027-01-01T00:00:00.000Z", stale: true },
+          },
+        });
+
+        const card = loadClaudeQuotaCard({ now: NOW, homeDir, env: {} });
+        expect(card.quotas[0].stale).toBe(true);
+      } finally {
+        rmSync(homeDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe("display rounding", () => {
+    function displayFor(usedPercent: number, remainingPercent: number): [string, string] {
+      const homeDir = makeHome();
+      try {
+        writeJson(path.join(homeDir, ".claude", "statusline-snapshot.json"), {
+          rate_limits: {
+            five_hour: { used_percentage: usedPercent, remaining_percentage: remainingPercent },
+          },
+        });
+        const card = loadClaudeQuotaCard({ now: NOW, homeDir, env: {} });
+        return [card.quotas[0].usedDisplay, card.quotas[0].remainingDisplay];
+      } finally {
+        rmSync(homeDir, { recursive: true, force: true });
+      }
+    }
+
+    it("always sums to 100% regardless of fractional used value", () => {
+      const pairs: Array<[number, number, string, string]> = [
+        [25, 75, "25%", "75%"],
+        [0, 100, "0%", "100%"],
+        [100, 0, "100%", "0%"],
+        [23.5, 76.5, "24%", "76%"],
+        [23.4, 76.6, "23%", "77%"],
+        [0.1, 99.9, "0%", "100%"],
+        [99.7, 0.3, "100%", "0%"],
+      ];
+      for (const [usedPct, remainingPct, expectedUsed, expectedRemaining] of pairs) {
+        const [used, remaining] = displayFor(usedPct, remainingPct);
+        expect(used).toBe(expectedUsed);
+        expect(remaining).toBe(expectedRemaining);
+        expect(parseInt(used, 10) + parseInt(remaining, 10)).toBe(100);
+      }
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns not_configured for Codex without auth.json", async () => {
+      const homeDir = makeHome();
+      try {
+        const snapshot = await loadUsageQuotaSnapshot({
+          now: NOW,
+          homeDir,
+          env: {},
+        });
+        const codex = snapshot.providers.find((p) => p.provider === "codex")!;
+        expect(codex.status).toBe("not_configured");
+      } finally {
+        rmSync(homeDir, { recursive: true, force: true });
+      }
+    });
+
+    it("shows unsupported_api_key for API-key-only Codex auth", async () => {
+      const homeDir = makeHome();
+      try {
+        writeJson(path.join(homeDir, ".codex", "auth.json"), {
+          OPENAI_API_KEY: "sk-test-key",
+        });
+
+        const card = await loadCodexQuotaCard({ now: NOW, homeDir, env: {} });
+        expect(card.status).toBe("unsupported_api_key");
+        expect(card.quotas).toEqual([]);
+      } finally {
+        rmSync(homeDir, { recursive: true, force: true });
+      }
+    });
+
+    it("returns empty quotas when Codex response has no windows", async () => {
+      const homeDir = makeHome();
+      try {
+        writeJson(path.join(homeDir, ".codex", "auth.json"), {
+          tokens: { access_token: "codex-token", account_id: "acc-1" },
+        });
+
+        const card = await loadCodexQuotaCard({
+          now: NOW,
+          homeDir,
+          env: {},
+          codexFetcher: async () => ({ plan_type: "free" }),
+        });
+
+        expect(card.status).toBe("supported");
+        expect(card.plan).toBe("Free");
+        expect(card.quotas).toEqual([]);
+        expect(card.detail).toContain("did not include limits");
+      } finally {
+        rmSync(homeDir, { recursive: true, force: true });
+      }
+    });
+
+    it("returns not_configured for Claude without any statusline file", () => {
+      const homeDir = makeHome();
+      try {
+        const card = loadClaudeQuotaCard({ now: NOW, homeDir, env: {} });
+        expect(card.status).toBe("not_configured");
+        expect(card.quotas).toEqual([]);
+      } finally {
+        rmSync(homeDir, { recursive: true, force: true });
+      }
+    });
+
+    it("reports error when Codex auth.json is invalid JSON", async () => {
+      const homeDir = makeHome();
+      try {
+        mkdirSync(path.join(homeDir, ".codex"), { recursive: true });
+        writeFileSync(path.join(homeDir, ".codex", "auth.json"), "{not valid json", "utf8");
+
+        const card = await loadCodexQuotaCard({ now: NOW, homeDir, env: {} });
+        expect(card.status).toBe("error");
+        expect(card.detail).toContain("not valid JSON");
+      } finally {
+        rmSync(homeDir, { recursive: true, force: true });
+      }
+    });
+
+    it("reports error when Claude statusline file is invalid JSON", () => {
+      const homeDir = makeHome();
+      try {
+        mkdirSync(path.join(homeDir, ".claude"), { recursive: true });
+        writeFileSync(path.join(homeDir, ".claude", "statusline-snapshot.json"), "{bad json", "utf8");
+
+        const card = loadClaudeQuotaCard({ now: NOW, homeDir, env: {} });
+        expect(card.status).toBe("error");
+        expect(card.detail).toContain("not valid JSON");
+      } finally {
+        rmSync(homeDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe("reset time edge cases", () => {
+    it("exposes resetsAt as ISO string and is never stale for future times", async () => {
+      const homeDir = makeHome();
+      try {
+        writeJson(path.join(homeDir, ".codex", "auth.json"), {
+          tokens: { access_token: "codex-token", account_id: "acc-1" },
+        });
+
+        const card = await loadCodexQuotaCard({
+          now: NOW,
+          homeDir,
+          env: {},
+          codexFetcher: async () => ({
+            rate_limit: {
+              primary_window: { used_percent: 50, reset_at: 1_807_800_000 },
+            },
+          }),
+        });
+
+        expect(card.quotas[0].resetsAt).toBe("2027-04-15T14:40:00.000Z");
+        expect(card.quotas[0].stale).toBe(false);
+      } finally {
+        rmSync(homeDir, { recursive: true, force: true });
+      }
+    });
+
+    it("computes reset time from reset_after_seconds relative to now", async () => {
+      const homeDir = makeHome();
+      try {
+        writeJson(path.join(homeDir, ".codex", "auth.json"), {
+          tokens: { access_token: "codex-token", account_id: "acc-1" },
+        });
+
+        const card = await loadCodexQuotaCard({
+          now: NOW, // 2026-06-01T12:00:00Z
+          homeDir,
+          env: {},
+          codexFetcher: async () => ({
+            rate_limit: {
+              primary_window: { used_percent: 50, reset_after_seconds: 7200 },
+            },
+          }),
+        });
+
+        // 12:00:00 + 7200s = 14:00:00
+        expect(card.quotas[0].resetsAt).toBe("2026-06-01T14:00:00.000Z");
+      } finally {
+        rmSync(homeDir, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/src/core/quota.ts
+++ b/src/core/quota.ts
@@ -35,7 +35,10 @@ export type CodexUsageFetcher = (accessToken: string, accountId: string) => Prom
 
 export interface CodexUsageWindow {
   used_percent?: number;
+  percent_left?: number;
+  remaining_percent?: number;
   reset_at?: number;
+  reset_after_seconds?: number;
   limit_window_seconds?: number;
 }
 
@@ -89,7 +92,9 @@ interface ClaudeOnwatchWindow {
 interface ClaudeStatuslineQuota {
   label?: string;
   used_percent?: number;
+  used_percentage?: number;
   remaining_percent?: number;
+  remaining_percentage?: number;
   resets_at?: string;
   stale?: boolean;
 }
@@ -243,8 +248,10 @@ function ensureClaudeStatuslineBridge(options: QuotaLoadOptions): ClaudeStatusli
   const existing = settings.statusLine;
   if (existing !== undefined && existing !== null) {
     const existingCommand = isPlainObject(existing) && typeof existing.command === "string" ? existing.command : "";
-    if (!isOurClaudeStatuslineCommand(existingCommand)) return "conflict";
-    if (existingCommand === command) return "already";
+    // If the existing statusLine command is already ours (regardless of path), leave it alone.
+    // Changing the path risks breaking the bridge when the resolved path differs between runs.
+    if (isOurClaudeStatuslineCommand(existingCommand)) return "already";
+    if (existingCommand) return "conflict";
   }
 
   settings.statusLine = { type: "command", command };
@@ -351,14 +358,34 @@ function expandHome(value: string, homeDir: string): string {
   return homeDir ? path.join(homeDir, value.slice(2)) : value;
 }
 
+function pickNumber(value: unknown): number | undefined {
+  return isFiniteNumber(value) ? value : undefined;
+}
+
+function codexWindowUsedPercent(window: CodexUsageWindow): number | undefined {
+  if (isFiniteNumber(window.used_percent)) return window.used_percent;
+  // Some API versions return the remaining percentage instead of the used percentage.
+  if (isFiniteNumber(window.percent_left)) return 100 - window.percent_left;
+  if (isFiniteNumber(window.remaining_percent)) return 100 - window.remaining_percent;
+  return undefined;
+}
+
+function codexWindowResetAt(window: CodexUsageWindow, now: Date): number | undefined {
+  if (isFiniteNumber(window.reset_at)) return window.reset_at;
+  if (isFiniteNumber(window.reset_after_seconds) && window.reset_after_seconds >= 0) {
+    return Math.floor(now.getTime() / 1000) + window.reset_after_seconds;
+  }
+  return undefined;
+}
+
 function codexQuotasFromResponse(response: CodexUsageResponse, now: Date): UsageQuota[] {
   const quotas: UsageQuota[] = [];
   const primary = response.rate_limit?.primary_window ?? null;
   const secondary = response.rate_limit?.secondary_window ?? null;
   const codeReview = response.code_review_rate_limit?.primary_window ?? null;
-  if (primary) quotas.push(quotaFromUsedPercent(QUOTA_FIVE_HOUR, "5h", primary.used_percent, primary.reset_at, now));
-  if (secondary) quotas.push(quotaFromUsedPercent(QUOTA_SEVEN_DAY, "7d", secondary.used_percent, secondary.reset_at, now));
-  if (codeReview) quotas.push(quotaFromUsedPercent(QUOTA_CODE_REVIEW, "Review", codeReview.used_percent, codeReview.reset_at, now));
+  if (primary) quotas.push(quotaFromUsedPercent(QUOTA_FIVE_HOUR, "5h", codexWindowUsedPercent(primary), codexWindowResetAt(primary, now), now));
+  if (secondary) quotas.push(quotaFromUsedPercent(QUOTA_SEVEN_DAY, "7d", codexWindowUsedPercent(secondary), codexWindowResetAt(secondary, now), now));
+  if (codeReview) quotas.push(quotaFromUsedPercent(QUOTA_CODE_REVIEW, "Review", codexWindowUsedPercent(codeReview), codexWindowResetAt(codeReview, now), now));
   return quotas.filter(Boolean);
 }
 
@@ -372,7 +399,14 @@ function claudeQuotasFromStatusline(raw: ClaudeStatuslineFile, now: Date): Usage
   if (raw.quotas && Object.keys(raw.quotas).length > 0) {
     for (const [key, value] of Object.entries(raw.quotas)) {
       if (!value) continue;
-      add(key, value.label || quotaLabel(key), value.used_percent, value.remaining_percent, value.resets_at, value.stale);
+      // Some tools write used_percentage / remaining_percentage (with "age" suffix)
+      // instead of used_percent / remaining_percent.
+      const usedPct = pickNumber(value.used_percent) ?? pickNumber(value.used_percentage);
+      const remainingPct = pickNumber(value.remaining_percent) ?? pickNumber(value.remaining_percentage);
+      // Leave stale undefined (not false) when the field is absent so normalizeQuota can still
+      // auto-detect staleness from resets_at; an explicit `false` would suppress that.
+      const staleFlag = value.stale === true ? true : undefined;
+      add(key, value.label || quotaLabel(key), usedPct, remainingPct, value.resets_at, staleFlag);
     }
     return quotas;
   }
@@ -424,12 +458,14 @@ function normalizeQuota(quota: Omit<UsageQuota, "usedDisplay" | "remainingDispla
   const usedPercent = normalizePercent(quota.usedPercent);
   const remainingPercent = normalizePercent(quota.remainingPercent);
   const resetsAt = quota.resetsAt?.trim() || undefined;
+  // Round consistently so usedDisplay + remainingDisplay always sums to 100.
+  const roundedUsed = Math.round(usedPercent);
   return {
     ...quota,
     usedPercent,
     remainingPercent,
-    usedDisplay: `${Math.round(usedPercent)}%`,
-    remainingDisplay: `${Math.round(remainingPercent)}%`,
+    usedDisplay: `${roundedUsed}%`,
+    remainingDisplay: `${100 - roundedUsed}%`,
     resetsAt,
     stale: quota.stale ?? isResetStale(resetsAt, now),
   };
@@ -462,13 +498,13 @@ function quotaLabel(key: string): string {
   return key;
 }
 
-const CODEX_REQUEST_TIMEOUT_MS = 12_000;
+const CODEX_REQUEST_TIMEOUT_MS = 20_000;
 
 // chatgpt.com is unreachable directly on many networks; Node's https does not honor proxy
 // env vars, so we resolve one here and tunnel through it via HTTP CONNECT. SOCKS proxies are
 // skipped because CONNECT tunneling only works with http(s) proxies.
 export function selectProxyUrl(env: Record<string, string | undefined> = process.env): string | undefined {
-  const candidates = [env.HTTPS_PROXY, env.https_proxy, env.ALL_PROXY, env.all_proxy];
+  const candidates = [env.HTTPS_PROXY, env.https_proxy, env.HTTP_PROXY, env.http_proxy, env.ALL_PROXY, env.all_proxy];
   for (const raw of candidates) {
     const value = raw?.trim();
     if (!value) continue;
@@ -480,24 +516,44 @@ export function selectProxyUrl(env: Record<string, string | undefined> = process
 
 async function fetchCodexUsageHTTP(accessToken: string, accountId: string, options: { proxyUrl?: string } = {}): Promise<CodexUsageResponse> {
   if (process.platform === "win32") {
-    try {
-      return await doCodexUsagePowerShellRequest(CODEX_USAGE_PRIMARY_URL, accessToken, accountId);
-    } catch (error) {
-      if (error instanceof CodexHttpError && error.statusCode === 404) {
-        return doCodexUsagePowerShellRequest(CODEX_USAGE_FALLBACK_URL, accessToken, accountId);
-      }
-      throw error;
-    }
+    return codexRequestWith404Fallback(
+      () => doCodexUsagePowerShellRequest(CODEX_USAGE_PRIMARY_URL, accessToken, accountId),
+      () => doCodexUsagePowerShellRequest(CODEX_USAGE_FALLBACK_URL, accessToken, accountId),
+    );
   }
 
+  // On macOS/Linux, prefer a Python subprocess: Node's bundled TLS ClientHello fingerprint is
+  // silently dropped by chatgpt.com's Cloudflare edge (the connection hangs until timeout),
+  // while Python's system-OpenSSL handshake passes through. Falls back to the Node https path
+  // only when python3 is not on PATH.
   try {
-    return await doCodexUsageRequest(CODEX_USAGE_PRIMARY_URL, accessToken, accountId, options.proxyUrl);
+    return await codexRequestWith404Fallback(
+      () => doCodexUsagePythonRequest(CODEX_USAGE_PRIMARY_URL, accessToken, accountId, options.proxyUrl),
+      () => doCodexUsagePythonRequest(CODEX_USAGE_FALLBACK_URL, accessToken, accountId, options.proxyUrl),
+    );
   } catch (error) {
-    if (error instanceof CodexHttpError && error.statusCode === 404) {
-      return doCodexUsageRequest(CODEX_USAGE_FALLBACK_URL, accessToken, accountId, options.proxyUrl);
-    }
+    if (!isCodexPythonUnavailable(error)) throw error;
+    return codexRequestWith404Fallback(
+      () => doCodexUsageRequest(CODEX_USAGE_PRIMARY_URL, accessToken, accountId, options.proxyUrl),
+      () => doCodexUsageRequest(CODEX_USAGE_FALLBACK_URL, accessToken, accountId, options.proxyUrl),
+    );
+  }
+}
+
+async function codexRequestWith404Fallback(
+  primary: () => Promise<CodexUsageResponse>,
+  fallback: () => Promise<CodexUsageResponse>,
+): Promise<CodexUsageResponse> {
+  try {
+    return await primary();
+  } catch (error) {
+    if (error instanceof CodexHttpError && error.statusCode === 404) return fallback();
     throw error;
   }
+}
+
+function isCodexPythonUnavailable(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException)?.code === "ENOENT";
 }
 
 function doCodexUsagePowerShellRequest(endpoint: string, accessToken: string, accountId: string): Promise<CodexUsageResponse> {
@@ -546,6 +602,95 @@ try {
       },
       (error, stdout, stderr) => {
         if (error) {
+          const message = stderr.trim() || error.message;
+          const statusCode = Number(message.match(/HTTP\s+(\d+)/)?.[1]);
+          if (Number.isFinite(statusCode)) {
+            reject(new CodexHttpError(codexHttpStatusMessage(statusCode), statusCode));
+            return;
+          }
+          reject(new Error(message));
+          return;
+        }
+        try {
+          resolve(JSON.parse(stdout) as CodexUsageResponse);
+        } catch (parseError) {
+          reject(parseError instanceof Error ? new Error(`Invalid Codex usage response: ${parseError.message}`) : parseError);
+        }
+      },
+    );
+  });
+}
+
+export function doCodexUsagePythonRequest(endpoint: string, accessToken: string, accountId: string, proxyUrl?: string): Promise<CodexUsageResponse> {
+  // urllib's default opener honors both *_proxy env vars and macOS SystemConfiguration proxies;
+  // Node's https honors neither unless wired up by hand. For users whose only proxy is set at the
+  // OS level (no env vars), the Node path connects directly to chatgpt.com and times out, while
+  // Python transparently routes through the system proxy. An explicit proxyUrl from selectProxyUrl
+  // (env-var based) overrides this when present.
+  const script = `
+import os, sys, urllib.request, urllib.error
+
+url = os.environ["AGENT_SESSION_SEARCH_CODEX_USAGE_URL"]
+token = os.environ["AGENT_SESSION_SEARCH_CODEX_ACCESS_TOKEN"]
+account = (os.environ.get("AGENT_SESSION_SEARCH_CODEX_ACCOUNT_ID") or "").strip()
+proxy_url = (os.environ.get("AGENT_SESSION_SEARCH_CODEX_PROXY") or "").strip()
+
+headers = {
+    "Accept": "application/json",
+    "Authorization": "Bearer " + token,
+    "User-Agent": "agent-session-search",
+}
+if account:
+    headers["X-Account-Id"] = account
+    headers["ChatClaude-Account-Id"] = account
+    headers["ChatGPT-Account-Id"] = account
+
+if proxy_url:
+    opener = urllib.request.build_opener(
+        urllib.request.ProxyHandler({"http": proxy_url, "https": proxy_url})
+    )
+else:
+    # Default handlers install a ProxyHandler that reads macOS SystemConfiguration proxies AND
+    # *_proxy env vars — this is exactly what the Node path is missing.
+    opener = urllib.request.build_opener()
+req = urllib.request.Request(url, headers=headers, method="GET")
+
+try:
+    resp = opener.open(req, timeout=15)
+except urllib.error.HTTPError as exc:
+    sys.stderr.write("HTTP {}".format(exc.code))
+    sys.exit(1)
+except Exception as exc:
+    name = type(exc).__name__
+    sys.stderr.write(name + (": " + str(exc) if str(exc) else ""))
+    sys.exit(1)
+else:
+    sys.stdout.buffer.write(resp.read())
+`;
+
+  return new Promise((resolve, reject) => {
+    execFile(
+      "python3",
+      ["-c", script],
+      {
+        timeout: CODEX_REQUEST_TIMEOUT_MS,
+        maxBuffer: HTTP_BODY_LIMIT,
+        env: {
+          ...process.env,
+          AGENT_SESSION_SEARCH_CODEX_USAGE_URL: endpoint,
+          AGENT_SESSION_SEARCH_CODEX_ACCESS_TOKEN: accessToken,
+          AGENT_SESSION_SEARCH_CODEX_ACCOUNT_ID: accountId,
+          AGENT_SESSION_SEARCH_CODEX_PROXY: proxyUrl ?? "",
+        },
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+            const err = new Error("python3 is not installed on PATH.");
+            (err as NodeJS.ErrnoException).code = "ENOENT";
+            reject(err);
+            return;
+          }
           const message = stderr.trim() || error.message;
           const statusCode = Number(message.match(/HTTP\s+(\d+)/)?.[1]);
           if (Number.isFinite(statusCode)) {


### PR DESCRIPTION
## 背景

修复两类额度(quota)显示问题:Codex 在部分网络环境下拉不到额度,以及 Claude Code 额度面板会间歇性变空。

## 改动

### Claude Code 额度间歇性丢失(`0068683`)
- 根因:Claude Code 的 statusLine payload **并非每次渲染都带 `rate_limits`/`plan`**(刚启动、某些刷新时机会缺)。桥接脚本每次全量覆盖快照,只要遇到一次缺字段的 payload,就把上次的好数据冲成空快照,额度面板随即变空,直到下次恰好带数据的渲染才恢复。
- 修复:写快照前先读旧快照,新 payload 缺 `rate_limits`/`plan` 时**保留上次的值**;过期仍由 `quota.ts` 基于 `resets_at` 的 stale 检测兜底。

### Codex 额度拉取与解析加固(`e9e2809`)
- macOS/Linux 改用 `python3` 子进程拉取 Codex usage(Node 的 TLS ClientHello 会被 chatgpt.com 的 Cloudflare 边缘丢弃导致超时),`python3` 不可用时回退到原 Node https 路径。
- 通过 python urllib 走系统级代理;env 代理链补充 `HTTP_PROXY` / `http_proxy`。
- 字段容错:`percent_left` / `remaining_percent` 反推已用百分比,`reset_after_seconds` 推算重置时间;兼容 `used_percentage` / `remaining_percentage` 命名。
- 修复 `quotas` 格式分支强制 `stale=false` 导致基于 `resets_at` 的过期自动检测失效的问题;清理重复 helper 与多余类型断言。

## 测试
- `tsc --noEmit` 通过
- quota / quota-proxy / claude-statusline-snapshot 全部测试通过(含新增回归测试)