### PR TITLE
feat: AI 找会话先提取关键字，本机 CLI 支持限轮多搜

### DIFF
--- a/src/core/ai-assistant.test.ts
+++ b/src/core/ai-assistant.test.ts
@@ -140,6 +140,20 @@ describe("extractFallbackKeywords", () => {
   });
 });
 
+// Helper: a fake `complete` that returns extraction keywords (when the system
+// prompt is the keyword-extraction one) vs a grounding reply otherwise.
+function makeFakeComplete(extraction: () => string, grounding: (prompt: string) => string) {
+  let groundingPrompt = "";
+  const complete = async (_e: SummaryEndpoint, messages: { role: string; content: string }[]) => {
+    const system = messages.find((m) => m.role === "system")?.content ?? "";
+    const isExtraction = system.includes("convert a developer's natural-language request into search keywords");
+    if (isExtraction) return extraction();
+    groundingPrompt = messages.map((m) => m.content).join("\n");
+    return grounding(groundingPrompt);
+  };
+  return { complete, getGroundingPrompt: () => groundingPrompt };
+}
+
 describe("runAiAssistantFallback", () => {
   it("extracts keywords, searches with them, and grounds the CLI answer over the hits", async () => {
     const hits: FallbackSessionHit[] = [
@@ -151,15 +165,10 @@ describe("runAiAssistantFallback", () => {
       searchedQuery = query;
       return hits;
     };
-    // complete is called twice: first for keyword extraction, then for grounding.
-    let groundingPrompt = "";
-    let call = 0;
-    const complete = async (_e: SummaryEndpoint, messages: { role: string; content: string }[]) => {
-      call += 1;
-      if (call === 1) return "sqlite migration"; // extraction
-      groundingPrompt = messages.map((m) => m.content).join("\n");
-      return "The first session matches best.";
-    };
+    const { complete, getGroundingPrompt } = makeFakeComplete(
+      () => "sqlite migration",
+      () => "The first session matches best.",
+    );
 
     const history: AiChatMessage[] = [{ role: "user", content: "find my sqlite migration fix" }];
     const result = await runAiAssistantFallback(codexEndpoint, history, search, { complete });
@@ -168,21 +177,77 @@ describe("runAiAssistantFallback", () => {
     expect(result.reply).toBe("The first session matches best.");
     expect(result.sessionKeys).toEqual(["s1", "s2"]);
     // The grounding prompt keeps the original request and the candidate catalog.
+    const groundingPrompt = getGroundingPrompt();
     expect(groundingPrompt).toContain("find my sqlite migration fix");
     expect(groundingPrompt).toContain("Fix SQLite migration");
     expect(groundingPrompt).toContain("[1]");
   });
 
-  it("tells the CLI when nothing matched", async () => {
-    const search = async (): Promise<FallbackSessionHit[]> => [];
-    let groundingPrompt = "";
-    let call = 0;
-    const complete = async (_e: SummaryEndpoint, messages: { role: string; content: string }[]) => {
-      call += 1;
-      if (call === 1) return "nonexistent topic"; // extraction
-      groundingPrompt = messages.map((m) => m.content).join("\n");
-      return "No matching sessions; try other keywords.";
+  it("retries with different keywords when the first search misses, then succeeds", async () => {
+    const queries: string[] = [];
+    const search = async (query: string): Promise<FallbackSessionHit[]> => {
+      queries.push(query);
+      // First keyword set misses; the second one hits.
+      return query === "second try"
+        ? [{ sessionKey: "s9", title: "Found it", source: "codex-cli", project: "/p", summary: null }]
+        : [];
     };
+    let extractionCalls = 0;
+    const extractionPrompts: string[] = [];
+    const complete = async (_e: SummaryEndpoint, messages: { role: string; content: string }[]) => {
+      const system = messages.find((m) => m.role === "system")?.content ?? "";
+      if (system.includes("convert a developer's natural-language request into search keywords")) {
+        extractionCalls += 1;
+        extractionPrompts.push(messages.find((m) => m.role === "user")?.content ?? "");
+        return extractionCalls === 1 ? "first try" : "second try";
+      }
+      return "Found the session you wanted.";
+    };
+
+    const result = await runAiAssistantFallback(
+      codexEndpoint,
+      [{ role: "user", content: "find that thing" }],
+      search,
+      { complete },
+    );
+
+    expect(queries).toEqual(["first try", "second try"]);
+    expect(result.sessionKeys).toEqual(["s9"]);
+    // The retry's extraction prompt must mention the keyword set that missed.
+    expect(extractionPrompts[1]).toContain("first try");
+    expect(extractionPrompts[1]).toContain("NO results");
+  });
+
+  it("stops retrying once a keyword set repeats", async () => {
+    const queries: string[] = [];
+    const search = async (query: string): Promise<FallbackSessionHit[]> => {
+      queries.push(query);
+      return [];
+    };
+    // Extraction always returns the same keywords -> loop must bail after one search.
+    const { complete } = makeFakeComplete(
+      () => "same keywords",
+      () => "Nothing found.",
+    );
+
+    const result = await runAiAssistantFallback(
+      codexEndpoint,
+      [{ role: "user", content: "x" }],
+      search,
+      { complete },
+    );
+
+    expect(queries).toEqual(["same keywords"]);
+    expect(result.sessionKeys).toEqual([]);
+  });
+
+  it("tells the CLI when nothing matched after all attempts", async () => {
+    const search = async (): Promise<FallbackSessionHit[]> => [];
+    let extractionCalls = 0;
+    const { complete, getGroundingPrompt } = makeFakeComplete(
+      () => `attempt-${++extractionCalls}`,
+      () => "No matching sessions; try other keywords.",
+    );
 
     const result = await runAiAssistantFallback(
       codexEndpoint,
@@ -192,6 +257,8 @@ describe("runAiAssistantFallback", () => {
     );
 
     expect(result.sessionKeys).toEqual([]);
-    expect(groundingPrompt).toContain("No sessions matched");
+    // It exhausts the round budget and reports the keyword sets it tried.
+    expect(extractionCalls).toBe(3);
+    expect(getGroundingPrompt()).toContain("No sessions matched");
   });
 });

--- a/src/core/ai-assistant.test.ts
+++ b/src/core/ai-assistant.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  extractFallbackKeywords,
   isLocalCliEndpoint,
   runAiAssistantFallback,
   runAiAssistantTurn,
@@ -98,8 +99,49 @@ describe("isLocalCliEndpoint", () => {
   });
 });
 
+describe("extractFallbackKeywords", () => {
+  it("distills the user's request into keywords via one CLI call", async () => {
+    let extractionPrompt = "";
+    const complete = async (_e: SummaryEndpoint, messages: { role: string; content: string }[]) => {
+      extractionPrompt = messages.map((m) => m.content).join("\n");
+      return "sqlite migration fix\n";
+    };
+    const keywords = await extractFallbackKeywords(
+      codexEndpoint,
+      [{ role: "user", content: "find my sqlite migration fix" }],
+      complete,
+    );
+    expect(keywords).toBe("sqlite migration fix");
+    expect(extractionPrompt).toContain("find my sqlite migration fix");
+  });
+
+  it("strips quotes and collapses whitespace, keeping only the first line", async () => {
+    const complete = async () => `  "sqlite   migration"  \nignored second line`;
+    const keywords = await extractFallbackKeywords(codexEndpoint, [{ role: "user", content: "x" }], complete);
+    expect(keywords).toBe("sqlite migration");
+  });
+
+  it("falls back to the verbatim request when extraction throws", async () => {
+    const complete = async () => {
+      throw new Error("cli crashed");
+    };
+    const keywords = await extractFallbackKeywords(
+      codexEndpoint,
+      [{ role: "user", content: "the auth refactor" }],
+      complete,
+    );
+    expect(keywords).toBe("the auth refactor");
+  });
+
+  it("falls back to the verbatim request when extraction returns empty", async () => {
+    const complete = async () => "   \n  ";
+    const keywords = await extractFallbackKeywords(codexEndpoint, [{ role: "user", content: "the auth refactor" }], complete);
+    expect(keywords).toBe("the auth refactor");
+  });
+});
+
 describe("runAiAssistantFallback", () => {
-  it("searches with the user's words and asks the CLI to ground its answer over the hits", async () => {
+  it("extracts keywords, searches with them, and grounds the CLI answer over the hits", async () => {
     const hits: FallbackSessionHit[] = [
       { sessionKey: "s1", title: "Fix SQLite migration", source: "claude-cli", project: "/p", summary: "fixed it" },
       { sessionKey: "s2", title: "Other", source: "codex-cli", project: "/q", summary: null },
@@ -109,28 +151,36 @@ describe("runAiAssistantFallback", () => {
       searchedQuery = query;
       return hits;
     };
-    let promptSeen = "";
+    // complete is called twice: first for keyword extraction, then for grounding.
+    let groundingPrompt = "";
+    let call = 0;
     const complete = async (_e: SummaryEndpoint, messages: { role: string; content: string }[]) => {
-      promptSeen = messages.map((m) => m.content).join("\n");
+      call += 1;
+      if (call === 1) return "sqlite migration"; // extraction
+      groundingPrompt = messages.map((m) => m.content).join("\n");
       return "The first session matches best.";
     };
 
     const history: AiChatMessage[] = [{ role: "user", content: "find my sqlite migration fix" }];
     const result = await runAiAssistantFallback(codexEndpoint, history, search, { complete });
 
-    expect(searchedQuery).toBe("find my sqlite migration fix");
+    expect(searchedQuery).toBe("sqlite migration");
     expect(result.reply).toBe("The first session matches best.");
     expect(result.sessionKeys).toEqual(["s1", "s2"]);
-    // The CLI prompt must include the candidate catalog so the answer is grounded.
-    expect(promptSeen).toContain("Fix SQLite migration");
-    expect(promptSeen).toContain("[1]");
+    // The grounding prompt keeps the original request and the candidate catalog.
+    expect(groundingPrompt).toContain("find my sqlite migration fix");
+    expect(groundingPrompt).toContain("Fix SQLite migration");
+    expect(groundingPrompt).toContain("[1]");
   });
 
   it("tells the CLI when nothing matched", async () => {
     const search = async (): Promise<FallbackSessionHit[]> => [];
-    let promptSeen = "";
+    let groundingPrompt = "";
+    let call = 0;
     const complete = async (_e: SummaryEndpoint, messages: { role: string; content: string }[]) => {
-      promptSeen = messages.map((m) => m.content).join("\n");
+      call += 1;
+      if (call === 1) return "nonexistent topic"; // extraction
+      groundingPrompt = messages.map((m) => m.content).join("\n");
       return "No matching sessions; try other keywords.";
     };
 
@@ -142,6 +192,6 @@ describe("runAiAssistantFallback", () => {
     );
 
     expect(result.sessionKeys).toEqual([]);
-    expect(promptSeen).toContain("No sessions matched");
+    expect(groundingPrompt).toContain("No sessions matched");
   });
 });

--- a/src/core/ai-assistant.ts
+++ b/src/core/ai-assistant.ts
@@ -198,15 +198,21 @@ const FALLBACK_SYSTEM_PROMPT =
   "title. If none fit, say so and suggest different keywords. Do not invent sessions.";
 
 // One-shot CLIs (codex exec / claude) cannot do HTTP function calling, so the
-// model never gets to pick search terms itself. To match the quality of the
-// tool-calling path we run a tiny extraction pass first: ask the CLI to turn the
-// user's natural-language request into a few FTS5-friendly keywords.
+// model never gets to pick search terms itself. To approximate the tool-calling
+// path we run a bounded search loop: ask the CLI for keywords, run the FTS
+// search, and — if nothing matched — ask it for *different* keywords and try
+// again, up to MAX_FALLBACK_SEARCH_ROUNDS times. Only the search tool is
+// exposed (no get_session etc.), keeping the protocol simple and predictable.
 const KEYWORD_EXTRACTION_SYSTEM_PROMPT =
   "You convert a developer's natural-language request into search keywords for a full-text search over their past " +
   "AI-coding sessions. Output ONLY the keywords, space-separated, on a single line — no quotes, no explanation, no " +
   "punctuation. Keep concrete nouns, technical terms, file names, error messages, and identifiers; drop filler " +
   "words, pronouns, and conversational phrasing (e.g. 'find the session where I', 'help me look for'). Preserve the " +
   "user's language. Return at most 8 keywords.";
+
+// How many keyword/search attempts the CLI fallback gets. The first round uses
+// the user's request; later rounds ask for alternative keywords after a miss.
+const MAX_FALLBACK_SEARCH_ROUNDS = 3;
 
 // Pulls the latest user message verbatim. Used as the grounding context and as
 // the fallback query when keyword extraction yields nothing useful.
@@ -229,24 +235,31 @@ function sanitizeKeywords(raw: string): string {
     .slice(0, 200);
 }
 
-// Asks the CLI to distill the request into keywords. On any failure (or empty
-// result) it returns the verbatim request so search still runs.
+// Asks the CLI to distill the request into keywords. `previousAttempts` lists
+// keyword sets that already returned nothing, so the model is told to try
+// different terms on a retry. On any failure (or empty result) it returns the
+// verbatim request so search still runs.
 export async function extractFallbackKeywords(
   endpoint: SummaryEndpoint,
   history: readonly AiChatMessage[],
   complete: PlainCompletionFn,
-  signal?: AbortSignal,
+  options: { previousAttempts?: readonly string[]; signal?: AbortSignal } = {},
 ): Promise<string> {
   const request = extractFallbackQuery(history);
   if (!request) return "";
+  const previousAttempts = options.previousAttempts ?? [];
+  const userContent = previousAttempts.length
+    ? `Request: ${request}\n\nThese keyword sets already returned NO results, so avoid them and try different ` +
+      `terms (synonyms, broader or more specific words):\n${previousAttempts.map((a) => `- ${a}`).join("\n")}`
+    : request;
   try {
     const raw = await complete(
       endpoint,
       [
         { role: "system", content: KEYWORD_EXTRACTION_SYSTEM_PROMPT },
-        { role: "user", content: request },
+        { role: "user", content: userContent },
       ],
-      signal,
+      options.signal,
     );
     const keywords = sanitizeKeywords(raw);
     return keywords || request;
@@ -264,9 +277,25 @@ export async function runAiAssistantFallback(
 ): Promise<AiAssistantReplyInternal> {
   const complete = options.complete ?? requestSummaryCompletion;
   const request = extractFallbackQuery(history);
-  const query = request ? await extractFallbackKeywords(endpoint, history, complete, options.signal) : "";
-  const hits = query ? await search(query) : [];
 
+  // Bounded keyword/search loop: keep trying different keywords until we get
+  // hits or run out of rounds. Only the search tool is exposed here.
+  const attempts: string[] = [];
+  let hits: FallbackSessionHit[] = [];
+  if (request) {
+    for (let round = 0; round < MAX_FALLBACK_SEARCH_ROUNDS; round += 1) {
+      const query = await extractFallbackKeywords(endpoint, history, complete, {
+        previousAttempts: attempts,
+        signal: options.signal,
+      });
+      if (!query || attempts.includes(query)) break; // nothing new to try
+      attempts.push(query);
+      hits = await search(query);
+      if (hits.length > 0) break;
+    }
+  }
+
+  const usedKeywords = attempts.join(" | ") || request;
   const catalog = hits
     .map((hit, index) => {
       const summary = hit.summary ? ` — ${hit.summary}` : "";
@@ -275,8 +304,8 @@ export async function runAiAssistantFallback(
     .join("\n");
 
   const userPrompt = hits.length
-    ? `User request: ${request}\n\nSearched with keywords: ${query}\n\nCandidate sessions:\n${catalog}\n\nWhich of these best match, and why?`
-    : `User request: ${request}\n\nSearched with keywords: ${query}\n\nNo sessions matched a keyword search of the local history.`;
+    ? `User request: ${request}\n\nSearched with keywords: ${usedKeywords}\n\nCandidate sessions:\n${catalog}\n\nWhich of these best match, and why?`
+    : `User request: ${request}\n\nTried these keyword sets: ${usedKeywords}\n\nNo sessions matched any of them in the local history.`;
 
   const reply = await complete(
     endpoint,

--- a/src/core/ai-assistant.ts
+++ b/src/core/ai-assistant.ts
@@ -52,9 +52,13 @@ export interface AiAssistantReplyInternal {
 export const AI_ASSISTANT_SYSTEM_PROMPT =
   "You are the session-search assistant inside a desktop app that indexes the user's past AI coding sessions " +
   "(Claude Code, Codex, CodeBuddy, etc.). The user describes a session they are trying to find; your job is to " +
-  "locate it. ALWAYS use the provided tools to search — never guess from memory. Prefer search_sessions with " +
-  "concise keywords; call it multiple times with different keywords if the first attempt misses. Use list_projects " +
-  "or list_tags to narrow scope when helpful, and get_session to confirm a candidate. " +
+  "locate it. ALWAYS use the provided tools to search — never guess from memory. " +
+  "Before searching, distill the user's request into a few precise search keywords: keep concrete nouns, " +
+  "technical terms, file names, error messages, and identifiers; drop filler words, pronouns, and conversational " +
+  "phrasing (e.g. 'find the session where I', 'help me look for'). Search in the same language the user wrote in. " +
+  "Prefer search_sessions with those concise keywords; call it multiple times with different keyword sets if the " +
+  "first attempt misses. Use list_projects or list_tags to narrow scope when helpful, and get_session to confirm a " +
+  "candidate. " +
   "When you have results, reply briefly (in the same language the user wrote in) and explain why each match fits. " +
   "Do not invent sessionKeys. If nothing matches, say so and suggest different keywords.";
 
@@ -193,13 +197,63 @@ const FALLBACK_SYSTEM_PROMPT =
   "Pick the best matches, answer briefly in the same language the user wrote in, and refer to sessions by their " +
   "title. If none fit, say so and suggest different keywords. Do not invent sessions.";
 
-// Pulls plain keywords from the latest user message for the store's FTS search.
-// We strip punctuation and keep it simple — the store does the real matching.
+// One-shot CLIs (codex exec / claude) cannot do HTTP function calling, so the
+// model never gets to pick search terms itself. To match the quality of the
+// tool-calling path we run a tiny extraction pass first: ask the CLI to turn the
+// user's natural-language request into a few FTS5-friendly keywords.
+const KEYWORD_EXTRACTION_SYSTEM_PROMPT =
+  "You convert a developer's natural-language request into search keywords for a full-text search over their past " +
+  "AI-coding sessions. Output ONLY the keywords, space-separated, on a single line — no quotes, no explanation, no " +
+  "punctuation. Keep concrete nouns, technical terms, file names, error messages, and identifiers; drop filler " +
+  "words, pronouns, and conversational phrasing (e.g. 'find the session where I', 'help me look for'). Preserve the " +
+  "user's language. Return at most 8 keywords.";
+
+// Pulls the latest user message verbatim. Used as the grounding context and as
+// the fallback query when keyword extraction yields nothing useful.
 export function extractFallbackQuery(history: readonly AiChatMessage[]): string {
   for (let i = history.length - 1; i >= 0; i -= 1) {
     if (history[i].role === "user") return history[i].content.trim();
   }
   return "";
+}
+
+// Single-line cleanup of whatever the CLI returns: collapse whitespace, strip
+// surrounding quotes/punctuation noise, and cap length so a chatty model can't
+// poison the FTS query.
+function sanitizeKeywords(raw: string): string {
+  const firstLine = raw.split(/\r?\n/).map((line) => line.trim()).find((line) => line.length > 0) ?? "";
+  return firstLine
+    .replace(/^["'`]+|["'`]+$/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 200);
+}
+
+// Asks the CLI to distill the request into keywords. On any failure (or empty
+// result) it returns the verbatim request so search still runs.
+export async function extractFallbackKeywords(
+  endpoint: SummaryEndpoint,
+  history: readonly AiChatMessage[],
+  complete: PlainCompletionFn,
+  signal?: AbortSignal,
+): Promise<string> {
+  const request = extractFallbackQuery(history);
+  if (!request) return "";
+  try {
+    const raw = await complete(
+      endpoint,
+      [
+        { role: "system", content: KEYWORD_EXTRACTION_SYSTEM_PROMPT },
+        { role: "user", content: request },
+      ],
+      signal,
+    );
+    const keywords = sanitizeKeywords(raw);
+    return keywords || request;
+  } catch {
+    // Extraction is best-effort; never let it break the actual search.
+    return request;
+  }
 }
 
 export async function runAiAssistantFallback(
@@ -209,7 +263,8 @@ export async function runAiAssistantFallback(
   options: { complete?: PlainCompletionFn; signal?: AbortSignal } = {},
 ): Promise<AiAssistantReplyInternal> {
   const complete = options.complete ?? requestSummaryCompletion;
-  const query = extractFallbackQuery(history);
+  const request = extractFallbackQuery(history);
+  const query = request ? await extractFallbackKeywords(endpoint, history, complete, options.signal) : "";
   const hits = query ? await search(query) : [];
 
   const catalog = hits
@@ -220,8 +275,8 @@ export async function runAiAssistantFallback(
     .join("\n");
 
   const userPrompt = hits.length
-    ? `User request: ${query}\n\nCandidate sessions:\n${catalog}\n\nWhich of these best match, and why?`
-    : `User request: ${query}\n\nNo sessions matched a keyword search of the local history.`;
+    ? `User request: ${request}\n\nSearched with keywords: ${query}\n\nCandidate sessions:\n${catalog}\n\nWhich of these best match, and why?`
+    : `User request: ${request}\n\nSearched with keywords: ${query}\n\nNo sessions matched a keyword search of the local history.`;
 
   const reply = await complete(
     endpoint,


### PR DESCRIPTION
## 背景

之前 AI 找会话在「本机 CLI 兜底」路径下，是把用户最后一句话原文直接丢进 FTS5 搜索，没有关键字提取，命中率一般；且只搜一轮，搜不到就直接放弃。

## 改动

### 1. 搜索前先提取关键字（两条路径都生效）

- **直连 API（function calling）路径**：在系统提示里加入明确指令——搜索前先把请求提炼成精确关键字，保留具体名词、技术词、文件名、报错、标识符，去掉填充词和代词，并用用户的语言搜索。
- **本机 CLI 兜底路径**：新增 `extractFallbackKeywords`，先调一次 CLI 把自然语言请求提炼成关键字，再喂给 FTS5；带输出清洗（取首行、去引号、压空白、截断），提取失败或为空时回退用原文，保证搜索一定能跑。

### 2. 本机 CLI 兜底支持限轮多搜

本机一次性 CLI 无法做 HTTP function calling，所以用文本协议模拟出有限的多轮搜索：

- 最多 **3 轮**：提关键字 → 搜索 → 没命中就让 CLI 换一组不同的关键字（把已失败的词集告诉它，引导避开）再搜。
- 命中即停；模型若重复同一组关键字也会停，避免空转。
- 仅开放 search 工具（不开放 get_session 等），保持文本协议简单可控。
- grounding 提示会列出所有尝试过的关键字集，回答更贴合实际检索过程。

## 测试

- 新增/更新 `ai-assistant.test.ts`：关键字提取（成功/清洗/异常回退/空回退）、多轮重试命中、重复关键字提前终止、全部落空后的报告。
- 全量 522 个测试通过，typecheck 干净，构建通过。