### PR TITLE
fix: Windows 下 Codex MCP 配置生成合法 TOML

### DIFF
--- a/bin/setup-mcp.cjs
+++ b/bin/setup-mcp.cjs
@@ -79,7 +79,9 @@ function applyClaudeConfig(config, scriptPath, remove, command = "node") {
 // --- Codex (~/.codex/config.toml, TOML) ------------------------------------
 
 function applyCodexConfig(toml, scriptPath, remove, command = "node") {
-  const block = `[${CODEX_SECTION}]\ncommand = ${JSON.stringify(command)}\nargs = ["${scriptPath}"]\n`;
+  // JSON.stringify both values: TOML basic-string escapes (\\, \") match JSON, so
+  // Windows paths with backslashes stay valid.
+  const block = `[${CODEX_SECTION}]\ncommand = ${JSON.stringify(command)}\nargs = [${JSON.stringify(scriptPath)}]\n`;
   const stripped = removeCodexBlock(toml);
   if (remove) return stripped;
   const base = stripped.trim();

--- a/src/core/setup-mcp.test.ts
+++ b/src/core/setup-mcp.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 const require = createRequire(import.meta.url);
 const { applyClaudeConfig, applyCodexConfig, removeCodexBlock } = require(path.resolve("bin", "setup-mcp.cjs")) as {
   applyClaudeConfig: (config: unknown, scriptPath: string, remove: boolean) => Record<string, unknown>;
-  applyCodexConfig: (toml: string, scriptPath: string, remove: boolean) => string;
+  applyCodexConfig: (toml: string, scriptPath: string, remove: boolean, command?: string) => string;
   removeCodexBlock: (toml: string) => string;
 };
 
@@ -44,5 +44,11 @@ describe("setup-mcp Codex config", () => {
     expect(removed).not.toContain("mcp_servers.agent_session_search");
     expect(removed).toContain("[other]");
     expect(removeCodexBlock(removed)).toBe(removed);
+  });
+
+  it("escapes Windows backslash paths into valid TOML", () => {
+    const toml = applyCodexConfig("", "C:\\Users\\me\\bin\\server.mjs", false, "C:\\Program Files\\nodejs\\node.exe");
+    expect(toml).toContain('args = ["C:\\\\Users\\\\me\\\\bin\\\\server.mjs"]');
+    expect(toml).toContain('command = "C:\\\\Program Files\\\\nodejs\\\\node.exe"');
   });
 });


### PR DESCRIPTION
setup-mcp 之前用裸字符串拼接 Codex `config.toml` 的 args,Windows 路径里的反斜杠会变成非法 TOML 转义,导致 Codex 读不到 MCP server。改用 JSON.stringify 序列化脚本路径与命令(其转义规则与 TOML 基本字符串一致)。Claude/CodeBuddy 走 JSON 配置,本就安全。

附带新增一个 Windows 路径转义的单测。仅此一处与 Windows 相关;通知已有 `setAppUserModelId` 兜底,其余新功能(AI 摘要 / MCP server / 翻页)均与平台无关。