### PR TITLE
[codex] 完善 Supabase Skills 同步文档并保留目录文件

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 - **统一查看 Agent 用量和额度**：
   统计今日、近 7 天、近 30 天和全部时间的各 Agent token 使用量；同时查看 Claude Code / Codex 的当前额度状态。
 - **统一管理 Skills 和 API Provider**：
-  查看和管理 Claude Code / Codex skills，统计 skill 使用情况；在界面里切换 Codex / Claude Code 的官方账号或第三方 API Provider。
+  查看和管理 Claude Code / Codex skills，统计 skill 使用情况；支持使用自己的 Supabase 项目同步 Skills，在不同机器之间上传、更新和安装；也可以在界面里切换 Codex / Claude Code 的官方账号或第三方 API Provider。
 
 ## 支持的数据源
 
@@ -53,6 +53,23 @@
 当 `~/.codex/session_index.jsonl` 存在时，应用会读取 Codex 的标题元数据。没有上游标题时，会使用第一个有效用户问题作为默认标题。
 
 CodeBuddy CLI、OpenClaw、Hermes、OpenCode、Cursor Agent 和 Trae 默认关闭，可在 Settings -> Optional sources 里选择监测。开启后支持本地只读索引、搜索、详情查看和来源过滤；Resume、远程 SSH 同步和专属用量统计会后续按来源单独补齐。Trae 额外支持打开状态检测。
+
+## Skills 管理与同步
+
+打开 Skills 管理窗口后，可以查看本机已安装的 Codex / Claude Code Skills，按来源筛选，查看使用次数，预览 `SKILL.md` 内容，并对非系统 Skill 执行删除、复制路径、在 Finder / 文件管理器中打开等操作。
+
+如果希望在多台机器之间同步自己的 Skills，可以在 Settings -> Skills -> Supabase skill sync 中启用 Supabase 同步：
+
+1. 在 [Supabase Dashboard](https://supabase.com/dashboard) 创建或选择一个自己的项目。
+2. 在 Project Settings -> API 中复制 Project URL 和 anon key。
+3. 回到应用的 Settings -> Skills，填入 Supabase URL 和 anon key，并启用同步。
+4. 如果远程表还不存在，打开 Skills 管理窗口的 Remote 视图，点击 Copy setup SQL，把 SQL 粘贴到 Supabase SQL Editor 执行一次。
+5. 回到 Local 视图，选择本地 Skill 后点击 Upload；同一个 Agent 下同名 Skill 会用稳定指纹识别，后续再次上传会更新远程记录。
+6. 在另一台机器配置相同的 Supabase URL 和 anon key 后，打开 Remote 视图，选择远程 Skill 并点击 Install locally / Update local。
+
+同步会上传整个 Skill 目录中的普通文件，包括 `SKILL.md`、`references/`、`scripts/`、示例文件等；下载时会还原到本机的用户级 Skill 目录中。Codex Skill 默认安装到 `$CODEX_HOME/skills`（未设置时为 `~/.codex/skills`），Claude Code Skill 默认安装到 `~/.claude/skills`。
+
+当前 Supabase 同步按个人项目设计，不会自动创建表，也不会使用 service role key。应用只保存 Project URL 和 anon key 到本地设置，并通过 Supabase REST API 访问 `agent_session_search_skills` 表。初始化 SQL 会为 anon role 创建可读写策略，适合个人私有项目或仅自己掌握 URL/key 的项目；如果要多人共享或公开分发，请先按自己的 Supabase 安全模型调整 RLS policy。
 
 ## 安装使用
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -32,7 +32,7 @@
 - **Unified agent usage and quota view**:
   Track token usage by agent for today, 7 days, 30 days, and all time; also view current Claude Code / Codex quota status.
 - **Unified Skills and API Provider management**:
-  View and manage Claude Code / Codex skills, track skill usage, and switch Codex / Claude Code between official accounts and third-party API providers.
+  View and manage Claude Code / Codex skills, track skill usage, sync personal skills across machines through your own Supabase project, and switch Codex / Claude Code between official accounts and third-party API providers.
 
 ## Supported Sources
 
@@ -53,6 +53,23 @@
 Codex title metadata is read from `~/.codex/session_index.jsonl` when that file exists. If no upstream title is available, the app uses the first meaningful user question as the default title.
 
 CodeBuddy CLI, OpenClaw, Hermes, OpenCode, Cursor Agent, and Trae are off by default and can be selected from Settings -> Optional sources. Once enabled, they support local read-only indexing, search, details, and source filtering. Resume, SSH remote sync, and provider-specific usage stats for these sources are intentionally separate follow-up work. Trae also supports open-state detection.
+
+## Skills Management and Sync
+
+The Skills window lists installed Codex / Claude Code skills, lets you filter by source, inspect usage counts, preview `SKILL.md`, copy paths, reveal skill folders, and delete non-system skills.
+
+To sync your personal skills between machines, enable Settings -> Skills -> Supabase skill sync:
+
+1. Create or select a project in the [Supabase Dashboard](https://supabase.com/dashboard).
+2. Copy the Project URL and anon key from Project Settings -> API.
+3. Paste them into Settings -> Skills and enable Supabase sync.
+4. If the remote table does not exist yet, open the Remote view in the Skills window, click Copy setup SQL, and run it once in the Supabase SQL Editor.
+5. In the Local view, select a local skill and click Upload. A stable fingerprint identifies skills by agent and name, so repeat uploads update the existing remote record.
+6. On another machine, configure the same Supabase URL and anon key, open the Remote view, then click Install locally / Update local.
+
+Sync uploads the full skill directory's regular files, including `SKILL.md`, `references/`, `scripts/`, examples, and other supporting files. Downloads restore them into the local user skill root. Codex skills install into `$CODEX_HOME/skills` or `~/.codex/skills`; Claude Code skills install into `~/.claude/skills`.
+
+Supabase sync is designed for personal projects. It does not create tables automatically and does not require a service role key. The app stores only the Project URL and anon key locally, then uses the Supabase REST API to access the `agent_session_search_skills` table. The copied setup SQL grants anon read/write access through RLS for personal sync convenience; adjust the RLS policy first if you plan to share the project with other users or expose it more broadly.
 
 ## Installation
 

--- a/src/core/skill-manager.test.ts
+++ b/src/core/skill-manager.test.ts
@@ -315,6 +315,37 @@ describe("skill manager", () => {
     fs.rmSync(homeDir, { recursive: true, force: true });
   });
 
+  it("installs bundled remote skill files alongside SKILL.md", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-skills-install-files-"));
+    const codexHome = path.join(homeDir, ".codex");
+    const remoteSkill: RemoteSkill = {
+      id: "remote-review",
+      name: "review-code",
+      description: "Review code changes",
+      agent: "codex",
+      source: "codex-user",
+      markdown: "# Review\n",
+      localFingerprint: "fp",
+      uploadedFromPath: "/old/SKILL.md",
+      createdAt: "2026-06-29T10:00:00.000Z",
+      updatedAt: "2026-06-29T10:01:00.000Z",
+      version: 1,
+      metadata: {
+        skillFiles: [
+          { relativePath: "SKILL.md", contentBase64: Buffer.from("# Review\n").toString("base64") },
+          { relativePath: "references/rubric.md", contentBase64: Buffer.from("Check edge cases.\n").toString("base64") },
+        ],
+      },
+    };
+
+    const result = installRemoteSkillLocally(remoteSkill, { homeDir, codexHome });
+
+    expect(fs.readFileSync(result.installedPath, "utf8")).toBe("# Review\n");
+    expect(fs.readFileSync(path.join(result.directoryPath, "references", "rubric.md"), "utf8")).toBe("Check edge cases.\n");
+
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
   it("installs a remote Claude skill into the user skill root and reports overwrite", () => {
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-skills-install-claude-"));
     const remoteSkill: RemoteSkill = {

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { RemoteSkill } from "./skill-sync";
+import { skillSyncFilesFromMetadata, type RemoteSkill, type SkillSyncFile } from "./skill-sync";
 
 export type SkillAgent = "codex" | "claude";
 export type SkillSource =
@@ -193,8 +193,38 @@ export function installRemoteSkillLocally(remoteSkill: RemoteSkill, options: Ins
 
   const overwritten = fs.existsSync(installedPath);
   fs.mkdirSync(directoryPath, { recursive: true });
+  for (const file of skillSyncFilesFromMetadata(remoteSkill.metadata)) {
+    writeBundledSkillFile(directoryPath, file);
+  }
   fs.writeFileSync(installedPath, remoteSkill.markdown, "utf8");
   return { installedPath, directoryPath, overwritten };
+}
+
+function writeBundledSkillFile(directoryPath: string, file: SkillSyncFile): void {
+  const targetPath = safeBundledSkillFilePath(directoryPath, file.relativePath);
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.writeFileSync(targetPath, Buffer.from(file.contentBase64, "base64"));
+  if (file.mode !== undefined) {
+    try {
+      fs.chmodSync(targetPath, file.mode);
+    } catch {
+      // Best effort only; Windows and some mounted filesystems may ignore POSIX modes.
+    }
+  }
+}
+
+function safeBundledSkillFilePath(directoryPath: string, relativePath: string): string {
+  const normalizedRelative = relativePath.replace(/\\/g, "/");
+  if (!normalizedRelative || normalizedRelative.startsWith("/") || normalizedRelative.includes("\0")) {
+    throw new Error("Refusing to install unsafe bundled skill file.");
+  }
+  const targetPath = path.resolve(directoryPath, ...normalizedRelative.split("/"));
+  const directoryKey = normalizePathKey(directoryPath);
+  if (targetPath !== directoryKey && !targetPath.startsWith(`${directoryKey}${path.sep}`)) {
+    throw new Error("Refusing to install bundled skill file outside the skill directory.");
+  }
+  if (targetPath === directoryKey) throw new Error("Refusing to install bundled skill file over the skill directory.");
+  return targetPath;
 }
 
 function collectClaudePluginRoots(pluginsDir: string): SkillRootConfig[] {

--- a/src/core/skill-sync.test.ts
+++ b/src/core/skill-sync.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
   AGENT_SESSION_SEARCH_SKILLS_TABLE,
   SupabaseSkillSyncClient,
@@ -102,7 +105,9 @@ describe("skill sync", () => {
       url: "https://example.supabase.co/",
       anonKey: "anon",
       fetchImpl: async (url, init) => {
-        expect(String(url)).toBe(`https://example.supabase.co/rest/v1/${AGENT_SESSION_SEARCH_SKILLS_TABLE}?select=*&order=updated_at.desc`);
+        expect(String(url)).toBe(
+          `https://example.supabase.co/rest/v1/${AGENT_SESSION_SEARCH_SKILLS_TABLE}?select=id,name,description,agent,source,markdown,local_fingerprint,uploaded_from_path,created_at,updated_at,version&order=updated_at.desc`,
+        );
         expect((init?.headers as Record<string, string>).apikey).toBe("anon");
         return new Response(JSON.stringify(rows), { status: 200 });
       },
@@ -156,6 +161,46 @@ describe("skill sync", () => {
       name: "review-code",
       localFingerprint: skillSyncFingerprint(uploaded),
     });
+  });
+
+  it("uploads the full skill directory as metadata files", async () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-skill-sync-files-"));
+    const skillDir = path.join(homeDir, ".codex", "skills", "review-code");
+    const skillPath = path.join(skillDir, "SKILL.md");
+    fs.mkdirSync(path.join(skillDir, "references"), { recursive: true });
+    fs.writeFileSync(skillPath, "# Review\n", "utf8");
+    fs.writeFileSync(path.join(skillDir, "references", "rubric.md"), "Check edge cases.\n", "utf8");
+    const uploaded = localSkill({ path: skillPath, directoryPath: skillDir, rootPath: path.dirname(skillDir), markdown: "# Review\n" });
+
+    const client = new SupabaseSkillSyncClient({
+      url: "https://example.supabase.co",
+      anonKey: "anon",
+      fetchImpl: async (_url, init) => {
+        const body = JSON.parse(String(init?.body));
+        expect(body.metadata.skillFiles).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              relativePath: "SKILL.md",
+              contentBase64: Buffer.from("# Review\n").toString("base64"),
+            }),
+            expect.objectContaining({
+              relativePath: "references/rubric.md",
+              contentBase64: Buffer.from("Check edge cases.\n").toString("base64"),
+            }),
+          ]),
+        );
+        return new Response(JSON.stringify([{
+          ...body,
+          id: "remote-1",
+          created_at: "2026-06-29T10:00:00.000Z",
+          updated_at: "2026-06-29T10:01:00.000Z",
+        }]), { status: 201 });
+      },
+    });
+
+    await client.upsertLocalSkill(uploaded);
+
+    fs.rmSync(homeDir, { recursive: true, force: true });
   });
 
   it("updates a remote skill by id when the local binding is known", async () => {

--- a/src/core/skill-sync.ts
+++ b/src/core/skill-sync.ts
@@ -1,8 +1,11 @@
 import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import type { SkillSyncBinding } from "./session-store";
 import type { InstalledSkill } from "./skill-manager";
 
 export const AGENT_SESSION_SEARCH_SKILLS_TABLE = "agent_session_search_skills";
+const REMOTE_SKILL_LIST_COLUMNS = "id,name,description,agent,source,markdown,local_fingerprint,uploaded_from_path,created_at,updated_at,version";
 
 export interface RemoteSkill {
   id: string;
@@ -17,6 +20,12 @@ export interface RemoteSkill {
   updatedAt: string;
   version: number;
   metadata: Record<string, unknown>;
+}
+
+export interface SkillSyncFile {
+  relativePath: string;
+  contentBase64: string;
+  mode?: number;
 }
 
 export type SkillSyncStatus =
@@ -146,7 +155,7 @@ export class SupabaseSkillSyncClient {
   }
 
   async listRemoteSkills(): Promise<RemoteSkill[]> {
-    const response = await this.request(`/${AGENT_SESSION_SEARCH_SKILLS_TABLE}?select=*&order=updated_at.desc`, { method: "GET" });
+    const response = await this.request(`/${AGENT_SESSION_SEARCH_SKILLS_TABLE}?select=${REMOTE_SKILL_LIST_COLUMNS}&order=updated_at.desc`, { method: "GET" });
     const body = await readResponseBody(response);
     if (!response.ok) throw new Error(supabaseErrorMessage(response.status, body));
     return parseRemoteRows(body);
@@ -217,6 +226,7 @@ function remotePayloadFromSkill(skill: InstalledSkill): Omit<SupabaseSkillRow, "
       directoryPath: skill.directoryPath,
       rootPath: skill.rootPath,
       mtimeMs: skill.mtimeMs,
+      skillFiles: collectSkillDirectoryFiles(skill.directoryPath),
     },
   };
 }
@@ -243,6 +253,7 @@ function isRemoteRow(value: unknown): value is SupabaseSkillRow {
 }
 
 function remoteSkillFromRow(row: SupabaseSkillRow): RemoteSkill {
+  const metadata = row.metadata ?? {};
   return {
     id: row.id,
     name: row.name,
@@ -255,8 +266,49 @@ function remoteSkillFromRow(row: SupabaseSkillRow): RemoteSkill {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     version: row.version ?? 1,
-    metadata: row.metadata ?? {},
+    metadata,
   };
+}
+
+export function skillSyncFilesFromMetadata(metadata: Record<string, unknown>): SkillSyncFile[] {
+  const value = metadata.skillFiles;
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!item || typeof item !== "object") return [];
+    const file = item as Partial<SkillSyncFile>;
+    if (typeof file.relativePath !== "string" || typeof file.contentBase64 !== "string") return [];
+    const mode = typeof file.mode === "number" && Number.isFinite(file.mode) ? file.mode : undefined;
+    return [{ relativePath: file.relativePath, contentBase64: file.contentBase64, ...(mode === undefined ? {} : { mode }) }];
+  });
+}
+
+function collectSkillDirectoryFiles(directoryPath: string): SkillSyncFile[] {
+  const root = path.resolve(directoryPath);
+  const files: SkillSyncFile[] = [];
+  const visit = (dir: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+      const filePath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(filePath);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const stat = fs.statSync(filePath);
+      files.push({
+        relativePath: path.relative(root, filePath).split(path.sep).join("/"),
+        contentBase64: fs.readFileSync(filePath).toString("base64"),
+        mode: stat.mode & 0o777,
+      });
+    }
+  };
+  visit(root);
+  return files;
 }
 
 async function readResponseBody(response: Response): Promise<unknown> {


### PR DESCRIPTION
## 背景

#45 已经合入 Supabase Skills 同步和远程会话加载优化。合并后继续检查时发现两个后续点：

1. README 还没有介绍 Supabase Skills 同步的配置方式、初始化 SQL、上传/下载流程和安全边界，用户第一次使用时缺少明确引导。
2. 原同步实现只保存 `SKILL.md` 的 markdown 内容。很多 Skill 会带 `references/`、`scripts/`、示例文件或其他辅助数据，仅同步 `SKILL.md` 会导致换机器安装后内容不完整。

## 改动内容

### 1. 补充 Supabase Skills 同步文档

- 更新中文 `README.md`，在核心功能里明确说明支持通过自己的 Supabase 项目同步 Skills。
- 新增「Skills 管理与同步」章节，说明：
  - 如何从 Supabase Dashboard 获取 Project URL 和 anon key。
  - 如何在 Settings -> Skills 中启用 Supabase skill sync。
  - 远程表不存在时如何复制初始化 SQL 并在 Supabase SQL Editor 执行。
  - 本地 Skill 如何 Upload / Update remote。
  - 另一台机器如何 Remote -> Install locally / Update local。
  - Codex / Claude Code Skill 分别会下载安装到哪个本地目录。
- 同步更新英文 `docs/README.en.md`，避免中英文文档信息不一致。
- 文档里明确说明当前不是自动建表，也不使用 service role key；默认 SQL 的 anon RLS policy 适合个人项目，如果多人共享需要自行调整 Supabase 安全策略。

### 2. 修复 Skill 目录辅助文件丢失问题

- 上传本地 Skill 时，不再只上传 `SKILL.md` 内容，而是会扫描整个 Skill 目录下的普通文件。
- 将文件以 `metadata.skillFiles` 的形式写入 Supabase 表，不需要修改现有表结构。
- 下载远程 Skill 时，会按相对路径还原这些文件，例如：
  - `SKILL.md`
  - `references/*.md`
  - `scripts/*`
  - 示例文件和其他辅助文件
- 写入本地时增加路径安全检查，拒绝绝对路径、空路径和试图逃逸 Skill 目录的相对路径。
- 保留旧数据兼容：如果远程记录没有 `metadata.skillFiles`，仍然会按原逻辑只安装 `SKILL.md`。

### 3. 避免远程 Skills 列表变重

完整目录文件包放在 metadata 后，如果 Remote 列表继续 `select=*`，会一次性下载所有远程 Skill 的文件内容，列表可能变慢。

这次把远程列表查询改为轻量字段 projection，只拉列表展示需要的字段；真正点击安装某个远程 Skill 时，才通过 `getRemoteSkill(id)` 拉完整记录和文件包。

## 用户影响

- 用户在不同机器之间同步 Skill 时，可以保留完整目录结构和辅助资料，不再只拿到一个孤立的 `SKILL.md`。
- README 现在能覆盖首次配置路径，降低 Supabase URL / anon key / 建表 SQL 的理解成本。
- Remote 列表不会因为每个 Skill 带完整文件包而明显变慢。

## 验证

本地已执行：

```bash
npm test
npm run typecheck
git diff --check
```

结果：

- `npm test` 通过：57 个测试文件，563 个测试全部通过。
- `npm run typecheck` 通过。
- `git diff --check` 通过。

## 提交

- `fix: sync bundled skill files`
- `docs: document Supabase skill sync`
