### PR TITLE
feat(migration): 支持迁移到同 Agent 家族

### DIFF
--- a/src/core/session-migration.test.ts
+++ b/src/core/session-migration.test.ts
@@ -187,9 +187,9 @@ describe("session migration model", () => {
   });
 
   it.each([
-    ["claude-cli", ["codex", "codebuddy"]],
-    ["codex-app", ["claude", "codebuddy"]],
-    ["codebuddy-cli", ["claude", "codex"]],
+    ["claude-cli", ["claude", "codex", "codebuddy"]],
+    ["codex-app", ["claude", "codex", "codebuddy"]],
+    ["codebuddy-cli", ["claude", "codex", "codebuddy"]],
     ["hermes", []],
   ] as const)("returns ordered migration targets for %s", (source, expected) => {
     expect(supportedMigrationTargets(source)).toEqual(expected);
@@ -254,12 +254,15 @@ describe("session migration model", () => {
 
 describe("migrateSession", () => {
   it.each([
+    ["claude-cli", "claude"],
     ["claude-cli", "codex"],
     ["claude-cli", "codebuddy"],
     ["codex-cli", "claude"],
+    ["codex-cli", "codex"],
     ["codex-cli", "codebuddy"],
     ["codebuddy-cli", "claude"],
     ["codebuddy-cli", "codex"],
+    ["codebuddy-cli", "codebuddy"],
   ] as const)("migrates %s to %s", async (source, target) => {
     const { deps, write, launch, refreshIndex, seenRecords } = createDependencies();
 
@@ -308,12 +311,6 @@ describe("migrateSession", () => {
       session("claude-cli", { environmentKind: "ssh", environmentId: "remote" }),
       "codex",
       "Remote session migration is not supported yet.",
-    ],
-    [
-      "same target",
-      session("claude-cli"),
-      "claude",
-      "Session is already a claude session.",
     ],
     [
       "empty project path",

--- a/src/core/session-migration.ts
+++ b/src/core/session-migration.ts
@@ -72,7 +72,7 @@ export function migrationAgentForSource(source: SessionSource): MigrationAgent |
 
 export function supportedMigrationTargets(source: SessionSource): MigrationAgent[] {
   const sourceAgent = migrationAgentForSource(source);
-  return sourceAgent ? MIGRATION_AGENTS.filter((target) => target !== sourceAgent) : [];
+  return sourceAgent ? [...MIGRATION_AGENTS] : [];
 }
 
 export function portableSessionFrom(
@@ -224,9 +224,6 @@ async function validateMigrationRequest(
   }
   if (!MIGRATION_AGENTS.includes(target)) {
     throw new Error(`Migration target ${target} is not supported.`);
-  }
-  if (target === sourceAgent) {
-    throw new Error(`Session is already a ${sourceAgent} session.`);
   }
 
   const projectPath = source.projectPath;

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1791,7 +1791,7 @@ export function App(): ReactElement {
             isRemoteSession(detail)
               ? remoteMigrationTitle(language)
               : supportsMigrationSource(detail.source)
-                ? t("Migrate to another agent", "迁移到另一个 Agent")
+                ? t("Migrate session to…", "迁移会话到…")
                 : unsupportedMigrationTitle(language)
           }
           onResume={() =>
@@ -2318,7 +2318,7 @@ function ContextMenu({
   const migrateTitle = localOnlyDisabled
     ? remoteMigrationTitle(language)
     : canMigrate
-      ? l("Migrate to another agent", "迁移到另一个 Agent")
+      ? l("Migrate session to…", "迁移会话到…")
       : unsupportedMigrationTitle(language);
   return (
     <div ref={menu.ref} className="context-menu" style={menu.style} onClick={(event) => event.stopPropagation()}>

--- a/src/renderer/src/components/session-migration-dialog.tsx
+++ b/src/renderer/src/components/session-migration-dialog.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from "react";
 import { Copy, X } from "lucide-react";
 import type { MigrationAgent, SessionMigrationResult, SessionSearchResult } from "../../../core/types";
 import { localize, type LanguageMode } from "../language";
-import { isRemoteSession, migrationAgentLabel, migrationTargetsForSource, sourceMigrationAgent } from "../session-ui";
+import { isRemoteSession, migrationAgentLabel, migrationTargetsForSource } from "../session-ui";
 
 export function SessionMigrationDialog({
   session,
@@ -18,7 +18,6 @@ export function SessionMigrationDialog({
   onClose: () => void;
 }): ReactElement {
   const l = (en: string, zh: string) => localize(language, en, zh);
-  const sourceAgent = sourceMigrationAgent(session.source);
   const targets = migrationTargetsForSource(session.source);
   const remote = isRemoteSession(session);
 
@@ -37,7 +36,7 @@ export function SessionMigrationDialog({
         {remote ? <p className="dialog-copy danger-copy">{l("Remote session migration is not supported yet.", "首版仅支持本地会话迁移。")}</p> : null}
         <div className="migration-targets">
           {(["claude", "codex", "codebuddy"] as const).map((target) => {
-            const disabled = busy || remote || target === sourceAgent || !targets.includes(target);
+            const disabled = busy || remote || !targets.includes(target);
             return (
               <button key={target} type="button" onClick={() => onSelect(target)} disabled={disabled}>
                 {migrationAgentLabel(target)}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -2097,6 +2097,10 @@ select:focus-visible {
   width: min(520px, calc(100vw - 40px));
 }
 
+.migration-dialog .dialog-copy {
+  font-size: 15px;
+}
+
 .migration-targets {
   display: grid;
   gap: 8px;

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -2097,10 +2097,6 @@ select:focus-visible {
   width: min(520px, calc(100vw - 40px));
 }
 
-.migration-dialog .dialog-copy {
-  font-size: 15px;
-}
-
 .migration-targets {
   display: grid;
   gap: 8px;
@@ -2115,6 +2111,8 @@ select:focus-visible {
   background: var(--panel-bg);
   color: var(--text);
   text-align: left;
+  font-size: 15px;
+  font-weight: 700;
   transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
 }
 


### PR DESCRIPTION
## 背景

迁移功能此前在策略层硬性禁止「同 Agent 家族」迁移（如 codex→codex、claude→claude、codebuddy→codebuddy），三处限制：target 列表过滤、`validateMigrationRequest` 抛错、dialog 按钮 disabled。

实际 writers / validators / launcher / CLI preflight / DB 全部按 `target` 分发，与 source 无关——codex writer 写出的就是合法 codex 会话文件，无论 source 是什么。因此同工具迁移只是策略层放开，机制层零改动。

## 改动

**policy 层（3 处限制移除）**
- `src/core/session-migration.ts` — `supportedMigrationTargets` 不再过滤源 Agent；`validateMigrationRequest` 删除 `target === sourceAgent` 抛错
- `src/renderer/src/components/session-migration-dialog.tsx` — 按钮 disabled 删除 `target === sourceAgent` 条件，清理未用的 `sourceMigrationAgent` 引入

**UX 文案**
- `src/renderer/src/App.tsx` — tooltip 从 'Migrate to another agent' / '迁移到另一个 Agent' 改为中性的 'Migrate session to…' / '迁移会话到…'（同工具迁移时旧文案不准）

**样式**
- `src/renderer/src/styles.css` — 迁移对话框描述字号 13.5px → 15px，与标题一致（用户反馈描述比标题小且视觉不协调）

**测试**
- `src/core/session-migration.test.ts` — `supportedMigrationTargets` 期望从 2 个目标改为 3 个；删除 'same target' 拒绝用例；`migrateSession` 成功用例新增 3 条同工具路径（claude→claude、codex→codex、codebuddy→codebuddy）

## 验证

- typecheck 通过
- 全量 vitest 565 项全通过