### PR TITLE
fix: 修正 token 统计的准确性（cache-creation 与 Codex 累计值）

### DIFF
--- a/src/core/session-loader.test.ts
+++ b/src/core/session-loader.test.ts
@@ -127,6 +127,74 @@ describe("Codex session loading", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("uses the cumulative total_token_usage rather than summing per-turn last usage", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-"));
+    const filePath = path.join(dir, "rollout.jsonl");
+    fs.writeFileSync(
+      filePath,
+      [
+        JSON.stringify({
+          type: "session_meta",
+          timestamp: "2026-06-01T10:00:00Z",
+          payload: { id: "codex-total-1", cwd: "/repo" },
+        }),
+        JSON.stringify({
+          type: "event_msg",
+          timestamp: "2026-06-01T10:01:00Z",
+          payload: {
+            type: "token_count",
+            info: {
+              model: "gpt-5-codex",
+              last_token_usage: { input_tokens: 1000, output_tokens: 200 },
+              total_token_usage: { input_tokens: 1000, output_tokens: 200 },
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "event_msg",
+          timestamp: "2026-06-01T10:02:00Z",
+          payload: {
+            type: "token_count",
+            info: {
+              model: "gpt-5-codex",
+              // last reflects only the final request of the turn (1200 input),
+              // but the cumulative total grew to 4000 input because intermediate
+              // tool-call requests were not emitted as their own last usage.
+              last_token_usage: { input_tokens: 1200, cached_input_tokens: 1000, output_tokens: 100, reasoning_output_tokens: 10 },
+              total_token_usage: { input_tokens: 4000, cached_input_tokens: 1000, output_tokens: 600, reasoning_output_tokens: 60 },
+            },
+          },
+        }),
+      ].join("\n"),
+    );
+
+    const loaded = loadCodexSessionFile(filePath);
+
+    // Authoritative cumulative total: input 4000 - cached 1000 = 3000 fresh,
+    // output 600 - reasoning 60 = 540, cached 1000, reasoning 60.
+    // (Summing per-turn last usage would wrongly yield input 1200, output 290.)
+    expect(loaded?.session.tokenUsage).toEqual({
+      inputTokens: 3000,
+      outputTokens: 540,
+      cachedInputTokens: 1000,
+      reasoningOutputTokens: 60,
+      totalTokens: 4600,
+    });
+    expect(loaded?.tokenEvents).toEqual([
+      {
+        dedupeKey: "codex-total:gpt-5-codex",
+        timestamp: new Date("2026-06-01T10:02:00Z").getTime(),
+        inputTokens: 3000,
+        outputTokens: 540,
+        cachedInputTokens: 1000,
+        reasoningOutputTokens: 60,
+        totalTokens: 4600,
+      },
+    ]);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("extracts Codex tool calls and execution events as trace events", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-"));
     const filePath = path.join(dir, "rollout.jsonl");
@@ -418,6 +486,55 @@ describe("Claude session loading", () => {
         totalTokens: 1360,
       },
     ]);
+
+    fs.rmSync(claudeDir, { recursive: true, force: true });
+  });
+
+  it("counts cache_creation_input_tokens as processed input", () => {
+    const claudeDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-claude-"));
+    const projectDir = path.join(claudeDir, "projects", "-repo");
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDir, "claude-cache-create.jsonl"),
+      [
+        JSON.stringify({
+          type: "user",
+          timestamp: "2026-06-01T10:00:00Z",
+          cwd: "/repo",
+          sessionId: "claude-cache-create",
+          message: { role: "user", content: "首轮请求会写入缓存" },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          timestamp: "2026-06-01T10:01:00Z",
+          cwd: "/repo",
+          sessionId: "claude-cache-create",
+          message: {
+            id: "msg_cache",
+            role: "assistant",
+            content: "好的",
+            usage: {
+              input_tokens: 500,
+              output_tokens: 100,
+              cache_creation_input_tokens: 2000,
+              cache_read_input_tokens: 300,
+            },
+          },
+        }),
+      ].join("\n"),
+    );
+
+    const loaded = loadClaudeCliSessions(claudeDir);
+
+    // cached bucket = cache_read 300 + cache_creation 2000 = 2300; the 2000
+    // cache-creation tokens were previously dropped entirely.
+    expect(loaded[0].session.tokenUsage).toEqual({
+      inputTokens: 500,
+      outputTokens: 100,
+      cachedInputTokens: 2300,
+      reasoningOutputTokens: 0,
+      totalTokens: 2900,
+    });
 
     fs.rmSync(claudeDir, { recursive: true, force: true });
   });

--- a/src/core/session-loader.ts
+++ b/src/core/session-loader.ts
@@ -468,9 +468,35 @@ function tokenUsageFromEvents(events: TokenUsageEvent[]): TokenUsage {
   return total;
 }
 
+// Codex reports OpenAI-style usage where `input_tokens` already includes cached
+// tokens and `output_tokens` already includes reasoning tokens. Split them into
+// the distinct buckets createTokenUsage expects (input excludes cached, output
+// excludes reasoning) so the summed total matches Codex's own accounting.
+function normalizeCodexUsage(usage: Record<string, unknown>): {
+  input: number;
+  output: number;
+  cached: number;
+  reasoning: number;
+} {
+  const cached = numberField(usage, "cached_input_tokens") + numberField(usage, "cache_read_input_tokens");
+  const reasoning = numberField(usage, "reasoning_output_tokens");
+  return {
+    input: Math.max(0, numberField(usage, "input_tokens") - cached),
+    output: Math.max(0, numberField(usage, "output_tokens") - reasoning),
+    cached,
+    reasoning,
+  };
+}
+
 function extractCodexTokenEvents(rows: unknown[]): TokenUsageEvent[] {
   const entries = new Map<string, TokenUsageEvent>();
   let currentModel = "";
+  // Codex carries a running cumulative `total_token_usage` on every token_count
+  // event; the final one is the authoritative session total. Prefer it over
+  // summing per-turn `last_token_usage`, which omits intermediate requests made
+  // within a single turn (e.g. tool-call round-trips) and undercounts. Fall back
+  // to summing last_token_usage only when no cumulative total is present.
+  let authoritative: TokenUsageEvent | null = null;
 
   for (const row of rows) {
     if (!isRecord(row)) continue;
@@ -481,24 +507,26 @@ function extractCodexTokenEvents(rows: unknown[]): TokenUsageEvent[] {
     }
     if (row.type !== "event_msg" || stringField(payload, "type") !== "token_count") continue;
     const info = objectField(payload, "info");
-    const usage = objectField(info, "last_token_usage") || objectField(info, "total_token_usage");
-    if (!usage) continue;
-    const totalUsage = objectField(info, "total_token_usage");
-
-    const rawInput = numberField(usage, "input_tokens");
-    const rawOutput = numberField(usage, "output_tokens");
-    const cached = numberField(usage, "cached_input_tokens") + numberField(usage, "cache_read_input_tokens");
-    const reasoning = numberField(usage, "reasoning_output_tokens");
-    const normalizedInput = Math.max(0, rawInput - cached);
-    const normalizedOutput = Math.max(0, rawOutput - reasoning);
     const model = stringField(info, "model") || currentModel;
-    const totalInput = numberField(totalUsage, "input_tokens");
-    const totalOutput = numberField(totalUsage, "output_tokens");
-    const key = ["codex", model, normalizedInput, normalizedOutput, cached, reasoning, totalInput, totalOutput].join(":");
-    putTokenEvent(entries, tokenEvent(parseTimestampMs(row.timestamp), key, normalizedInput, normalizedOutput, cached, reasoning));
+    const timestamp = parseTimestampMs(row.timestamp);
+
+    const totalUsage = objectField(info, "total_token_usage");
+    if (totalUsage) {
+      const t = normalizeCodexUsage(totalUsage);
+      authoritative = tokenEvent(timestamp, `codex-total:${model}`, t.input, t.output, t.cached, t.reasoning);
+    }
+
+    const lastUsage = objectField(info, "last_token_usage");
+    if (lastUsage) {
+      const l = normalizeCodexUsage(lastUsage);
+      const totalInput = numberField(totalUsage, "input_tokens");
+      const totalOutput = numberField(totalUsage, "output_tokens");
+      const key = ["codex", model, l.input, l.output, l.cached, l.reasoning, totalInput, totalOutput].join(":");
+      putTokenEvent(entries, tokenEvent(timestamp, key, l.input, l.output, l.cached, l.reasoning));
+    }
   }
 
-  return [...entries.values()];
+  return authoritative ? [authoritative] : [...entries.values()];
 }
 
 function extractClaudeTokenEvents(rows: unknown[]): TokenUsageEvent[] {
@@ -510,7 +538,14 @@ function extractClaudeTokenEvents(rows: unknown[]): TokenUsageEvent[] {
     const usage = objectField(message, "usage");
     if (!usage) return;
 
-    const cached = numberField(usage, "cache_read_input_tokens") + numberField(usage, "cached_input_tokens");
+    // Anthropic splits input across three billed buckets: fresh `input_tokens`,
+    // `cache_creation_input_tokens` (written to cache, billed ~1.25x) and
+    // `cache_read_input_tokens` (cache hit, billed ~0.1x). All three are really
+    // processed, so the cache buckets belong in the cached total.
+    const cached =
+      numberField(usage, "cache_read_input_tokens") +
+      numberField(usage, "cached_input_tokens") +
+      numberField(usage, "cache_creation_input_tokens");
     const entry = createTokenUsage(
       numberField(usage, "input_tokens"),
       numberField(usage, "output_tokens"),


### PR DESCRIPTION
## 背景

对照 Claude Code 与 Codex 的 token 统计逻辑，发现两处会导致**少算**真实消耗的问题。目标是让统计口径准确反映「整个会话实际处理/计费的 token 总量」（缓存命中虽折扣计费，但确实被处理，应计入）。

## 改动

**1. Claude 补上 `cache_creation_input_tokens`**

之前 `cached` 只统计 `cache_read_input_tokens` + `cached_input_tokens`，完全丢掉了写入缓存的输入 token（按约 1.25x 计费）。Anthropic 的输入分三桶：`input_tokens`（新）+ `cache_creation`（写缓存）+ `cache_read`（命中），三者都是真实处理量。现已全部计入。

**2. Codex 改用累计真值 `total_token_usage`**

之前累加每个 `token_count` 事件的 `last_token_usage`，而 `last` 只反映一轮里最后一次请求，会漏掉同一轮内工具调用产生的中间请求 → 少算。Codex 在每个事件上自带累计的 `total_token_usage`（此前仅用于 dedupe key）。现改为：存在 `total_token_usage` 时取最后一个作为权威累计，否则回退到累加 `last`（兼容精简数据）。

顺带将 Codex 归一化逻辑抽成 `normalizeCodexUsage`，供 `last` / `total` 两条路径共用。