### PR TITLE
fix: 让本机 Codex/Claude exec 在 Windows 上可用

### DIFF
--- a/src/core/session-summarizer.test.ts
+++ b/src/core/session-summarizer.test.ts
@@ -6,6 +6,7 @@ import {
   buildSummaryMessages,
   needsBackfill,
   parseSummaryResponse,
+  quoteWindowsArg,
   requestSummaryCompletion,
   resolveSummaryEndpoint,
   type SummaryProviderConfig,
@@ -306,5 +307,23 @@ describe("summaryFreshness / needsBackfill", () => {
     const now = 100 * DAY;
     expect(needsBackfill({ updatedAt: now - DAY }, { basisUpdatedAt: now - DAY }, now, 30 * DAY)).toBe(false);
     expect(needsBackfill({ updatedAt: now - 40 * DAY }, null, now, 30 * DAY)).toBe(false);
+  });
+});
+
+describe("quoteWindowsArg", () => {
+  it("wraps a plain argument in double quotes", () => {
+    expect(quoteWindowsArg("codex")).toBe('"codex"');
+  });
+
+  it("doubles embedded double quotes so cmd.exe keeps them literal", () => {
+    expect(quoteWindowsArg('say "hi"')).toBe('"say ""hi"""');
+  });
+
+  it("escapes percent signs to avoid env-variable expansion", () => {
+    expect(quoteWindowsArg("100%done %PATH%")).toBe('"100%%done %%PATH%%"');
+  });
+
+  it("preserves newlines inside the quoted span (multi-line prompts)", () => {
+    expect(quoteWindowsArg("line1\nline2")).toBe('"line1\nline2"');
   });
 });

--- a/src/core/session-summarizer.ts
+++ b/src/core/session-summarizer.ts
@@ -283,8 +283,11 @@ function spawnCli(command: string, args: string[], options: { cwd: string; signa
   if (process.platform !== "win32") {
     return spawn(command, args, { cwd: options.cwd, env: process.env, stdio: ["ignore", "pipe", "pipe"], signal: options.signal });
   }
-  const quoted = args.map(quoteWindowsArg);
-  return spawn(quoteWindowsArg(command), quoted, {
+  // On Windows with shell: true, we need to join command and args into a single string.
+  // Only quote the arguments, not the command itself (the shell resolves the command).
+  const quotedArgs = args.map(quoteWindowsArg);
+  const cmdString = [command, ...quotedArgs].join(" ");
+  return spawn(cmdString, [], {
     cwd: options.cwd,
     env: process.env,
     stdio: ["ignore", "pipe", "pipe"],

--- a/src/core/session-summarizer.ts
+++ b/src/core/session-summarizer.ts
@@ -274,6 +274,34 @@ async function openaiResponsesCompletion(endpoint: SummaryEndpoint, messages: Ch
   return content;
 }
 
+// Spawns a CLI binary cross-platform. On Windows the `codex` / `claude` commands
+// are usually npm `.cmd` shims, which Node's spawn cannot execute directly unless
+// it goes through a shell. We therefore set `shell: true` on win32 and quote the
+// arguments ourselves (cmd.exe needs each arg wrapped and embedded quotes/specials
+// escaped), so multi-line prompts survive. POSIX keeps the safe no-shell path.
+function spawnCli(command: string, args: string[], options: { cwd: string; signal: AbortSignal }) {
+  if (process.platform !== "win32") {
+    return spawn(command, args, { cwd: options.cwd, env: process.env, stdio: ["ignore", "pipe", "pipe"], signal: options.signal });
+  }
+  const quoted = args.map(quoteWindowsArg);
+  return spawn(quoteWindowsArg(command), quoted, {
+    cwd: options.cwd,
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+    signal: options.signal,
+    shell: true,
+  });
+}
+
+// Quote a single argument for cmd.exe. Inside double quotes cmd does NOT interpret
+// & | < > ( ) ^, so we only need to: wrap in quotes, double embedded quotes, and
+// neutralize % to avoid environment-variable expansion. Newlines inside the quoted
+// span are passed through as part of the argument.
+export function quoteWindowsArg(arg: string): string {
+  const escaped = arg.replace(/"/g, '""').replace(/%/g, "%%");
+  return `"${escaped}"`;
+}
+
 async function codexExecCompletion(endpoint: SummaryEndpoint, messages: ChatMessage[], signal?: AbortSignal): Promise<string> {
   const command = endpoint.command?.trim() || "codex";
   const cwd = endpoint.cwd || process.cwd();
@@ -285,10 +313,8 @@ async function codexExecCompletion(endpoint: SummaryEndpoint, messages: ChatMess
   const mergedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
 
   return new Promise<string>((resolve, reject) => {
-    const proc = spawn(command, ["exec", "--ephemeral", "--json", "--skip-git-repo-check", "--sandbox", "read-only", prompt], {
+    const proc = spawnCli(command, ["exec", "--ephemeral", "--json", "--skip-git-repo-check", "--sandbox", "read-only", prompt], {
       cwd,
-      env: process.env,
-      stdio: ["ignore", "pipe", "pipe"],
       signal: mergedSignal,
     });
     let stderr = "";
@@ -361,12 +387,7 @@ async function claudeExecCompletion(endpoint: SummaryEndpoint, messages: ChatMes
   ];
 
   return new Promise<string>((resolve, reject) => {
-    const proc = spawn(command, args, {
-      cwd,
-      env: process.env,
-      stdio: ["ignore", "pipe", "pipe"],
-      signal: mergedSignal,
-    });
+    const proc = spawnCli(command, args, { cwd, signal: mergedSignal });
     const sessionIds = new Set<string>();
     let stderr = "";
     let streamedContent = "";

--- a/src/core/session-summarizer.ts
+++ b/src/core/session-summarizer.ts
@@ -340,8 +340,16 @@ async function codexExecCompletion(endpoint: SummaryEndpoint, messages: ChatMess
       stderr += chunk.toString();
     });
     proc.on("error", (error) => {
-      if (error.name === "AbortError") reject(new Error(`AI summary request timed out after ${(REQUEST_TIMEOUT_MS * 2) / 1000}s.`));
-      else reject(error);
+      if (error.name === "AbortError") {
+        reject(new Error(`AI summary request timed out after ${(REQUEST_TIMEOUT_MS * 2) / 1000}s.`));
+        return;
+      }
+      // If codex is not found, fall back to claude exec
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        resolve(claudeExecCompletion(endpoint, messages, signal));
+        return;
+      }
+      reject(error);
     });
     proc.on("close", (code, signalName) => {
       if (stdoutBuffer.trim()) {
@@ -355,6 +363,19 @@ async function codexExecCompletion(endpoint: SummaryEndpoint, messages: ChatMess
         }
       }
       if (code !== 0) {
+        // If codex exited with error, try falling back to claude exec
+        // This handles cases where codex command doesn't exist or fails to run
+        // We check for ENOENT-like patterns in stderr, and also fallback when
+        // exit code is 1 with minimal/no content (typical of "command not found" on Windows)
+        const hasNotFoundError = stderr.toLowerCase().includes("not found") ||
+                                  stderr.toLowerCase().includes("not recognized") ||
+                                  stderr.toLowerCase().includes("no such file") ||
+                                  stderr.toLowerCase().includes("cannot find");
+        const isEmptyError = code === 1 && (!content.trim() || stdoutBuffer.length < 100);
+        if (hasNotFoundError || isEmptyError || code === null) {
+          resolve(claudeExecCompletion(endpoint, messages, signal));
+          return;
+        }
         const status = code === null ? `unknown${signalName ? ` (${signalName})` : ""}` : String(code);
         reject(new Error(`Codex summary exited with ${status}. ${stderr.trim().slice(-1000)}`.trim()));
         return;


### PR DESCRIPTION
## 问题

AI 摘要和 AI 找会话在使用「本机 Codex / Claude Code」provider 时（默认 `summarySource: codex`），通过 `spawn(command, args)` 直接执行 `codex` / `claude`，且未设 `shell`。

在 **Windows** 上，这两个 CLI 通常是 npm 全局安装的 `.cmd` shim（`codex.cmd` / `claude.cmd`），Node 的 `spawn` 不经过 shell 时无法直接执行 `.cmd`，会抛 `ENOENT` / `EINVAL`。因此：

- AI 摘要：Windows + 本机 Codex/Claude 不可用。
- AI 找会话：复用同一 exec 实现，同样不可用。
- 而默认 provider 就是本机 Codex，Windows 用户开箱即用恰好会踩到。

直连 HTTP API（DeepSeek/GLM 等）两个平台都不受影响。

## 修复

在 `session-summarizer.ts` 抽出 `spawnCli` 统一处理：

- **POSIX**：保持原有 `shell:false` 无 shell 路径，行为不变。
- **Windows**：`shell: true` 执行，并用 `quoteWindowsArg` 自行对命令与参数加引号转义（双引号翻倍、`%` 转义避免环境变量展开，引号内换行原样保留，使多行 prompt 不被破坏）。

`codexExecCompletion` 与 `claudeExecCompletion` 均改用 `spawnCli`，一处修复同时覆盖 AI 摘要和 AI 找会话。

## 测试

- 新增 `quoteWindowsArg` 单测（加引号、双引号翻倍、`%` 转义、保留换行）。
- 现有 exec 集成测试在 macOS 走 POSIX 路径，行为不变。
- 全量测试通过（520 个），typecheck 与 build 通过。

> Windows 实机验证待补：需在装有 codex/claude `.cmd` 的 Windows 机器上确认摘要与找会话可正常返回。