### PR TITLE
feat: AI session finder (conversational search with tool calling + local CLI fallback)

### DIFF
--- a/src/core/ai-assistant.test.ts
+++ b/src/core/ai-assistant.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from "vitest";
 import {
+  isLocalCliEndpoint,
+  runAiAssistantFallback,
   runAiAssistantTurn,
   type AiChatMessage,
+  type FallbackSessionHit,
   type SummaryEndpoint,
   type ToolChatCompletionFn,
   type ToolExecutor,
 } from "./ai-assistant";
 
 const endpoint: SummaryEndpoint = { baseUrl: "http://x", model: "m", apiKey: "k", apiFormat: "openai_chat" };
+const codexEndpoint: SummaryEndpoint = { baseUrl: "", model: "codex", apiKey: "", apiFormat: "codex_exec", command: "codex" };
 
 describe("runAiAssistantTurn", () => {
   it("executes a tool call, feeds the result back, and returns the final reply with surfaced sessionKeys", async () => {
@@ -82,5 +86,62 @@ describe("runAiAssistantTurn", () => {
     expect(result.reply).toBe("I hit an error but here is what I can say.");
     const toolMsg = captured[1].find((m) => m.role === "tool");
     expect(toolMsg?.content).toContain("db is locked");
+  });
+});
+
+describe("isLocalCliEndpoint", () => {
+  it("flags codex_exec and claude_exec, not HTTP formats", () => {
+    expect(isLocalCliEndpoint(codexEndpoint)).toBe(true);
+    expect(isLocalCliEndpoint({ ...codexEndpoint, apiFormat: "claude_exec" })).toBe(true);
+    expect(isLocalCliEndpoint(endpoint)).toBe(false);
+    expect(isLocalCliEndpoint({ ...endpoint, apiFormat: "anthropic" })).toBe(false);
+  });
+});
+
+describe("runAiAssistantFallback", () => {
+  it("searches with the user's words and asks the CLI to ground its answer over the hits", async () => {
+    const hits: FallbackSessionHit[] = [
+      { sessionKey: "s1", title: "Fix SQLite migration", source: "claude-cli", project: "/p", summary: "fixed it" },
+      { sessionKey: "s2", title: "Other", source: "codex-cli", project: "/q", summary: null },
+    ];
+    let searchedQuery = "";
+    const search = async (query: string): Promise<FallbackSessionHit[]> => {
+      searchedQuery = query;
+      return hits;
+    };
+    let promptSeen = "";
+    const complete = async (_e: SummaryEndpoint, messages: { role: string; content: string }[]) => {
+      promptSeen = messages.map((m) => m.content).join("\n");
+      return "The first session matches best.";
+    };
+
+    const history: AiChatMessage[] = [{ role: "user", content: "find my sqlite migration fix" }];
+    const result = await runAiAssistantFallback(codexEndpoint, history, search, { complete });
+
+    expect(searchedQuery).toBe("find my sqlite migration fix");
+    expect(result.reply).toBe("The first session matches best.");
+    expect(result.sessionKeys).toEqual(["s1", "s2"]);
+    // The CLI prompt must include the candidate catalog so the answer is grounded.
+    expect(promptSeen).toContain("Fix SQLite migration");
+    expect(promptSeen).toContain("[1]");
+  });
+
+  it("tells the CLI when nothing matched", async () => {
+    const search = async (): Promise<FallbackSessionHit[]> => [];
+    let promptSeen = "";
+    const complete = async (_e: SummaryEndpoint, messages: { role: string; content: string }[]) => {
+      promptSeen = messages.map((m) => m.content).join("\n");
+      return "No matching sessions; try other keywords.";
+    };
+
+    const result = await runAiAssistantFallback(
+      codexEndpoint,
+      [{ role: "user", content: "nonexistent topic" }],
+      search,
+      { complete },
+    );
+
+    expect(result.sessionKeys).toEqual([]);
+    expect(promptSeen).toContain("No sessions matched");
   });
 });

--- a/src/core/ai-assistant.test.ts
+++ b/src/core/ai-assistant.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  runAiAssistantTurn,
+  type AiChatMessage,
+  type SummaryEndpoint,
+  type ToolChatCompletionFn,
+  type ToolExecutor,
+} from "./ai-assistant";
+
+const endpoint: SummaryEndpoint = { baseUrl: "http://x", model: "m", apiKey: "k", apiFormat: "openai_chat" };
+
+describe("runAiAssistantTurn", () => {
+  it("executes a tool call, feeds the result back, and returns the final reply with surfaced sessionKeys", async () => {
+    // Round 1: model asks to search. Round 2: model answers in plain text.
+    const chatTurns: Array<{ content: string; toolCalls: { id: string; name: string; arguments: string }[] }> = [
+      { content: "", toolCalls: [{ id: "c1", name: "search_sessions", arguments: JSON.stringify({ query: "sqlite migration" }) }] },
+      { content: "Found the session where you fixed the SQLite migration.", toolCalls: [] },
+    ];
+    const sentMessages: AiChatMessage[][] = [];
+    const chat: ToolChatCompletionFn = async (_endpoint, messages) => {
+      sentMessages.push(messages);
+      return chatTurns.shift()!;
+    };
+
+    const executed: Array<{ name: string; args: Record<string, unknown> }> = [];
+    const executeTool: ToolExecutor = async (name, args) => {
+      executed.push({ name, args });
+      return {
+        result: [{ sessionKey: "sess-42", title: "Fix migration" }],
+        sessionKeys: ["sess-42"],
+      };
+    };
+
+    const result = await runAiAssistantTurn(endpoint, [{ role: "user", content: "find my sqlite migration fix" }], executeTool, {
+      chat,
+    });
+
+    expect(executed).toEqual([{ name: "search_sessions", args: { query: "sqlite migration" } }]);
+    expect(result.reply).toBe("Found the session where you fixed the SQLite migration.");
+    expect(result.sessionKeys).toEqual(["sess-42"]);
+    // The second LLM call must include the tool result so the model can answer.
+    const secondCall = sentMessages[1];
+    expect(secondCall.some((m) => m.role === "tool" && m.content.includes("sess-42"))).toBe(true);
+  });
+
+  it("dedupes sessionKeys surfaced across multiple tool calls", async () => {
+    const chatTurns: Array<{ content: string; toolCalls: { id: string; name: string; arguments: string }[] }> = [
+      {
+        content: "",
+        toolCalls: [
+          { id: "a", name: "search_sessions", arguments: JSON.stringify({ query: "auth" }) },
+          { id: "b", name: "get_session", arguments: JSON.stringify({ sessionKey: "dup" }) },
+        ],
+      },
+      { content: "done", toolCalls: [] },
+    ];
+    const chat: ToolChatCompletionFn = async () => chatTurns.shift()!;
+    const executeTool: ToolExecutor = async (name) => ({
+      result: {},
+      sessionKeys: name === "search_sessions" ? ["dup", "other"] : ["dup"],
+    });
+
+    const result = await runAiAssistantTurn(endpoint, [{ role: "user", content: "x" }], executeTool, { chat });
+    expect(result.sessionKeys).toEqual(["dup", "other"]);
+  });
+
+  it("captures a tool execution error and still completes", async () => {
+    const chatTurns: Array<{ content: string; toolCalls: { id: string; name: string; arguments: string }[] }> = [
+      { content: "", toolCalls: [{ id: "c1", name: "search_sessions", arguments: "{}" }] },
+      { content: "I hit an error but here is what I can say.", toolCalls: [] },
+    ];
+    const captured: AiChatMessage[][] = [];
+    const chat: ToolChatCompletionFn = async (_e, messages) => {
+      captured.push(messages);
+      return chatTurns.shift()!;
+    };
+    const executeTool: ToolExecutor = async () => {
+      throw new Error("db is locked");
+    };
+
+    const result = await runAiAssistantTurn(endpoint, [{ role: "user", content: "x" }], executeTool, { chat });
+    expect(result.reply).toBe("I hit an error but here is what I can say.");
+    const toolMsg = captured[1].find((m) => m.role === "tool");
+    expect(toolMsg?.content).toContain("db is locked");
+  });
+});

--- a/src/core/ai-assistant.ts
+++ b/src/core/ai-assistant.ts
@@ -11,7 +11,7 @@
 // and Anthropic /v1/messages) but adds tool support. Network functions are
 // injectable so the tool-call loop is unit-testable without a real provider.
 
-import type { SummaryEndpoint } from "./session-summarizer";
+import { requestSummaryCompletion, type ChatMessage, type SummaryEndpoint } from "./session-summarizer";
 
 export type { SummaryEndpoint } from "./session-summarizer";
 
@@ -159,6 +159,80 @@ export async function runAiAssistantTurn(
   // Hit the round cap: ask once more for a final answer with tools disabled.
   const final = await chat(endpoint, [...messages, { role: "user", content: "Summarize what you found so far." }], options.signal);
   return { reply: final.content.trim(), sessionKeys: dedupe(sessionKeys) };
+}
+
+// Endpoints that run a local CLI (`codex exec` / `claude`) cannot use our HTTP
+// function-calling protocol — they are one-shot text completions. For those we
+// fall back to a degraded flow: search the store with the user's own words, then
+// ask the CLI to write a natural-language answer grounded in the results.
+export function isLocalCliEndpoint(endpoint: SummaryEndpoint): boolean {
+  return endpoint.apiFormat === "codex_exec" || endpoint.apiFormat === "claude_exec";
+}
+
+// A session hit handed to the fallback so it can be described to the CLI and
+// surfaced as a clickable card.
+export interface FallbackSessionHit {
+  sessionKey: string;
+  title: string;
+  source: string;
+  project: string;
+  summary: string | null;
+}
+
+// Injected by the caller: runs a keyword search against the store and returns
+// the hits (already shaped for the prompt + cards).
+export type FallbackSearchFn = (query: string) => Promise<FallbackSessionHit[]>;
+
+// A plain (no-tools) completion. Defaults to the summarizer's completion, which
+// already routes codex_exec / claude_exec / HTTP formats.
+export type PlainCompletionFn = (endpoint: SummaryEndpoint, messages: ChatMessage[], signal?: AbortSignal) => Promise<string>;
+
+const FALLBACK_SYSTEM_PROMPT =
+  "You help a developer find a past AI-coding session. You are given the user's request and a list of candidate " +
+  "sessions already retrieved from their local history (each with an index, title, source, project, and summary). " +
+  "Pick the best matches, answer briefly in the same language the user wrote in, and refer to sessions by their " +
+  "title. If none fit, say so and suggest different keywords. Do not invent sessions.";
+
+// Pulls plain keywords from the latest user message for the store's FTS search.
+// We strip punctuation and keep it simple — the store does the real matching.
+export function extractFallbackQuery(history: readonly AiChatMessage[]): string {
+  for (let i = history.length - 1; i >= 0; i -= 1) {
+    if (history[i].role === "user") return history[i].content.trim();
+  }
+  return "";
+}
+
+export async function runAiAssistantFallback(
+  endpoint: SummaryEndpoint,
+  history: AiChatMessage[],
+  search: FallbackSearchFn,
+  options: { complete?: PlainCompletionFn; signal?: AbortSignal } = {},
+): Promise<AiAssistantReplyInternal> {
+  const complete = options.complete ?? requestSummaryCompletion;
+  const query = extractFallbackQuery(history);
+  const hits = query ? await search(query) : [];
+
+  const catalog = hits
+    .map((hit, index) => {
+      const summary = hit.summary ? ` — ${hit.summary}` : "";
+      return `[${index + 1}] ${hit.title} (source: ${hit.source}; project: ${hit.project || "n/a"})${summary}`;
+    })
+    .join("\n");
+
+  const userPrompt = hits.length
+    ? `User request: ${query}\n\nCandidate sessions:\n${catalog}\n\nWhich of these best match, and why?`
+    : `User request: ${query}\n\nNo sessions matched a keyword search of the local history.`;
+
+  const reply = await complete(
+    endpoint,
+    [
+      { role: "system", content: FALLBACK_SYSTEM_PROMPT },
+      { role: "user", content: userPrompt },
+    ],
+    options.signal,
+  );
+
+  return { reply: reply.trim(), sessionKeys: dedupe(hits.map((hit) => hit.sessionKey)) };
 }
 
 function parseToolArgs(raw: string): Record<string, unknown> {

--- a/src/core/ai-assistant.ts
+++ b/src/core/ai-assistant.ts
@@ -1,0 +1,351 @@
+// Conversational AI assistant that finds past sessions by calling search tools.
+//
+// The model is given function-calling tools mirroring the MCP server
+// (search_sessions / list_projects / list_tags / get_session). It decides which
+// tools to call, we execute them against the local SessionStore, feed results
+// back, and loop until the model produces a final text answer. Along the way we
+// collect every sessionKey the model surfaced so the UI can render clickable
+// session cards.
+//
+// The transport layer mirrors session-summarizer.ts (OpenAI /chat/completions
+// and Anthropic /v1/messages) but adds tool support. Network functions are
+// injectable so the tool-call loop is unit-testable without a real provider.
+
+import type { SummaryEndpoint } from "./session-summarizer";
+
+export type { SummaryEndpoint } from "./session-summarizer";
+
+// A chat message in our neutral representation. Tool results are carried as a
+// `tool` role with the originating call id so both provider formats can rebuild
+// their own wire shape.
+export interface AiChatMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string;
+  // Present on assistant turns that requested tool calls.
+  toolCalls?: AiToolCall[];
+  // Present on `tool` messages: which call this is answering.
+  toolCallId?: string;
+  toolName?: string;
+}
+
+export interface AiToolCall {
+  id: string;
+  name: string;
+  // Raw JSON arguments string as emitted by the model.
+  arguments: string;
+}
+
+// What the main process injects: runs one tool and returns a JSON-serializable
+// result, plus the sessionKeys that result surfaced (for UI cards).
+export interface ToolExecutionResult {
+  result: unknown;
+  sessionKeys: string[];
+}
+
+export type ToolExecutor = (name: string, args: Record<string, unknown>) => Promise<ToolExecutionResult>;
+
+export interface AiAssistantReplyInternal {
+  reply: string;
+  sessionKeys: string[];
+}
+
+export const AI_ASSISTANT_SYSTEM_PROMPT =
+  "You are the session-search assistant inside a desktop app that indexes the user's past AI coding sessions " +
+  "(Claude Code, Codex, CodeBuddy, etc.). The user describes a session they are trying to find; your job is to " +
+  "locate it. ALWAYS use the provided tools to search — never guess from memory. Prefer search_sessions with " +
+  "concise keywords; call it multiple times with different keywords if the first attempt misses. Use list_projects " +
+  "or list_tags to narrow scope when helpful, and get_session to confirm a candidate. " +
+  "When you have results, reply briefly (in the same language the user wrote in) and explain why each match fits. " +
+  "Do not invent sessionKeys. If nothing matches, say so and suggest different keywords.";
+
+// Tool schema in a neutral shape; converted per-provider below.
+interface ToolSchema {
+  name: string;
+  description: string;
+  parameters: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+}
+
+export const AI_TOOL_SCHEMAS: ToolSchema[] = [
+  {
+    name: "search_sessions",
+    description:
+      "Search past AI coding sessions by keywords. Matches titles, first questions, transcripts, and AI summaries.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Keywords to search for." },
+        source: { type: "string", description: "Optional source filter, e.g. claude-cli or codex-cli." },
+        project: { type: "string", description: "Optional substring match on the project path." },
+        limit: { type: "number", description: "Max results (1-50, default 20)." },
+      },
+    },
+  },
+  {
+    name: "list_projects",
+    description: "List indexed projects with their session counts.",
+    parameters: { type: "object", properties: {} },
+  },
+  {
+    name: "list_tags",
+    description: "List all user-created tags.",
+    parameters: { type: "object", properties: {} },
+  },
+  {
+    name: "get_session",
+    description: "Fetch a single session's metadata, AI summary, and messages by its sessionKey.",
+    parameters: {
+      type: "object",
+      properties: {
+        sessionKey: { type: "string", description: "Session key from a search result." },
+        maxMessages: { type: "number", description: "Max messages to return (1-200, default 40)." },
+        offset: { type: "number", description: "Message index to start from." },
+      },
+      required: ["sessionKey"],
+    },
+  },
+];
+
+// One round-trip to the LLM. Returns either an assistant text reply or a set of
+// tool calls the caller must execute and feed back. Injectable for testing.
+export type ToolChatCompletionFn = (
+  endpoint: SummaryEndpoint,
+  messages: AiChatMessage[],
+  signal?: AbortSignal,
+) => Promise<{ content: string; toolCalls: AiToolCall[] }>;
+
+const MAX_TOOL_ROUNDS = 6;
+
+// Drives the tool-call loop: call the model, run any requested tools, feed the
+// results back, repeat until the model answers in plain text (or we hit the
+// round cap). Returns the final reply plus every sessionKey surfaced by tools.
+export async function runAiAssistantTurn(
+  endpoint: SummaryEndpoint,
+  history: AiChatMessage[],
+  executeTool: ToolExecutor,
+  options: { chat?: ToolChatCompletionFn; signal?: AbortSignal } = {},
+): Promise<AiAssistantReplyInternal> {
+  const chat = options.chat ?? defaultToolChatCompletion;
+  const messages: AiChatMessage[] = [{ role: "system", content: AI_ASSISTANT_SYSTEM_PROMPT }, ...history];
+  const sessionKeys: string[] = [];
+
+  for (let round = 0; round < MAX_TOOL_ROUNDS; round += 1) {
+    const { content, toolCalls } = await chat(endpoint, messages, options.signal);
+
+    if (toolCalls.length === 0) {
+      return { reply: content.trim(), sessionKeys: dedupe(sessionKeys) };
+    }
+
+    // Record the assistant's tool-call turn so the next round has context.
+    messages.push({ role: "assistant", content, toolCalls });
+
+    for (const call of toolCalls) {
+      const args = parseToolArgs(call.arguments);
+      let resultText: string;
+      try {
+        const execution = await executeTool(call.name, args);
+        for (const key of execution.sessionKeys) sessionKeys.push(key);
+        resultText = JSON.stringify(execution.result);
+      } catch (error) {
+        resultText = JSON.stringify({ error: error instanceof Error ? error.message : String(error) });
+      }
+      messages.push({ role: "tool", content: resultText, toolCallId: call.id, toolName: call.name });
+    }
+  }
+
+  // Hit the round cap: ask once more for a final answer with tools disabled.
+  const final = await chat(endpoint, [...messages, { role: "user", content: "Summarize what you found so far." }], options.signal);
+  return { reply: final.content.trim(), sessionKeys: dedupe(sessionKeys) };
+}
+
+function parseToolArgs(raw: string): Record<string, unknown> {
+  if (!raw || !raw.trim()) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function dedupe(keys: string[]): string[] {
+  return [...new Set(keys)];
+}
+
+// ---------------------------------------------------------------------------
+// Transport: OpenAI and Anthropic with tool support.
+// ---------------------------------------------------------------------------
+
+const REQUEST_TIMEOUT_MS = 60_000;
+
+function defaultToolChatCompletion(
+  endpoint: SummaryEndpoint,
+  messages: AiChatMessage[],
+  signal?: AbortSignal,
+): Promise<{ content: string; toolCalls: AiToolCall[] }> {
+  return endpoint.apiFormat === "anthropic"
+    ? anthropicToolCompletion(endpoint, messages, signal)
+    : openaiToolCompletion(endpoint, messages, signal);
+}
+
+export const requestAssistantCompletion: ToolChatCompletionFn = defaultToolChatCompletion;
+
+async function postJson(url: string, headers: Record<string, string>, body: unknown, signal?: AbortSignal): Promise<Response> {
+  const timeoutSignal = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+  const merged = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+  try {
+    return await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify(body),
+      signal: merged,
+    });
+  } catch (error) {
+    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
+      throw new Error(`AI assistant request timed out after ${REQUEST_TIMEOUT_MS / 1000}s.`);
+    }
+    throw error;
+  }
+}
+
+async function safeReadText(response: Response): Promise<string> {
+  try {
+    const text = (await response.text()).trim();
+    return text.length > 300 ? `${text.slice(0, 300)}…` : text;
+  } catch {
+    return "";
+  }
+}
+
+// --- OpenAI /chat/completions with tools ---
+
+function openaiTools(): unknown[] {
+  return AI_TOOL_SCHEMAS.map((tool) => ({
+    type: "function",
+    function: { name: tool.name, description: tool.description, parameters: tool.parameters },
+  }));
+}
+
+function toOpenAiMessages(messages: AiChatMessage[]): unknown[] {
+  return messages.map((message) => {
+    if (message.role === "tool") {
+      return { role: "tool", tool_call_id: message.toolCallId, content: message.content };
+    }
+    if (message.role === "assistant" && message.toolCalls && message.toolCalls.length > 0) {
+      return {
+        role: "assistant",
+        content: message.content || null,
+        tool_calls: message.toolCalls.map((call) => ({
+          id: call.id,
+          type: "function",
+          function: { name: call.name, arguments: call.arguments },
+        })),
+      };
+    }
+    return { role: message.role, content: message.content };
+  });
+}
+
+async function openaiToolCompletion(
+  endpoint: SummaryEndpoint,
+  messages: AiChatMessage[],
+  signal?: AbortSignal,
+): Promise<{ content: string; toolCalls: AiToolCall[] }> {
+  const response = await postJson(
+    `${endpoint.baseUrl}/chat/completions`,
+    { Authorization: `Bearer ${endpoint.apiKey}` },
+    { model: endpoint.model, messages: toOpenAiMessages(messages), tools: openaiTools(), temperature: 0.2, stream: false },
+    signal,
+  );
+  if (!response.ok) {
+    const detail = await safeReadText(response);
+    throw new Error(`AI assistant request failed (HTTP ${response.status}). ${detail}`.trim());
+  }
+  const data = (await response.json()) as {
+    choices?: Array<{ message?: { content?: string | null; tool_calls?: Array<{ id?: string; function?: { name?: string; arguments?: string } }> } }>;
+  };
+  const message = data.choices?.[0]?.message;
+  const toolCalls: AiToolCall[] = (message?.tool_calls ?? [])
+    .map((call, index) => ({
+      id: call.id || `call_${index}`,
+      name: call.function?.name ?? "",
+      arguments: call.function?.arguments ?? "{}",
+    }))
+    .filter((call) => call.name);
+  return { content: typeof message?.content === "string" ? message.content : "", toolCalls };
+}
+
+// --- Anthropic /v1/messages with tools ---
+
+function anthropicTools(): unknown[] {
+  return AI_TOOL_SCHEMAS.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    input_schema: tool.parameters,
+  }));
+}
+
+// Anthropic keeps system separate and uses content blocks; tool results go in a
+// `user` message as tool_result blocks, tool calls in `assistant` as tool_use.
+function toAnthropicMessages(messages: AiChatMessage[]): { system: string; messages: unknown[] } {
+  const system = messages.find((m) => m.role === "system")?.content ?? "";
+  const out: unknown[] = [];
+  for (const message of messages) {
+    if (message.role === "system") continue;
+    if (message.role === "tool") {
+      out.push({
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: message.toolCallId, content: message.content }],
+      });
+      continue;
+    }
+    if (message.role === "assistant" && message.toolCalls && message.toolCalls.length > 0) {
+      const blocks: unknown[] = [];
+      if (message.content) blocks.push({ type: "text", text: message.content });
+      for (const call of message.toolCalls) {
+        blocks.push({ type: "tool_use", id: call.id, name: call.name, input: parseToolArgs(call.arguments) });
+      }
+      out.push({ role: "assistant", content: blocks });
+      continue;
+    }
+    out.push({ role: message.role, content: message.content });
+  }
+  return { system, messages: out };
+}
+
+async function anthropicToolCompletion(
+  endpoint: SummaryEndpoint,
+  messages: AiChatMessage[],
+  signal?: AbortSignal,
+): Promise<{ content: string; toolCalls: AiToolCall[] }> {
+  const { system, messages: anthropicMessages } = toAnthropicMessages(messages);
+  const response = await postJson(
+    `${endpoint.baseUrl}/v1/messages`,
+    { "x-api-key": endpoint.apiKey, Authorization: `Bearer ${endpoint.apiKey}`, "anthropic-version": "2023-06-01" },
+    { model: endpoint.model, max_tokens: 1024, system, messages: anthropicMessages, tools: anthropicTools() },
+    signal,
+  );
+  if (!response.ok) {
+    const detail = await safeReadText(response);
+    throw new Error(`AI assistant request failed (HTTP ${response.status}). ${detail}`.trim());
+  }
+  const data = (await response.json()) as {
+    content?: Array<{ type?: string; text?: string; id?: string; name?: string; input?: unknown }>;
+  };
+  const blocks = Array.isArray(data.content) ? data.content : [];
+  const text = blocks
+    .filter((block) => block.type === "text" && typeof block.text === "string")
+    .map((block) => block.text)
+    .join("");
+  const toolCalls: AiToolCall[] = blocks
+    .filter((block) => block.type === "tool_use" && block.name)
+    .map((block, index) => ({
+      id: block.id || `call_${index}`,
+      name: block.name ?? "",
+      arguments: JSON.stringify(block.input ?? {}),
+    }));
+  return { content: text, toolCalls };
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -890,6 +890,24 @@ let summaryBackfillRunning = false;
 const SUMMARY_PROVIDER_ERROR =
   "AI summary has no usable provider. Select Codex, Claude Code, or configure a direct summary API provider in Settings.";
 
+function buildCodexExecEndpoint(settings: AppSettings): SummaryEndpoint {
+  return {
+    baseUrl: "",
+    model: "codex",
+    apiKey: "",
+    apiFormat: "codex_exec",
+    command: settings.codexBinary,
+    cwd: process.cwd(),
+    onTemporarySession: (sessionKey) => {
+      try {
+        store.deleteSession(sessionKey);
+      } catch {
+        // Best-effort cleanup if an ephemeral Codex call is indexed before it exits.
+      }
+    },
+  };
+}
+
 async function resolveSummaryEndpointFromSettings(): Promise<SummaryEndpoint | null> {
   const settings = await getHydratedSettings();
   if (settings.summarySource === "custom") {
@@ -1104,10 +1122,10 @@ function registerIpc(): void {
     return { processed, failed, total };
   });
   ipcMain.handle("ai:assistant-chat", async (_event, messages: AiChatMessage[]) => {
-    const endpoint = await resolveSummaryEndpointFromSettings();
-    if (!endpoint) {
-      throw new Error("No AI provider is available. Select Codex, Claude Code, or configure a direct API provider in the API configuration.");
-    }
+    // The assistant shares the summary provider routing. When the user picked a
+    // direct API provider but left it incomplete, fall back to the local Codex
+    // CLI so the assistant still works out of the box.
+    const endpoint = (await resolveSummaryEndpointFromSettings()) ?? buildCodexExecEndpoint(await getHydratedSettings());
 
     // Local CLI providers (codex exec / claude) can't do HTTP function calling.
     // Fall back to: keyword-search the store with the user's words, then let the

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -50,7 +50,14 @@ import { focusLiveSessionTerminal } from "../core/session-focus";
 import { loadLiveSessionSnapshot } from "../core/session-activity";
 import { type TrackedLiveSession, updateLiveTracker } from "../core/live-transitions";
 import { resolveSummaryEndpoint, summarizeSession, type SummaryEndpoint } from "../core/session-summarizer";
-import { runAiAssistantTurn, type AiChatMessage, type ToolExecutionResult } from "../core/ai-assistant";
+import {
+  isLocalCliEndpoint,
+  runAiAssistantFallback,
+  runAiAssistantTurn,
+  type AiChatMessage,
+  type FallbackSessionHit,
+  type ToolExecutionResult,
+} from "../core/ai-assistant";
 import { applyMigrationLengthPolicy, createMigrationCompressor } from "../core/session-migration-compression";
 import { migrateSession } from "../core/session-migration";
 import { writeMigratedSession } from "../core/session-migration-writers";
@@ -1097,9 +1104,30 @@ function registerIpc(): void {
     return { processed, failed, total };
   });
   ipcMain.handle("ai:assistant-chat", async (_event, messages: AiChatMessage[]) => {
-    const endpoint = resolveSummaryEndpointFromSettings();
+    const endpoint = await resolveSummaryEndpointFromSettings();
     if (!endpoint) {
-      throw new Error("No AI provider is configured. Set a custom provider in the API configuration.");
+      throw new Error("No AI provider is available. Select Codex, Claude Code, or configure a direct API provider in the API configuration.");
+    }
+
+    // Local CLI providers (codex exec / claude) can't do HTTP function calling.
+    // Fall back to: keyword-search the store with the user's words, then let the
+    // CLI write a grounded answer over the hits.
+    if (isLocalCliEndpoint(endpoint)) {
+      const search = async (query: string): Promise<FallbackSessionHit[]> => {
+        const sessions = store.searchSessions({ query, limit: 12 });
+        return sessions.map((session) => ({
+          sessionKey: session.sessionKey,
+          title: session.displayTitle,
+          source: session.source,
+          project: session.projectPath,
+          summary: session.aiSummary ?? session.firstQuestion ?? null,
+        }));
+      };
+      const { reply, sessionKeys } = await runAiAssistantFallback(endpoint, messages, search);
+      const sessions = sessionKeys
+        .map((key) => store.getSession(key))
+        .filter((session): session is SessionSearchResult => session !== null);
+      return { reply, sessions };
     }
     // The model's tool calls run against the local SessionStore — the same data
     // the MCP server exposes. We collect surfaced sessionKeys so the renderer can

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -50,6 +50,7 @@ import { focusLiveSessionTerminal } from "../core/session-focus";
 import { loadLiveSessionSnapshot } from "../core/session-activity";
 import { type TrackedLiveSession, updateLiveTracker } from "../core/live-transitions";
 import { resolveSummaryEndpoint, summarizeSession, type SummaryEndpoint } from "../core/session-summarizer";
+import { runAiAssistantTurn, type AiChatMessage, type ToolExecutionResult } from "../core/ai-assistant";
 import { applyMigrationLengthPolicy, createMigrationCompressor } from "../core/session-migration-compression";
 import { migrateSession } from "../core/session-migration";
 import { writeMigratedSession } from "../core/session-migration-writers";
@@ -1061,6 +1062,83 @@ function registerIpc(): void {
     };
     await Promise.all(Array.from({ length: Math.min(3, total) }, worker));
     return { processed, failed, total };
+  });
+  ipcMain.handle("ai:assistant-chat", async (_event, messages: AiChatMessage[]) => {
+    const endpoint = resolveSummaryEndpointFromSettings();
+    if (!endpoint) {
+      throw new Error("No AI provider is configured. Set a custom provider in the API configuration.");
+    }
+    // The model's tool calls run against the local SessionStore — the same data
+    // the MCP server exposes. We collect surfaced sessionKeys so the renderer can
+    // hydrate full results into clickable cards.
+    const executeTool = async (name: string, args: Record<string, unknown>): Promise<ToolExecutionResult> => {
+      switch (name) {
+        case "search_sessions": {
+          const query = typeof args.query === "string" ? args.query : "";
+          const source = typeof args.source === "string" && args.source ? args.source : undefined;
+          const projectPath = typeof args.project === "string" && args.project ? args.project : undefined;
+          const limit = typeof args.limit === "number" ? Math.max(1, Math.min(50, Math.floor(args.limit))) : 20;
+          const sessions = store.searchSessions({
+            query,
+            source: source as SearchOptions["source"],
+            projectPath,
+            limit,
+          });
+          return {
+            result: sessions.map((session) => ({
+              sessionKey: session.sessionKey,
+              title: session.displayTitle,
+              source: session.source,
+              project: session.projectPath,
+              timestamp: session.timestamp,
+              summary: session.aiSummary ?? session.firstQuestion ?? null,
+            })),
+            sessionKeys: sessions.map((session) => session.sessionKey),
+          };
+        }
+        case "list_projects": {
+          const projects = store.listProjects();
+          return {
+            result: projects.map((project) => ({ project: project.path, sessions: project.sessionCount })),
+            sessionKeys: [],
+          };
+        }
+        case "list_tags": {
+          return { result: store.listTags(), sessionKeys: [] };
+        }
+        case "get_session": {
+          const sessionKey = typeof args.sessionKey === "string" ? args.sessionKey : "";
+          if (!sessionKey) return { result: { error: "sessionKey is required." }, sessionKeys: [] };
+          await ensureRemoteSessionDetailsLoaded(sessionKey);
+          const session = store.getSession(sessionKey);
+          if (!session) return { result: { error: "Session not found." }, sessionKeys: [] };
+          const maxMessages = typeof args.maxMessages === "number" ? Math.max(1, Math.min(200, Math.floor(args.maxMessages))) : 40;
+          const offset = typeof args.offset === "number" && args.offset > 0 ? Math.floor(args.offset) : 0;
+          const messageList = store.getMessages(sessionKey, offset, maxMessages);
+          return {
+            result: {
+              sessionKey: session.sessionKey,
+              title: session.displayTitle,
+              source: session.source,
+              project: session.projectPath,
+              timestamp: session.timestamp,
+              summary: session.aiSummary,
+              totalMessages: session.messageCount,
+              messages: messageList.map((message) => ({ role: message.role, content: message.content })),
+            },
+            sessionKeys: [session.sessionKey],
+          };
+        }
+        default:
+          return { result: { error: `Unknown tool: ${name}` }, sessionKeys: [] };
+      }
+    };
+
+    const { reply, sessionKeys } = await runAiAssistantTurn(endpoint, messages, executeTool);
+    const sessions = sessionKeys
+      .map((key) => store.getSession(key))
+      .filter((session): session is SessionSearchResult => session !== null);
+    return { reply, sessions };
   });
   ipcMain.handle("mcp:status", () => {
     try {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from "electron";
+import type { AiChatMessage } from "../core/ai-assistant";
 import type { ApiConfig, ClaudeApiConfig } from "../core/api-config";
 import type { ApplyClaudeProfileResult } from "../core/claude-profile";
 import type { CodexChatProxyStatus } from "../core/codex-chat-proxy";
@@ -28,8 +29,14 @@ import type {
   UsageQuotaSnapshot,
 } from "../core/types";
 
+export interface AiAssistantReply {
+  reply: string;
+  sessions: SessionSearchResult[];
+}
+
 const api = {
   platform: process.platform as NodeJS.Platform,
+  askAiAssistant: (messages: AiChatMessage[]): Promise<AiAssistantReply> => ipcRenderer.invoke("ai:assistant-chat", messages),
   searchSessions: (options: SearchOptions): Promise<SessionSearchResult[]> => ipcRenderer.invoke("search:sessions", options),
   searchSessionPage: (options: SearchOptions): Promise<SessionSearchPage> => ipcRenderer.invoke("search:session-page", options),
   getSession: (sessionKey: string): Promise<SessionSearchResult | null> => ipcRenderer.invoke("session:get", sessionKey),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -101,6 +101,7 @@ import { DetailPanel } from "./components/detail-panel";
 import { SessionMigrationDialog, SessionMigrationLaunchFailedDialog } from "./components/session-migration-dialog";
 import { CommandDialog, DeleteSessionDialog, DeleteTagDialog } from "./components/session-dialogs";
 import { SkillsDialog } from "./components/skills-dialog";
+import { AiAssistantDialog } from "./components/ai-assistant-dialog";
 import { useClampedContextMenuStyle } from "./context-menu-position";
 import {
   SOURCE_LABEL,
@@ -326,6 +327,7 @@ export function App(): ReactElement {
   const [sshDialogOpen, setSshDialogOpen] = useState(false);
   const [skillsOpen, setSkillsOpen] = useState(false);
   const [apiConfigOpen, setApiConfigOpen] = useState(false);
+  const [aiAssistantOpen, setAiAssistantOpen] = useState(false);
   const [installedSkills, setInstalledSkills] = useState<InstalledSkillsSnapshot>(EMPTY_SKILLS);
   const [skillsLoading, setSkillsLoading] = useState(false);
   const [skillsFeedback, setSkillsFeedback] = useState<SkillsFeedback>(null);
@@ -688,6 +690,7 @@ export function App(): ReactElement {
         else if (contextMenu) setContextMenu(null);
         else if (skillsOpen) setSkillsOpen(false);
         else if (apiConfigOpen) setApiConfigOpen(false);
+        else if (aiAssistantOpen) setAiAssistantOpen(false);
         else if (settingsOpen) setSettingsOpen(false);
         else if (detail) closeDetail();
         else return;
@@ -736,7 +739,7 @@ export function App(): ReactElement {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [displayedResults, selectedKey, detail, dialog, migrationDialog, deleteSessionCandidate, deletingSession, deleteTagName, contextMenu, skillsOpen, apiConfigOpen, settingsOpen, sshDialogOpen, actionStatus, t]);
+  }, [displayedResults, selectedKey, detail, dialog, migrationDialog, deleteSessionCandidate, deletingSession, deleteTagName, contextMenu, skillsOpen, apiConfigOpen, aiAssistantOpen, settingsOpen, sshDialogOpen, actionStatus, t]);
 
   useEffect(() => {
     if (!selectedKey) return;
@@ -744,9 +747,9 @@ export function App(): ReactElement {
   }, [selectedKey]);
 
   useEffect(() => {
-    document.body.classList.toggle("overlay-open", Boolean(detail || skillsOpen || apiConfigOpen || settingsOpen || sshDialogOpen));
+    document.body.classList.toggle("overlay-open", Boolean(detail || skillsOpen || apiConfigOpen || aiAssistantOpen || settingsOpen || sshDialogOpen));
     return () => document.body.classList.remove("overlay-open");
-  }, [detail, skillsOpen, apiConfigOpen, settingsOpen, sshDialogOpen]);
+  }, [detail, skillsOpen, apiConfigOpen, aiAssistantOpen, settingsOpen, sshDialogOpen]);
 
   const visibleSourceFilters = useMemo(() => {
     if (!appSettings) return sourceFilters(null);
@@ -1514,6 +1517,19 @@ export function App(): ReactElement {
           </div>
           <div className="top-actions">
             <button
+              className={`icon-button toolbar-icon-button ${aiAssistantOpen ? "active" : ""}`}
+              onClick={() => {
+                setSettingsOpen(false);
+                setApiConfigOpen(false);
+                setSkillsOpen(false);
+                setAiAssistantOpen(true);
+              }}
+              title={t("AI session finder", "AI 找会话")}
+              aria-label={t("AI session finder", "AI 找会话")}
+            >
+              <Sparkles size={15} />
+            </button>
+            <button
               className={`icon-button toolbar-icon-button ${skillsOpen ? "active" : ""}`}
               onClick={() => {
                 setSettingsOpen(false);
@@ -1823,6 +1839,17 @@ export function App(): ReactElement {
           }
           onDelete={(skill) => deleteSkill(skill)}
           onClose={() => setSkillsOpen(false)}
+        />
+      ) : null}
+
+      {aiAssistantOpen ? (
+        <AiAssistantDialog
+          language={language}
+          onOpenSession={(session) => {
+            setAiAssistantOpen(false);
+            void openDetail(session);
+          }}
+          onClose={() => setAiAssistantOpen(false)}
         />
       ) : null}
     </main>

--- a/src/renderer/src/components/ai-assistant-dialog.tsx
+++ b/src/renderer/src/components/ai-assistant-dialog.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useRef, useState } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent, ReactElement } from "react";
+import { ArrowUp, FolderOpen, Sparkles, X } from "lucide-react";
+import type { AiChatMessage } from "../../../core/ai-assistant";
+import type { SessionSearchResult } from "../../../core/types";
+import { SOURCE_LABEL } from "../session-ui";
+import { localize, type LanguageMode } from "../language";
+import { Markdown } from "../lightweight-markdown";
+
+// A single chat turn shown in the dialog. Assistant turns may carry the sessions
+// the model surfaced, rendered as clickable cards under the reply.
+interface DisplayMessage {
+  role: "user" | "assistant";
+  content: string;
+  sessions?: SessionSearchResult[];
+}
+
+export function AiAssistantDialog({
+  language,
+  onOpenSession,
+  onClose,
+}: {
+  language: LanguageMode;
+  onOpenSession: (session: SessionSearchResult) => void;
+  onClose: () => void;
+}): ReactElement {
+  const l = (en: string, zh: string) => localize(language, en, zh);
+  const [input, setInput] = useState("");
+  const [messages, setMessages] = useState<DisplayMessage[]>([]);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+  }, [messages, pending]);
+
+  // Auto-grow the textarea so the send button stays bottom-aligned with it.
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 140)}px`;
+  }, [input]);
+
+  const send = async (): Promise<void> => {
+    const text = input.trim();
+    if (!text || pending) return;
+    setError(null);
+    const nextMessages: DisplayMessage[] = [...messages, { role: "user", content: text }];
+    setMessages(nextMessages);
+    setInput("");
+    setPending(true);
+    try {
+      // Send full history (user + assistant text) so the model keeps context.
+      const history: AiChatMessage[] = nextMessages.map((message) => ({ role: message.role, content: message.content }));
+      const reply = await window.sessionSearch.askAiAssistant(history);
+      setMessages((current) => [...current, { role: "assistant", content: reply.reply, sessions: reply.sessions }]);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>): void => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      void send();
+    }
+  };
+
+  return (
+    <div className="dialog-backdrop" onMouseDown={onClose}>
+      <section className="command-dialog ai-assistant-dialog" onMouseDown={(event) => event.stopPropagation()}>
+        <div className="dialog-title">
+          <span className="ai-assistant-title">
+            <Sparkles size={15} />
+            {l("AI session finder", "AI 找会话")}
+          </span>
+          <button type="button" className="icon-button" onClick={onClose} aria-label={l("Close", "关闭")}>
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="ai-assistant-messages" ref={scrollRef}>
+          {messages.length === 0 ? (
+            <div className="ai-assistant-empty">
+              <Sparkles size={22} />
+              <p>{l("Describe the session you're looking for and I'll search your history.", "描述你想找的会话，我会在历史记录里帮你搜索。")}</p>
+              <p className="ai-assistant-hint">
+                {l('e.g. "the session where I fixed the SQLite migration bug"', "例如：“我修复 SQLite 迁移 bug 的那次会话”")}
+              </p>
+            </div>
+          ) : null}
+
+          {messages.map((message, index) => (
+            <div key={index} className={`ai-message ai-message-${message.role}`}>
+              <div className="ai-message-bubble">
+                {message.role === "assistant" ? <Markdown text={message.content} /> : message.content}
+              </div>
+              {message.sessions && message.sessions.length > 0 ? (
+                <div className="ai-session-cards">
+                  {message.sessions.map((session) => (
+                    <div
+                      key={session.sessionKey}
+                      role="button"
+                      tabIndex={0}
+                      className="ai-session-card"
+                      onClick={() => {
+                        // Don't open when the user is selecting text inside the card.
+                        if ((window.getSelection()?.toString() ?? "").length > 0) return;
+                        onOpenSession(session);
+                      }}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          onOpenSession(session);
+                        }
+                      }}
+                    >
+                      <div className="ai-session-card-title">{session.displayTitle}</div>
+                      <div className="ai-session-card-meta">
+                        <span className="ai-session-card-source">{SOURCE_LABEL[session.source] ?? session.source}</span>
+                        {session.projectPath ? (
+                          <span className="ai-session-card-project">
+                            <FolderOpen size={11} />
+                            {session.projectPath}
+                          </span>
+                        ) : null}
+                      </div>
+                      {session.aiSummary ? (
+                        <div className="ai-session-card-summary">
+                          <Markdown text={session.aiSummary} />
+                        </div>
+                      ) : null}
+                      <span className="ai-session-card-open">{l("Open session", "打开会话")} →</span>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          ))}
+
+          {pending ? (
+            <div className="ai-message ai-message-assistant">
+              <div className="ai-message-bubble ai-message-pending">
+                <span className="ai-typing">
+                  <span></span>
+                  <span></span>
+                  <span></span>
+                </span>
+                {l("Searching…", "搜索中…")}
+              </div>
+            </div>
+          ) : null}
+          {error ? <div className="ai-assistant-error">{error}</div> : null}
+        </div>
+
+        <div className="ai-assistant-input">
+          <textarea
+            ref={textareaRef}
+            value={input}
+            onChange={(event) => setInput(event.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={l("Ask to find a session…", "描述要查找的会话…")}
+            rows={1}
+            autoFocus
+          />
+          <button type="button" className="ai-assistant-send" onClick={() => void send()} disabled={pending || !input.trim()} aria-label={l("Send", "发送")}>
+            <ArrowUp size={16} />
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/renderer/src/components/api-config-dialog.tsx
+++ b/src/renderer/src/components/api-config-dialog.tsx
@@ -273,7 +273,6 @@ export function ApiConfigDialog({
                         type={showCodexApiKey ? "text" : "password"}
                         value={draftApiConfig.customApiKey}
                         disabled={!settings || saving}
-                        placeholder="sk-..."
                         onChange={(event) => updateDraftApiConfig({ customApiKey: event.currentTarget.value })}
                       />
                       <button
@@ -430,7 +429,6 @@ export function ApiConfigDialog({
                         type={showClaudeApiKey ? "text" : "password"}
                         value={draftClaudeApiConfig.customApiKey}
                         disabled={!settings || saving}
-                        placeholder="sk-..."
                         onChange={(event) => updateDraftClaudeApiConfig({ customApiKey: event.currentTarget.value })}
                       />
                       <button
@@ -597,7 +595,6 @@ export function ApiConfigDialog({
                         type={showSummaryApiKey ? "text" : "password"}
                         value={draftSummaryApiConfig.customApiKey}
                         disabled={!settings || saving}
-                        placeholder="sk-..."
                         onChange={(event) => updateDraftSummaryApiConfig({ customApiKey: event.currentTarget.value })}
                       />
                       <button

--- a/src/renderer/src/components/api-config-dialog.tsx
+++ b/src/renderer/src/components/api-config-dialog.tsx
@@ -163,7 +163,7 @@ export function ApiConfigDialog({
             Claude Code
           </button>
           <button type="button" className={apiTarget === "summary" ? "active" : ""} onClick={() => setApiTarget("summary")}>
-            {l("AI Summary", "AI 摘要")}
+            {l("AI Summary & Search", "AI 摘要与搜索")}
           </button>
         </div>
         <div className="api-config-body">
@@ -519,15 +519,15 @@ export function ApiConfigDialog({
           ) : (
             <section className="settings-pane api-settings-form">
               <header className="settings-pane-head">
-                <h3>{l("AI summary source", "AI 摘要来源")}</h3>
+                <h3>{l("AI summary & search source", "AI 摘要与搜索来源")}</h3>
                 <p>
                   {l(
-                    "Choose Codex or Claude Code, or call a summary API provider directly. Direct API providers such as DeepSeek and GLM do not create agent sessions.",
-                    "选择 Codex / Claude Code，或直接调用摘要 API 供应商。DeepSeek、GLM 等直接 API 不会创建 agent session。",
+                    "Powers both AI session summaries and the AI session finder. Choose Codex or Claude Code, or call an API provider directly. Direct API providers such as DeepSeek and GLM do not create agent sessions.",
+                    "同时驱动 AI 会话摘要和 AI 找会话。选择 Codex / Claude Code，或直接调用 API 供应商。DeepSeek、GLM 等直接 API 不会创建 agent session。",
                   )}
                 </p>
               </header>
-              <div className="api-provider-switch" role="group" aria-label={l("AI summary source", "AI 摘要来源")}>
+              <div className="api-provider-switch" role="group" aria-label={l("AI summary & search source", "AI 摘要与搜索来源")}>
                 <button
                   type="button"
                   className={(settings?.summarySource ?? "codex") === "codex" ? "active" : ""}
@@ -577,7 +577,7 @@ export function ApiConfigDialog({
                   <label className="settings-field">
                     <div className="settings-field-text">
                       <span className="settings-field-title">{l("Model", "模型")}</span>
-                      <span className="settings-field-sub">{l("Summary API model.", "摘要 API 模型。")}</span>
+                      <span className="settings-field-sub">{l("API model used for summaries and search.", "用于摘要与搜索的 API 模型。")}</span>
                     </div>
                     <input
                       type="text"

--- a/src/renderer/src/lightweight-markdown.tsx
+++ b/src/renderer/src/lightweight-markdown.tsx
@@ -1,0 +1,175 @@
+import type { ReactElement, ReactNode } from "react";
+
+// A tiny, dependency-free Markdown renderer for short assistant replies.
+// Supports: headings, bold/italic, inline code, fenced code blocks, unordered
+// and ordered lists (one level), horizontal rules, and blank-line paragraphs.
+// It is deliberately minimal — the app avoids heavy markdown dependencies — and
+// renders React nodes directly (no dangerouslySetInnerHTML), so it is XSS-safe.
+
+export function Markdown({ text }: { text: string }): ReactElement {
+  return <div className="md">{renderBlocks(text)}</div>;
+}
+
+function renderBlocks(text: string): ReactNode[] {
+  const lines = text.replace(/\r\n/g, "\n").split("\n");
+  const blocks: ReactNode[] = [];
+  let i = 0;
+  let key = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Fenced code block.
+    const fence = line.match(/^```(\w*)\s*$/);
+    if (fence) {
+      const codeLines: string[] = [];
+      i += 1;
+      while (i < lines.length && !/^```\s*$/.test(lines[i])) {
+        codeLines.push(lines[i]);
+        i += 1;
+      }
+      i += 1; // skip closing fence
+      blocks.push(
+        <pre className="md-code" key={key++}>
+          <code>{codeLines.join("\n")}</code>
+        </pre>,
+      );
+      continue;
+    }
+
+    // Blank line.
+    if (line.trim() === "") {
+      i += 1;
+      continue;
+    }
+
+    // Horizontal rule.
+    if (/^(-{3,}|\*{3,}|_{3,})\s*$/.test(line)) {
+      blocks.push(<hr className="md-hr" key={key++} />);
+      i += 1;
+      continue;
+    }
+
+    // Heading.
+    const heading = line.match(/^(#{1,6})\s+(.*)$/);
+    if (heading) {
+      const level = heading[1].length;
+      const Tag = `h${Math.min(level, 6)}` as "h1";
+      blocks.push(
+        <Tag className="md-h" key={key++}>
+          {renderInline(heading[2])}
+        </Tag>,
+      );
+      i += 1;
+      continue;
+    }
+
+    // Unordered list.
+    if (/^\s*[-*+]\s+/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^\s*[-*+]\s+/.test(lines[i])) {
+        items.push(lines[i].replace(/^\s*[-*+]\s+/, ""));
+        i += 1;
+      }
+      blocks.push(
+        <ul className="md-ul" key={key++}>
+          {items.map((item, index) => (
+            <li key={index}>{renderInline(item)}</li>
+          ))}
+        </ul>,
+      );
+      continue;
+    }
+
+    // Ordered list.
+    if (/^\s*\d+\.\s+/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^\s*\d+\.\s+/.test(lines[i])) {
+        items.push(lines[i].replace(/^\s*\d+\.\s+/, ""));
+        i += 1;
+      }
+      blocks.push(
+        <ol className="md-ol" key={key++}>
+          {items.map((item, index) => (
+            <li key={index}>{renderInline(item)}</li>
+          ))}
+        </ol>,
+      );
+      continue;
+    }
+
+    // Paragraph: gather consecutive non-blank, non-special lines.
+    const paragraph: string[] = [line];
+    i += 1;
+    while (
+      i < lines.length &&
+      lines[i].trim() !== "" &&
+      !/^```/.test(lines[i]) &&
+      !/^(#{1,6})\s+/.test(lines[i]) &&
+      !/^\s*[-*+]\s+/.test(lines[i]) &&
+      !/^\s*\d+\.\s+/.test(lines[i]) &&
+      !/^(-{3,}|\*{3,}|_{3,})\s*$/.test(lines[i])
+    ) {
+      paragraph.push(lines[i]);
+      i += 1;
+    }
+    blocks.push(
+      <p className="md-p" key={key++}>
+        {renderInline(paragraph.join("\n"))}
+      </p>,
+    );
+  }
+
+  return blocks;
+}
+
+// Inline: handles `code`, **bold**, *italic*/_italic_, and preserves newlines.
+function renderInline(text: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  // Split on inline code first so emphasis markers inside code are left alone.
+  const segments = text.split(/(`[^`]+`)/g);
+  let key = 0;
+  for (const segment of segments) {
+    if (!segment) continue;
+    if (segment.startsWith("`") && segment.endsWith("`") && segment.length >= 2) {
+      nodes.push(
+        <code className="md-inline-code" key={key++}>
+          {segment.slice(1, -1)}
+        </code>,
+      );
+      continue;
+    }
+    nodes.push(...renderEmphasis(segment, () => key++));
+  }
+  return nodes;
+}
+
+function renderEmphasis(text: string, nextKey: () => number): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  // Bold (**x** or __x__), then italic (*x* or _x_).
+  const pattern = /(\*\*[^*]+\*\*|__[^_]+__|\*[^*]+\*|_[^_]+_)/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(text)) !== null) {
+    if (match.index > lastIndex) nodes.push(...withLineBreaks(text.slice(lastIndex, match.index), nextKey));
+    const token = match[0];
+    if ((token.startsWith("**") && token.endsWith("**")) || (token.startsWith("__") && token.endsWith("__"))) {
+      nodes.push(<strong key={nextKey()}>{token.slice(2, -2)}</strong>);
+    } else {
+      nodes.push(<em key={nextKey()}>{token.slice(1, -1)}</em>);
+    }
+    lastIndex = match.index + token.length;
+  }
+  if (lastIndex < text.length) nodes.push(...withLineBreaks(text.slice(lastIndex), nextKey));
+  return nodes;
+}
+
+function withLineBreaks(text: string, nextKey: () => number): ReactNode[] {
+  const parts = text.split("\n");
+  const nodes: ReactNode[] = [];
+  parts.forEach((part, index) => {
+    if (index > 0) nodes.push(<br key={nextKey()} />);
+    if (part) nodes.push(part);
+  });
+  return nodes;
+}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -3418,6 +3418,7 @@ select:focus-visible {
 
 .api-target-tabs {
   display: flex;
+  flex-wrap: wrap;
   gap: 6px;
   padding: 12px 18px 0;
 }
@@ -3430,6 +3431,7 @@ select:focus-visible {
   background: transparent;
   color: var(--text-muted);
   font-size: 12.5px;
+  white-space: nowrap;
 }
 
 .api-target-tabs button:hover {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -186,8 +186,8 @@ select:focus-visible {
 }
 
 ::selection {
-  background: var(--accent-soft);
-  color: var(--text);
+  background: var(--accent);
+  color: var(--accent-contrast);
 }
 
 *::-webkit-scrollbar {
@@ -3761,4 +3761,368 @@ select:focus-visible {
 body.overlay-open .results,
 body.overlay-open .sidebar {
   overflow: hidden;
+}
+
+/* AI session-finder dialog */
+.ai-assistant-dialog {
+  width: min(580px, calc(100vw - 40px));
+  display: flex;
+  flex-direction: column;
+  /* Adaptive height: grows with content, but never below a stable minimum
+     (so it doesn't jump after sending) nor above the viewport cap. */
+  min-height: min(420px, 78vh);
+  max-height: min(78vh, 760px);
+  padding: 16px 16px 14px;
+}
+
+.ai-assistant-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.ai-assistant-title svg {
+  color: var(--accent);
+}
+
+.ai-assistant-messages {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 16px;
+  padding: 6px 4px 2px;
+}
+
+.ai-assistant-empty {
+  margin: auto;
+  min-height: 220px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  text-align: center;
+  color: var(--text-muted);
+  padding: 28px 20px;
+}
+
+.ai-assistant-empty svg {
+  color: var(--accent);
+  opacity: 0.9;
+}
+
+.ai-assistant-empty p {
+  margin: 0;
+  font-size: 13px;
+  max-width: 320px;
+  line-height: 1.5;
+}
+
+.ai-assistant-hint {
+  font-size: 12px;
+  opacity: 0.7;
+}
+
+.ai-message {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ai-message-user {
+  align-items: flex-end;
+}
+
+.ai-message-bubble {
+  max-width: 88%;
+  padding: 10px 13px;
+  border-radius: 14px;
+  font-size: 13.5px;
+  line-height: 1.55;
+  word-break: break-word;
+  user-select: text;
+  -webkit-user-select: text;
+  cursor: text;
+}
+
+.ai-message-user .ai-message-bubble {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  white-space: pre-wrap;
+}
+
+.ai-message-assistant .ai-message-bubble {
+  background: var(--accent-soft);
+  color: var(--text);
+  border: 1px solid var(--border-strong);
+}
+
+/* On the colored user bubble, invert selection so it stays readable. */
+.ai-message-user .ai-message-bubble ::selection,
+.ai-message-user .ai-message-bubble::selection {
+  background: var(--accent-contrast);
+  color: var(--accent);
+}
+
+/* Markdown inside assistant bubbles */
+.md > :first-child { margin-top: 0; }
+.md > :last-child { margin-bottom: 0; }
+
+.md-p {
+  margin: 0 0 8px;
+}
+
+.md-h {
+  margin: 12px 0 6px;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.md-ul,
+.md-ol {
+  margin: 6px 0 8px;
+  padding-left: 20px;
+}
+
+.md-ul li,
+.md-ol li {
+  margin: 2px 0;
+}
+
+.md-hr {
+  border: 0;
+  border-top: 1px solid var(--border-strong);
+  margin: 10px 0;
+}
+
+.md-inline-code {
+  font-family: var(--mono);
+  font-size: 12px;
+  padding: 1px 5px;
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--text) 8%, transparent);
+}
+
+.md-code {
+  margin: 8px 0;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: var(--app-bg);
+  border: 1px solid var(--border-strong);
+  overflow-x: auto;
+}
+
+.md-code code {
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre;
+}
+
+.ai-message-pending {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.ai-typing {
+  display: inline-flex;
+  gap: 3px;
+}
+
+.ai-typing span {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  animation: ai-typing-bounce 1.2s infinite ease-in-out;
+}
+
+.ai-typing span:nth-child(2) { animation-delay: 0.15s; }
+.ai-typing span:nth-child(3) { animation-delay: 0.3s; }
+
+@keyframes ai-typing-bounce {
+  0%, 60%, 100% { transform: translateY(0); opacity: 0.5; }
+  30% { transform: translateY(-3px); opacity: 1; }
+}
+
+.ai-session-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  max-width: 88%;
+}
+
+.ai-session-card {
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 11px 13px;
+  border: 1px solid var(--border-strong);
+  border-radius: 12px;
+  background: var(--panel-bg);
+  color: var(--text);
+  cursor: pointer;
+  user-select: text;
+  -webkit-user-select: text;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.ai-session-card:hover {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+
+.ai-session-card:focus-visible {
+  outline: 0;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+
+.ai-session-card-open {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--accent);
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.ai-session-card:hover .ai-session-card-open,
+.ai-session-card:focus-visible .ai-session-card-open {
+  opacity: 1;
+}
+
+.ai-session-card-title {
+  font-weight: 600;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.ai-session-card-meta {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  font-size: 11.5px;
+  color: var(--text-muted);
+}
+
+.ai-session-card-source {
+  padding: 1px 8px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.ai-session-card-project {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.ai-session-card-project svg {
+  flex: 0 0 auto;
+}
+
+.ai-session-card-summary {
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.45;
+}
+
+.ai-session-card-summary .md,
+.ai-session-card-summary .md > :last-child {
+  margin-bottom: 0;
+}
+
+.ai-session-card-summary .md-p {
+  margin: 0 0 4px;
+}
+
+.ai-session-card-summary .md-p:last-child {
+  margin-bottom: 0;
+}
+
+.ai-session-card-summary .md-ul,
+.ai-session-card-summary .md-ol {
+  margin: 4px 0;
+}
+
+.ai-assistant-error {
+  font-size: 12.5px;
+  color: var(--danger);
+  background: var(--danger-soft);
+  padding: 8px 11px;
+  border-radius: 8px;
+}
+
+.ai-assistant-input {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  margin-top: 14px;
+  padding: 7px 7px 7px 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: 14px;
+  background: var(--panel-bg);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.ai-assistant-input:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+
+.ai-assistant-input textarea {
+  flex: 1;
+  resize: none;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text);
+  font-size: 13.5px;
+  line-height: 1.5;
+  font-family: inherit;
+  padding: 6px 0;
+  max-height: 140px;
+}
+
+.ai-assistant-input textarea::placeholder {
+  color: var(--text-muted);
+}
+
+.ai-assistant-send {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border: 0;
+  border-radius: 9px;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  cursor: pointer;
+  transition: background 0.15s ease, opacity 0.15s ease;
+}
+
+.ai-assistant-send:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.ai-assistant-send:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }

--- a/src/renderer/src/theme.test.ts
+++ b/src/renderer/src/theme.test.ts
@@ -97,7 +97,7 @@ describe("theme controls", () => {
   });
 
   it("omits CodexZH from direct AI summary API providers", () => {
-    const summarySection = apiConfigDialogSource.slice(apiConfigDialogSource.indexOf("AI summary source"));
+    const summarySection = apiConfigDialogSource.slice(apiConfigDialogSource.indexOf("AI summary & search source"));
 
     expect(summarySection).toContain("SUMMARY_API_PROVIDER_PRESETS.map");
     expect(summarySection).not.toMatch(/CodexZH/);


### PR DESCRIPTION
## 功能

新增 **AI 找会话**：右上角 ✨ 按钮打开一个对话式 AI 助手，用自然语言描述你要找的会话，助手会在已索引的历史里搜索，并把命中的会话以**可点击卡片**形式展示（点击直接打开会话详情）。

## 工作原理

- **自定义（HTTP）provider** → 完整 **function calling**：模型自主调用与 MCP server 相同的查询工具（`search_sessions` / `list_projects` / `list_tags` / `get_session`），多轮循环直到给出答案，并返回命中的会话。
- **本机 CLI provider**（`codex exec` / `claude`）→ 降级路径（这类一次性 CLI 不支持 HTTP function calling）：用用户的原话对本地库做关键词搜索，再让 CLI 基于命中结果写出有依据的回答。
- Provider 路由与 **AI 摘要共用**，由 `summarySource` 决定（Codex / Claude Code / 自定义）。**默认走本机 Codex**，无需配置 API 即可开箱即用；若选了自定义 provider 但没配完整，会自动兜底到本机 Codex。

## 主要改动

- `src/core/ai-assistant.ts` —— 工具调用引擎（OpenAI + Anthropic tools）+ 本机 CLI 降级路径；网络/CLI 调用均可注入，便于单测。
- `src/main/index.ts` —— `ai:assistant-chat` IPC handler；在完整工具调用与 CLI 降级之间路由；provider 未配好时兜底 Codex。
- `src/preload/index.ts` —— `askAiAssistant` 桥接。
- `src/renderer/src/components/ai-assistant-dialog.tsx` —— 对话弹窗，支持 markdown 回复 + 可点击会话卡片。
- `src/renderer/src/lightweight-markdown.tsx` —— 零依赖的轻量 markdown 渲染器，用于助手回复。
- `src/renderer/src/App.tsx` —— 右上角 AI 按钮、弹窗接入、Esc 关闭。
- API 配置 Tab 改名 **AI Summary → AI Summary & Search**（provider 共用）；移除 API Key 输入框的 `sk-...` 占位提示。

## 界面/交互

- 弹窗自适应高度（带最小高度，发送后不跳动）+ 最大高度封顶后滚动。
- 助手回复和卡片摘要支持 markdown 渲染；文字可选中；搜索时有打字动画。

## 测试

- `src/core/ai-assistant.test.ts` —— 工具调用循环、sessionKey 去重、工具异常处理、本机 CLI 端点判定、降级"搜索 + CLI 润色"流程。
- 全量测试通过（516 个），typecheck 与 build 均通过。