### PR TITLE
[codex] 支持 Supabase Skills 同步并优化远程会话加载

### DIFF
--- a/src/core/platform.test.ts
+++ b/src/core/platform.test.ts
@@ -385,6 +385,24 @@ describe("API settings", () => {
     expect(mergeAppSettings(defaultSettings, { sessionSearchMcpEnabled: false }).sessionSearchMcpEnabled).toBe(false);
   });
 
+  it("keeps Supabase skill sync disabled by default and normalizes saved credentials", () => {
+    expect(defaultSettings.skillSyncEnabled).toBe(false);
+    expect(defaultSettings.skillSyncSupabaseUrl).toBe("");
+    expect(defaultSettings.skillSyncSupabaseAnonKey).toBe("");
+
+    expect(
+      mergeAppSettings(defaultSettings, {
+        skillSyncEnabled: true,
+        skillSyncSupabaseUrl: " https://example.supabase.co/ ",
+        skillSyncSupabaseAnonKey: " anon-key ",
+      }),
+    ).toMatchObject({
+      skillSyncEnabled: true,
+      skillSyncSupabaseUrl: "https://example.supabase.co",
+      skillSyncSupabaseAnonKey: "anon-key",
+    });
+  });
+
   it("keeps explicitly saved empty API keys empty instead of refilling profile defaults", () => {
     expect(
       mergeApiConfigWithProfileDefaults(

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -71,6 +71,9 @@ export interface AppSettings {
   summaryMaxAgeDays: number;
   summarySource: "codex" | "claude" | "custom";
   sessionSearchMcpEnabled: boolean;
+  skillSyncEnabled: boolean;
+  skillSyncSupabaseUrl: string;
+  skillSyncSupabaseAnonKey: string;
   apiConfig: ApiConfig;
   claudeApiConfig: ClaudeApiConfig;
   summaryApiConfig: ApiConfig;
@@ -104,6 +107,9 @@ export const defaultSettings: AppSettings = {
   summaryMaxAgeDays: 30,
   summarySource: "codex",
   sessionSearchMcpEnabled: true,
+  skillSyncEnabled: false,
+  skillSyncSupabaseUrl: "",
+  skillSyncSupabaseAnonKey: "",
   apiConfig: defaultApiConfig,
   claudeApiConfig: defaultClaudeApiConfig,
   summaryApiConfig: defaultApiConfig,
@@ -118,10 +124,17 @@ export function mergeAppSettings(previous: AppSettings, updates: AppSettingsUpda
     notifyMinDurationSeconds: normalizeNotifyDuration(merged.notifyMinDurationSeconds),
     summaryMaxAgeDays: normalizeSummaryMaxAgeDays(merged.summaryMaxAgeDays),
     summarySource: merged.summarySource === "claude" || merged.summarySource === "custom" ? merged.summarySource : "codex",
+    skillSyncEnabled: Boolean(merged.skillSyncEnabled),
+    skillSyncSupabaseUrl: normalizeSupabaseSettingUrl(merged.skillSyncSupabaseUrl),
+    skillSyncSupabaseAnonKey: String(merged.skillSyncSupabaseAnonKey ?? "").trim(),
     apiConfig: normalizeApiConfig({ ...previous.apiConfig, ...(updates.apiConfig ?? {}) }),
     claudeApiConfig: normalizeClaudeApiConfig({ ...previous.claudeApiConfig, ...(updates.claudeApiConfig ?? {}) }),
     summaryApiConfig: normalizeApiConfig({ ...previous.summaryApiConfig, ...(updates.summaryApiConfig ?? {}) }),
   };
+}
+
+function normalizeSupabaseSettingUrl(value: string | undefined): string {
+  return String(value ?? "").trim().replace(/\/+$/, "");
 }
 
 function normalizeNotifyDuration(value: number): number {

--- a/src/core/remote-sync.test.ts
+++ b/src/core/remote-sync.test.ts
@@ -82,7 +82,7 @@ describe("remote sync", () => {
     expect(status.indexed).toBe(1);
     expect(session).toMatchObject({
       originalTitle: "Remote Summary",
-      displayTitle: "summary first question",
+      displayTitle: "Remote Summary",
       firstQuestion: "summary first question",
       messageCount: 12,
       projectPath: "/repo",

--- a/src/core/remote-sync.test.ts
+++ b/src/core/remote-sync.test.ts
@@ -3,6 +3,7 @@ import { createInMemoryStore } from "./session-store";
 import {
   buildRemoteSyncSshArgs,
   encodeRemotePayloadForTest,
+  fetchRemoteSessionMessagePage,
   fetchRemoteSessionFilePayload,
   formatRemoteSyncProcessError,
   REMOTE_SYNC_EXEC_OPTIONS,
@@ -89,6 +90,59 @@ describe("remote sync", () => {
       fileSize: 2048,
     });
     expect(store.getMessages("ssh:ssh-devbox:codex:remote-codex-summary")).toEqual([]);
+  });
+
+  it("fetches a remote session message page without transferring the full session payload", async () => {
+    const store = createInMemoryStore();
+    const environment = upsertSshEnvironment(store);
+    const session = {
+      sessionKey: "ssh:ssh-devbox:codex:remote-codex-summary",
+      rawId: "remote-codex-summary",
+      source: "codex-cli",
+      filePath: "/home/me/.codex/sessions/rollout.jsonl",
+      projectPath: "/repo",
+      environmentId: "ssh-devbox",
+      environmentKind: "ssh",
+      environmentLabel: "devbox",
+      originalTitle: "Remote Summary",
+      firstQuestion: "older prompt",
+      timestamp: new Date("2026-06-04T10:00:00Z").getTime(),
+      fileMtimeMs: 100,
+      fileSize: 2048,
+      prUrl: null,
+      prNumber: null,
+      tokenUsage: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, reasoningOutputTokens: 0, totalTokens: 0 },
+      customTitle: null,
+      displayTitle: "Remote Summary",
+      favorited: false,
+      pinned: false,
+      hidden: false,
+      tags: [],
+      matchSnippet: null,
+      lastOpenedAt: null,
+      lastResumedAt: null,
+      lastActivityAt: new Date("2026-06-04T10:00:00Z").getTime(),
+      messageCount: 12,
+      aiSummary: null,
+      aiSummaryStale: false,
+    } as SessionSearchResult;
+
+    const page = await fetchRemoteSessionMessagePage(environment, session, 10, 2, {
+      runSsh: async (_environment, remoteCommand) => {
+        expect(remoteCommand).toContain("python3 -c");
+        return JSON.stringify({
+          messages: [
+            { index: 10, role: "user", content: "older prompt", timestamp: "2026-06-04T10:10:00Z" },
+            { index: 11, role: "assistant", content: "older answer", timestamp: "2026-06-04T10:11:00Z" },
+          ],
+        });
+      },
+    });
+
+    expect(page).toEqual([
+      { index: 10, role: "user", content: "older prompt", timestamp: "2026-06-04T10:10:00Z" },
+      { index: 11, role: "assistant", content: "older answer", timestamp: "2026-06-04T10:11:00Z" },
+    ]);
   });
 
   it("rejects invalid remote payload protocol output and records sync error", async () => {

--- a/src/core/remote-sync.ts
+++ b/src/core/remote-sync.ts
@@ -2,7 +2,7 @@ import { execFile, type ExecFileOptions } from "node:child_process";
 import { loadRemoteSessionPayloads, type RemoteSessionFilePayload } from "./remote-session-loader";
 import type { SessionStore } from "./session-store";
 import { buildSshArgs } from "./ssh-config";
-import type { IndexedSession, SessionEnvironment, SessionSearchResult, SessionSource } from "./types";
+import type { IndexedSession, SessionEnvironment, SessionMessage, SessionSearchResult, SessionSource } from "./types";
 
 export interface RemoteSyncStatus {
   environmentId: string;
@@ -158,6 +158,18 @@ export async function fetchRemoteSessionFilePayload(
   return payload;
 }
 
+export async function fetchRemoteSessionMessagePage(
+  environment: SessionEnvironment,
+  session: SessionSearchResult,
+  offset = 0,
+  limit = 120,
+  options: RemoteSessionFileFetchOptions = {},
+): Promise<SessionMessage[]> {
+  const runSsh = options.runSsh ?? runSystemSsh;
+  const output = await runSsh(environment, buildRemoteMessagePageCommand(session, offset, limit));
+  return decodeRemoteMessagePage(output);
+}
+
 function buildRemoteFileFetchCommand(filePath: string): string {
   const script = String.raw`import base64, json
 from pathlib import Path
@@ -175,6 +187,131 @@ print(json.dumps({
   "contentBase64": base64.b64encode(content).decode("ascii"),
 }, ensure_ascii=False))`.replace("__PATH_B64__", Buffer.from(filePath, "utf-8").toString("base64"));
   return buildPythonBase64Command(script);
+}
+
+function buildRemoteMessagePageCommand(session: SessionSearchResult, offset: number, limit: number): string {
+  const request = {
+    path: session.filePath,
+    kind: session.source.startsWith("claude") ? "claude" : "codex",
+    offset: Math.max(0, Math.floor(offset)),
+    limit: Math.max(0, Math.min(500, Math.floor(limit))),
+  };
+  const script = String.raw`import json
+from pathlib import Path
+
+request = __REQUEST_JSON__
+path = Path(request["path"])
+kind = request["kind"]
+offset = int(request["offset"])
+limit = int(request["limit"])
+end = offset + limit
+
+def text_from_blocks(content):
+  if isinstance(content, str):
+    return content
+  if not isinstance(content, list):
+    return ""
+  parts = []
+  for block in content:
+    if not isinstance(block, dict):
+      continue
+    if block.get("type") in {"tool_use", "tool_result", "input_image"}:
+      continue
+    text = block.get("text")
+    if isinstance(text, str) and text:
+      parts.append(text)
+  return "\n".join(parts)
+
+def meaningful_user(text):
+  value = text.strip()
+  if not value:
+    return False
+  import re
+  if re.match(r"^#\s*(AGENTS|CLAUDE)\.md", value, re.I):
+    return False
+  if re.match(r"^<(system-reminder|environment_context|command-message|command-name|command-args|task-notification|local-command-stdout|local-command-stderr|user-prompt-submit-hook|bash-input|bash-stdout|bash-stderr)[\s>]", value):
+    return False
+  if value.startswith("Caveat:"):
+    return False
+  if re.match(r"^\[Request interrupted by user(?: for tool use)?\]$", value):
+    return False
+  if re.match(r"^\[Image:[^\]]*\]$", value):
+    return False
+  return True
+
+def parse_message(row):
+  if not isinstance(row, dict):
+    return None
+  if kind == "codex":
+    role = None
+    content = None
+    if row.get("type") == "response_item":
+      payload = row.get("payload")
+      if isinstance(payload, dict) and payload.get("type") == "message":
+        role = payload.get("role")
+        content = payload.get("content")
+    elif row.get("type") == "message":
+      role = row.get("role")
+      content = row.get("content")
+    if role not in {"user", "assistant"}:
+      return None
+    text = text_from_blocks(content)
+    if not text or (role == "user" and not meaningful_user(text)):
+      return None
+    return {"role": role, "content": text, "timestamp": row.get("timestamp") if isinstance(row.get("timestamp"), str) else ""}
+  if row.get("type") not in {"user", "assistant"}:
+    return None
+  message = row.get("message")
+  content = message.get("content") if isinstance(message, dict) else None
+  text = text_from_blocks(content)
+  if not text or (row.get("type") == "user" and not meaningful_user(text)):
+    return None
+  return {"role": row.get("type"), "content": text, "timestamp": row.get("timestamp") if isinstance(row.get("timestamp"), str) else ""}
+
+messages = []
+message_index = 0
+with path.open("r", encoding="utf-8", errors="replace") as handle:
+  for line in handle:
+    if limit <= 0:
+      break
+    try:
+      row = json.loads(line)
+    except Exception:
+      continue
+    parsed = parse_message(row)
+    if not parsed:
+      continue
+    if message_index >= offset and message_index < end:
+      messages.append({
+        "index": message_index,
+        "role": parsed["role"],
+        "content": parsed["content"],
+        "timestamp": parsed["timestamp"],
+      })
+    message_index += 1
+    if message_index >= end:
+      break
+
+print(json.dumps({"messages": messages}, ensure_ascii=False))`.replace("__REQUEST_JSON__", JSON.stringify(request));
+  return buildPythonBase64Command(script);
+}
+
+function decodeRemoteMessagePage(output: string): SessionMessage[] {
+  const line = output
+    .split("\n")
+    .map((item) => item.trim())
+    .find(Boolean);
+  if (!line) return [];
+  const parsed = JSON.parse(line) as unknown;
+  if (!isRecord(parsed) || !Array.isArray(parsed.messages)) throw new Error("Invalid remote message page payload.");
+  return parsed.messages.flatMap((item): SessionMessage[] => {
+    if (!isRecord(item)) return [];
+    const index = numberField(item, "index");
+    const role = item.role;
+    const content = stringField(item, "content");
+    if ((role !== "user" && role !== "assistant") || !content) return [];
+    return [{ index: Math.max(0, Math.floor(index)), role, content, timestamp: stringField(item, "timestamp") }];
+  });
 }
 
 export function formatRemoteSyncProcessError(error: unknown, stdout: string, stderr: string): string {

--- a/src/core/session-store.test.ts
+++ b/src/core/session-store.test.ts
@@ -438,6 +438,47 @@ describe("SessionStore", () => {
     expect(store.getApiProviderKey("codex", "codexzh")).toBe("sk-codexzh");
   });
 
+  it("stores skill sync bindings for local and remote lookup", () => {
+    const store = createInMemoryStore();
+
+    store.upsertSkillSyncBinding({
+      localSkillPath: "/tmp/.codex/skills/review-code/SKILL.md",
+      remoteSkillId: "remote-review",
+      remoteUpdatedAt: "2026-06-29T10:00:00.000Z",
+      lastSyncedAt: 100,
+      direction: "upload",
+    });
+
+    expect(store.getSkillSyncBindingForLocalPath("/tmp/.codex/skills/review-code/SKILL.md")).toEqual({
+      localSkillPath: "/tmp/.codex/skills/review-code/SKILL.md",
+      remoteSkillId: "remote-review",
+      remoteUpdatedAt: "2026-06-29T10:00:00.000Z",
+      lastSyncedAt: 100,
+      direction: "upload",
+    });
+    expect(store.getSkillSyncBindingForRemoteId("remote-review")?.localSkillPath).toBe("/tmp/.codex/skills/review-code/SKILL.md");
+
+    store.upsertSkillSyncBinding({
+      localSkillPath: "/tmp/.codex/skills/review-code/SKILL.md",
+      remoteSkillId: "remote-review",
+      remoteUpdatedAt: "2026-06-29T11:00:00.000Z",
+      lastSyncedAt: 200,
+      direction: "download",
+    });
+
+    expect(store.listSkillSyncBindings()).toEqual([
+      {
+        localSkillPath: "/tmp/.codex/skills/review-code/SKILL.md",
+        remoteSkillId: "remote-review",
+        remoteUpdatedAt: "2026-06-29T11:00:00.000Z",
+        lastSyncedAt: 200,
+        direction: "download",
+      },
+    ]);
+
+    store.close();
+  });
+
   it("records duplicate session migrations and lists them in descending creation order", () => {
     const store = createInMemoryStore();
     try {

--- a/src/core/session-store.test.ts
+++ b/src/core/session-store.test.ts
@@ -164,6 +164,32 @@ describe("SessionStore", () => {
     expect(results[0].matchSnippet).toContain("refresh token");
   });
 
+  it("uses the indexed title for display when first question is a long remote summary prompt", () => {
+    const store = createInMemoryStore();
+    const longFirstQuestion = [
+      "# AGENTS.md instructions for /data00/home/xuguowei.x/meta_resource_generator",
+      "<INSTRUCTIONS>",
+      "Global Coding Preferences - Before concrete code work or commit preparation, read the target repository's local rules first.",
+    ].join("\n");
+    store.upsertIndexedSession(
+      sampleSession({
+        sessionKey: "ssh:dev:codex:remote",
+        rawId: "remote",
+        environmentId: "ssh-dev",
+        environmentKind: "ssh",
+        environmentLabel: "SSH · dev",
+        originalTitle: "# AGENTS.md instructions for /data00/home/xuguowei.x/meta_resource_generator",
+        firstQuestion: longFirstQuestion,
+      }),
+      [],
+    );
+
+    const session = store.getSession("ssh:dev:codex:remote");
+
+    expect(session?.displayTitle).toBe("# AGENTS.md instructions for /data00/home/xuguowei.x/meta_resource_generator");
+    expect(session?.displayTitle).not.toContain("<INSTRUCTIONS>");
+  });
+
   it("stores token usage per session and aggregates selected stats periods by source", () => {
     const store = createInMemoryStore();
     const now = new Date("2026-06-01T12:00:00Z").getTime();

--- a/src/core/session-store.test.ts
+++ b/src/core/session-store.test.ts
@@ -1156,6 +1156,19 @@ describe("SessionStore", () => {
     expect(stored.detail).toContain("characters omitted");
   });
 
+  it("limits trace events to the visible message timestamp window", () => {
+    const store = createInMemoryStore();
+    store.upsertIndexedSession(sampleSession(), messages, [], traceEvents);
+
+    expect(
+      store.getTraceEvents("codex:abc", {
+        startTimestamp: "2026-06-01T10:02:30Z",
+        endTimestamp: "2026-06-01T10:04:00Z",
+        limit: 1,
+      }),
+    ).toEqual([traceEvents[1]]);
+  });
+
   it("creates a local environment and stores environment metadata on sessions", () => {
     const store = createInMemoryStore();
 

--- a/src/core/session-store.ts
+++ b/src/core/session-store.ts
@@ -123,6 +123,24 @@ interface SkillUsageEventRow {
   timestamp: number;
 }
 
+export type SkillSyncDirection = "upload" | "download";
+
+export interface SkillSyncBinding {
+  localSkillPath: string;
+  remoteSkillId: string;
+  remoteUpdatedAt: string;
+  lastSyncedAt: number;
+  direction: SkillSyncDirection;
+}
+
+interface SkillSyncBindingRow {
+  local_skill_path: string;
+  remote_skill_id: string;
+  remote_updated_at: string;
+  last_synced_at: number;
+  direction: SkillSyncDirection;
+}
+
 interface SessionMigrationRow {
   id: string;
   source_session_key: string;
@@ -846,6 +864,64 @@ export class SessionStore {
     return skillUsageSnapshotFromEvents(rows, "", sourceCountRow.count > 0 || rows.length > 0);
   }
 
+  upsertSkillSyncBinding(binding: SkillSyncBinding): void {
+    const localSkillPath = binding.localSkillPath.trim();
+    const remoteSkillId = binding.remoteSkillId.trim();
+    if (!localSkillPath || !remoteSkillId) return;
+    this.db
+      .prepare(
+        `
+        INSERT INTO skill_sync_bindings (local_skill_path, remote_skill_id, remote_updated_at, last_synced_at, direction)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(local_skill_path) DO UPDATE SET
+          remote_skill_id = excluded.remote_skill_id,
+          remote_updated_at = excluded.remote_updated_at,
+          last_synced_at = excluded.last_synced_at,
+          direction = excluded.direction
+      `,
+      )
+      .run(localSkillPath, remoteSkillId, binding.remoteUpdatedAt, binding.lastSyncedAt, binding.direction);
+  }
+
+  getSkillSyncBindingForLocalPath(localSkillPath: string): SkillSyncBinding | null {
+    const row = this.db
+      .prepare(
+        `
+        SELECT local_skill_path, remote_skill_id, remote_updated_at, last_synced_at, direction
+        FROM skill_sync_bindings
+        WHERE local_skill_path = ?
+      `,
+      )
+      .get(localSkillPath) as SkillSyncBindingRow | undefined;
+    return row ? skillSyncBindingFromRow(row) : null;
+  }
+
+  getSkillSyncBindingForRemoteId(remoteSkillId: string): SkillSyncBinding | null {
+    const row = this.db
+      .prepare(
+        `
+        SELECT local_skill_path, remote_skill_id, remote_updated_at, last_synced_at, direction
+        FROM skill_sync_bindings
+        WHERE remote_skill_id = ?
+      `,
+      )
+      .get(remoteSkillId) as SkillSyncBindingRow | undefined;
+    return row ? skillSyncBindingFromRow(row) : null;
+  }
+
+  listSkillSyncBindings(): SkillSyncBinding[] {
+    const rows = this.db
+      .prepare(
+        `
+        SELECT local_skill_path, remote_skill_id, remote_updated_at, last_synced_at, direction
+        FROM skill_sync_bindings
+        ORDER BY last_synced_at DESC, local_skill_path
+      `,
+      )
+      .all() as unknown as SkillSyncBindingRow[];
+    return rows.map(skillSyncBindingFromRow);
+  }
+
   getApiProviderKey(target: ApiProviderKeyTarget, providerId: string): string {
     const normalizedProviderId = providerId.trim();
     if (!normalizedProviderId) return "";
@@ -1178,6 +1254,14 @@ export class SessionStore {
         FOREIGN KEY (source_path) REFERENCES skill_usage_sources(source_path) ON DELETE CASCADE
       );
 
+      CREATE TABLE IF NOT EXISTS skill_sync_bindings (
+        local_skill_path TEXT PRIMARY KEY,
+        remote_skill_id TEXT NOT NULL UNIQUE,
+        remote_updated_at TEXT NOT NULL,
+        last_synced_at INTEGER NOT NULL,
+        direction TEXT NOT NULL
+      );
+
       CREATE TABLE IF NOT EXISTS api_provider_keys (
         target TEXT NOT NULL,
         provider_id TEXT NOT NULL,
@@ -1224,6 +1308,8 @@ export class SessionStore {
         ON skill_usage_events(agent, skill);
       CREATE INDEX IF NOT EXISTS idx_skill_usage_events_timestamp
         ON skill_usage_events(timestamp);
+      CREATE INDEX IF NOT EXISTS idx_skill_sync_bindings_remote_id
+        ON skill_sync_bindings(remote_skill_id);
       CREATE INDEX IF NOT EXISTS idx_session_migrations_source_session_key_created_at_id
         ON session_migrations(source_session_key, created_at DESC, id DESC);
     `);
@@ -1895,6 +1981,16 @@ function normalizeTokenEvent(event: TokenUsageEvent): TokenUsageEvent {
     ...normalizeTokenUsage(event),
     timestamp: nonNegativeNumber(event.timestamp),
     dedupeKey: event.dedupeKey.trim(),
+  };
+}
+
+function skillSyncBindingFromRow(row: SkillSyncBindingRow): SkillSyncBinding {
+  return {
+    localSkillPath: row.local_skill_path,
+    remoteSkillId: row.remote_skill_id,
+    remoteUpdatedAt: row.remote_updated_at,
+    lastSyncedAt: row.last_synced_at,
+    direction: row.direction,
   };
 }
 

--- a/src/core/session-store.ts
+++ b/src/core/session-store.ts
@@ -1362,7 +1362,7 @@ export class SessionStore {
     ) as Array<{ content: string }>)
       .map((message) => message.content)
       .join("\n\n");
-    const title = row.custom_title || row.first_question || row.original_title || "Untitled Session";
+    const title = row.custom_title || row.original_title || row.first_question || "Untitled Session";
     // Prepend the AI summary so its normalized wording is searchable alongside the raw transcript.
     const summary = row.ai_summary?.trim();
     const ftsContent = summary ? `${summary}\n\n${contentText}` : contentText;
@@ -1791,7 +1791,7 @@ export class SessionStore {
   }
 
   private hydrateRow(row: SessionRow, snippet: string | null, tags = this.getTagsForSession(row.session_key)): SessionSearchResult {
-    const displayTitle = row.custom_title || row.first_question || row.original_title || "Untitled Session";
+    const displayTitle = row.custom_title || row.original_title || row.first_question || "Untitled Session";
     const environment = this.getEnvironment(row.environment_id) ?? localEnvironment();
     return {
       sessionKey: row.session_key,

--- a/src/core/session-store.ts
+++ b/src/core/session-store.ts
@@ -133,6 +133,12 @@ export interface SkillSyncBinding {
   direction: SkillSyncDirection;
 }
 
+export interface TraceEventQueryOptions {
+  startTimestamp?: string;
+  endTimestamp?: string;
+  limit?: number;
+}
+
 interface SkillSyncBindingRow {
   local_skill_path: string;
   remote_skill_id: string;
@@ -776,18 +782,31 @@ export class SessionStore {
     return this.getMessages(sessionKey, 0, 100_000);
   }
 
-  getTraceEvents(sessionKey: string): SessionTraceEvent[] {
+  getTraceEvents(sessionKey: string, options: TraceEventQueryOptions = {}): SessionTraceEvent[] {
+    const where = ["session_key = ?"];
+    const params: Array<string | number> = [sessionKey];
+    if (options.startTimestamp) {
+      where.push("timestamp >= ?");
+      params.push(options.startTimestamp);
+    }
+    if (options.endTimestamp) {
+      where.push("timestamp <= ?");
+      params.push(options.endTimestamp);
+    }
+    const limit = Number.isFinite(options.limit) ? Math.max(0, Math.floor(options.limit ?? 0)) : 0;
+    if (limit > 0) params.push(limit);
     return (
       this.db
         .prepare(
           `
           SELECT trace_index, kind, source, title, detail, timestamp, call_id, event_type, status
           FROM trace_events
-          WHERE session_key = ?
+          WHERE ${where.join(" AND ")}
           ORDER BY trace_index
+          ${limit > 0 ? "LIMIT ?" : ""}
         `,
         )
-        .all(sessionKey) as unknown as TraceEventRow[]
+        .all(...params) as unknown as TraceEventRow[]
     ).map((row) => ({
       index: row.trace_index,
       kind: row.kind,

--- a/src/core/skill-manager.test.ts
+++ b/src/core/skill-manager.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { deleteInstalledSkill, listInstalledSkills, skillProjectDirsFromIndexedProjects } from "./skill-manager";
+import {
+  deleteInstalledSkill,
+  installRemoteSkillLocally,
+  listInstalledSkills,
+  skillProjectDirsFromIndexedProjects,
+} from "./skill-manager";
+import type { RemoteSkill } from "./skill-sync";
 
 function writeSkill(root: string, directoryName: string, content: string): string {
   const skillDir = path.join(root, directoryName);
@@ -275,6 +281,65 @@ describe("skill manager", () => {
 
     expect(() => deleteInstalledSkill(skillPath, { homeDir, codexHome, projectDirs: [] })).toThrow("Codex system skills cannot be deleted from this app.");
     expect(fs.existsSync(path.dirname(skillPath))).toBe(true);
+
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("installs a remote Codex skill into the user skill root", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-skills-install-codex-"));
+    const codexHome = path.join(homeDir, ".codex");
+    const remoteSkill: RemoteSkill = {
+      id: "remote-review",
+      name: "Review Code!",
+      description: "Review code changes",
+      agent: "codex",
+      source: "codex-user",
+      markdown: "---\nname: Review Code!\ndescription: Review code changes\n---\n\n# Review",
+      localFingerprint: "fp",
+      uploadedFromPath: "/old/SKILL.md",
+      createdAt: "2026-06-29T10:00:00.000Z",
+      updatedAt: "2026-06-29T10:01:00.000Z",
+      version: 1,
+      metadata: {},
+    };
+
+    const result = installRemoteSkillLocally(remoteSkill, { homeDir, codexHome });
+
+    expect(result).toEqual({
+      installedPath: path.join(codexHome, "skills", "review-code", "SKILL.md"),
+      directoryPath: path.join(codexHome, "skills", "review-code"),
+      overwritten: false,
+    });
+    expect(fs.readFileSync(result.installedPath, "utf8")).toBe(remoteSkill.markdown);
+
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("installs a remote Claude skill into the user skill root and reports overwrite", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-skills-install-claude-"));
+    const remoteSkill: RemoteSkill = {
+      id: "remote-deploy",
+      name: "deploy-helper",
+      description: "Deploy safely",
+      agent: "claude",
+      source: "claude-user",
+      markdown: "# Deploy v2",
+      localFingerprint: "fp",
+      uploadedFromPath: "/old/SKILL.md",
+      createdAt: "2026-06-29T10:00:00.000Z",
+      updatedAt: "2026-06-29T10:01:00.000Z",
+      version: 2,
+      metadata: {},
+    };
+    const target = path.join(homeDir, ".claude", "skills", "deploy-helper", "SKILL.md");
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, "# Deploy v1", "utf8");
+
+    const result = installRemoteSkillLocally(remoteSkill, { homeDir });
+
+    expect(result.installedPath).toBe(target);
+    expect(result.overwritten).toBe(true);
+    expect(fs.readFileSync(target, "utf8")).toBe("# Deploy v2");
 
     fs.rmSync(homeDir, { recursive: true, force: true });
   });

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import type { RemoteSkill } from "./skill-sync";
 
 export type SkillAgent = "codex" | "claude";
 export type SkillSource =
@@ -66,6 +67,17 @@ export interface SkillProjectSource {
 export interface DeleteInstalledSkillResult {
   deletedPath: string;
   skillName: string;
+}
+
+export interface InstallRemoteSkillOptions {
+  homeDir?: string;
+  codexHome?: string;
+}
+
+export interface InstallRemoteSkillResult {
+  installedPath: string;
+  directoryPath: string;
+  overwritten: boolean;
 }
 
 interface SkillRootConfig {
@@ -166,6 +178,23 @@ export function deleteInstalledSkill(skillPath: string, options: SkillManagerOpt
 
   fs.rmSync(directoryPath, { recursive: true, force: false });
   return { deletedPath: directoryPath, skillName: skill.name };
+}
+
+export function installRemoteSkillLocally(remoteSkill: RemoteSkill, options: InstallRemoteSkillOptions = {}): InstallRemoteSkillResult {
+  const homeDir = options.homeDir || os.homedir();
+  const codexHome = options.codexHome || process.env.CODEX_HOME || path.join(homeDir, ".codex");
+  const rootPath = remoteSkill.agent === "codex" ? path.join(codexHome, "skills") : path.join(homeDir, ".claude", "skills");
+  const directoryName = safeSkillDirectoryName(remoteSkill.name);
+  const directoryPath = path.join(rootPath, directoryName);
+  const installedPath = path.join(directoryPath, "SKILL.md");
+  const rootKey = normalizePathKey(rootPath);
+  const directoryKey = normalizePathKey(directoryPath);
+  if (!directoryKey.startsWith(`${rootKey}${path.sep}`)) throw new Error("Refusing to install skill outside the managed root.");
+
+  const overwritten = fs.existsSync(installedPath);
+  fs.mkdirSync(directoryPath, { recursive: true });
+  fs.writeFileSync(installedPath, remoteSkill.markdown, "utf8");
+  return { installedPath, directoryPath, overwritten };
 }
 
 function collectClaudePluginRoots(pluginsDir: string): SkillRootConfig[] {
@@ -368,6 +397,16 @@ function hasProjectSkillRoot(projectDir: string): boolean {
 
 function shouldSkipProjectSkillSearchDir(name: string): boolean {
   return name.startsWith(".") || name === "node_modules" || name === "vendor" || name === "out" || name === "dist" || name === "build";
+}
+
+function safeSkillDirectoryName(name: string): string {
+  const normalized = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+  return normalized || "skill";
 }
 
 function dedupePaths(paths: string[]): string[] {

--- a/src/core/skill-sync.test.ts
+++ b/src/core/skill-sync.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+import { createHash } from "node:crypto";
+import {
+  AGENT_SESSION_SEARCH_SKILLS_TABLE,
+  SupabaseSkillSyncClient,
+  buildSkillSyncSetupSql,
+  skillSyncFingerprint,
+  type RemoteSkill,
+} from "./skill-sync";
+import type { InstalledSkill } from "./skill-manager";
+
+function localSkill(overrides: Partial<InstalledSkill> = {}): InstalledSkill {
+  return {
+    id: "codex-user:/tmp/.codex/skills/review-code/SKILL.md",
+    name: "review-code",
+    description: "Review code changes",
+    agent: "codex",
+    source: "codex-user",
+    path: "/tmp/.codex/skills/review-code/SKILL.md",
+    directoryPath: "/tmp/.codex/skills/review-code",
+    rootPath: "/tmp/.codex/skills",
+    markdown: "---\nname: review-code\ndescription: Review code changes\n---\n\n# Review",
+    mtimeMs: 100,
+    ...overrides,
+  };
+}
+
+function remoteSkill(overrides: Partial<RemoteSkill> = {}): RemoteSkill {
+  return {
+    id: "remote-1",
+    name: "review-code",
+    description: "Review code changes",
+    agent: "codex",
+    source: "codex-user",
+    markdown: "# Review",
+    localFingerprint: skillSyncFingerprint(localSkill()),
+    uploadedFromPath: "/tmp/.codex/skills/review-code/SKILL.md",
+    createdAt: "2026-06-29T10:00:00.000Z",
+    updatedAt: "2026-06-29T10:00:00.000Z",
+    version: 1,
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe("skill sync", () => {
+  it("builds Supabase setup SQL for the expected personal skills table", () => {
+    const sql = buildSkillSyncSetupSql();
+
+    expect(sql).toContain(`create table if not exists public.${AGENT_SESSION_SEARCH_SKILLS_TABLE}`);
+    expect(sql).toContain("local_fingerprint text not null");
+    expect(sql).toContain(`create unique index if not exists ${AGENT_SESSION_SEARCH_SKILLS_TABLE}_fingerprint_idx`);
+    expect(sql).toContain(`alter table public.${AGENT_SESSION_SEARCH_SKILLS_TABLE} enable row level security`);
+    expect(sql).toContain("create policy \"agent_session_search_skills_personal_sync\"");
+    expect(sql).not.toContain("service_role");
+  });
+
+  it("uses an agent and skill name fingerprint for repeat uploads across local paths", () => {
+    const expected = createHash("sha256").update("codex:review-code").digest("hex");
+
+    expect(skillSyncFingerprint(localSkill({ path: "/a/SKILL.md" }))).toBe(expected);
+    expect(skillSyncFingerprint(localSkill({ path: "/b/SKILL.md" }))).toBe(expected);
+    expect(skillSyncFingerprint(localSkill({ agent: "claude" }))).not.toBe(expected);
+  });
+
+  it("reports missing-table status when Supabase has not been initialized", async () => {
+    const fetchCalls: string[] = [];
+    const client = new SupabaseSkillSyncClient({
+      url: "https://example.supabase.co",
+      anonKey: "anon",
+      fetchImpl: async (url) => {
+        fetchCalls.push(String(url));
+        return new Response(JSON.stringify({ code: "PGRST205", message: "Could not find the table" }), { status: 404 });
+      },
+    });
+
+    const status = await client.checkStatus();
+
+    expect(fetchCalls[0]).toContain(`/rest/v1/${AGENT_SESSION_SEARCH_SKILLS_TABLE}`);
+    expect(status.kind).toBe("missing-table");
+    expect(status.setupSql).toContain(AGENT_SESSION_SEARCH_SKILLS_TABLE);
+  });
+
+  it("lists remote skills through Supabase REST", async () => {
+    const rows = [
+      {
+        id: "remote-1",
+        name: "review-code",
+        description: "Review code changes",
+        agent: "codex",
+        source: "codex-user",
+        markdown: "# Review",
+        local_fingerprint: "fp",
+        uploaded_from_path: "/tmp/SKILL.md",
+        created_at: "2026-06-29T10:00:00.000Z",
+        updated_at: "2026-06-29T10:01:00.000Z",
+        version: 2,
+        metadata: { syncedBy: "test" },
+      },
+    ];
+    const client = new SupabaseSkillSyncClient({
+      url: "https://example.supabase.co/",
+      anonKey: "anon",
+      fetchImpl: async (url, init) => {
+        expect(String(url)).toBe(`https://example.supabase.co/rest/v1/${AGENT_SESSION_SEARCH_SKILLS_TABLE}?select=*&order=updated_at.desc`);
+        expect((init?.headers as Record<string, string>).apikey).toBe("anon");
+        return new Response(JSON.stringify(rows), { status: 200 });
+      },
+    });
+
+    await expect(client.listRemoteSkills()).resolves.toEqual([
+      {
+        id: "remote-1",
+        name: "review-code",
+        description: "Review code changes",
+        agent: "codex",
+        source: "codex-user",
+        markdown: "# Review",
+        localFingerprint: "fp",
+        uploadedFromPath: "/tmp/SKILL.md",
+        createdAt: "2026-06-29T10:00:00.000Z",
+        updatedAt: "2026-06-29T10:01:00.000Z",
+        version: 2,
+        metadata: { syncedBy: "test" },
+      },
+    ]);
+  });
+
+  it("upserts local skills by fingerprint and returns the remote row", async () => {
+    const uploaded = localSkill();
+    const client = new SupabaseSkillSyncClient({
+      url: "https://example.supabase.co",
+      anonKey: "anon",
+      fetchImpl: async (url, init) => {
+        expect(String(url)).toBe(`https://example.supabase.co/rest/v1/${AGENT_SESSION_SEARCH_SKILLS_TABLE}?on_conflict=local_fingerprint`);
+        expect(init?.method).toBe("POST");
+        expect((init?.headers as Record<string, string>).Prefer).toBe("resolution=merge-duplicates,return=representation");
+        const body = JSON.parse(String(init?.body));
+        expect(body).toMatchObject({
+          name: "review-code",
+          agent: "codex",
+          local_fingerprint: skillSyncFingerprint(uploaded),
+          markdown: uploaded.markdown,
+        });
+        return new Response(JSON.stringify([{
+          ...body,
+          id: "remote-1",
+          created_at: "2026-06-29T10:00:00.000Z",
+          updated_at: "2026-06-29T10:01:00.000Z",
+        }]), { status: 201 });
+      },
+    });
+
+    await expect(client.upsertLocalSkill(uploaded)).resolves.toMatchObject({
+      id: "remote-1",
+      name: "review-code",
+      localFingerprint: skillSyncFingerprint(uploaded),
+    });
+  });
+
+  it("updates a remote skill by id when the local binding is known", async () => {
+    const uploaded = localSkill();
+    const client = new SupabaseSkillSyncClient({
+      url: "https://example.supabase.co",
+      anonKey: "anon",
+      fetchImpl: async (url, init) => {
+        expect(String(url)).toBe(`https://example.supabase.co/rest/v1/${AGENT_SESSION_SEARCH_SKILLS_TABLE}?id=eq.remote-1`);
+        expect(init?.method).toBe("PATCH");
+        expect((init?.headers as Record<string, string>).Prefer).toBe("return=representation");
+        const body = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify([{
+          ...body,
+          id: "remote-1",
+          created_at: "2026-06-29T10:00:00.000Z",
+          updated_at: "2026-06-29T10:02:00.000Z",
+        }]), { status: 200 });
+      },
+    });
+
+    await expect(client.updateRemoteSkill("remote-1", uploaded)).resolves.toMatchObject({
+      id: "remote-1",
+      updatedAt: "2026-06-29T10:02:00.000Z",
+    });
+  });
+
+  it("fetches one remote skill by id before installing it locally", async () => {
+    const remote = remoteSkill();
+    const client = new SupabaseSkillSyncClient({
+      url: "https://example.supabase.co",
+      anonKey: "anon",
+      fetchImpl: async (url) => {
+        expect(String(url)).toBe(`https://example.supabase.co/rest/v1/${AGENT_SESSION_SEARCH_SKILLS_TABLE}?id=eq.remote-1&select=*&limit=1`);
+        return new Response(JSON.stringify([{
+          id: remote.id,
+          name: remote.name,
+          description: remote.description,
+          agent: remote.agent,
+          source: remote.source,
+          markdown: remote.markdown,
+          local_fingerprint: remote.localFingerprint,
+          uploaded_from_path: remote.uploadedFromPath,
+          created_at: remote.createdAt,
+          updated_at: remote.updatedAt,
+          version: remote.version,
+          metadata: remote.metadata,
+        }]), { status: 200 });
+      },
+    });
+
+    await expect(client.getRemoteSkill("remote-1")).resolves.toEqual(remote);
+  });
+});

--- a/src/core/skill-sync.ts
+++ b/src/core/skill-sync.ts
@@ -1,0 +1,295 @@
+import { createHash } from "node:crypto";
+import type { SkillSyncBinding } from "./session-store";
+import type { InstalledSkill } from "./skill-manager";
+
+export const AGENT_SESSION_SEARCH_SKILLS_TABLE = "agent_session_search_skills";
+
+export interface RemoteSkill {
+  id: string;
+  name: string;
+  description: string;
+  agent: InstalledSkill["agent"];
+  source: InstalledSkill["source"];
+  markdown: string;
+  localFingerprint: string;
+  uploadedFromPath: string;
+  createdAt: string;
+  updatedAt: string;
+  version: number;
+  metadata: Record<string, unknown>;
+}
+
+export type SkillSyncStatus =
+  | { kind: "unconfigured"; setupSql: string; message: string }
+  | { kind: "ready"; setupSql: string }
+  | { kind: "missing-table"; setupSql: string; message: string }
+  | { kind: "error"; setupSql: string; message: string };
+
+export interface SkillSyncSnapshot {
+  status: SkillSyncStatus;
+  remoteSkills: RemoteSkill[];
+  bindings: SkillSyncBinding[];
+  scannedAt: number;
+}
+
+export interface SkillSyncUploadResult {
+  remoteSkill: RemoteSkill;
+  binding: SkillSyncBinding;
+}
+
+export interface SkillSyncInstallResult {
+  remoteSkill: RemoteSkill;
+  binding: SkillSyncBinding;
+  installedPath: string;
+  overwritten: boolean;
+}
+
+export interface SupabaseSkillSyncClientOptions {
+  url: string;
+  anonKey: string;
+  fetchImpl?: typeof fetch;
+}
+
+interface SupabaseSkillRow {
+  id: string;
+  name: string;
+  description: string | null;
+  agent: string;
+  source: string;
+  markdown: string;
+  local_fingerprint: string;
+  uploaded_from_path: string | null;
+  created_at: string;
+  updated_at: string;
+  version: number | null;
+  metadata: Record<string, unknown> | null;
+}
+
+export function buildSkillSyncSetupSql(tableName = AGENT_SESSION_SEARCH_SKILLS_TABLE): string {
+  return [
+    `create table if not exists public.${tableName} (`,
+    "  id uuid primary key default gen_random_uuid(),",
+    "  name text not null,",
+    "  description text not null default '',",
+    "  agent text not null check (agent in ('codex', 'claude')),",
+    "  source text not null,",
+    "  markdown text not null,",
+    "  local_fingerprint text not null,",
+    "  uploaded_from_path text not null default '',",
+    "  version integer not null default 1,",
+    "  metadata jsonb not null default '{}'::jsonb,",
+    "  created_at timestamptz not null default now(),",
+    "  updated_at timestamptz not null default now()",
+    ");",
+    "",
+    `create unique index if not exists ${tableName}_fingerprint_idx`,
+    `  on public.${tableName} (local_fingerprint);`,
+    "",
+    `create or replace function public.${tableName}_touch_updated_at()`,
+    "returns trigger",
+    "language plpgsql",
+    "as $$",
+    "begin",
+    "  new.updated_at = now();",
+    "  return new;",
+    "end;",
+    "$$;",
+    "",
+    `drop trigger if exists ${tableName}_touch_updated_at on public.${tableName};`,
+    `create trigger ${tableName}_touch_updated_at`,
+    `  before update on public.${tableName}`,
+    "  for each row",
+    `  execute function public.${tableName}_touch_updated_at();`,
+    "",
+    `alter table public.${tableName} enable row level security;`,
+    "",
+    `drop policy if exists "agent_session_search_skills_personal_sync" on public.${tableName};`,
+    `create policy "agent_session_search_skills_personal_sync"`,
+    `  on public.${tableName}`,
+    "  for all",
+    "  to anon",
+    "  using (true)",
+    "  with check (true);",
+  ].join("\n");
+}
+
+export function skillSyncFingerprint(skill: Pick<InstalledSkill, "agent" | "name">): string {
+  return createHash("sha256").update(`${skill.agent}:${skill.name.trim().toLowerCase()}`).digest("hex");
+}
+
+export class SupabaseSkillSyncClient {
+  private readonly baseUrl: string;
+  private readonly anonKey: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: SupabaseSkillSyncClientOptions) {
+    this.baseUrl = normalizeSupabaseUrl(options.url);
+    this.anonKey = options.anonKey.trim();
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    if (!this.baseUrl) throw new Error("Supabase URL is required.");
+    if (!this.anonKey) throw new Error("Supabase anon key is required.");
+  }
+
+  async checkStatus(): Promise<SkillSyncStatus> {
+    const setupSql = buildSkillSyncSetupSql();
+    const response = await this.request(`/${AGENT_SESSION_SEARCH_SKILLS_TABLE}?select=id&limit=1`, { method: "GET" });
+    if (response.ok) return { kind: "ready", setupSql };
+    const body = await readResponseBody(response);
+    if (isMissingTableError(response.status, body)) {
+      return {
+        kind: "missing-table",
+        setupSql,
+        message: `Supabase table ${AGENT_SESSION_SEARCH_SKILLS_TABLE} was not found.`,
+      };
+    }
+    return { kind: "error", setupSql, message: supabaseErrorMessage(response.status, body) };
+  }
+
+  async listRemoteSkills(): Promise<RemoteSkill[]> {
+    const response = await this.request(`/${AGENT_SESSION_SEARCH_SKILLS_TABLE}?select=*&order=updated_at.desc`, { method: "GET" });
+    const body = await readResponseBody(response);
+    if (!response.ok) throw new Error(supabaseErrorMessage(response.status, body));
+    return parseRemoteRows(body);
+  }
+
+  async getRemoteSkill(remoteSkillId: string): Promise<RemoteSkill> {
+    const response = await this.request(`/${AGENT_SESSION_SEARCH_SKILLS_TABLE}?id=eq.${encodeURIComponent(remoteSkillId)}&select=*&limit=1`, {
+      method: "GET",
+    });
+    const body = await readResponseBody(response);
+    if (!response.ok) throw new Error(supabaseErrorMessage(response.status, body));
+    const [skill] = parseRemoteRows(body);
+    if (!skill) throw new Error("Remote skill was not found.");
+    return skill;
+  }
+
+  async upsertLocalSkill(skill: InstalledSkill): Promise<RemoteSkill> {
+    const payload = remotePayloadFromSkill(skill);
+    const response = await this.request(`/${AGENT_SESSION_SEARCH_SKILLS_TABLE}?on_conflict=local_fingerprint`, {
+      method: "POST",
+      headers: { Prefer: "resolution=merge-duplicates,return=representation" },
+      body: JSON.stringify(payload),
+    });
+    const body = await readResponseBody(response);
+    if (!response.ok) throw new Error(supabaseErrorMessage(response.status, body));
+    const [remoteSkill] = parseRemoteRows(body);
+    if (!remoteSkill) throw new Error("Supabase did not return the uploaded skill.");
+    return remoteSkill;
+  }
+
+  async updateRemoteSkill(remoteSkillId: string, skill: InstalledSkill): Promise<RemoteSkill> {
+    const response = await this.request(`/${AGENT_SESSION_SEARCH_SKILLS_TABLE}?id=eq.${encodeURIComponent(remoteSkillId)}`, {
+      method: "PATCH",
+      headers: { Prefer: "return=representation" },
+      body: JSON.stringify(remotePayloadFromSkill(skill)),
+    });
+    const body = await readResponseBody(response);
+    if (!response.ok) throw new Error(supabaseErrorMessage(response.status, body));
+    const [remoteSkill] = parseRemoteRows(body);
+    if (!remoteSkill) throw new Error("Supabase did not return the updated skill.");
+    return remoteSkill;
+  }
+
+  private request(path: string, init: RequestInit): Promise<Response> {
+    return this.fetchImpl(`${this.baseUrl}/rest/v1${path}`, {
+      ...init,
+      headers: {
+        apikey: this.anonKey,
+        Authorization: `Bearer ${this.anonKey}`,
+        "Content-Type": "application/json",
+        ...(init.headers ?? {}),
+      },
+    });
+  }
+}
+
+function remotePayloadFromSkill(skill: InstalledSkill): Omit<SupabaseSkillRow, "id" | "created_at" | "updated_at"> {
+  return {
+    name: skill.name,
+    description: skill.description,
+    agent: skill.agent,
+    source: skill.source,
+    markdown: skill.markdown,
+    local_fingerprint: skillSyncFingerprint(skill),
+    uploaded_from_path: skill.path,
+    version: 1,
+    metadata: {
+      directoryPath: skill.directoryPath,
+      rootPath: skill.rootPath,
+      mtimeMs: skill.mtimeMs,
+    },
+  };
+}
+
+function parseRemoteRows(body: unknown): RemoteSkill[] {
+  if (!Array.isArray(body)) return [];
+  return body.flatMap((row) => (isRemoteRow(row) ? [remoteSkillFromRow(row)] : []));
+}
+
+function isRemoteRow(value: unknown): value is SupabaseSkillRow {
+  if (!value || typeof value !== "object") return false;
+  const row = value as Partial<SupabaseSkillRow>;
+  return (
+    typeof row.id === "string" &&
+    typeof row.name === "string" &&
+    typeof row.agent === "string" &&
+    (row.agent === "codex" || row.agent === "claude") &&
+    typeof row.source === "string" &&
+    typeof row.markdown === "string" &&
+    typeof row.local_fingerprint === "string" &&
+    typeof row.created_at === "string" &&
+    typeof row.updated_at === "string"
+  );
+}
+
+function remoteSkillFromRow(row: SupabaseSkillRow): RemoteSkill {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description ?? "",
+    agent: row.agent as RemoteSkill["agent"],
+    source: row.source as RemoteSkill["source"],
+    markdown: row.markdown,
+    localFingerprint: row.local_fingerprint,
+    uploadedFromPath: row.uploaded_from_path ?? "",
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    version: row.version ?? 1,
+    metadata: row.metadata ?? {},
+  };
+}
+
+async function readResponseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function supabaseErrorMessage(status: number, body: unknown): string {
+  if (body && typeof body === "object") {
+    const message = (body as { message?: unknown }).message;
+    if (typeof message === "string" && message.trim()) return message;
+  }
+  if (typeof body === "string" && body.trim()) return body;
+  return `Supabase request failed with status ${status}.`;
+}
+
+function isMissingTableError(status: number, body: unknown): boolean {
+  if (status === 404) return true;
+  if (!body || typeof body !== "object") return false;
+  const code = (body as { code?: unknown }).code;
+  const message = (body as { message?: unknown }).message;
+  return (
+    code === "42P01" ||
+    code === "PGRST205" ||
+    (typeof message === "string" && /table|relation/i.test(message) && /not found|does not exist/i.test(message))
+  );
+}
+
+function normalizeSupabaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -70,7 +70,21 @@ import { loadRemoteSessionDetailPayload } from "../core/remote-session-loader";
 import { RemoteEnvironmentLifecycle } from "../core/remote-environment-lifecycle";
 import { RemoteWatchManager } from "../core/remote-watch";
 import { SessionStore } from "../core/session-store";
-import { deleteInstalledSkill, listInstalledSkills, skillProjectDirsFromIndexedProjects, type InstalledSkillsSnapshot } from "../core/skill-manager";
+import {
+  deleteInstalledSkill,
+  installRemoteSkillLocally,
+  listInstalledSkills,
+  skillProjectDirsFromIndexedProjects,
+  type InstalledSkill,
+  type InstalledSkillsSnapshot,
+} from "../core/skill-manager";
+import {
+  buildSkillSyncSetupSql,
+  SupabaseSkillSyncClient,
+  type SkillSyncInstallResult,
+  type SkillSyncSnapshot,
+  type SkillSyncUploadResult,
+} from "../core/skill-sync";
 import {
   listSkillUsageSources,
   readSkillUsageSourceEvents,
@@ -196,6 +210,89 @@ function refreshSkillUsageIndexSafely(): void {
   } catch (error) {
     console.error(`Failed to refresh skill usage: ${error instanceof Error ? error.message : String(error)}`);
   }
+}
+
+function createSkillSyncClient(): SupabaseSkillSyncClient {
+  const settings = getSettings();
+  if (!settings.skillSyncEnabled || !settings.skillSyncSupabaseUrl || !settings.skillSyncSupabaseAnonKey) {
+    throw new Error("Supabase skill sync is not configured.");
+  }
+  return new SupabaseSkillSyncClient({
+    url: settings.skillSyncSupabaseUrl,
+    anonKey: settings.skillSyncSupabaseAnonKey,
+  });
+}
+
+async function buildSkillSyncSnapshot(): Promise<SkillSyncSnapshot> {
+  const setupSql = buildSkillSyncSetupSql();
+  const settings = getSettings();
+  if (!settings.skillSyncEnabled || !settings.skillSyncSupabaseUrl || !settings.skillSyncSupabaseAnonKey) {
+    return {
+      status: {
+        kind: "unconfigured",
+        setupSql,
+        message: "Configure Supabase URL and anon key in Settings to sync skills.",
+      },
+      remoteSkills: [],
+      bindings: store.listSkillSyncBindings(),
+      scannedAt: Date.now(),
+    };
+  }
+
+  const client = createSkillSyncClient();
+  const status = await client.checkStatus();
+  const remoteSkills = status.kind === "ready" ? await client.listRemoteSkills() : [];
+  return {
+    status,
+    remoteSkills,
+    bindings: store.listSkillSyncBindings(),
+    scannedAt: Date.now(),
+  };
+}
+
+async function uploadLocalSkillToSupabase(skillPath: string): Promise<SkillSyncUploadResult> {
+  const skill = findInstalledSkillByPath(skillPath);
+  const client = createSkillSyncClient();
+  const existing = store.getSkillSyncBindingForLocalPath(skill.path);
+  const remoteSkill = existing
+    ? await client.updateRemoteSkill(existing.remoteSkillId, skill)
+    : await client.upsertLocalSkill(skill);
+  const binding = {
+    localSkillPath: skill.path,
+    remoteSkillId: remoteSkill.id,
+    remoteUpdatedAt: remoteSkill.updatedAt,
+    lastSyncedAt: Date.now(),
+    direction: "upload" as const,
+  };
+  store.upsertSkillSyncBinding(binding);
+  return { remoteSkill, binding };
+}
+
+async function installRemoteSkillFromSupabase(remoteSkillId: string): Promise<SkillSyncInstallResult> {
+  const client = createSkillSyncClient();
+  const remoteSkill = await client.getRemoteSkill(remoteSkillId);
+  const installed = installRemoteSkillLocally(remoteSkill);
+  const binding = {
+    localSkillPath: installed.installedPath,
+    remoteSkillId: remoteSkill.id,
+    remoteUpdatedAt: remoteSkill.updatedAt,
+    lastSyncedAt: Date.now(),
+    direction: "download" as const,
+  };
+  store.upsertSkillSyncBinding(binding);
+  return {
+    remoteSkill,
+    binding,
+    installedPath: installed.installedPath,
+    overwritten: installed.overwritten,
+  };
+}
+
+function findInstalledSkillByPath(skillPath: string): InstalledSkill {
+  const normalized = path.resolve(skillPath);
+  const skill = buildSkillsSnapshot().skills.find((item) => path.resolve(item.path) === normalized);
+  if (!skill) throw new Error("Skill is no longer installed or is outside managed roots.");
+  return skill;
 }
 
 app.setName(PRODUCT_NAME);
@@ -1313,6 +1410,12 @@ function registerIpc(): void {
   );
   ipcMain.handle("skills:list", () => buildSkillsSnapshot());
   ipcMain.handle("skills:refresh-usage", () => refreshSkillUsageIndex());
+  ipcMain.handle("skills:sync-snapshot", () => buildSkillSyncSnapshot());
+  ipcMain.handle("skills:sync-upload", (_event, skillPath: string) => uploadLocalSkillToSupabase(skillPath));
+  ipcMain.handle("skills:sync-install", (_event, remoteSkillId: string) => installRemoteSkillFromSupabase(remoteSkillId));
+  ipcMain.handle("skills:sync-copy-setup-sql", () => {
+    clipboard.writeText(buildSkillSyncSetupSql());
+  });
   ipcMain.handle("skills:copy-path", (_event, skillPath: string) => {
     clipboard.writeText(skillPath);
   });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -65,11 +65,11 @@ import { writeMigratedSession } from "../core/session-migration-writers";
 import { writeDbPointer } from "../core/app-paths";
 import { routeResumeSession } from "../core/resume-router";
 import { diagnoseRemoteEnvironment, preflightRemoteSessionResume } from "../core/remote-health";
-import { fetchRemoteSessionFilePayload, syncRemoteEnvironment } from "../core/remote-sync";
+import { fetchRemoteSessionFilePayload, fetchRemoteSessionMessagePage, syncRemoteEnvironment } from "../core/remote-sync";
 import { loadRemoteSessionDetailPayload } from "../core/remote-session-loader";
 import { RemoteEnvironmentLifecycle } from "../core/remote-environment-lifecycle";
 import { RemoteWatchManager } from "../core/remote-watch";
-import { SessionStore } from "../core/session-store";
+import { SessionStore, type TraceEventQueryOptions } from "../core/session-store";
 import {
   deleteInstalledSkill,
   installRemoteSkillLocally,
@@ -600,10 +600,14 @@ async function ensureRemoteResumePreflight(session: SessionSearchResult): Promis
   throw new Error(`Remote resume preflight failed: ${detail}`);
 }
 
+function hasHydratedRemoteDetails(sessionKey: string): boolean {
+  return store.getMessages(sessionKey, 0, 1).length > 0;
+}
+
 async function ensureRemoteSessionDetailsLoaded(sessionKey: string): Promise<void> {
   const session = store.getSession(sessionKey);
   if (!session || isLocalSession(session)) return;
-  if (store.getMessages(sessionKey, 0, 1).length > 0) return;
+  if (hasHydratedRemoteDetails(sessionKey)) return;
 
   const active = remoteDetailLoads.get(sessionKey);
   if (active) return active;
@@ -1187,12 +1191,23 @@ function registerIpc(): void {
     return store.getSession(sessionKey);
   });
   ipcMain.handle("session:messages", async (_event, sessionKey: string, offset?: number, limit?: number) => {
+    const pageOffset = offset ?? 0;
+    const pageLimit = limit ?? 120;
+    const session = store.getSession(sessionKey);
+    if (session && !isLocalSession(session) && !hasHydratedRemoteDetails(sessionKey)) {
+      if (session.messageCount <= 0) return [];
+      const environment = requireRemoteSshEnvironment(session);
+      if (!environment) return [];
+      return fetchRemoteSessionMessagePage(environment, session, pageOffset, pageLimit);
+    }
     await ensureRemoteSessionDetailsLoaded(sessionKey);
-    return store.getMessages(sessionKey, offset ?? 0, limit ?? 120);
+    return store.getMessages(sessionKey, pageOffset, pageLimit);
   });
-  ipcMain.handle("session:trace-events", async (_event, sessionKey: string) => {
+  ipcMain.handle("session:trace-events", async (_event, sessionKey: string, options?: TraceEventQueryOptions) => {
+    const session = store.getSession(sessionKey);
+    if (session && !isLocalSession(session) && !hasHydratedRemoteDetails(sessionKey)) return [];
     await ensureRemoteSessionDetailsLoaded(sessionKey);
-    return store.getTraceEvents(sessionKey);
+    return store.getTraceEvents(sessionKey, options);
   });
   ipcMain.handle("sessions:live", () => loadLiveSessionSnapshot({ includeTrae: getSettings().includeTrae }));
   ipcMain.handle("session:summarize", async (_event, sessionKey: string) => {
@@ -1441,13 +1456,11 @@ function registerIpc(): void {
     return result.status;
   });
   ipcMain.handle("command:copy-resume", async (_event, sessionKey: string) => {
-    await ensureRemoteSessionDetailsLoaded(sessionKey);
     const session = store.getSession(sessionKey);
     if (!session) return;
     clipboard.writeText(getResumeCommand(session, getSettings(), { sshArgs: requireSshArgsForRemoteSession(session) }));
   });
   ipcMain.handle("command:resume", async (_event, sessionKey: string) => {
-    await ensureRemoteSessionDetailsLoaded(sessionKey);
     const session = store.getSession(sessionKey);
     if (!session) return { route: "resume" as const };
     const sshArgs = requireSshArgsForRemoteSession(session);
@@ -1469,7 +1482,6 @@ function registerIpc(): void {
     return route;
   });
   ipcMain.handle("command:resume-iterm", async (_event, sessionKey: string) => {
-    await ensureRemoteSessionDetailsLoaded(sessionKey);
     const session = store.getSession(sessionKey);
     if (!session) return;
     const sshArgs = requireSshArgsForRemoteSession(session);

--- a/src/main/skill-sync-ipc.test.ts
+++ b/src/main/skill-sync-ipc.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const mainSource = readFileSync(new URL("./index.ts", import.meta.url), "utf8");
+const preloadSource = readFileSync(new URL("../preload/index.ts", import.meta.url), "utf8");
+
+describe("skill sync IPC", () => {
+  it("exposes Supabase skill sync handlers through main and preload", () => {
+    for (const channel of [
+      "skills:sync-snapshot",
+      "skills:sync-upload",
+      "skills:sync-install",
+      "skills:sync-copy-setup-sql",
+    ]) {
+      expect(mainSource).toContain(`ipcMain.handle("${channel}"`);
+      expect(preloadSource).toContain(`ipcRenderer.invoke("${channel}"`);
+    }
+  });
+});

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -8,6 +8,7 @@ import type { AppSettings, AppSettingsUpdate } from "../core/platform";
 import type { IndexStatus } from "../core/indexer";
 import type { RemoteHealthReport } from "../core/remote-health";
 import type { ResumeRouteResult } from "../core/resume-router";
+import type { SkillSyncInstallResult, SkillSyncSnapshot, SkillSyncUploadResult } from "../core/skill-sync";
 import type { DeleteInstalledSkillResult, InstalledSkillsSnapshot } from "../core/skill-manager";
 import type { SkillUsageRefreshStatus } from "../core/skill-usage";
 import type { SshConfigHost } from "../core/ssh-config";
@@ -86,6 +87,10 @@ const api = {
     ipcRenderer.invoke("api-provider-key:get", target, providerId),
   listSkills: (): Promise<InstalledSkillsSnapshot> => ipcRenderer.invoke("skills:list"),
   refreshSkillUsage: (): Promise<SkillUsageRefreshStatus> => ipcRenderer.invoke("skills:refresh-usage"),
+  getSkillSyncSnapshot: (): Promise<SkillSyncSnapshot> => ipcRenderer.invoke("skills:sync-snapshot"),
+  uploadSkillToSync: (skillPath: string): Promise<SkillSyncUploadResult> => ipcRenderer.invoke("skills:sync-upload", skillPath),
+  installSyncedSkill: (remoteSkillId: string): Promise<SkillSyncInstallResult> => ipcRenderer.invoke("skills:sync-install", remoteSkillId),
+  copySkillSyncSetupSql: (): Promise<void> => ipcRenderer.invoke("skills:sync-copy-setup-sql"),
   copySkillPath: (skillPath: string): Promise<void> => ipcRenderer.invoke("skills:copy-path", skillPath),
   revealSkill: (targetPath: string): Promise<void> => ipcRenderer.invoke("skills:reveal", targetPath),
   deleteSkill: (skillPath: string): Promise<DeleteInstalledSkillResult> => ipcRenderer.invoke("skills:delete", skillPath),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -8,6 +8,7 @@ import type { AppSettings, AppSettingsUpdate } from "../core/platform";
 import type { IndexStatus } from "../core/indexer";
 import type { RemoteHealthReport } from "../core/remote-health";
 import type { ResumeRouteResult } from "../core/resume-router";
+import type { TraceEventQueryOptions } from "../core/session-store";
 import type { SkillSyncInstallResult, SkillSyncSnapshot, SkillSyncUploadResult } from "../core/skill-sync";
 import type { DeleteInstalledSkillResult, InstalledSkillsSnapshot } from "../core/skill-manager";
 import type { SkillUsageRefreshStatus } from "../core/skill-usage";
@@ -43,7 +44,8 @@ const api = {
   getSession: (sessionKey: string): Promise<SessionSearchResult | null> => ipcRenderer.invoke("session:get", sessionKey),
   getMessages: (sessionKey: string, offset?: number, limit?: number): Promise<SessionMessage[]> =>
     ipcRenderer.invoke("session:messages", sessionKey, offset, limit),
-  getTraceEvents: (sessionKey: string): Promise<SessionTraceEvent[]> => ipcRenderer.invoke("session:trace-events", sessionKey),
+  getTraceEvents: (sessionKey: string, options?: TraceEventQueryOptions): Promise<SessionTraceEvent[]> =>
+    ipcRenderer.invoke("session:trace-events", sessionKey, options),
   getLiveSessions: (): Promise<LiveSessionSnapshot> => ipcRenderer.invoke("sessions:live"),
   summarizeSession: (sessionKey: string): Promise<SessionSearchResult | null> =>
     ipcRenderer.invoke("session:summarize", sessionKey),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -46,6 +46,7 @@ import { formatRelativeTime } from "../../core/format-session";
 import { QUOTA_REFRESH_INTERVAL_MS } from "../../core/refresh-policy";
 import type { AppSettings, AppSettingsUpdate } from "../../core/platform";
 import type { RemoteHealthReport } from "../../core/remote-health";
+import type { SkillSyncSnapshot } from "../../core/skill-sync";
 import type { InstalledSkill, InstalledSkillsSnapshot } from "../../core/skill-manager";
 import { globalShortcutOptions } from "../../core/shortcuts";
 import { terminalSelectOptions } from "../../core/terminal-options";
@@ -208,6 +209,17 @@ const EMPTY_LIVE_SESSIONS: LiveSessionSnapshot = {
 const EMPTY_SKILLS: InstalledSkillsSnapshot = {
   skills: [],
   roots: [],
+  scannedAt: 0,
+};
+
+const EMPTY_SKILL_SYNC: SkillSyncSnapshot = {
+  status: {
+    kind: "unconfigured",
+    setupSql: "",
+    message: "Configure Supabase URL and anon key in Settings to sync skills.",
+  },
+  remoteSkills: [],
+  bindings: [],
   scannedAt: 0,
 };
 
@@ -383,6 +395,7 @@ export function App(): ReactElement {
   const [apiConfigOpen, setApiConfigOpen] = useState(false);
   const [aiAssistantOpen, setAiAssistantOpen] = useState(false);
   const [installedSkills, setInstalledSkills] = useState<InstalledSkillsSnapshot>(EMPTY_SKILLS);
+  const [skillSyncSnapshot, setSkillSyncSnapshot] = useState<SkillSyncSnapshot>(EMPTY_SKILL_SYNC);
   const [skillsLoading, setSkillsLoading] = useState(false);
   const [skillsFeedback, setSkillsFeedback] = useState<SkillsFeedback>(null);
   const [appSettings, setAppSettings] = useState<AppSettings | null>(null);
@@ -523,7 +536,12 @@ export function App(): ReactElement {
           usageError = error;
         }
       }
-      setInstalledSkills(await window.sessionSearch.listSkills());
+      const [nextSkills, nextSkillSync] = await Promise.all([
+        window.sessionSearch.listSkills(),
+        window.sessionSearch.getSkillSyncSnapshot(),
+      ]);
+      setInstalledSkills(nextSkills);
+      setSkillSyncSnapshot(nextSkillSync);
       if (usageError) {
         if (!silent) setSkillsFeedback({ kind: "error", message: usageError instanceof Error ? usageError.message : String(usageError) });
         return;
@@ -539,7 +557,10 @@ export function App(): ReactElement {
         }, 2200);
       }
     } catch (error) {
-      if (!refreshUsage) setInstalledSkills(EMPTY_SKILLS);
+      if (!refreshUsage) {
+        setInstalledSkills(EMPTY_SKILLS);
+        setSkillSyncSnapshot(EMPTY_SKILL_SYNC);
+      }
       setSkillsFeedback({ kind: "error", message: error instanceof Error ? error.message : String(error) });
     } finally {
       setSkillsLoading(false);
@@ -551,7 +572,12 @@ export function App(): ReactElement {
     setSkillsFeedback({ kind: "running", message: t(`Deleting ${skill.name}...`, `正在删除 ${skill.name}...`) });
     try {
       const result = await window.sessionSearch.deleteSkill(skill.path);
-      setInstalledSkills(await window.sessionSearch.listSkills());
+      const [nextSkills, nextSkillSync] = await Promise.all([
+        window.sessionSearch.listSkills(),
+        window.sessionSearch.getSkillSyncSnapshot(),
+      ]);
+      setInstalledSkills(nextSkills);
+      setSkillSyncSnapshot(nextSkillSync);
       const message = t(`Deleted ${result.skillName}.`, `已删除 ${result.skillName}。`);
       setSkillsFeedback({ kind: "success", message });
       window.setTimeout(() => {
@@ -563,6 +589,52 @@ export function App(): ReactElement {
       throw error;
     } finally {
       setSkillsLoading(false);
+    }
+  }, [t]);
+
+  const uploadSkillToSync = useCallback(async (skill: InstalledSkill) => {
+    setSkillsLoading(true);
+    setSkillsFeedback({ kind: "running", message: t(`Uploading ${skill.name}...`, `正在上传 ${skill.name}...`) });
+    try {
+      const result = await window.sessionSearch.uploadSkillToSync(skill.path);
+      await loadSkills({ silent: true });
+      const message = t(`Uploaded ${result.remoteSkill.name}.`, `已上传 ${result.remoteSkill.name}。`);
+      setSkillsFeedback({ kind: "success", message });
+      window.setTimeout(() => {
+        setSkillsFeedback((current) => (current?.kind === "success" && current.message === message ? null : current));
+      }, 2200);
+    } catch (error) {
+      setSkillsFeedback({ kind: "error", message: error instanceof Error ? error.message : String(error) });
+    } finally {
+      setSkillsLoading(false);
+    }
+  }, [loadSkills, t]);
+
+  const installSyncedSkill = useCallback(async (remoteSkillId: string) => {
+    setSkillsLoading(true);
+    setSkillsFeedback({ kind: "running", message: t("Installing remote skill...", "正在安装远程 Skill...") });
+    try {
+      const result = await window.sessionSearch.installSyncedSkill(remoteSkillId);
+      await loadSkills({ silent: true });
+      const verb = result.overwritten ? t("Updated", "已更新") : t("Installed", "已安装");
+      const message = `${verb} ${result.remoteSkill.name}.`;
+      setSkillsFeedback({ kind: "success", message });
+      window.setTimeout(() => {
+        setSkillsFeedback((current) => (current?.kind === "success" && current.message === message ? null : current));
+      }, 2200);
+    } catch (error) {
+      setSkillsFeedback({ kind: "error", message: error instanceof Error ? error.message : String(error) });
+    } finally {
+      setSkillsLoading(false);
+    }
+  }, [loadSkills, t]);
+
+  const copySkillSyncSetupSql = useCallback(async () => {
+    try {
+      await window.sessionSearch.copySkillSyncSetupSql();
+      setSkillsFeedback({ kind: "success", message: t("Supabase setup SQL copied.", "Supabase 初始化 SQL 已复制。") });
+    } catch (error) {
+      setSkillsFeedback({ kind: "error", message: error instanceof Error ? error.message : String(error) });
     }
   }, [t]);
 
@@ -1890,11 +1962,16 @@ export function App(): ReactElement {
       {skillsOpen ? (
         <SkillsDialog
           snapshot={installedSkills}
+          syncSnapshot={skillSyncSnapshot}
           loading={skillsLoading}
           feedback={skillsFeedback}
           language={language}
           revealLabel={FILE_MANAGER_LABEL}
           onRefresh={() => void loadSkills({ refreshUsage: true })}
+          onUpload={(skill) => uploadSkillToSync(skill)}
+          onInstallRemote={(remoteSkillId) => installSyncedSkill(remoteSkillId)}
+          onRefreshRemote={() => void loadSkills({ silent: true })}
+          onCopySetupSql={() => void copySkillSyncSetupSql()}
           onCopyPath={(skillPath) =>
             void runUtilityAction(t("Copying skill path", "正在复制 Skill 路径"), () => window.sessionSearch.copySkillPath(skillPath), t("Skill path copied.", "Skill 路径已复制。"))
           }
@@ -2415,7 +2492,7 @@ function SettingsDialog({
             </button>
             <button className={activeSection === "skills" ? "active" : ""} onClick={() => setActiveSection("skills")}>
               <PackageSearch size={15} />
-              <span>{l("Skill usage", "Skill 统计")}</span>
+              <span>{l("Skills", "Skills")}</span>
             </button>
             <button className={activeSection === "appearance" ? "active" : ""} onClick={() => setActiveSection("appearance")}>
               <Sun size={15} />
@@ -2837,6 +2914,56 @@ function SettingsDialog({
                     checked={Boolean(skillHookInstalled)}
                     disabled={skillHookInstalled === null || skillHookBusy}
                     onChange={(event) => onSkillHookChange(event.currentTarget.checked)}
+                  />
+                </label>
+                <header className="settings-pane-head" style={{ marginTop: 18 }}>
+                  <h3>{l("Supabase skill sync", "Supabase Skill 同步")}</h3>
+                  <p>
+                    {l(
+                      "Use your own Supabase project to upload local skills and install them on another machine. Get the Project URL and anon key from supabase.com/dashboard.",
+                      "使用你自己的 Supabase 项目上传本地 Skills，并在另一台机器安装。可在 supabase.com/dashboard 获取 Project URL 和 anon key。",
+                    )}
+                  </p>
+                </header>
+                <label className="settings-field settings-toggle">
+                  <div className="settings-field-text">
+                    <span className="settings-field-title">{l("Enable Supabase sync", "启用 Supabase 同步")}</span>
+                    <span className="settings-field-sub">
+                      {l("Advanced automatic table creation is not used; the app will show SQL when the table is missing.", "不使用高级自动建表；缺表时应用会展示可复制的初始化 SQL。")}
+                    </span>
+                  </div>
+                  <input
+                    type="checkbox"
+                    className="switch"
+                    checked={Boolean(settings?.skillSyncEnabled)}
+                    disabled={!settings || saving}
+                    onChange={(event) => onSettingsChange({ skillSyncEnabled: event.currentTarget.checked })}
+                  />
+                </label>
+                <label className="settings-field">
+                  <div className="settings-field-text">
+                    <span className="settings-field-title">Supabase URL</span>
+                    <span className="settings-field-sub">https://your-project.supabase.co</span>
+                  </div>
+                  <input
+                    type="text"
+                    value={settings?.skillSyncSupabaseUrl ?? ""}
+                    disabled={!settings || saving}
+                    placeholder="https://your-project.supabase.co"
+                    onChange={(event) => onSettingsChange({ skillSyncSupabaseUrl: event.currentTarget.value })}
+                  />
+                </label>
+                <label className="settings-field">
+                  <div className="settings-field-text">
+                    <span className="settings-field-title">anon key</span>
+                    <span className="settings-field-sub">{l("Stored locally and used only for the skills sync table.", "保存在本地，仅用于 Skills 同步表。")}</span>
+                  </div>
+                  <input
+                    type="password"
+                    value={settings?.skillSyncSupabaseAnonKey ?? ""}
+                    disabled={!settings || saving}
+                    placeholder="eyJhbGciOi..."
+                    onChange={(event) => onSettingsChange({ skillSyncSupabaseAnonKey: event.currentTarget.value })}
                   />
                 </label>
               </section>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -46,6 +46,7 @@ import { formatRelativeTime } from "../../core/format-session";
 import { QUOTA_REFRESH_INTERVAL_MS } from "../../core/refresh-policy";
 import type { AppSettings, AppSettingsUpdate } from "../../core/platform";
 import type { RemoteHealthReport } from "../../core/remote-health";
+import type { TraceEventQueryOptions } from "../../core/session-store";
 import type { SkillSyncSnapshot } from "../../core/skill-sync";
 import type { InstalledSkill, InstalledSkillsSnapshot } from "../../core/skill-manager";
 import { globalShortcutOptions } from "../../core/shortcuts";
@@ -177,6 +178,7 @@ const INITIAL_SESSION_LIMIT = 30;
 const SESSION_PAGE_SIZE = 30;
 const INITIAL_MESSAGE_LIMIT = 20;
 const MESSAGE_PAGE_SIZE = 80;
+const TRACE_EVENT_WINDOW_LIMIT = 300;
 
 const EMPTY_STATS: SessionStats = {
   total: {
@@ -222,6 +224,25 @@ const EMPTY_SKILL_SYNC: SkillSyncSnapshot = {
   bindings: [],
   scannedAt: 0,
 };
+
+function traceWindowForMessages(messages: SessionMessage[]): TraceEventQueryOptions {
+  const times = messages
+    .map((message) => new Date(message.timestamp).getTime())
+    .filter((time) => Number.isFinite(time));
+  if (times.length === 0) return { limit: TRACE_EVENT_WINDOW_LIMIT };
+  return {
+    startTimestamp: new Date(Math.min(...times)).toISOString(),
+    endTimestamp: new Date(Math.max(...times)).toISOString(),
+    limit: TRACE_EVENT_WINDOW_LIMIT,
+  };
+}
+
+function mergeTraceEventsByIndex(current: SessionTraceEvent[], next: SessionTraceEvent[]): SessionTraceEvent[] {
+  if (next.length === 0) return current;
+  const byIndex = new Map(current.map((event) => [event.index, event]));
+  for (const event of next) byIndex.set(event.index, event);
+  return [...byIndex.values()].sort((a, b) => a.index - b.index);
+}
 
 function sortLabel(value: SessionSortBy, language: LanguageMode): string {
   if (value === "created") return localize(language, "Created", "创建时间");
@@ -946,10 +967,7 @@ export function App(): ReactElement {
 
     const sessionKey = session.sessionKey;
     try {
-      const [fresh, loadedTraceEvents] = await Promise.all([
-        window.sessionSearch.getSession(sessionKey),
-        window.sessionSearch.getTraceEvents(sessionKey),
-      ]);
+      const fresh = await window.sessionSearch.getSession(sessionKey);
       if (requestId !== detailLoadSeqRef.current) return;
       if (!fresh) {
         setMessagesLoading(false);
@@ -958,6 +976,8 @@ export function App(): ReactElement {
 
       const initialOffset = Math.max(0, fresh.messageCount - INITIAL_MESSAGE_LIMIT);
       const loadedMessages = await window.sessionSearch.getMessages(sessionKey, initialOffset, INITIAL_MESSAGE_LIMIT);
+      if (requestId !== detailLoadSeqRef.current) return;
+      const loadedTraceEvents = await window.sessionSearch.getTraceEvents(sessionKey, traceWindowForMessages(loadedMessages));
       if (requestId !== detailLoadSeqRef.current) return;
 
       setDetail(fresh);
@@ -991,9 +1011,11 @@ export function App(): ReactElement {
     setMessagesLoading(true);
     try {
       const nextMessages = await window.sessionSearch.getMessages(sessionKey, nextOffset, limit);
+      const nextTraceEvents = await window.sessionSearch.getTraceEvents(sessionKey, traceWindowForMessages(nextMessages));
       if (requestId !== detailLoadSeqRef.current) return;
       setMessageOffset(nextOffset);
       setMessages((current) => [...nextMessages, ...current]);
+      setTraceEvents((current) => mergeTraceEventsByIndex(current, nextTraceEvents));
     } catch (error) {
       if (requestId === detailLoadSeqRef.current) {
         setActionStatus({ kind: "error", message: error instanceof Error ? error.message : String(error) });

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2962,7 +2962,7 @@ function SettingsDialog({
                     onChange={(event) => onSettingsChange({ skillSyncEnabled: event.currentTarget.checked })}
                   />
                 </label>
-                <label className="settings-field">
+                <label className="settings-field skills-sync-field">
                   <div className="settings-field-text">
                     <span className="settings-field-title">Supabase URL</span>
                     <span className="settings-field-sub">https://your-project.supabase.co</span>
@@ -2975,7 +2975,7 @@ function SettingsDialog({
                     onChange={(event) => onSettingsChange({ skillSyncSupabaseUrl: event.currentTarget.value })}
                   />
                 </label>
-                <label className="settings-field">
+                <label className="settings-field skills-sync-field">
                   <div className="settings-field-text">
                     <span className="settings-field-title">anon key</span>
                     <span className="settings-field-sub">{l("Stored locally and used only for the skills sync table.", "保存在本地，仅用于 Skills 同步表。")}</span>

--- a/src/renderer/src/components/skills-dialog.tsx
+++ b/src/renderer/src/components/skills-dialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { KeyboardEvent as ReactKeyboardEvent, ReactElement } from "react";
-import { Copy, FolderOpen, RefreshCw, Search, Trash2, X } from "lucide-react";
+import { Copy, Download, FolderOpen, RefreshCw, Search, Trash2, Upload, X } from "lucide-react";
+import type { RemoteSkill, SkillSyncSnapshot } from "../../../core/skill-sync";
 import type { InstalledSkill, InstalledSkillsSnapshot, SkillRootStatus, SkillSource } from "../../../core/skill-manager";
 import { formatCompactNumber } from "../format-count";
 import { localize, type LanguageMode } from "../language";
@@ -10,22 +11,32 @@ import { useClampedContextMenuStyle } from "../context-menu-position";
 
 export function SkillsDialog({
   snapshot,
+  syncSnapshot,
   loading,
   feedback,
   language,
   revealLabel,
   onRefresh,
+  onUpload,
+  onInstallRemote,
+  onRefreshRemote,
+  onCopySetupSql,
   onCopyPath,
   onReveal,
   onDelete,
   onClose,
 }: {
   snapshot: InstalledSkillsSnapshot;
+  syncSnapshot: SkillSyncSnapshot;
   loading: boolean;
   feedback: SkillsFeedback;
   language: LanguageMode;
   revealLabel: string;
   onRefresh: () => void;
+  onUpload: (skill: InstalledSkill) => Promise<void>;
+  onInstallRemote: (remoteSkillId: string) => Promise<void>;
+  onRefreshRemote: () => void;
+  onCopySetupSql: () => void;
   onCopyPath: (skillPath: string) => void;
   onReveal: (skillPath: string) => void;
   onDelete: (skill: InstalledSkill) => Promise<void>;
@@ -33,9 +44,11 @@ export function SkillsDialog({
 }): ReactElement {
   const l = (en: string, zh: string) => localize(language, en, zh);
   const [query, setQuery] = useState("");
+  const [syncView, setSyncView] = useState<"local" | "remote">("local");
   const [sourceFilter, setSourceFilter] = useState<SkillSourceFilter>("all");
   const [sortKey, setSortKey] = useState<SkillSortKey>("usage");
   const [selectedSkillId, setSelectedSkillId] = useState<string | null>(null);
+  const [selectedRemoteId, setSelectedRemoteId] = useState<string | null>(null);
   const [skillContextMenu, setSkillContextMenu] = useState<{ x: number; y: number; skill: InstalledSkill } | null>(null);
   const [deleteCandidate, setDeleteCandidate] = useState<InstalledSkill | null>(null);
   const [deletingSkill, setDeletingSkill] = useState(false);
@@ -44,10 +57,18 @@ export function SkillsDialog({
     return sortInstalledSkills(filtered, sortKey);
   }, [snapshot.skills, query, sourceFilter, sortKey]);
   const visibleRoots = useMemo(() => summarizeSkillRoots(snapshot.roots), [snapshot.roots]);
+  const remoteSkills = useMemo(() => filterRemoteSkills(syncSnapshot.remoteSkills, query), [syncSnapshot.remoteSkills, query]);
   const selectedSkill =
     filteredSkills.find((skill) => skill.id === selectedSkillId) ??
     filteredSkills[0] ??
     null;
+  const selectedRemote =
+    remoteSkills.find((skill) => skill.id === selectedRemoteId) ??
+    remoteSkills[0] ??
+    null;
+  const selectedSkillBinding = selectedSkill ? syncSnapshot.bindings.find((binding) => binding.localSkillPath === selectedSkill.path) : null;
+  const selectedRemoteBinding = selectedRemote ? syncSnapshot.bindings.find((binding) => binding.remoteSkillId === selectedRemote.id) : null;
+  const syncReady = syncSnapshot.status.kind === "ready";
   const codexCount = snapshot.skills.filter((skill) => skill.agent === "codex").length;
   const claudeCount = snapshot.skills.filter((skill) => skill.agent === "claude").length;
   const activeItemRef = useRef<HTMLButtonElement>(null);
@@ -64,6 +85,14 @@ export function SkillsDialog({
     activeItemRef.current?.scrollIntoView({ block: "nearest" });
   }, [selectedSkill?.id]);
 
+  useEffect(() => {
+    if (!remoteSkills.length) {
+      if (selectedRemoteId) setSelectedRemoteId(null);
+      return;
+    }
+    if (!selectedRemoteId || !remoteSkills.some((skill) => skill.id === selectedRemoteId)) setSelectedRemoteId(remoteSkills[0].id);
+  }, [remoteSkills, selectedRemoteId]);
+
   const handleListKeyDown = (event: ReactKeyboardEvent) => {
     if (event.key === "Escape") {
       if (deleteCandidate) setDeleteCandidate(null);
@@ -73,6 +102,7 @@ export function SkillsDialog({
       event.stopPropagation();
       return;
     }
+    if (syncView !== "local") return;
     if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
     if (!filteredSkills.length) return;
     event.preventDefault();
@@ -111,10 +141,19 @@ export function SkillsDialog({
         <div className="dialog-title">
           <span>{l("Skills", "Skills 管理")}</span>
           <span className="skills-dialog-count">
-            Codex {formatCompactNumber(codexCount)} · Claude Code {formatCompactNumber(claudeCount)}
+            Codex {formatCompactNumber(codexCount)} · Claude Code {formatCompactNumber(claudeCount)} · Remote {formatCompactNumber(syncSnapshot.remoteSkills.length)}
           </span>
           <button type="button" className="icon-button" onClick={onClose} aria-label={l("Close", "关闭")}>
             <X size={16} />
+          </button>
+        </div>
+
+        <div className="skills-view-tabs" role="tablist" aria-label={l("Skills view", "Skills 视图")}>
+          <button type="button" className={syncView === "local" ? "active" : ""} onClick={() => setSyncView("local")}>
+            {l("Local", "本地")}
+          </button>
+          <button type="button" className={syncView === "remote" ? "active" : ""} onClick={() => setSyncView("remote")}>
+            {l("Remote", "远程")}
           </button>
         </div>
 
@@ -124,39 +163,42 @@ export function SkillsDialog({
             <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder={l("Search name, description, or path", "搜索名称、描述或路径")} autoFocus />
           </label>
           <div className="skills-filter" role="group" aria-label={l("Skill source filter", "Skill 来源筛选")}>
-            {SKILL_SOURCE_FILTERS.map((filter) => (
-              <button key={filter} className={sourceFilter === filter ? "active" : ""} onClick={() => setSourceFilter(filter)}>
-                {skillFilterLabel(filter, language)}
-              </button>
-            ))}
+            {syncView === "local"
+              ? SKILL_SOURCE_FILTERS.map((filter) => (
+                  <button key={filter} className={sourceFilter === filter ? "active" : ""} onClick={() => setSourceFilter(filter)}>
+                    {skillFilterLabel(filter, language)}
+                  </button>
+                ))
+              : null}
           </div>
-          <label className="skills-sort" title={l("Sort skills", "排序 Skills")}>
+          {syncView === "local" ? <label className="skills-sort" title={l("Sort skills", "排序 Skills")}>
             <span>{l("Sort", "排序")}</span>
             <select value={sortKey} onChange={(event) => setSortKey(event.currentTarget.value as SkillSortKey)} aria-label={l("Sort skills", "排序 Skills")}>
               <option value="usage">{l("Most used", "最多使用")}</option>
               <option value="usage-asc">{l("Least used", "最少使用")}</option>
             </select>
-          </label>
-          <button className="stats-refresh" onClick={onRefresh} disabled={loading} title={l("Refresh skill usage", "刷新 Skill 使用统计")} aria-label={l("Refresh skill usage", "刷新 Skill 使用统计")}>
+          </label> : null}
+          <button className="stats-refresh" onClick={syncView === "local" ? onRefresh : onRefreshRemote} disabled={loading} title={l("Refresh skills", "刷新 Skills")} aria-label={l("Refresh skills", "刷新 Skills")}>
             <RefreshCw size={13} />
           </button>
         </div>
 
-        <div className="skills-roots">
+        {syncView === "local" ? <div className="skills-roots">
           {visibleRoots.map((root) => (
             <span key={`${root.source}:${root.path}`} className={root.exists ? "" : "missing"} title={root.path}>
               <strong>{skillSourceUiLabel(root.source, language)}</strong>
               {root.exists ? l(`${root.skillCount} skills`, `${root.skillCount} 个`) : l("Missing", "未找到")}
             </span>
           ))}
-        </div>
+        </div> : <SkillSyncStatusPanel snapshot={syncSnapshot} language={language} onCopySetupSql={onCopySetupSql} />}
 
         {feedback ? <div className={`skills-feedback ${feedback.kind}`}>{feedback.message}</div> : null}
         <div className="skills-shell">
           <div className="skills-list">
-            {loading ? <div className="skills-empty">{l("Loading installed skills...", "正在加载已安装 Skills...")}</div> : null}
-            {!loading && filteredSkills.length === 0 ? <div className="skills-empty">{l("No skills found.", "没有找到 Skill。")}</div> : null}
-            {!loading
+            {loading ? <div className="skills-empty">{syncView === "local" ? l("Loading installed skills...", "正在加载已安装 Skills...") : l("Loading remote skills...", "正在加载远程 Skills...")}</div> : null}
+            {!loading && syncView === "local" && filteredSkills.length === 0 ? <div className="skills-empty">{l("No skills found.", "没有找到 Skill。")}</div> : null}
+            {!loading && syncView === "remote" && remoteSkills.length === 0 ? <div className="skills-empty">{remoteEmptyLabel(syncSnapshot, language)}</div> : null}
+            {!loading && syncView === "local"
               ? filteredSkills.map((skill) => (
                   <button
                     key={skill.id}
@@ -180,10 +222,28 @@ export function SkillsDialog({
                   </button>
                 ))
               : null}
+            {!loading && syncView === "remote"
+              ? remoteSkills.map((skill) => (
+                  <button
+                    key={skill.id}
+                    type="button"
+                    className={`skill-item ${selectedRemote?.id === skill.id ? "active" : ""}`}
+                    onClick={() => setSelectedRemoteId(skill.id)}
+                  >
+                    <span className="skill-item-head">
+                      <strong>{skill.name}</strong>
+                      {syncSnapshot.bindings.some((binding) => binding.remoteSkillId === skill.id) ? <span className="skill-usage-count">{l("Local", "本地")}</span> : null}
+                      <span className={`skill-source-badge ${skill.source}`}>{skill.agent === "codex" ? "Codex" : "Claude Code"}</span>
+                    </span>
+                    <span className="skill-item-desc">{skill.description || l("No description", "无描述")}</span>
+                    <span className="skill-item-path">{new Date(skill.updatedAt).toLocaleString()}</span>
+                  </button>
+                ))
+              : null}
           </div>
 
           <div className="skill-preview">
-            {selectedSkill ? (
+            {syncView === "local" && selectedSkill ? (
               <>
                 <div className="skill-preview-head">
                   <div>
@@ -192,6 +252,12 @@ export function SkillsDialog({
                       <SkillSourceBadge source={selectedSkill.source} language={language} />
                     </div>
                     <p>{selectedSkill.description || l("No description", "无描述")}</p>
+                  </div>
+                  <div className="skill-preview-actions">
+                    <button type="button" disabled={!syncReady || loading} onClick={() => void onUpload(selectedSkill)} title={!syncReady ? syncDisabledTitle(syncSnapshot, language) : ""}>
+                      <Upload size={14} />
+                      {selectedSkillBinding ? l("Update remote", "更新远程") : l("Upload", "上传")}
+                    </button>
                   </div>
                 </div>
                 <dl className="skill-meta">
@@ -215,8 +281,53 @@ export function SkillsDialog({
                     <dt>{l("Path", "路径")}</dt>
                     <dd title={selectedSkill.path}>{selectedSkill.path}</dd>
                   </div>
+                  {selectedSkillBinding ? (
+                    <div>
+                      <dt>{l("Remote", "远程")}</dt>
+                      <dd>{new Date(selectedSkillBinding.lastSyncedAt).toLocaleString()}</dd>
+                    </div>
+                  ) : null}
                 </dl>
                 <pre className="skill-markdown-preview">{skillPreviewMarkdown(selectedSkill.markdown, language)}</pre>
+              </>
+            ) : syncView === "remote" && selectedRemote ? (
+              <>
+                <div className="skill-preview-head">
+                  <div>
+                    <div className="skill-preview-title">
+                      <h3>{selectedRemote.name}</h3>
+                      <span className={`skill-source-badge ${selectedRemote.source}`}>{selectedRemote.agent === "codex" ? "Codex" : "Claude Code"}</span>
+                    </div>
+                    <p>{selectedRemote.description || l("No description", "无描述")}</p>
+                  </div>
+                  <div className="skill-preview-actions">
+                    <button type="button" disabled={!syncReady || loading} onClick={() => void onInstallRemote(selectedRemote.id)}>
+                      <Download size={14} />
+                      {selectedRemoteBinding ? l("Update local", "更新本地") : l("Install locally", "安装到本地")}
+                    </button>
+                  </div>
+                </div>
+                <dl className="skill-meta">
+                  <div>
+                    <dt>{l("Agent", "Agent")}</dt>
+                    <dd>{selectedRemote.agent === "codex" ? "Codex" : "Claude Code"}</dd>
+                  </div>
+                  <div>
+                    <dt>{l("Updated", "更新时间")}</dt>
+                    <dd>{new Date(selectedRemote.updatedAt).toLocaleString()}</dd>
+                  </div>
+                  <div>
+                    <dt>{l("Remote ID", "远程 ID")}</dt>
+                    <dd title={selectedRemote.id}>{selectedRemote.id}</dd>
+                  </div>
+                  {selectedRemoteBinding ? (
+                    <div>
+                      <dt>{l("Local", "本地")}</dt>
+                      <dd title={selectedRemoteBinding.localSkillPath}>{selectedRemoteBinding.localSkillPath}</dd>
+                    </div>
+                  ) : null}
+                </dl>
+                <pre className="skill-markdown-preview">{skillPreviewMarkdown(selectedRemote.markdown, language)}</pre>
               </>
             ) : (
               <div className="skills-empty">{l("Select a skill to preview it.", "选择一个 Skill 查看内容。")}</div>
@@ -303,6 +414,56 @@ function skillSourceUiLabel(source: SkillSource, language: LanguageMode): string
   if (source === "claude-project") return localize(language, "Project", "项目");
   if (source === "claude-plugin") return localize(language, "Claude Plugin", "Claude 插件");
   return skillSourceLabel(source);
+}
+
+function filterRemoteSkills(skills: RemoteSkill[], query: string): RemoteSkill[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  const filtered = normalizedQuery
+    ? skills.filter((skill) => [skill.name, skill.description, skill.agent, skill.source, skill.id].join("\n").toLowerCase().includes(normalizedQuery))
+    : skills;
+  return [...filtered].sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt) || a.name.localeCompare(b.name));
+}
+
+function syncDisabledTitle(snapshot: SkillSyncSnapshot, language: LanguageMode): string {
+  if (snapshot.status.kind === "missing-table") return localize(language, "Initialize the Supabase table first.", "请先初始化 Supabase 表。");
+  if (snapshot.status.kind === "unconfigured") return localize(language, "Configure Supabase sync in Settings first.", "请先在设置中配置 Supabase 同步。");
+  if (snapshot.status.kind === "error") return snapshot.status.message;
+  return "";
+}
+
+function remoteEmptyLabel(snapshot: SkillSyncSnapshot, language: LanguageMode): string {
+  if (snapshot.status.kind === "ready") return localize(language, "No remote skills found.", "没有远程 Skill。");
+  return syncDisabledTitle(snapshot, language);
+}
+
+function SkillSyncStatusPanel({
+  snapshot,
+  language,
+  onCopySetupSql,
+}: {
+  snapshot: SkillSyncSnapshot;
+  language: LanguageMode;
+  onCopySetupSql: () => void;
+}): ReactElement {
+  const l = (en: string, zh: string) => localize(language, en, zh);
+  if (snapshot.status.kind === "ready") {
+    return (
+      <div className="skill-sync-panel ready">
+        <span>{l(`${snapshot.remoteSkills.length} remote skills`, `${snapshot.remoteSkills.length} 个远程 Skill`)}</span>
+      </div>
+    );
+  }
+  return (
+    <div className={`skill-sync-panel ${snapshot.status.kind}`}>
+      <span>{snapshot.status.message}</span>
+      {snapshot.status.kind === "missing-table" ? (
+        <button type="button" onClick={onCopySetupSql}>
+          <Copy size={14} />
+          {l("Copy setup SQL", "复制初始化 SQL")}
+        </button>
+      ) : null}
+    </div>
+  );
 }
 
 function SkillSourceBadge({ source, language }: { source: SkillSource; language: LanguageMode }): ReactElement {

--- a/src/renderer/src/detail-panel-actions.test.ts
+++ b/src/renderer/src/detail-panel-actions.test.ts
@@ -63,6 +63,20 @@ describe("detail panel actions", () => {
     expect(detailPanelSource).toContain("Show ${Math.min(messagePageSize, olderMessageCount)} older messages");
   });
 
+  it("loads the visible message window before trace events when opening detail", () => {
+    const openDetail = appSource.slice(appSource.indexOf("async function openDetail"), appSource.indexOf("function closeDetail"));
+    const freshIndex = openDetail.indexOf("const fresh = await window.sessionSearch.getSession(sessionKey)");
+    const messagesIndex = openDetail.indexOf(
+      "window.sessionSearch.getMessages(sessionKey, initialOffset, INITIAL_MESSAGE_LIMIT)",
+    );
+    const traceIndex = openDetail.indexOf("window.sessionSearch.getTraceEvents(sessionKey, traceWindowForMessages(loadedMessages))");
+
+    expect(freshIndex).toBeGreaterThanOrEqual(0);
+    expect(messagesIndex).toBeGreaterThan(freshIndex);
+    expect(traceIndex).toBeGreaterThan(messagesIndex);
+    expect(openDetail).not.toContain("const [fresh, loadedTraceEvents] = await Promise.all");
+  });
+
   it("keeps title rename icon but removes the duplicate rename action from the detail toolbar", () => {
     const detailActions = detailPanelSource.slice(detailPanelSource.indexOf('<div className="detail-actions">'), detailPanelSource.indexOf('<div className="detail-tags">'));
 
@@ -131,15 +145,25 @@ describe("detail panel actions", () => {
     expect(mainSource).toContain("await ensureRemoteSessionDetailsLoaded(sessionKey)");
   });
 
-  it("loads remote session details before building resume commands", () => {
+  it("does not hydrate remote session details before building resume commands", () => {
     for (const channel of ["command:copy-resume", "command:resume", "command:resume-iterm"]) {
       const handler = mainHandlerSource(channel);
-      expect(handler).toContain("await ensureRemoteSessionDetailsLoaded(sessionKey)");
-      expect(handler.indexOf("await ensureRemoteSessionDetailsLoaded(sessionKey)")).toBeLessThan(
-        handler.indexOf("const session = store.getSession(sessionKey)"),
-      );
+      expect(handler).not.toContain("ensureRemoteSessionDetailsLoaded(sessionKey)");
+      expect(handler).toContain("const session = store.getSession(sessionKey)");
     }
     expect(mainHandlerSource("command:copy-resume")).toContain("async (_event, sessionKey: string)");
+  });
+
+  it("uses lightweight remote message paging for unhydrated remote detail views", () => {
+    const messagesHandler = mainHandlerSource("session:messages");
+    const traceHandler = mainHandlerSource("session:trace-events");
+
+    expect(messagesHandler).toContain("fetchRemoteSessionMessagePage");
+    expect(messagesHandler.indexOf("fetchRemoteSessionMessagePage")).toBeLessThan(
+      messagesHandler.indexOf("await ensureRemoteSessionDetailsLoaded(sessionKey)"),
+    );
+    expect(traceHandler).toContain("return []");
+    expect(traceHandler).toContain("store.getTraceEvents(sessionKey, options)");
   });
 
   it("exposes cross-agent session migration through IPC", () => {

--- a/src/renderer/src/skills-dialog-actions.test.ts
+++ b/src/renderer/src/skills-dialog-actions.test.ts
@@ -4,6 +4,7 @@ import { summarizeSkillRoots } from "./components/skills-dialog";
 import type { SkillRootStatus } from "../../core/skill-manager";
 
 const skillsDialogSource = readFileSync(new URL("./components/skills-dialog.tsx", import.meta.url), "utf8");
+const appSource = readFileSync(new URL("./App.tsx", import.meta.url), "utf8");
 
 describe("skills dialog actions", () => {
   it("copies the SKILL.md path but reveals the skill directory", () => {
@@ -26,5 +27,15 @@ describe("skills dialog actions", () => {
       { source: "codex-shared", exists: true, skillCount: 3 },
       { source: "codex-project", exists: true, skillCount: 2 },
     ]);
+  });
+
+  it("surfaces Supabase sync configuration and local/remote skill actions", () => {
+    expect(appSource).toContain("skillSyncSupabaseUrl");
+    expect(appSource).toContain("skillSyncSupabaseAnonKey");
+    expect(appSource).toContain("supabase.com/dashboard");
+    expect(skillsDialogSource).toContain("syncView");
+    expect(skillsDialogSource).toContain("onUpload");
+    expect(skillsDialogSource).toContain("onInstallRemote");
+    expect(skillsDialogSource).toContain("onCopySetupSql");
   });
 });

--- a/src/renderer/src/skills-dialog-actions.test.ts
+++ b/src/renderer/src/skills-dialog-actions.test.ts
@@ -30,9 +30,13 @@ describe("skills dialog actions", () => {
   });
 
   it("surfaces Supabase sync configuration and local/remote skill actions", () => {
+    const supabaseSettings = appSource.slice(appSource.indexOf("Supabase skill sync"), appSource.indexOf("Appearance", appSource.indexOf("Supabase skill sync")));
+
     expect(appSource).toContain("skillSyncSupabaseUrl");
     expect(appSource).toContain("skillSyncSupabaseAnonKey");
     expect(appSource).toContain("supabase.com/dashboard");
+    expect(appSource.match(/settings-field skills-sync-field/g)).toHaveLength(2);
+    expect(supabaseSettings.match(/settings-field skills-sync-field/g)).toHaveLength(2);
     expect(skillsDialogSource).toContain("syncView");
     expect(skillsDialogSource).toContain("onUpload");
     expect(skillsDialogSource).toContain("onInstallRemote");

--- a/src/renderer/src/style-contract.test.ts
+++ b/src/renderer/src/style-contract.test.ts
@@ -58,6 +58,14 @@ describe("stylesheet theme contract", () => {
     expect(sshBody).toMatch(/overflow-y:\s*auto/);
   });
 
+  it("clamps the detail title so long remote prompts cannot push conversation out of view", () => {
+    const detailTitle = stylesheet.match(/\.detail-header h2\s*\{[^}]*\}/)?.[0] ?? "";
+
+    expect(detailTitle).toMatch(/display:\s*-webkit-box/);
+    expect(detailTitle).toMatch(/-webkit-line-clamp:\s*3/);
+    expect(detailTitle).toMatch(/-webkit-box-orient:\s*vertical/);
+  });
+
   it("keeps toolbar action buttons isolated from remote environment filter chips", () => {
     const toolbar = stylesheet.match(/\.toolbar\s*\{[^}]*\}/)?.[0] ?? "";
     const toolbarFilters = stylesheet.match(/\.toolbar-filters\s*\{[^}]*\}/)?.[0] ?? "";

--- a/src/renderer/src/style-contract.test.ts
+++ b/src/renderer/src/style-contract.test.ts
@@ -58,6 +58,18 @@ describe("stylesheet theme contract", () => {
     expect(sshBody).toMatch(/overflow-y:\s*auto/);
   });
 
+  it("keeps Supabase skill sync inputs from overlapping their labels", () => {
+    const syncField = stylesheet.match(/\.skills-sync-field\s*\{[^}]*\}/)?.[0] ?? "";
+    const syncInput = stylesheet.match(/\.skills-sync-field\s+input\s*\{[^}]*\}/)?.[0] ?? "";
+    const narrowSyncField = stylesheet.match(/@media \(max-width:\s*640px\)\s*\{[\s\S]*?\.skills-sync-field\s*\{[^}]*\}/)?.[0] ?? "";
+
+    expect(syncField).toMatch(/display:\s*grid/);
+    expect(syncField).toMatch(/grid-template-columns:\s*minmax\(160px,\s*220px\)\s+minmax\(0,\s*1fr\)/);
+    expect(syncInput).toMatch(/width:\s*100%/);
+    expect(syncInput).toMatch(/min-width:\s*0/);
+    expect(narrowSyncField).toMatch(/grid-template-columns:\s*minmax\(0,\s*1fr\)/);
+  });
+
   it("clamps the detail title so long remote prompts cannot push conversation out of view", () => {
     const detailTitle = stylesheet.match(/\.detail-header h2\s*\{[^}]*\}/)?.[0] ?? "";
 

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -2196,6 +2196,34 @@ select:focus-visible {
   white-space: nowrap;
 }
 
+.skills-view-tabs {
+  display: inline-flex;
+  flex: 0 0 auto;
+  gap: 3px;
+  margin: 10px 14px 0;
+  padding: 2px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--panel-subtle);
+}
+
+.skills-view-tabs button {
+  height: 30px;
+  min-width: 76px;
+  padding: 0 12px;
+  border: 0;
+  border-radius: 6px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.skills-view-tabs button.active {
+  background: var(--panel-bg);
+  color: var(--accent-bright);
+  box-shadow: inset 0 0 0 1px var(--border-subtle);
+}
+
 .skills-toolbar {
   display: grid;
   grid-template-columns: minmax(180px, 1fr) auto auto auto;
@@ -2321,6 +2349,53 @@ select:focus-visible {
 
 .skills-roots .missing {
   opacity: 0.62;
+}
+
+.skill-sync-panel {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 35px;
+  margin: 0 14px 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--panel-subtle);
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.skill-sync-panel.ready {
+  color: var(--text-dim);
+}
+
+.skill-sync-panel.missing-table,
+.skill-sync-panel.error {
+  border-color: var(--danger-soft);
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+.skill-sync-panel button,
+.skill-preview-actions button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: 7px;
+  background: var(--panel-bg);
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.skill-preview-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
 }
 
 .skill-usage-count {
@@ -2467,10 +2542,16 @@ select:focus-visible {
 
 .skill-preview-head {
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 12px;
   padding: 16px 18px 12px;
   border-bottom: 1px solid var(--border-subtle);
+}
+
+.skill-preview-actions {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
 }
 
 .skill-preview-title {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1581,6 +1581,9 @@ select:focus-visible {
 .detail-header h2 {
   margin: 0;
   min-width: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
   overflow: hidden;
   color: var(--text);
   font-size: 18px;

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -3013,6 +3013,17 @@ select:focus-visible {
   cursor: pointer;
 }
 
+.skills-sync-field {
+  display: grid;
+  grid-template-columns: minmax(160px, 220px) minmax(0, 1fr);
+  align-items: center;
+}
+
+.skills-sync-field input {
+  width: 100%;
+  min-width: 0;
+}
+
 /* A single card that stacks a toggle row with a dependent sub-row (e.g. its threshold). */
 .settings-field.settings-stack {
   flex-direction: column;
@@ -3632,6 +3643,11 @@ select:focus-visible {
 }
 
 @media (max-width: 640px) {
+  .skills-sync-field {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: stretch;
+  }
+
   .api-settings-form .settings-field {
     grid-template-columns: minmax(0, 1fr);
     align-items: stretch;


### PR DESCRIPTION
## 背景

这次改动围绕两个问题：

1. 用户希望能把本机的 Codex skills 上传到自己的 Supabase 项目中，在切换机器后可以从远程下载/安装，减少重复配置成本。
2. 远程会话详情打开时存在体验问题：长标题可能把详情内容区域挤出视野，大会话点开时加载很慢，也没有真正做到按需加载。
3. Skills 设置页里 Supabase URL / anon key 输入框在较窄内容区会和说明文字重叠，需要修复布局。

## 主要改动

### Supabase Skills 同步

- 在 Settings 的 Skills 页面增加 Supabase skill sync 配置入口。
- 支持配置并本地保存 Supabase Project URL 和 anon key。
- 在文案中引导用户前往 `supabase.com/dashboard` 获取 Project URL 和 anon key。
- 增加 Skills 管理中的本地/远程视图能力。
- 支持将本地 skill 上传到远程 Supabase 表。
- 支持从远程 skill 列表下载并安装到本地。
- 使用 skill id 作为同步标识，便于本地重复上传时更新远程记录。
- 不做自动建表高级模式；如果远程表不存在，会向用户展示需要执行的 SQL，让用户在 Supabase SQL Editor 中创建表。

### 远程会话详情修复与性能优化

- 修复远程会话长标题导致详情页内容被挤压、正文区域不可见的问题。
- 远程会话详情改为分页/按需加载，避免点开大会话时一次性加载全部内容。
- 保留本地会话原有展示行为，同时让远程会话点击后可以逐步加载完整对话。
- 补充远程会话 loader、详情面板行为和 UI 契约测试，降低回归风险。

### Settings 输入框布局修复

- 修复 Supabase URL 和 anon key 输入框在 Skills 设置页里覆盖 label/说明文字的问题。
- 对这两个字段使用专用 grid 布局，桌面端保持左右结构，窄屏下自动变为单列。
- 增加样式契约测试，确保后续不会再次退化为重叠布局。

## 提交拆分

- `feat: add Supabase skill sync`
- `fix: clamp remote detail titles`
- `perf: page remote session detail loading`
- `fix: prevent Supabase settings input overlap`

## 验证

已在本地执行：

```bash
npm test
npm run typecheck
git diff --check
```

结果：

- `npm test` 通过，57 个测试文件 / 550 个测试全部通过。
- `npm run typecheck` 通过。
- `git diff --check` 通过。

## 注意事项

- 当前版本不会自动在 Supabase 中建表。第一次使用时，如果表不存在，应用会展示建表 SQL，需要用户手动复制到 Supabase SQL Editor 执行。
- Supabase anon key 只保存在本地配置中，用于访问用户自己的 skills 同步表。
- PR 先以 draft 形式提交，便于继续检查 UI 细节和 Supabase 实际项目联调。
