### PR TITLE
add:  新增会话远程同步功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@
   可以使用 AI 摘要增强历史会话检索，也支持自然语言找会话；同时开放只读 MCP 能力，让 Claude Code / Codex / CodeBuddy 可以在对话里直接搜索和读取历史会话。
 - **跨 Agent 迁移会话**：
   **支持把 Claude / Codex / CodeBuddy 会话迁移到Claude / Codex / CodeBuddy，并在迁移后继续工作，非常好用！！！**。
+- **远程保存和跨设备恢复会话**：
+  支持使用自己的 Supabase 项目手动上传会话快照，在另一台设备搜索远程会话、查看完整详情，并恢复到 Claude Code / Codex / CodeBuddy 中继续工作。
 - **统一查看 Agent 用量和额度**：
   统计今日、近 7 天、近 30 天和全部时间的各 Agent token 使用量；同时查看 Claude Code / Codex 的当前额度状态。
 - **统一管理 Skills 和 API Provider**：
@@ -55,6 +57,57 @@
 当 `~/.codex/session_index.jsonl` 存在时，应用会读取 Codex 的标题元数据。没有上游标题时，会使用第一个有效用户问题作为默认标题。
 
 CodeBuddy CLI、TClaude、TCodex、OpenClaw、Hermes、OpenCode、Cursor Agent 和 Trae 默认关闭，可在 Settings -> Optional sources 里选择监测。开启后支持本地只读索引、搜索、详情查看和来源过滤；其中 TClaude / TCodex 因为与 Claude Code / Codex 格式一致，额外支持 Resume 和一键启动（分别调用 `tclaude` / `tcodex` 命令）。OpenClaw 等其他来源的 Resume、远程 SSH 同步和专属用量统计会后续按来源单独补齐。Trae 额外支持打开状态检测。
+
+## 远程会话同步
+
+远程会话同步用于把本机某段会话保存到你自己的 Supabase 项目里。另一台设备配置同一个 Supabase URL 和 anon key 后，可以打开远程会话列表，搜索、按来源筛选、查看详情，并把远程会话恢复到本机任意支持的 Agent 中。比如设备 A 上传了一段 Codex 会话，设备 B 可以在远程会话列表里查看这段会话，并选择恢复到 Claude Code、Codex 或 CodeBuddy。
+
+当前版本按**单人使用、手动同步快照**设计：
+
+- 不做用户隔离，也不需要登录系统；默认使用你自己的 Supabase 项目和 anon key。
+- 不会自动后台同步。本地会话继续对话后，远程仍然是上次上传时的快照；需要再次点击上传才会更新远程版本。
+- 同一段本地会话重复上传会覆盖远程的最新快照；内容没变会自动跳过，不维护多版本历史。
+- 远程详情包含会话元数据、消息、tool call / trace event、标签和 AI summary 等当前详情页支持的信息。
+- 恢复时会使用远程保存的 portable session，并要求在当前设备选择一个本地项目目录作为恢复目标路径。
+
+### 配置 Supabase
+
+1. 在 [Supabase Dashboard](https://supabase.com/dashboard) 创建或选择一个自己的项目。
+2. 在 Project Settings -> API 中复制 Project URL 和 anon key。
+3. 回到应用的 Settings -> Remote sync，填入 Supabase URL 和 anon key，并开启 Enable remote session sync。
+4. 打开顶部工具栏的云图标 Remote Sessions，点击 Copy SQL。
+5. 把复制出来的 SQL 粘贴到 Supabase SQL Editor 执行一次。
+
+初始化 SQL 会创建：
+
+- 表：`public.agent_session_remote_sessions`
+- Storage bucket：`agent-session-remote`
+- Storage 对象路径：
+  - `sessions/{id}/detail.json`：用于远程详情查看
+  - `sessions/{id}/portable.json`：用于跨设备、跨 Agent 恢复
+
+脚本是幂等的，可以重复执行。它会为 anon role 创建适合个人项目的读写策略。这个策略方便单人同步，但不是多用户隔离方案；如果要多人共享或公开分发，请先按自己的 Supabase 安全模型调整 RLS policy。
+
+### 上传会话
+
+1. 在本地搜索结果里打开一段会话详情。
+2. 点击详情页顶部带云上传图标的 Upload / 上传按钮。
+3. 上传成功后，这段会话会出现在 Remote Sessions 列表中。
+
+如果同一段会话已经上传过：
+
+- 内容没变：提示远程会话已经是最新。
+- 内容有变化：更新远程表记录和 Storage 中的 `detail.json` / `portable.json`。
+
+### 搜索、查看和恢复远程会话
+
+点击顶部工具栏的云图标打开 Remote Sessions：
+
+- 使用搜索框按标题、项目路径、摘要、标签和全文搜索远程会话。
+- 使用 Source / 来源筛选只看 Claude、Codex 或 CodeBuddy 上传的会话。
+- 点击 View / 查看可以打开远程详情页；这个详情页是只读的。
+- 在 Restore to / 恢复到 中选择目标 Agent，再点击某条会话的 Restore。
+- 第一次恢复时需要选择当前设备上的本地项目目录；恢复完成后会写入目标 Agent 的本机会话目录，并尝试启动对应 Agent 继续工作。
 
 ## Skills 管理与同步
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -29,6 +29,8 @@
   Use AI summaries to improve history search, ask for sessions in natural language, and expose read-only MCP capabilities so Claude Code / Codex / CodeBuddy can search and read session history directly in chat.
 - **Cross-agent session migration**:
   Migrate Claude / Codex / CodeBuddy sessions into another agent and continue from the migrated session.
+- **Remote session storage and cross-device restore**:
+  Upload session snapshots manually to your own Supabase project, search and inspect them on another device, and restore them into Claude Code / Codex / CodeBuddy.
 - **Unified agent usage and quota view**:
   Track token usage by agent for today, 7 days, 30 days, and all time; also view current Claude Code / Codex quota status.
 - **Unified Skills and API Provider management**:
@@ -55,6 +57,57 @@
 Codex title metadata is read from `~/.codex/session_index.jsonl` when that file exists. If no upstream title is available, the app uses the first meaningful user question as the default title.
 
 CodeBuddy CLI, TClaude, TCodex, OpenClaw, Hermes, OpenCode, Cursor Agent, and Trae are off by default and can be selected from Settings -> Optional sources. Once enabled, they support local read-only indexing, search, details, and source filtering. Because TClaude / TCodex share the Claude Code / Codex formats, they additionally support Resume and one-click launch (invoking the `tclaude` / `tcodex` commands respectively). For the other sources, Resume, SSH remote sync, and provider-specific usage stats are intentionally separate follow-up work. Trae also supports open-state detection.
+
+## Remote Session Sync
+
+Remote session sync saves a selected local session into your own Supabase project. After configuring the same Supabase URL and anon key on another device, you can open the remote session list, search, filter by source, inspect details, and restore the remote session into any supported local agent. For example, device A can upload a Codex session, and device B can view that session from Remote Sessions and restore it into Claude Code, Codex, or CodeBuddy.
+
+This version is designed for **single-user, manual snapshot sync**:
+
+- There is no user isolation or app login. It assumes you control the Supabase project and anon key.
+- There is no automatic background sync. If you continue a local session after uploading it, the remote copy stays at the last uploaded snapshot until you upload it again.
+- Re-uploading the same local session updates the latest remote snapshot. If the content has not changed, the upload is skipped. Remote sessions do not keep version history.
+- Remote details include the session metadata, messages, tool calls / trace events, tags, AI summary, and the other information currently supported by the detail view.
+- Restore uses the stored portable session and asks you to choose a local project directory on the current device as the target project path.
+
+### Configure Supabase
+
+1. Create or select a project in the [Supabase Dashboard](https://supabase.com/dashboard).
+2. Copy the Project URL and anon key from Project Settings -> API.
+3. In the app, open Settings -> Remote sync, paste the Supabase URL and anon key, and enable remote session sync.
+4. Open Remote Sessions from the cloud icon in the top toolbar, then click Copy SQL.
+5. Paste the copied SQL into the Supabase SQL Editor and run it once.
+
+The setup SQL creates:
+
+- Table: `public.agent_session_remote_sessions`
+- Storage bucket: `agent-session-remote`
+- Storage object paths:
+  - `sessions/{id}/detail.json`: used by the remote detail view
+  - `sessions/{id}/portable.json`: used for cross-device and cross-agent restore
+
+The script is idempotent and can be run more than once. It creates anon-role read/write policies suitable for a personal project. Those policies are convenient for single-user sync, but they are not a multi-user isolation model. If you plan to share the project with other users or expose it more broadly, adjust the RLS policies for your own Supabase security model first.
+
+### Upload A Session
+
+1. Open a local session from the search results.
+2. Click the Upload button with the cloud-upload icon at the top of the detail view.
+3. After upload succeeds, the session appears in the Remote Sessions list.
+
+If the same session has already been uploaded:
+
+- Unchanged content: the app reports that the remote session is already up to date.
+- Changed content: the app updates the remote table row and the `detail.json` / `portable.json` objects in Storage.
+
+### Search, Inspect, And Restore Remote Sessions
+
+Click the cloud icon in the top toolbar to open Remote Sessions:
+
+- Search remote sessions by title, project path, summary, tags, and full text.
+- Use Source to filter uploaded sessions by Claude, Codex, or CodeBuddy.
+- Click View to open a read-only remote detail view.
+- Choose the target agent under Restore to, then click Restore on a session row.
+- On first restore, choose a local project directory on the current device. The app writes the session into the target agent's local session directory and attempts to launch that agent so you can continue working.
 
 ## Skills Management and Sync
 

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -78,6 +78,9 @@ export interface AppSettings {
   skillSyncEnabled: boolean;
   skillSyncSupabaseUrl: string;
   skillSyncSupabaseAnonKey: string;
+  remoteSyncEnabled: boolean;
+  remoteSyncSupabaseUrl: string;
+  remoteSyncSupabaseAnonKey: string;
   apiConfig: ApiConfig;
   claudeApiConfig: ClaudeApiConfig;
   summaryApiConfig: ApiConfig;
@@ -118,6 +121,9 @@ export const defaultSettings: AppSettings = {
   skillSyncEnabled: false,
   skillSyncSupabaseUrl: "",
   skillSyncSupabaseAnonKey: "",
+  remoteSyncEnabled: false,
+  remoteSyncSupabaseUrl: "",
+  remoteSyncSupabaseAnonKey: "",
   apiConfig: defaultApiConfig,
   claudeApiConfig: defaultClaudeApiConfig,
   summaryApiConfig: defaultApiConfig,
@@ -135,6 +141,9 @@ export function mergeAppSettings(previous: AppSettings, updates: AppSettingsUpda
     skillSyncEnabled: Boolean(merged.skillSyncEnabled),
     skillSyncSupabaseUrl: normalizeSupabaseSettingUrl(merged.skillSyncSupabaseUrl),
     skillSyncSupabaseAnonKey: String(merged.skillSyncSupabaseAnonKey ?? "").trim(),
+    remoteSyncEnabled: Boolean(merged.remoteSyncEnabled),
+    remoteSyncSupabaseUrl: normalizeSupabaseSettingUrl(merged.remoteSyncSupabaseUrl),
+    remoteSyncSupabaseAnonKey: String(merged.remoteSyncSupabaseAnonKey ?? "").trim(),
     apiConfig: normalizeApiConfig({ ...previous.apiConfig, ...(updates.apiConfig ?? {}) }),
     claudeApiConfig: normalizeClaudeApiConfig({ ...previous.claudeApiConfig, ...(updates.claudeApiConfig ?? {}) }),
     summaryApiConfig: normalizeApiConfig({ ...previous.summaryApiConfig, ...(updates.summaryApiConfig ?? {}) }),

--- a/src/core/remote-session-restore.test.ts
+++ b/src/core/remote-session-restore.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { restoreRemotePortableSession } from "./remote-session-restore";
+import type { PortableSession } from "./types";
+
+const PORTABLE: PortableSession = {
+  sourceSessionKey: "codex:abc",
+  sourceAgent: "codex",
+  title: "Fix auth",
+  projectPath: "/device-a/repo",
+  startedAt: "2026-07-03T10:00:00.000Z",
+  messages: [
+    { role: "user", content: "broken auth", timestamp: "2026-07-03T10:00:00.000Z", index: 0 },
+    { role: "assistant", content: "fixed auth", timestamp: "2026-07-03T10:01:00.000Z", index: 1 },
+  ],
+};
+
+describe("restoreRemotePortableSession", () => {
+  it("restores a remote portable session with the selected local project path", async () => {
+    const write = vi.fn(async (_target, session: PortableSession) => ({
+      sessionId: "target-session",
+      filePath: "/target/session.jsonl",
+      projectPath: session.projectPath,
+    }));
+    const record = vi.fn();
+    const refreshIndex = vi.fn();
+    const launch = vi.fn();
+
+    const result = await restoreRemotePortableSession({
+      remoteId: "remote-1",
+      portable: PORTABLE,
+      target: "claude",
+      localProjectPath: "/device-b/repo",
+      deps: {
+        inspectCli: vi.fn(),
+        prepare: async (session) => ({ session, strategy: "complete" }),
+        write,
+        record,
+        refreshIndex,
+        launch,
+        resumeCommand: (_target, sessionId, projectPath) => `cd ${projectPath} && claude --resume ${sessionId}`,
+        fallbackResumeCommand: () => "claude --resume target-session",
+        idFactory: () => "migration-id",
+        now: () => 123,
+        projectPathExists: async () => true,
+        projectPathIsDirectory: async () => true,
+      },
+    });
+
+    expect(write).toHaveBeenCalledWith("claude", expect.objectContaining({ projectPath: "/device-b/repo" }));
+    expect(record).toHaveBeenCalledWith(expect.objectContaining({
+      sourceSessionKey: "remote:remote-1",
+      sourceAgent: "codex",
+      targetAgent: "claude",
+    }));
+    expect(refreshIndex).toHaveBeenCalledWith("claude", "/target/session.jsonl");
+    expect(launch).toHaveBeenCalledWith("claude", "target-session", "/device-b/repo");
+    expect(result).toMatchObject({
+      target: "claude",
+      targetSessionId: "target-session",
+      strategy: "complete",
+      launched: true,
+      indexed: true,
+    });
+  });
+
+  it("rejects a missing local project path before writing", async () => {
+    const write = vi.fn();
+    await expect(
+      restoreRemotePortableSession({
+        remoteId: "remote-1",
+        portable: PORTABLE,
+        target: "codex",
+        localProjectPath: "/missing",
+        deps: {
+          inspectCli: vi.fn(),
+          prepare: async (session) => ({ session, strategy: "complete" }),
+          write,
+          record: vi.fn(),
+          refreshIndex: vi.fn(),
+          launch: vi.fn(),
+          resumeCommand: () => "codex resume target-session",
+          fallbackResumeCommand: () => "codex resume target-session",
+          idFactory: () => "migration-id",
+          now: () => 123,
+          projectPathExists: async () => false,
+          projectPathIsDirectory: async () => false,
+        },
+      }),
+    ).rejects.toThrow("does not exist");
+    expect(write).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/remote-session-restore.ts
+++ b/src/core/remote-session-restore.ts
@@ -1,0 +1,178 @@
+import type { PreparedMigrationSession } from "./session-migration-compression";
+import type { WrittenMigratedSession } from "./session-migration-writers";
+import type {
+  MigrationAgent,
+  PortableSession,
+  SessionMigrationProgress,
+  SessionMigrationRecord,
+  SessionMigrationResult,
+} from "./types";
+
+export interface RemoteSessionRestoreDependencies {
+  inspectCli: (target: MigrationAgent) => Promise<void> | void;
+  prepare: (session: PortableSession) => Promise<PreparedMigrationSession>;
+  write: (target: MigrationAgent, session: PortableSession) => Promise<WrittenMigratedSession>;
+  record: (record: SessionMigrationRecord) => Promise<void> | void;
+  refreshIndex: (target: MigrationAgent, targetFilePath: string) => Promise<void>;
+  launch: (target: MigrationAgent, sessionId: string, projectPath: string) => Promise<void>;
+  resumeCommand: (target: MigrationAgent, sessionId: string, projectPath: string) => string;
+  fallbackResumeCommand: (target: MigrationAgent, sessionId: string, projectPath: string) => string;
+  onProgress?: (progress: SessionMigrationProgress) => void;
+  idFactory: () => string;
+  now: () => number;
+  projectPathExists: (projectPath: string) => Promise<boolean> | boolean;
+  projectPathIsDirectory: (projectPath: string) => Promise<boolean> | boolean;
+}
+
+export interface RestoreRemoteSessionOptions {
+  remoteId: string;
+  portable: PortableSession;
+  target: MigrationAgent;
+  localProjectPath: string;
+  deps: RemoteSessionRestoreDependencies;
+}
+
+const RESTORE_TARGETS: MigrationAgent[] = ["claude", "codex", "codebuddy"];
+
+export async function restoreRemotePortableSession({
+  remoteId,
+  portable,
+  target,
+  localProjectPath,
+  deps,
+}: RestoreRemoteSessionOptions): Promise<SessionMigrationResult> {
+  await validateRestoreRequest(portable, target, localProjectPath, deps);
+
+  notifyProgress(deps.onProgress, {
+    sessionKey: remoteId,
+    target,
+    stage: "reading",
+  });
+
+  await deps.inspectCli(target);
+
+  const localPortable: PortableSession = {
+    ...portable,
+    projectPath: localProjectPath,
+  };
+
+  const prepared = await deps.prepare(localPortable);
+
+  notifyProgress(deps.onProgress, {
+    sessionKey: remoteId,
+    target,
+    stage: "writing",
+  });
+  const written = await deps.write(target, prepared.session);
+
+  const warnings: string[] = [];
+  await collectWarning(warnings, async () => {
+    await deps.record({
+      id: deps.idFactory(),
+      sourceSessionKey: `remote:${remoteId}`,
+      sourceAgent: portable.sourceAgent,
+      targetAgent: target,
+      targetSessionId: written.sessionId,
+      targetFilePath: written.filePath,
+      strategy: prepared.strategy,
+      createdAt: deps.now(),
+    });
+  }, "Failed to record remote restore metadata");
+
+  const resumeCommand = safeResumeCommand(deps, warnings, target, written.sessionId, prepared.session.projectPath);
+
+  notifyProgress(deps.onProgress, {
+    sessionKey: remoteId,
+    target,
+    stage: "indexing",
+  });
+  let indexed = true;
+  try {
+    await deps.refreshIndex(target, written.filePath);
+  } catch (error) {
+    indexed = false;
+    warnings.push(formatWarning("Failed to refresh session index", error));
+  }
+
+  notifyProgress(deps.onProgress, {
+    sessionKey: remoteId,
+    target,
+    stage: "launching",
+  });
+  let launched = true;
+  try {
+    await deps.launch(target, written.sessionId, prepared.session.projectPath);
+  } catch (error) {
+    launched = false;
+    warnings.push(formatWarning("Failed to launch target session", error));
+  }
+
+  return {
+    target,
+    targetSessionId: written.sessionId,
+    targetFilePath: written.filePath,
+    strategy: prepared.strategy,
+    resumeCommand,
+    indexed,
+    launched,
+    ...(warnings.length > 0 ? { warning: warnings.join("\n") } : {}),
+  };
+}
+
+async function validateRestoreRequest(
+  portable: PortableSession,
+  target: MigrationAgent,
+  localProjectPath: string,
+  deps: RemoteSessionRestoreDependencies,
+): Promise<void> {
+  if (!RESTORE_TARGETS.includes(target)) {
+    throw new Error(`Migration target ${target} is not supported.`);
+  }
+  if (!localProjectPath.trim()) {
+    throw new Error("Choose a local project path before restoring.");
+  }
+  if (!(await deps.projectPathExists(localProjectPath))) {
+    throw new Error(`Local project path does not exist: ${localProjectPath}`);
+  }
+  if (!(await deps.projectPathIsDirectory(localProjectPath))) {
+    throw new Error(`Local project path is not a directory: ${localProjectPath}`);
+  }
+  if (!portable.messages.some((message) => message.role === "user" || message.role === "assistant")) {
+    throw new Error("Remote session has no readable user/assistant messages to restore.");
+  }
+}
+
+function notifyProgress(onProgress: RemoteSessionRestoreDependencies["onProgress"], progress: SessionMigrationProgress): void {
+  try {
+    onProgress?.(progress);
+  } catch {
+    // Observer failures must not break restore.
+  }
+}
+
+async function collectWarning(warnings: string[], action: () => Promise<void>, prefix: string): Promise<void> {
+  try {
+    await action();
+  } catch (error) {
+    warnings.push(formatWarning(prefix, error));
+  }
+}
+
+function safeResumeCommand(
+  deps: RemoteSessionRestoreDependencies,
+  warnings: string[],
+  target: MigrationAgent,
+  sessionId: string,
+  projectPath: string,
+): string {
+  try {
+    return deps.resumeCommand(target, sessionId, projectPath);
+  } catch (error) {
+    warnings.push(formatWarning("Failed to build resume command", error));
+    return deps.fallbackResumeCommand(target, sessionId, projectPath);
+  }
+}
+
+function formatWarning(prefix: string, error: unknown): string {
+  return `${prefix}: ${error instanceof Error ? error.message : String(error)}`;
+}

--- a/src/core/remote-session-sync.test.ts
+++ b/src/core/remote-session-sync.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRemoteSessionPayload,
+  buildRemoteSessionSetupSql,
+  buildRemoteSessionSnapshot,
+  filterRemoteSessions,
+  parseDetailSnapshot,
+  parsePortableSession,
+  remoteSessionContentHash,
+  remoteSessionId,
+} from "./remote-session-sync";
+import type { PortableSession, SessionSearchResult } from "./types";
+
+const SESSION: SessionSearchResult = {
+  sessionKey: "codex:abc",
+  rawId: "abc",
+  source: "codex-cli",
+  projectPath: "/repo",
+  filePath: "/home/.codex/sessions/abc.jsonl",
+  originalTitle: "Original title",
+  firstQuestion: "Fix login bug",
+  timestamp: 1_000,
+  fileMtimeMs: 2_000,
+  fileSize: 123,
+  prUrl: null,
+  prNumber: null,
+  gitBranch: null,
+  environmentId: "local",
+  environmentKind: "local",
+  environmentLabel: "Local",
+  tokenUsage: {
+    inputTokens: 1,
+    outputTokens: 2,
+    cachedInputTokens: 0,
+    reasoningOutputTokens: 0,
+    totalTokens: 3,
+  },
+  customTitle: null,
+  displayTitle: "Fix login bug",
+  favorited: false,
+  pinned: false,
+  hidden: false,
+  tags: ["auth", "react"],
+  matchSnippet: null,
+  lastOpenedAt: null,
+  lastResumedAt: null,
+  lastActivityAt: 3_000,
+  messageCount: 2,
+  aiSummary: "Fixed the login bug by updating auth state handling.",
+  aiSummaryStale: false,
+};
+
+const MESSAGES = [
+  { role: "user" as const, content: "Login is broken", timestamp: "2026-07-03T10:00:00.000Z", index: 0 },
+  { role: "assistant" as const, content: "Update auth state handling", timestamp: "2026-07-03T10:01:00.000Z", index: 1 },
+];
+
+const PORTABLE: PortableSession = {
+  sourceSessionKey: "codex:abc",
+  sourceAgent: "codex",
+  title: "Fix login bug",
+  projectPath: "/repo",
+  startedAt: "2026-07-03T10:00:00.000Z",
+  messages: MESSAGES,
+};
+
+describe("remote session sync model", () => {
+  it("builds setup SQL for the table and storage bucket", () => {
+    const sql = buildRemoteSessionSetupSql();
+    expect(sql).toContain("agent_session_remote_sessions");
+    expect(sql).toContain("agent-session-remote");
+    expect(sql).toContain("storage.buckets");
+    expect(sql).toContain("to anon");
+  });
+
+  it("builds a stable remote upload payload with detail and portable object keys", () => {
+    const detail = buildRemoteSessionSnapshot(SESSION, MESSAGES, [], 10_000);
+    const first = buildRemoteSessionPayload({ session: SESSION, detail, portable: PORTABLE, now: 11_000 });
+    const second = buildRemoteSessionPayload({ session: SESSION, detail, portable: PORTABLE, now: 11_000 });
+
+    expect(first.payload.id).toBe(remoteSessionId("codex:abc"));
+    expect(first.payload.detail_object_key).toBe(`sessions/${first.payload.id}/detail.json`);
+    expect(first.payload.portable_object_key).toBe(`sessions/${first.payload.id}/portable.json`);
+    expect(first.payload.content_hash).toBe(second.payload.content_hash);
+    expect(first.payload.search_text).toContain("Login is broken");
+    expect(first.payload.search_text).toContain("Fixed the login bug");
+  });
+
+  it("rounds timestamp fields for Supabase bigint columns", () => {
+    const detail = buildRemoteSessionSnapshot(SESSION, MESSAGES, [], 10_000.9);
+    const { payload } = buildRemoteSessionPayload({
+      session: { ...SESSION, lastActivityAt: 1_783_088_915_792.1865 },
+      detail,
+      portable: PORTABLE,
+      now: 1_783_088_916_001.9,
+    });
+
+    expect(payload.updated_at).toBe(1_783_088_915_792);
+    expect(payload.created_at).toBe(1_783_088_916_001);
+    expect(payload.synced_at).toBe(1_783_088_916_001);
+  });
+
+  it("hashes remote content deterministically", () => {
+    const detail = buildRemoteSessionSnapshot(SESSION, MESSAGES, [], 10_000);
+    expect(remoteSessionContentHash(detail, PORTABLE)).toBe(remoteSessionContentHash(detail, { ...PORTABLE, messages: [...PORTABLE.messages] }));
+  });
+
+  it("parses detail and portable snapshots defensively", () => {
+    const detail = buildRemoteSessionSnapshot(SESSION, MESSAGES, [], 10_000);
+    expect(parseDetailSnapshot(detail).messages).toHaveLength(2);
+    expect(parsePortableSession(PORTABLE).sourceAgent).toBe("codex");
+    expect(() => parsePortableSession({ ...PORTABLE, sourceAgent: "hermes" })).toThrow("unsupported");
+  });
+
+  it("filters remote sessions by title, summary, tags, and search text", () => {
+    const sessions = [
+      {
+        id: "1",
+        sourceSessionKey: "codex:1",
+        sourceAgent: "codex" as const,
+        sourceSource: "codex-cli",
+        title: "Auth fix",
+        projectPath: "/repo",
+        startedAt: "2026-07-03T10:00:00.000Z",
+        updatedAt: 1,
+        contentHash: "h",
+        messageCount: 2,
+        traceEventCount: 0,
+        aiSummary: "login state",
+        tags: ["react"],
+        searchText: "oauth callback",
+        detailObjectKey: "d",
+        portableObjectKey: "p",
+        detailSha256: "dh",
+        portableSha256: "ph",
+        createdAt: 1,
+        syncedAt: 1,
+      },
+    ];
+    expect(filterRemoteSessions(sessions, "oauth")).toHaveLength(1);
+    expect(filterRemoteSessions(sessions, "missing")).toHaveLength(0);
+  });
+});

--- a/src/core/remote-session-sync.ts
+++ b/src/core/remote-session-sync.ts
@@ -1,0 +1,632 @@
+import { createHash } from "node:crypto";
+import { portableSessionFrom } from "./session-migration";
+import type { SessionStore } from "./session-store";
+import type { MigrationAgent, PortableSession, SessionMessage, SessionSearchResult, SessionTraceEvent } from "./types";
+
+export const REMOTE_SESSION_TABLE = "agent_session_remote_sessions";
+export const REMOTE_SESSION_BUCKET = "agent-session-remote";
+const REMOTE_SESSION_COLUMNS =
+  "id,source_session_key,source_agent,source_source,title,project_path,started_at,updated_at,content_hash,message_count,trace_event_count,ai_summary,tags,search_text,detail_object_key,portable_object_key,detail_sha256,portable_sha256,created_at,synced_at";
+
+export interface RemoteSessionDetailSnapshot {
+  schemaVersion: 1;
+  exportedAt: number;
+  session: SessionSearchResult;
+  messages: SessionMessage[];
+  traceEvents: SessionTraceEvent[];
+}
+
+export interface RemoteSessionListItem {
+  id: string;
+  sourceSessionKey: string;
+  sourceAgent: MigrationAgent;
+  sourceSource: string;
+  title: string;
+  projectPath: string;
+  startedAt: string;
+  updatedAt: number;
+  contentHash: string;
+  messageCount: number;
+  traceEventCount: number;
+  aiSummary: string | null;
+  tags: string[];
+  searchText: string;
+  detailObjectKey: string;
+  portableObjectKey: string;
+  detailSha256: string;
+  portableSha256: string;
+  createdAt: number;
+  syncedAt: number;
+}
+
+export type RemoteSessionStatus =
+  | { kind: "unconfigured"; setupSql: string; message: string }
+  | { kind: "ready"; setupSql: string }
+  | { kind: "missing-table"; setupSql: string; message: string }
+  | { kind: "error"; setupSql: string; message: string };
+
+export type RemoteSessionUploadResult =
+  | { status: "uploaded"; remoteSession: RemoteSessionListItem }
+  | { status: "updated"; remoteSession: RemoteSessionListItem }
+  | { status: "skipped"; remoteSession: RemoteSessionListItem };
+
+export interface RemoteSessionClientOptions {
+  url: string;
+  anonKey: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+interface RemoteSessionRow {
+  id: string;
+  source_session_key: string;
+  source_agent: string;
+  source_source: string;
+  title: string;
+  project_path: string;
+  started_at: string;
+  updated_at: number;
+  content_hash: string;
+  message_count: number;
+  trace_event_count: number | null;
+  ai_summary: string | null;
+  tags: unknown;
+  search_text: string | null;
+  detail_object_key: string;
+  portable_object_key: string;
+  detail_sha256: string;
+  portable_sha256: string;
+  created_at: number;
+  synced_at: number;
+}
+
+interface RemoteSessionUploadPayload {
+  id: string;
+  source_session_key: string;
+  source_agent: MigrationAgent;
+  source_source: string;
+  title: string;
+  project_path: string;
+  started_at: string;
+  updated_at: number;
+  content_hash: string;
+  message_count: number;
+  trace_event_count: number;
+  ai_summary: string | null;
+  tags: string[];
+  search_text: string;
+  detail_object_key: string;
+  portable_object_key: string;
+  detail_sha256: string;
+  portable_sha256: string;
+  created_at: number;
+  synced_at: number;
+}
+
+const DEFAULT_REMOTE_SESSION_TIMEOUT_MS = 20_000;
+
+export function buildRemoteSessionSetupSql(tableName = REMOTE_SESSION_TABLE, bucketName = REMOTE_SESSION_BUCKET): string {
+  return [
+    `create table if not exists public.${tableName} (`,
+    "  id text primary key,",
+    "  source_session_key text not null,",
+    "  source_agent text not null check (source_agent in ('claude', 'codex', 'codebuddy')),",
+    "  source_source text not null,",
+    "  title text not null,",
+    "  project_path text not null,",
+    "  started_at text not null,",
+    "  updated_at bigint not null,",
+    "  content_hash text not null,",
+    "  message_count integer not null,",
+    "  trace_event_count integer not null default 0,",
+    "  ai_summary text,",
+    "  tags jsonb not null default '[]'::jsonb,",
+    "  search_text text not null default '',",
+    "  detail_object_key text not null,",
+    "  portable_object_key text not null,",
+    "  detail_sha256 text not null,",
+    "  portable_sha256 text not null,",
+    "  created_at bigint not null,",
+    "  synced_at bigint not null",
+    ");",
+    "",
+    `create unique index if not exists ${tableName}_content_hash_idx`,
+    `  on public.${tableName} (content_hash);`,
+    `create index if not exists ${tableName}_updated_at_idx`,
+    `  on public.${tableName} (updated_at desc);`,
+    `create index if not exists ${tableName}_title_idx`,
+    `  on public.${tableName} (title);`,
+    "",
+    `alter table public.${tableName} enable row level security;`,
+    "",
+    `drop policy if exists "${tableName}_personal_sync" on public.${tableName};`,
+    `create policy "${tableName}_personal_sync"`,
+    `  on public.${tableName}`,
+    "  for all",
+    "  to anon",
+    "  using (true)",
+    "  with check (true);",
+    "",
+    "-- Create the private Storage bucket used for remote detail snapshots.",
+    "insert into storage.buckets (id, name, public)",
+    `values ('${bucketName}', '${bucketName}', false)`,
+    "on conflict (id) do nothing;",
+    "",
+    `drop policy if exists "${bucketName}_objects_personal_sync" on storage.objects;`,
+    `create policy "${bucketName}_objects_personal_sync"`,
+    "  on storage.objects",
+    "  for all",
+    "  to anon",
+    `  using (bucket_id = '${bucketName}')`,
+    `  with check (bucket_id = '${bucketName}');`,
+  ].join("\n");
+}
+
+export function buildRemoteSessionSnapshot(
+  session: SessionSearchResult,
+  messages: SessionMessage[],
+  traceEvents: SessionTraceEvent[],
+  now = Date.now(),
+): RemoteSessionDetailSnapshot {
+  return {
+    schemaVersion: 1,
+    exportedAt: now,
+    session,
+    messages,
+    traceEvents,
+  };
+}
+
+export function remoteSessionSearchText(
+  session: SessionSearchResult,
+  messages: SessionMessage[],
+  traceEvents: SessionTraceEvent[],
+): string {
+  const parts = [
+    session.displayTitle,
+    session.originalTitle,
+    session.firstQuestion,
+    session.projectPath,
+    session.aiSummary ?? "",
+    ...session.tags,
+    ...messages.map((message) => message.content),
+    ...traceEvents.map((event) => `${event.title}\n${event.detail}`),
+  ];
+  return parts.map((part) => part.trim()).filter(Boolean).join("\n\n").slice(0, 200_000);
+}
+
+export function remoteSessionContentHash(detail: RemoteSessionDetailSnapshot, portable: PortableSession): string {
+  return sha256(stableJson({ detail, portable }));
+}
+
+export function remoteSessionId(sourceSessionKey: string): string {
+  return sha256(sourceSessionKey).slice(0, 32);
+}
+
+export function buildRemoteSessionPayload(options: {
+  session: SessionSearchResult;
+  detail: RemoteSessionDetailSnapshot;
+  portable: PortableSession;
+  now?: number;
+}): { payload: RemoteSessionUploadPayload; detailJson: string; portableJson: string } {
+  const now = integerTimestamp(options.now ?? Date.now());
+  const detailJson = stableJson(options.detail);
+  const portableJson = stableJson(options.portable);
+  const id = remoteSessionId(options.session.sessionKey);
+  const detailObjectKey = `sessions/${id}/detail.json`;
+  const portableObjectKey = `sessions/${id}/portable.json`;
+  const contentHash = remoteSessionContentHash(options.detail, options.portable);
+  return {
+    detailJson,
+    portableJson,
+    payload: {
+      id,
+      source_session_key: options.session.sessionKey,
+      source_agent: options.portable.sourceAgent,
+      source_source: options.session.source,
+      title: options.session.displayTitle,
+      project_path: options.session.projectPath,
+      started_at: options.portable.startedAt,
+      updated_at: integerTimestamp(options.session.lastActivityAt || options.session.fileMtimeMs || options.session.timestamp),
+      content_hash: contentHash,
+      message_count: options.detail.messages.length,
+      trace_event_count: options.detail.traceEvents.length,
+      ai_summary: options.session.aiSummary,
+      tags: options.session.tags,
+      search_text: remoteSessionSearchText(options.session, options.detail.messages, options.detail.traceEvents),
+      detail_object_key: detailObjectKey,
+      portable_object_key: portableObjectKey,
+      detail_sha256: sha256(detailJson),
+      portable_sha256: sha256(portableJson),
+      created_at: now,
+      synced_at: now,
+    },
+  };
+}
+
+export function buildRemoteSessionUploadFromStore(
+  store: Pick<SessionStore, "getSession" | "getAllMessages" | "getTraceEvents">,
+  sessionKey: string,
+  now = Date.now(),
+): { session: SessionSearchResult; detail: RemoteSessionDetailSnapshot; portable: PortableSession; payload: RemoteSessionUploadPayload; detailJson: string; portableJson: string } {
+  const session = store.getSession(sessionKey);
+  if (!session) throw new Error("Session not found.");
+  const messages = store.getAllMessages(sessionKey);
+  const traceEvents = store.getTraceEvents(sessionKey);
+  const portable = portableSessionFrom(session, messages);
+  const detail = buildRemoteSessionSnapshot(session, messages, traceEvents, now);
+  const { payload, detailJson, portableJson } = buildRemoteSessionPayload({ session, detail, portable, now });
+  return { session, detail, portable, payload, detailJson, portableJson };
+}
+
+export function filterRemoteSessions(sessions: RemoteSessionListItem[], query: string): RemoteSessionListItem[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return sessions;
+  return sessions.filter((session) => {
+    const haystack = [
+      session.title,
+      session.projectPath,
+      session.aiSummary ?? "",
+      session.tags.join(" "),
+      session.searchText,
+    ].join("\n").toLowerCase();
+    return haystack.includes(normalized);
+  });
+}
+
+export class SupabaseRemoteSessionClient {
+  private readonly baseUrl: string;
+  private readonly anonKey: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+
+  constructor(options: RemoteSessionClientOptions) {
+    this.baseUrl = normalizeSupabaseUrl(options.url);
+    this.anonKey = options.anonKey.trim();
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.timeoutMs = options.timeoutMs && options.timeoutMs > 0 ? options.timeoutMs : DEFAULT_REMOTE_SESSION_TIMEOUT_MS;
+    if (!this.baseUrl) throw new Error("Supabase URL is required.");
+    if (!this.anonKey) throw new Error("Supabase anon key is required.");
+  }
+
+  async checkStatus(): Promise<RemoteSessionStatus> {
+    const setupSql = buildRemoteSessionSetupSql();
+    const response = await this.restRequest(`/${REMOTE_SESSION_TABLE}?select=id&limit=1`, { method: "GET" });
+    if (response.ok) return { kind: "ready", setupSql };
+    const body = await readResponseBody(response);
+    if (isMissingTableError(response.status, body)) {
+      return {
+        kind: "missing-table",
+        setupSql,
+        message: `Supabase table ${REMOTE_SESSION_TABLE} was not found.`,
+      };
+    }
+    return { kind: "error", setupSql, message: supabaseErrorMessage(response.status, body) };
+  }
+
+  async listRemoteSessions(query = ""): Promise<RemoteSessionListItem[]> {
+    const response = await this.restRequest(
+      `/${REMOTE_SESSION_TABLE}?select=${REMOTE_SESSION_COLUMNS}&order=updated_at.desc`,
+      { method: "GET" },
+    );
+    const body = await readResponseBody(response);
+    if (!response.ok) throw new Error(supabaseErrorMessage(response.status, body));
+    return filterRemoteSessions(parseRows(body), query);
+  }
+
+  async getRemoteSession(remoteId: string): Promise<RemoteSessionListItem> {
+    const response = await this.restRequest(
+      `/${REMOTE_SESSION_TABLE}?id=eq.${encodeURIComponent(remoteId)}&select=${REMOTE_SESSION_COLUMNS}&limit=1`,
+      { method: "GET" },
+    );
+    const body = await readResponseBody(response);
+    if (!response.ok) throw new Error(supabaseErrorMessage(response.status, body));
+    const [session] = parseRows(body);
+    if (!session) throw new Error("Remote session was not found.");
+    return session;
+  }
+
+  async uploadSession(payload: RemoteSessionUploadPayload, detailJson: string, portableJson: string): Promise<RemoteSessionUploadResult> {
+    const existing = await this.getRemoteSessionOrNull(payload.id);
+    if (existing?.contentHash === payload.content_hash) return { status: "skipped", remoteSession: existing };
+
+    await this.uploadStorageObject(payload.detail_object_key, detailJson);
+    await this.uploadStorageObject(payload.portable_object_key, portableJson);
+
+    const response = await this.restRequest(`/${REMOTE_SESSION_TABLE}?on_conflict=id`, {
+      method: "POST",
+      headers: { Prefer: "resolution=merge-duplicates,return=representation" },
+      body: JSON.stringify(payload),
+    });
+    const body = await readResponseBody(response);
+    if (!response.ok) throw new Error(supabaseErrorMessage(response.status, body));
+    const [remoteSession] = parseRows(body);
+    if (!remoteSession) throw new Error("Supabase did not return the uploaded remote session.");
+    return { status: existing ? "updated" : "uploaded", remoteSession };
+  }
+
+  async getDetailSnapshot(remoteIdOrSession: string | RemoteSessionListItem): Promise<RemoteSessionDetailSnapshot> {
+    const remote = typeof remoteIdOrSession === "string" ? await this.getRemoteSession(remoteIdOrSession) : remoteIdOrSession;
+    const text = await this.downloadStorageObject(remote.detailObjectKey);
+    if (sha256(text) !== remote.detailSha256) throw new Error("Remote detail snapshot checksum mismatch.");
+    return parseDetailSnapshot(JSON.parse(text));
+  }
+
+  async getPortableSession(remoteIdOrSession: string | RemoteSessionListItem): Promise<PortableSession> {
+    const remote = typeof remoteIdOrSession === "string" ? await this.getRemoteSession(remoteIdOrSession) : remoteIdOrSession;
+    const text = await this.downloadStorageObject(remote.portableObjectKey);
+    if (sha256(text) !== remote.portableSha256) throw new Error("Remote portable session checksum mismatch.");
+    return parsePortableSession(JSON.parse(text));
+  }
+
+  async deleteRemoteSession(remoteId: string): Promise<boolean> {
+    const remote = await this.getRemoteSession(remoteId).catch(() => null);
+    if (!remote) return false;
+    await Promise.allSettled([
+      this.deleteStorageObject(remote.detailObjectKey),
+      this.deleteStorageObject(remote.portableObjectKey),
+    ]);
+    const response = await this.restRequest(`/${REMOTE_SESSION_TABLE}?id=eq.${encodeURIComponent(remoteId)}`, { method: "DELETE" });
+    const body = await readResponseBody(response);
+    if (!response.ok) throw new Error(supabaseErrorMessage(response.status, body));
+    return true;
+  }
+
+  private async getRemoteSessionOrNull(remoteId: string): Promise<RemoteSessionListItem | null> {
+    try {
+      return await this.getRemoteSession(remoteId);
+    } catch {
+      return null;
+    }
+  }
+
+  private async restRequest(path: string, init: RequestInit): Promise<Response> {
+    return this.request(`${this.baseUrl}/rest/v1${path}`, {
+      ...init,
+      headers: {
+        apikey: this.anonKey,
+        Authorization: `Bearer ${this.anonKey}`,
+        "Content-Type": "application/json",
+        ...(init.headers ?? {}),
+      },
+    });
+  }
+
+  private async storageRequest(path: string, init: RequestInit): Promise<Response> {
+    return this.request(`${this.baseUrl}/storage/v1/object/${REMOTE_SESSION_BUCKET}/${path}`, {
+      ...init,
+      headers: {
+        apikey: this.anonKey,
+        Authorization: `Bearer ${this.anonKey}`,
+        ...(init.headers ?? {}),
+      },
+    });
+  }
+
+  private async uploadStorageObject(key: string, body: string): Promise<void> {
+    const response = await this.storageRequest(key, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-cache",
+        "x-upsert": "true",
+      },
+      body,
+    });
+    const responseBody = await readResponseBody(response);
+    if (!response.ok) throw new Error(supabaseErrorMessage(response.status, responseBody));
+  }
+
+  private async downloadStorageObject(key: string): Promise<string> {
+    const response = await this.storageRequest(key, { method: "GET" });
+    const text = await response.text();
+    if (!response.ok) throw new Error(supabaseErrorMessage(response.status, text));
+    return text;
+  }
+
+  private async deleteStorageObject(key: string): Promise<void> {
+    const response = await this.storageRequest(key, { method: "DELETE" });
+    if (response.status === 404) return;
+    const body = await readResponseBody(response);
+    if (!response.ok) throw new Error(supabaseErrorMessage(response.status, body));
+  }
+
+  private async request(url: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      return await this.fetchImpl(url, { ...init, signal: controller.signal });
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw new Error(`Supabase request timed out after ${Math.round(this.timeoutMs / 1000)}s.`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+function parseRows(body: unknown): RemoteSessionListItem[] {
+  if (!Array.isArray(body)) return [];
+  return body.flatMap((row) => (isRow(row) ? [fromRow(row)] : []));
+}
+
+function isRow(value: unknown): value is RemoteSessionRow {
+  if (!value || typeof value !== "object") return false;
+  const row = value as Partial<RemoteSessionRow>;
+  return (
+    typeof row.id === "string" &&
+    typeof row.source_session_key === "string" &&
+    typeof row.source_agent === "string" &&
+    typeof row.source_source === "string" &&
+    typeof row.title === "string" &&
+    typeof row.project_path === "string" &&
+    typeof row.started_at === "string" &&
+    typeof row.updated_at === "number" &&
+    typeof row.content_hash === "string" &&
+    typeof row.message_count === "number" &&
+    typeof row.detail_object_key === "string" &&
+    typeof row.portable_object_key === "string" &&
+    typeof row.detail_sha256 === "string" &&
+    typeof row.portable_sha256 === "string" &&
+    typeof row.created_at === "number" &&
+    typeof row.synced_at === "number"
+  );
+}
+
+function fromRow(row: RemoteSessionRow): RemoteSessionListItem {
+  return {
+    id: row.id,
+    sourceSessionKey: row.source_session_key,
+    sourceAgent: parseMigrationAgent(row.source_agent),
+    sourceSource: row.source_source,
+    title: row.title,
+    projectPath: row.project_path,
+    startedAt: row.started_at,
+    updatedAt: row.updated_at,
+    contentHash: row.content_hash,
+    messageCount: row.message_count,
+    traceEventCount: row.trace_event_count ?? 0,
+    aiSummary: row.ai_summary,
+    tags: parseTags(row.tags),
+    searchText: row.search_text ?? "",
+    detailObjectKey: row.detail_object_key,
+    portableObjectKey: row.portable_object_key,
+    detailSha256: row.detail_sha256,
+    portableSha256: row.portable_sha256,
+    createdAt: row.created_at,
+    syncedAt: row.synced_at,
+  };
+}
+
+export function parseDetailSnapshot(value: unknown): RemoteSessionDetailSnapshot {
+  if (!value || typeof value !== "object") throw new Error("Remote detail snapshot was not an object.");
+  const snapshot = value as Partial<RemoteSessionDetailSnapshot>;
+  if (snapshot.schemaVersion !== 1) throw new Error("Remote detail snapshot schema version is unsupported.");
+  if (!snapshot.session || typeof snapshot.session !== "object") throw new Error("Remote detail snapshot has no session.");
+  if (!Array.isArray(snapshot.messages)) throw new Error("Remote detail snapshot has no messages.");
+  if (!Array.isArray(snapshot.traceEvents)) throw new Error("Remote detail snapshot has no trace events.");
+  return {
+    schemaVersion: 1,
+    exportedAt: typeof snapshot.exportedAt === "number" ? snapshot.exportedAt : 0,
+    session: snapshot.session as SessionSearchResult,
+    messages: snapshot.messages.filter(isSessionMessage),
+    traceEvents: snapshot.traceEvents.filter(isTraceEvent),
+  };
+}
+
+export function parsePortableSession(value: unknown): PortableSession {
+  if (!value || typeof value !== "object") throw new Error("Remote portable session was not an object.");
+  const session = value as Partial<PortableSession>;
+  if (typeof session.sourceSessionKey !== "string") throw new Error("Remote portable session has no source key.");
+  if (!isMigrationAgent(session.sourceAgent)) throw new Error("Remote portable session source agent is unsupported.");
+  if (typeof session.title !== "string") throw new Error("Remote portable session has no title.");
+  if (typeof session.projectPath !== "string") throw new Error("Remote portable session has no project path.");
+  if (typeof session.startedAt !== "string") throw new Error("Remote portable session has no start time.");
+  if (!Array.isArray(session.messages)) throw new Error("Remote portable session has no messages.");
+  return {
+    sourceSessionKey: session.sourceSessionKey,
+    sourceAgent: session.sourceAgent,
+    title: session.title,
+    projectPath: session.projectPath,
+    startedAt: session.startedAt,
+    messages: session.messages.filter(isSessionMessage),
+  };
+}
+
+function isSessionMessage(value: unknown): value is SessionMessage {
+  if (!value || typeof value !== "object") return false;
+  const message = value as Partial<SessionMessage>;
+  return (
+    (message.role === "user" || message.role === "assistant") &&
+    typeof message.content === "string" &&
+    typeof message.timestamp === "string" &&
+    typeof message.index === "number"
+  );
+}
+
+function isTraceEvent(value: unknown): value is SessionTraceEvent {
+  if (!value || typeof value !== "object") return false;
+  const event = value as Partial<SessionTraceEvent>;
+  return (
+    typeof event.index === "number" &&
+    (event.kind === "tool_call" || event.kind === "tool_result" || event.kind === "event") &&
+    typeof event.source === "string" &&
+    typeof event.title === "string" &&
+    typeof event.detail === "string" &&
+    typeof event.timestamp === "string"
+  );
+}
+
+function parseMigrationAgent(value: string): MigrationAgent {
+  if (isMigrationAgent(value)) return value;
+  throw new Error(`Unsupported remote session agent: ${value}`);
+}
+
+function isMigrationAgent(value: unknown): value is MigrationAgent {
+  return value === "claude" || value === "codex" || value === "codebuddy";
+}
+
+function parseTags(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((tag): tag is string => typeof tag === "string");
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(sortJson(value));
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (!value || typeof value !== "object") return value;
+  const input = value as Record<string, unknown>;
+  const output: Record<string, unknown> = {};
+  for (const key of Object.keys(input).sort()) {
+    output[key] = sortJson(input[key]);
+  }
+  return output;
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function integerTimestamp(value: number): number {
+  return Number.isFinite(value) ? Math.trunc(value) : 0;
+}
+
+async function readResponseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function supabaseErrorMessage(status: number, body: unknown): string {
+  if (body && typeof body === "object") {
+    const message = (body as { message?: unknown }).message;
+    if (typeof message === "string" && message.trim()) return message;
+  }
+  if (typeof body === "string" && body.trim()) return body;
+  return `Supabase request failed with status ${status}.`;
+}
+
+function isMissingTableError(status: number, body: unknown): boolean {
+  if (status === 404) return true;
+  if (!body || typeof body !== "object") return false;
+  const code = (body as { code?: unknown }).code;
+  const message = (body as { message?: unknown }).message;
+  return (
+    code === "42P01" ||
+    code === "PGRST205" ||
+    (typeof message === "string" && /table|relation/i.test(message) && /not found|does not exist/i.test(message))
+  );
+}
+
+function normalizeSupabaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import {
   Notification,
   screen,
   Tray,
+  type IpcMainInvokeEvent,
   type MenuItemConstructorOptions,
 } from "electron";
 import Store from "electron-store";
@@ -67,6 +68,16 @@ import { routeResumeSession } from "../core/resume-router";
 import { diagnoseRemoteEnvironment, preflightRemoteSessionResume } from "../core/remote-health";
 import { fetchRemoteSessionFilePayload, fetchRemoteSessionMessagePage, syncRemoteEnvironment } from "../core/remote-sync";
 import { loadRemoteSessionDetailPayload } from "../core/remote-session-loader";
+import { restoreRemotePortableSession } from "../core/remote-session-restore";
+import {
+  buildRemoteSessionSetupSql,
+  buildRemoteSessionUploadFromStore,
+  SupabaseRemoteSessionClient,
+  type RemoteSessionDetailSnapshot,
+  type RemoteSessionListItem,
+  type RemoteSessionStatus,
+  type RemoteSessionUploadResult,
+} from "../core/remote-session-sync";
 import { RemoteEnvironmentLifecycle } from "../core/remote-environment-lifecycle";
 import { RemoteWatchManager } from "../core/remote-watch";
 import { SessionStore, type SkillSyncBinding, type TraceEventQueryOptions } from "../core/session-store";
@@ -109,6 +120,7 @@ import type {
   MigrationAgent,
   SearchOptions,
   SessionEnvironment,
+  SessionMigrationResult,
   SessionSearchResult,
   SessionSource,
   SessionStatsOptions,
@@ -317,6 +329,82 @@ function persistSkillSyncBinding(
   const binding: SkillSyncBinding = { localSkillPath, remoteSkillId, remoteUpdatedAt, remoteVersion, lastSyncedAt: Date.now(), direction };
   store.upsertSkillSyncBinding(binding);
   return binding;
+}
+
+function createRemoteSessionClient(): SupabaseRemoteSessionClient {
+  const settings = getSettings();
+  if (!settings.remoteSyncEnabled || !settings.remoteSyncSupabaseUrl || !settings.remoteSyncSupabaseAnonKey) {
+    throw new Error("Supabase remote session sync is not configured.");
+  }
+  return new SupabaseRemoteSessionClient({
+    url: settings.remoteSyncSupabaseUrl,
+    anonKey: settings.remoteSyncSupabaseAnonKey,
+  });
+}
+
+async function getRemoteSessionStatus(): Promise<RemoteSessionStatus> {
+  const setupSql = buildRemoteSessionSetupSql();
+  const settings = getSettings();
+  if (!settings.remoteSyncEnabled || !settings.remoteSyncSupabaseUrl || !settings.remoteSyncSupabaseAnonKey) {
+    return {
+      kind: "unconfigured",
+      setupSql,
+      message: "Configure Supabase URL and anon key in Settings to sync remote sessions.",
+    };
+  }
+  return createRemoteSessionClient().checkStatus();
+}
+
+async function uploadSessionToRemote(sessionKey: string): Promise<RemoteSessionUploadResult> {
+  const client = createRemoteSessionClient();
+  const { payload, detailJson, portableJson } = buildRemoteSessionUploadFromStore(store, sessionKey);
+  return client.uploadSession(payload, detailJson, portableJson);
+}
+
+function listRemoteSessions(query = ""): Promise<RemoteSessionListItem[]> {
+  return createRemoteSessionClient().listRemoteSessions(query);
+}
+
+function getRemoteSessionDetail(remoteId: string): Promise<RemoteSessionDetailSnapshot> {
+  return createRemoteSessionClient().getDetailSnapshot(remoteId);
+}
+
+async function restoreRemoteSession(
+  event: IpcMainInvokeEvent,
+  remoteId: string,
+  target: MigrationAgent,
+  localProjectPath: string,
+): Promise<SessionMigrationResult> {
+  const client = createRemoteSessionClient();
+  const portable = await client.getPortableSession(remoteId);
+  const endpoint = await resolveSummaryEndpointFromSettings();
+  const compressor = endpoint ? createMigrationCompressor(endpoint) : null;
+  return restoreRemotePortableSession({
+    remoteId,
+    portable,
+    target,
+    localProjectPath,
+    deps: {
+      inspectCli: (migrationTarget) => inspectMigrationCli(migrationTarget, getSettings()),
+      prepare: (session) => applyMigrationLengthPolicy(session, compressor),
+      write: (migrationTarget, session) => writeMigratedSession({ target: migrationTarget, session }),
+      record: (record) => store.recordSessionMigration(record),
+      refreshIndex: async (migrationTarget, writtenFilePath) => {
+        const status = indexMigratedSessionFile(store, migrationTarget, writtenFilePath);
+        indexStatus = status;
+        mainWindow?.webContents.send("index-status", indexStatus);
+      },
+      launch: (migrationTarget, targetSessionId, projectPath) =>
+        openMigrationResumeInTerminal(migrationTarget, targetSessionId, projectPath, getSettings()),
+      resumeCommand: migrationResumeDisplayCommand,
+      fallbackResumeCommand: fallbackMigrationResumeDisplayCommand,
+      onProgress: (progress) => event.sender.send("session:migration-progress", progress),
+      idFactory: () => randomUUID(),
+      now: () => Date.now(),
+      projectPathExists: pathExists,
+      projectPathIsDirectory: pathIsDirectory,
+    },
+  });
 }
 
 function findInstalledSkillByPath(skillPath: string): InstalledSkill {
@@ -668,6 +756,16 @@ async function chooseMarkdownExportPath(defaultFileName: string): Promise<string
   const result = mainWindow ? await dialog.showSaveDialog(mainWindow, options) : await dialog.showSaveDialog(options);
   if (result.canceled || !result.filePath) return null;
   return path.extname(result.filePath) ? result.filePath : `${result.filePath}.md`;
+}
+
+async function chooseLocalProjectDirectory(): Promise<string | null> {
+  const options: Electron.OpenDialogOptions = {
+    title: "Choose local project directory",
+    properties: ["openDirectory", "createDirectory"],
+  };
+  const result = mainWindow ? await dialog.showOpenDialog(mainWindow, options) : await dialog.showOpenDialog(options);
+  if (result.canceled) return null;
+  return result.filePaths[0] ?? null;
 }
 
 function getPreferredWindowBounds(): { width: number; height: number; x: number; y: number } {
@@ -1467,6 +1565,18 @@ function registerIpc(): void {
   ipcMain.handle("skills:sync-copy-setup-sql", () => {
     clipboard.writeText(buildSkillSyncSetupSql());
   });
+  ipcMain.handle("remote-session:status", () => getRemoteSessionStatus());
+  ipcMain.handle("remote-session:copy-setup-sql", () => {
+    clipboard.writeText(buildRemoteSessionSetupSql());
+  });
+  ipcMain.handle("remote-session:upload", (_event, sessionKey: string) => uploadSessionToRemote(sessionKey));
+  ipcMain.handle("remote-session:list", (_event, query?: string) => listRemoteSessions(query ?? ""));
+  ipcMain.handle("remote-session:detail", (_event, remoteId: string) => getRemoteSessionDetail(remoteId));
+  ipcMain.handle("remote-session:choose-project", () => chooseLocalProjectDirectory());
+  ipcMain.handle("remote-session:restore", (event, remoteId: string, target: MigrationAgent, localProjectPath: string) =>
+    restoreRemoteSession(event, remoteId, target, localProjectPath),
+  );
+  ipcMain.handle("remote-session:delete", (_event, remoteId: string) => createRemoteSessionClient().deleteRemoteSession(remoteId));
   ipcMain.handle("skills:copy-path", (_event, skillPath: string) => {
     clipboard.writeText(skillPath);
   });

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -7,6 +7,12 @@ import type { ApplyCodexProfileResult } from "../core/codex-profile";
 import type { AppSettings, AppSettingsUpdate } from "../core/platform";
 import type { IndexStatus } from "../core/indexer";
 import type { RemoteHealthReport } from "../core/remote-health";
+import type {
+  RemoteSessionDetailSnapshot,
+  RemoteSessionListItem,
+  RemoteSessionStatus,
+  RemoteSessionUploadResult,
+} from "../core/remote-session-sync";
 import type { ResumeRouteResult } from "../core/resume-router";
 import type { TraceEventQueryOptions } from "../core/session-store";
 import type { RemoteSkill, SkillSyncInstallResult, SkillSyncSnapshot, SkillSyncUploadOutcome } from "../core/skill-sync";
@@ -94,6 +100,15 @@ const api = {
   installSyncedSkill: (remoteSkillId: string): Promise<SkillSyncInstallResult> => ipcRenderer.invoke("skills:sync-install", remoteSkillId),
   getSyncedSkillVersion: (remoteSkillId: string): Promise<RemoteSkill> => ipcRenderer.invoke("skills:sync-get-version", remoteSkillId),
   copySkillSyncSetupSql: (): Promise<void> => ipcRenderer.invoke("skills:sync-copy-setup-sql"),
+  getRemoteSessionStatus: (): Promise<RemoteSessionStatus> => ipcRenderer.invoke("remote-session:status"),
+  copyRemoteSessionSetupSql: (): Promise<void> => ipcRenderer.invoke("remote-session:copy-setup-sql"),
+  uploadRemoteSession: (sessionKey: string): Promise<RemoteSessionUploadResult> => ipcRenderer.invoke("remote-session:upload", sessionKey),
+  listRemoteSessions: (query?: string): Promise<RemoteSessionListItem[]> => ipcRenderer.invoke("remote-session:list", query),
+  getRemoteSessionDetail: (remoteId: string): Promise<RemoteSessionDetailSnapshot> => ipcRenderer.invoke("remote-session:detail", remoteId),
+  chooseRemoteRestoreProject: (): Promise<string | null> => ipcRenderer.invoke("remote-session:choose-project"),
+  restoreRemoteSession: (remoteId: string, target: MigrationAgent, localProjectPath: string): Promise<SessionMigrationResult> =>
+    ipcRenderer.invoke("remote-session:restore", remoteId, target, localProjectPath),
+  deleteRemoteSession: (remoteId: string): Promise<boolean> => ipcRenderer.invoke("remote-session:delete", remoteId),
   copySkillPath: (skillPath: string): Promise<void> => ipcRenderer.invoke("skills:copy-path", skillPath),
   revealSkill: (targetPath: string): Promise<void> => ipcRenderer.invoke("skills:reveal", targetPath),
   deleteSkill: (skillPath: string): Promise<DeleteInstalledSkillResult> => ipcRenderer.invoke("skills:delete", skillPath),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -8,6 +8,7 @@ import {
   ChevronDown,
   ChevronRight,
   Clipboard,
+  Cloud,
   Code2,
   Copy,
   Download,
@@ -46,6 +47,7 @@ import { formatRelativeTime } from "../../core/format-session";
 import { QUOTA_REFRESH_INTERVAL_MS } from "../../core/refresh-policy";
 import type { AppSettings, AppSettingsUpdate } from "../../core/platform";
 import type { RemoteHealthReport } from "../../core/remote-health";
+import type { RemoteSessionDetailSnapshot } from "../../core/remote-session-sync";
 import type { TraceEventQueryOptions } from "../../core/session-store";
 import type { RemoteSkill, SkillSyncSnapshot, SkillSyncUploadOutcome } from "../../core/skill-sync";
 import type { InstalledSkill, InstalledSkillsSnapshot } from "../../core/skill-manager";
@@ -105,6 +107,7 @@ import { SessionMigrationDialog, SessionMigrationLaunchFailedDialog } from "./co
 import { CommandDialog, DeleteSessionDialog, DeleteTagDialog } from "./components/session-dialogs";
 import { SkillsDialog } from "./components/skills-dialog";
 import { AiAssistantDialog } from "./components/ai-assistant-dialog";
+import { RemoteSessionsDialog } from "./components/remote-sessions-dialog";
 import { useClampedContextMenuStyle } from "./context-menu-position";
 import {
   SOURCE_LABEL,
@@ -401,6 +404,7 @@ export function App(): ReactElement {
   const [indexStatus, setIndexStatus] = useState<IndexStatus | null>(null);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [detail, setDetail] = useState<SessionSearchResult | null>(null);
+  const [remoteDetail, setRemoteDetail] = useState<{ snapshot: RemoteSessionDetailSnapshot; query: string } | null>(null);
   const [messages, setMessages] = useState<SessionMessage[]>([]);
   const [messageOffset, setMessageOffset] = useState(0);
   const [traceEvents, setTraceEvents] = useState<SessionTraceEvent[]>([]);
@@ -420,6 +424,7 @@ export function App(): ReactElement {
   const [skillsOpen, setSkillsOpen] = useState(false);
   const [apiConfigOpen, setApiConfigOpen] = useState(false);
   const [aiAssistantOpen, setAiAssistantOpen] = useState(false);
+  const [remoteSessionsOpen, setRemoteSessionsOpen] = useState(false);
   const [installedSkills, setInstalledSkills] = useState<InstalledSkillsSnapshot>(EMPTY_SKILLS);
   const [skillSyncSnapshot, setSkillSyncSnapshot] = useState<SkillSyncSnapshot>(EMPTY_SKILL_SYNC);
   const [skillsLoading, setSkillsLoading] = useState(false);
@@ -881,14 +886,16 @@ export function App(): ReactElement {
         else if (apiConfigOpen) setApiConfigOpen(false);
         else if (aiAssistantOpen) setAiAssistantOpen(false);
         else if (settingsOpen) setSettingsOpen(false);
+        else if (remoteSessionsOpen) setRemoteSessionsOpen(false);
         else if (detail) closeDetail();
+        else if (remoteDetail) setRemoteDetail(null);
         else return;
         event.preventDefault();
         return;
       }
 
       // Leave list navigation alone while an overlay or menu is in front.
-      if (detail || dialog || migrationDialog || deleteSessionCandidate || deleteTagName || contextMenu || skillsOpen || apiConfigOpen || settingsOpen || sshDialogOpen) return;
+      if (detail || remoteDetail || dialog || migrationDialog || deleteSessionCandidate || deleteTagName || contextMenu || skillsOpen || apiConfigOpen || aiAssistantOpen || settingsOpen || sshDialogOpen || remoteSessionsOpen) return;
 
       if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
         event.preventDefault();
@@ -928,7 +935,7 @@ export function App(): ReactElement {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [displayedResults, selectedKey, detail, dialog, migrationDialog, deleteSessionCandidate, deletingSession, deleteTagName, contextMenu, skillsOpen, apiConfigOpen, aiAssistantOpen, settingsOpen, sshDialogOpen, actionStatus, t]);
+  }, [displayedResults, selectedKey, detail, remoteDetail, dialog, migrationDialog, deleteSessionCandidate, deletingSession, deleteTagName, contextMenu, skillsOpen, apiConfigOpen, aiAssistantOpen, settingsOpen, sshDialogOpen, remoteSessionsOpen, actionStatus, t]);
 
   useEffect(() => {
     if (!selectedKey) return;
@@ -936,9 +943,9 @@ export function App(): ReactElement {
   }, [selectedKey]);
 
   useEffect(() => {
-    document.body.classList.toggle("overlay-open", Boolean(detail || skillsOpen || apiConfigOpen || aiAssistantOpen || settingsOpen || sshDialogOpen));
+    document.body.classList.toggle("overlay-open", Boolean(detail || remoteDetail || skillsOpen || apiConfigOpen || aiAssistantOpen || settingsOpen || sshDialogOpen || remoteSessionsOpen));
     return () => document.body.classList.remove("overlay-open");
-  }, [detail, skillsOpen, apiConfigOpen, aiAssistantOpen, settingsOpen, sshDialogOpen]);
+  }, [detail, remoteDetail, skillsOpen, apiConfigOpen, aiAssistantOpen, settingsOpen, sshDialogOpen, remoteSessionsOpen]);
 
   const visibleSourceFilters = useMemo(() => {
     if (!appSettings) return sourceFilters(null);
@@ -998,6 +1005,7 @@ export function App(): ReactElement {
   async function openDetail(session: SessionSearchResult): Promise<void> {
     const requestId = ++detailLoadSeqRef.current;
     setContextMenu(null);
+    setRemoteDetail(null);
     setDetail(session);
     setMessages([]);
     setMessageOffset(0);
@@ -1039,6 +1047,17 @@ export function App(): ReactElement {
     setMessageOffset(0);
     setTraceEvents([]);
     setMessagesLoading(false);
+  }
+
+  function openRemoteDetail(snapshot: RemoteSessionDetailSnapshot, detailQuery: string): void {
+    detailLoadSeqRef.current++;
+    setDetail(null);
+    setMessages([]);
+    setMessageOffset(0);
+    setTraceEvents([]);
+    setMessagesLoading(false);
+    setRemoteSessionsOpen(false);
+    setRemoteDetail({ snapshot, query: detailQuery });
   }
 
   async function loadMoreMessages(): Promise<void> {
@@ -1202,6 +1221,18 @@ export function App(): ReactElement {
     } catch (error) {
       setActionStatus({ kind: "error", message: error instanceof Error ? error.message : String(error) });
     }
+  }
+
+  async function uploadRemoteSession(session: SessionSearchResult): Promise<void> {
+    await runAction(
+      t("Uploading remote session", "正在上传远程会话"),
+      () => window.sessionSearch.uploadRemoteSession(session.sessionKey),
+      (result) => {
+        if (result.status === "skipped") return t("Remote session is already up to date.", "远程会话已是最新。");
+        if (result.status === "updated") return t("Remote session updated.", "远程会话已更新。");
+        return t("Remote session uploaded.", "远程会话已上传。");
+      },
+    );
   }
 
   async function exportMarkdown(sessionKey: string): Promise<void> {
@@ -1723,6 +1754,7 @@ export function App(): ReactElement {
                 setSettingsOpen(false);
                 setApiConfigOpen(false);
                 setSkillsOpen(false);
+                setRemoteSessionsOpen(false);
                 setAiAssistantOpen(true);
               }}
               title={t("AI session finder", "AI 找会话")}
@@ -1735,6 +1767,7 @@ export function App(): ReactElement {
               onClick={() => {
                 setSettingsOpen(false);
                 setApiConfigOpen(false);
+                setRemoteSessionsOpen(false);
                 setSkillsOpen(true);
               }}
               title={t("Skills", "Skills 管理")}
@@ -1743,10 +1776,24 @@ export function App(): ReactElement {
               <PackageSearch size={15} />
             </button>
             <button
+              className={`icon-button toolbar-icon-button ${remoteSessionsOpen ? "active" : ""}`}
+              onClick={() => {
+                setSettingsOpen(false);
+                setApiConfigOpen(false);
+                setSkillsOpen(false);
+                setRemoteSessionsOpen(true);
+              }}
+              title={t("Remote sessions", "远程会话")}
+              aria-label={t("Remote sessions", "远程会话")}
+            >
+              <Cloud size={15} />
+            </button>
+            <button
               className={`icon-button toolbar-icon-button ${apiConfigOpen ? "active" : ""}`}
               onClick={() => {
                 setSkillsOpen(false);
                 setSettingsOpen(false);
+                setRemoteSessionsOpen(false);
                 setApiConfigOpen(true);
               }}
               title={t("API configuration", "API 配置")}
@@ -1759,6 +1806,7 @@ export function App(): ReactElement {
               onClick={() => {
                 setSkillsOpen(false);
                 setApiConfigOpen(false);
+                setRemoteSessionsOpen(false);
                 setSettingsOpen(true);
               }}
               title={t("Settings", "设置")}
@@ -1840,6 +1888,7 @@ export function App(): ReactElement {
             void runAction(t("Opening iTerm", "正在打开 iTerm"), () => window.sessionSearch.resumeSessionInIterm(detail.sessionKey), t("Resume command sent to iTerm.", "Resume 命令已发送到 iTerm。"))
           }
           onMigrate={() => beginMigrate(detail)}
+          onUploadRemote={() => void uploadRemoteSession(detail)}
           onCopyResume={() =>
             void runAction(t("Copying resume command", "正在复制 Resume 命令"), () => window.sessionSearch.copyResumeCommand(detail.sessionKey), t("Resume command copied.", "Resume 命令已复制。"))
           }
@@ -1858,6 +1907,44 @@ export function App(): ReactElement {
               `${FILE_MANAGER_LABEL} opened.`,
             )
           }
+        />
+      ) : null}
+
+      {remoteDetail ? (
+        <DetailPanel
+          session={remoteDetail.snapshot.session}
+          messages={remoteDetail.snapshot.messages}
+          traceEvents={remoteDetail.snapshot.traceEvents}
+          loading={false}
+          actionStatus={null}
+          query={remoteDetail.query}
+          liveState="closed"
+          language={language}
+          messagePageSize={MESSAGE_PAGE_SIZE}
+          olderMessageCount={0}
+          revealLabel={FILE_MANAGER_LABEL}
+          showItermAction={false}
+          onClose={() => setRemoteDetail(null)}
+          onShowMore={() => undefined}
+          onRename={() => undefined}
+          onAddTag={() => undefined}
+          onRemoveTag={() => undefined}
+          onFavorite={() => undefined}
+          onSummarize={() => undefined}
+          summarizing={false}
+          canResume={false}
+          canMigrate={false}
+          migrationTitle={t("Use Restore from the remote session list.", "请从远程会话列表点击恢复。")}
+          onResume={() => undefined}
+          onResumeIterm={() => undefined}
+          onMigrate={() => undefined}
+          onCopyResume={() => undefined}
+          onCopyMarkdown={() => undefined}
+          onExportMarkdown={() => undefined}
+          onCopyPlain={() => undefined}
+          onDelete={() => undefined}
+          onReveal={() => undefined}
+          readOnly
         />
       ) : null}
 
@@ -2006,6 +2093,10 @@ export function App(): ReactElement {
             setSettingsOpen(false);
             setApiConfigOpen(true);
           }}
+          onOpenRemoteSessions={() => {
+            setSettingsOpen(false);
+            setRemoteSessionsOpen(true);
+          }}
           onClose={() => setSettingsOpen(false)}
         />
       ) : null}
@@ -2042,6 +2133,18 @@ export function App(): ReactElement {
           }
           onDelete={(skill) => deleteSkill(skill)}
           onClose={() => setSkillsOpen(false)}
+        />
+      ) : null}
+
+      {remoteSessionsOpen ? (
+        <RemoteSessionsDialog
+          language={language}
+          onRestored={(result) => {
+            if (!result.launched) setActionStatus({ kind: "error", message: result.warning || result.resumeCommand });
+            void Promise.all([load(), loadSidebarMetadata()]);
+          }}
+          onOpenDetail={openRemoteDetail}
+          onClose={() => setRemoteSessionsOpen(false)}
         />
       ) : null}
 
@@ -2436,6 +2539,7 @@ function SettingsDialog({
   onDeleteEnvironment,
   onAddSsh,
   onOpenApiConfig,
+  onOpenRemoteSessions,
   onClose,
 }: {
   settings: AppSettings | null;
@@ -2458,6 +2562,7 @@ function SettingsDialog({
   onDeleteEnvironment: (environment: SessionEnvironment) => void;
   onAddSsh: () => void;
   onOpenApiConfig: () => void;
+  onOpenRemoteSessions: () => void;
   onClose: () => void;
 }): ReactElement {
   const defaultTerminal = settings?.defaultTerminal ?? (RUNTIME_PLATFORM === "win32" ? "WindowsTerminal" : "Terminal");
@@ -2515,7 +2620,7 @@ function SettingsDialog({
     }
   }
   const l = (en: string, zh: string) => localize(language, en, zh);
-  const [activeSection, setActiveSection] = useState<"terminal" | "shortcut" | "connections" | "sources" | "usage" | "ai" | "skills" | "appearance">("terminal");
+  const [activeSection, setActiveSection] = useState<"terminal" | "shortcut" | "connections" | "sources" | "usage" | "ai" | "remote" | "skills" | "appearance">("terminal");
 
   return (
     <div className="dialog-backdrop" onMouseDown={onClose}>
@@ -2551,6 +2656,10 @@ function SettingsDialog({
             <button className={activeSection === "ai" ? "active" : ""} onClick={() => setActiveSection("ai")}>
               <Sparkles size={15} />
               <span>{l("AI", "AI")}</span>
+            </button>
+            <button className={activeSection === "remote" ? "active" : ""} onClick={() => setActiveSection("remote")}>
+              <Cloud size={15} />
+              <span>{l("Remote sync", "远程同步")}</span>
             </button>
             <button className={activeSection === "skills" ? "active" : ""} onClick={() => setActiveSection("skills")}>
               <PackageSearch size={15} />
@@ -2976,6 +3085,67 @@ function SettingsDialog({
                     checked={Boolean(mcpEnabled)}
                     disabled={mcpEnabled === null || mcpBusy}
                     onChange={(event) => void toggleMcp(event.currentTarget.checked)}
+                  />
+                </label>
+              </section>
+            ) : null}
+            {activeSection === "remote" ? (
+              <section className="settings-pane">
+                <header className="settings-pane-head settings-pane-head-row">
+                  <div>
+                    <h3>{l("Supabase remote sessions", "Supabase 远程会话")}</h3>
+                    <p>
+                      {l(
+                        "Use your own single-user Supabase project to upload sessions, search them on another device, view details, and restore them to Claude Code / Codex / CodeBuddy.",
+                        "使用你自己的单人 Supabase 项目上传会话，在另一台设备搜索、查看详情，并恢复到 Claude Code / Codex / CodeBuddy。",
+                      )}
+                    </p>
+                  </div>
+                  <button type="button" className="settings-action-button" onClick={onOpenRemoteSessions}>
+                    {l("Remote Sessions", "远程会话")}
+                  </button>
+                </header>
+                <label className="settings-field settings-toggle">
+                  <div className="settings-field-text">
+                    <span className="settings-field-title">{l("Enable remote session sync", "启用远程会话同步")}</span>
+                    <span className="settings-field-sub">
+                      {l("Manual upload and restore in this version. Automatic background sync comes later.", "当前版本为手动上传和恢复；后台自动同步后续再做。")}
+                    </span>
+                  </div>
+                  <input
+                    type="checkbox"
+                    className="switch"
+                    checked={Boolean(settings?.remoteSyncEnabled)}
+                    disabled={!settings || saving}
+                    onChange={(event) => onSettingsChange({ remoteSyncEnabled: event.currentTarget.checked })}
+                  />
+                </label>
+                <label className="settings-field remote-sync-field">
+                  <div className="settings-field-text">
+                    <span className="settings-field-title">Supabase URL</span>
+                    <span className="settings-field-sub">https://your-project.supabase.co</span>
+                  </div>
+                  <input
+                    type="text"
+                    value={settings?.remoteSyncSupabaseUrl ?? ""}
+                    disabled={!settings || saving}
+                    placeholder="https://your-project.supabase.co"
+                    onChange={(event) => onSettingsChange({ remoteSyncSupabaseUrl: event.currentTarget.value })}
+                  />
+                </label>
+                <label className="settings-field remote-sync-field">
+                  <div className="settings-field-text">
+                    <span className="settings-field-title">anon key</span>
+                    <span className="settings-field-sub">
+                      {l("Stored locally. Do not commit this value to the repository.", "保存在本地，请不要提交到仓库。")}
+                    </span>
+                  </div>
+                  <input
+                    type="password"
+                    value={settings?.remoteSyncSupabaseAnonKey ?? ""}
+                    disabled={!settings || saving}
+                    placeholder="eyJhbGciOi..."
+                    onChange={(event) => onSettingsChange({ remoteSyncSupabaseAnonKey: event.currentTarget.value })}
                   />
                 </label>
               </section>

--- a/src/renderer/src/components/detail-panel.tsx
+++ b/src/renderer/src/components/detail-panel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from "react";
 import type { ReactElement } from "react";
-import { ArrowRightLeft, Copy, Download, Edit3, FolderOpen, Laptop, Play, Server, Sparkles, Star, Tag, Terminal as TerminalIcon, Trash2, X } from "lucide-react";
+import { ArrowRightLeft, CloudUpload, Copy, Download, Edit3, FolderOpen, Laptop, Play, Server, Sparkles, Star, Tag, Terminal as TerminalIcon, Trash2, X } from "lucide-react";
 import { formatMessageTime } from "../../../core/format-session";
 import type { SessionMessage, SessionSearchResult, SessionTraceEvent } from "../../../core/types";
 import { formatTokenCount } from "../format-count";
@@ -94,12 +94,14 @@ export function DetailPanel({
   onResume,
   onResumeIterm,
   onMigrate,
+  onUploadRemote,
   onCopyResume,
   onCopyMarkdown,
   onExportMarkdown,
   onCopyPlain,
   onDelete,
   onReveal,
+  readOnly = false,
 }: {
   session: SessionSearchResult;
   messages: SessionMessage[];
@@ -127,12 +129,14 @@ export function DetailPanel({
   onResume: () => void;
   onResumeIterm: () => void;
   onMigrate: () => void;
+  onUploadRemote?: () => void;
   onCopyResume: () => void;
   onCopyMarkdown: () => void;
   onExportMarkdown: () => void;
   onCopyPlain: () => void;
   onDelete: () => void;
   onReveal: () => void;
+  readOnly?: boolean;
 }): ReactElement {
   const matchIndex = query
     ? messages.findIndex((message) => message.content.toLowerCase().includes(query.toLowerCase()))
@@ -216,9 +220,11 @@ export function DetailPanel({
             </div>
             <div className="detail-title-row">
               <h2>{session.displayTitle}</h2>
-              <button className="title-edit-button detail-title-edit" onClick={onRename} aria-label={l("Rename session", "重命名会话")} title={l("Rename session", "重命名会话")}>
-                <Edit3 size={14} />
-              </button>
+              {!readOnly ? (
+                <button className="title-edit-button detail-title-edit" onClick={onRename} aria-label={l("Rename session", "重命名会话")} title={l("Rename session", "重命名会话")}>
+                  <Edit3 size={14} />
+                </button>
+              ) : null}
             </div>
             <p>
               {session.projectPath || l("No project", "无项目")} · {new Date(session.timestamp).toLocaleString()} · {l(`${messages.length} messages`, `${messages.length} 条消息`)} ·{" "}
@@ -227,20 +233,22 @@ export function DetailPanel({
             </p>
           </div>
           <div className="detail-header-actions">
-            <button
-              className={`icon-button favorite-button ${session.favorited ? "active" : ""}`}
-              onClick={onFavorite}
-              aria-label={session.favorited ? l("Remove from favorites", "取消收藏") : l("Add to favorites", "加入收藏")}
-              title={session.favorited ? l("Remove from favorites", "取消收藏") : l("Add to favorites", "加入收藏")}
-            >
-              <Star size={17} fill={session.favorited ? "currentColor" : "none"} />
-            </button>
+            {!readOnly ? (
+              <button
+                className={`icon-button favorite-button ${session.favorited ? "active" : ""}`}
+                onClick={onFavorite}
+                aria-label={session.favorited ? l("Remove from favorites", "取消收藏") : l("Add to favorites", "加入收藏")}
+                title={session.favorited ? l("Remove from favorites", "取消收藏") : l("Add to favorites", "加入收藏")}
+              >
+                <Star size={17} fill={session.favorited ? "currentColor" : "none"} />
+              </button>
+            ) : null}
             <button className="icon-button" onClick={onClose} aria-label={l("Close", "关闭")}>
               <X size={17} />
             </button>
           </div>
         </div>
-        <div className="detail-actions">
+        {!readOnly ? <div className="detail-actions">
           {canResume ? (
             <button onClick={onResume} disabled={actionRunning}>
               <Play size={15} /> Resume
@@ -265,6 +273,11 @@ export function DetailPanel({
           <button onClick={onMigrate} disabled={actionRunning || !canMigrate} title={migrationTitle}>
             <ArrowRightLeft size={15} /> {l("Migrate to…", "迁移到…")}
           </button>
+          {onUploadRemote ? (
+            <button onClick={onUploadRemote} disabled={actionRunning}>
+              <CloudUpload size={15} /> {l("Upload", "上传")}
+            </button>
+          ) : null}
           {canResume ? (
             <button onClick={onCopyResume} disabled={actionRunning}>
               <Copy size={15} /> {l("Copy Cmd", "复制命令")}
@@ -281,7 +294,7 @@ export function DetailPanel({
           <button onClick={onReveal} disabled={actionRunning || localOnlyDisabled} title={revealTitle}>
             <FolderOpen size={15} /> {revealLabel}
           </button>
-        </div>
+        </div> : null}
         {session.aiSummary ? (
           <div className="detail-summary">
             <span className="detail-summary-label">
@@ -293,7 +306,7 @@ export function DetailPanel({
         ) : null}
         <div className="detail-tags">
           {session.tags.map((tagName) => (
-            <button key={tagName} className={`chip ${isBranchTag(tagName) ? "branch-tag" : ""}`} onClick={() => onRemoveTag(tagName)}>
+            <button key={tagName} className={`chip ${isBranchTag(tagName) ? "branch-tag" : ""}`} onClick={() => onRemoveTag(tagName)} disabled={readOnly}>
               #{tagName} ×
             </button>
           ))}

--- a/src/renderer/src/components/remote-sessions-dialog.tsx
+++ b/src/renderer/src/components/remote-sessions-dialog.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useMemo, useState } from "react";
+import type { ReactElement } from "react";
+import { ArrowRightLeft, Cloud, Database, FolderOpen, RefreshCw, Search, Trash2, X } from "lucide-react";
+import type { RemoteSessionDetailSnapshot, RemoteSessionListItem, RemoteSessionStatus } from "../../../core/remote-session-sync";
+import type { MigrationAgent, SessionMigrationResult } from "../../../core/types";
+import { formatRelativeTime } from "../../../core/format-session";
+import { localize, type LanguageMode } from "../language";
+import { migrationAgentLabel, SOURCE_LABEL, sourceUiFamily } from "../session-ui";
+import type { ActionStatus } from "../app-types";
+
+const RESTORE_TARGETS: MigrationAgent[] = ["claude", "codex", "codebuddy"];
+type RemoteSourceFilter = "all" | MigrationAgent;
+const SOURCE_FILTERS: RemoteSourceFilter[] = ["all", ...RESTORE_TARGETS];
+
+export function RemoteSessionsDialog({
+  language,
+  onClose,
+  onRestored,
+  onOpenDetail,
+}: {
+  language: LanguageMode;
+  onClose: () => void;
+  onRestored: (result: SessionMigrationResult) => void;
+  onOpenDetail: (detail: RemoteSessionDetailSnapshot, query: string) => void;
+}): ReactElement {
+  const l = (en: string, zh: string) => localize(language, en, zh);
+  const [status, setStatus] = useState<RemoteSessionStatus | null>(null);
+  const [sessions, setSessions] = useState<RemoteSessionListItem[]>([]);
+  const [query, setQuery] = useState("");
+  const [sourceFilter, setSourceFilter] = useState<RemoteSourceFilter>("all");
+  const [loading, setLoading] = useState(true);
+  const [feedback, setFeedback] = useState<ActionStatus | null>(null);
+  const [detailLoadingId, setDetailLoadingId] = useState<string | null>(null);
+  const [restoreTarget, setRestoreTarget] = useState<MigrationAgent>("claude");
+  const [localProjectPath, setLocalProjectPath] = useState("");
+  const [restoringId, setRestoringId] = useState<string | null>(null);
+
+  const filtered = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    return sessions.filter((session) => {
+      if (sourceFilter !== "all" && session.sourceAgent !== sourceFilter) return false;
+      if (!normalized) return true;
+      return [session.title, session.projectPath, session.aiSummary ?? "", session.tags.join(" "), session.searchText]
+        .join("\n")
+        .toLowerCase()
+        .includes(normalized);
+    });
+  }, [query, sessions, sourceFilter]);
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  async function refresh(): Promise<void> {
+    setLoading(true);
+    try {
+      const nextStatus = await window.sessionSearch.getRemoteSessionStatus();
+      setStatus(nextStatus);
+      if (nextStatus.kind === "ready") {
+        setSessions(await window.sessionSearch.listRemoteSessions(""));
+        setFeedback(null);
+      } else {
+        setSessions([]);
+        setFeedback({ kind: nextStatus.kind === "error" ? "error" : "success", message: nextStatus.message });
+      }
+    } catch (error) {
+      setSessions([]);
+      setStatus(null);
+      setFeedback({ kind: "error", message: error instanceof Error ? error.message : String(error) });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function copySetupSql(): Promise<void> {
+    try {
+      await window.sessionSearch.copyRemoteSessionSetupSql();
+      setFeedback({ kind: "success", message: l("Supabase setup SQL copied.", "Supabase 初始化 SQL 已复制。") });
+    } catch (error) {
+      setFeedback({ kind: "error", message: error instanceof Error ? error.message : String(error) });
+    }
+  }
+
+  async function openDetail(remote: RemoteSessionListItem): Promise<void> {
+    setDetailLoadingId(remote.id);
+    try {
+      onOpenDetail(await window.sessionSearch.getRemoteSessionDetail(remote.id), query);
+      setFeedback(null);
+    } catch (error) {
+      setFeedback({ kind: "error", message: error instanceof Error ? error.message : String(error) });
+    } finally {
+      setDetailLoadingId(null);
+    }
+  }
+
+  async function chooseProject(): Promise<void> {
+    const selected = await window.sessionSearch.chooseRemoteRestoreProject();
+    if (selected) setLocalProjectPath(selected);
+  }
+
+  async function restore(remote: RemoteSessionListItem): Promise<void> {
+    let projectPath = localProjectPath.trim();
+    if (!projectPath) {
+      const selected = await window.sessionSearch.chooseRemoteRestoreProject();
+      if (!selected) return;
+      projectPath = selected;
+      setLocalProjectPath(selected);
+    }
+    setRestoringId(remote.id);
+    setFeedback({ kind: "running", message: l("Restoring remote session...", "正在恢复远程会话...") });
+    try {
+      const result = await window.sessionSearch.restoreRemoteSession(remote.id, restoreTarget, projectPath);
+      onRestored(result);
+      const message = l(`Restored to ${migrationAgentLabel(result.target)}.`, `已恢复到 ${migrationAgentLabel(result.target)}。`);
+      setFeedback({ kind: "success", message });
+    } catch (error) {
+      setFeedback({ kind: "error", message: error instanceof Error ? error.message : String(error) });
+    } finally {
+      setRestoringId(null);
+    }
+  }
+
+  async function deleteRemote(remote: RemoteSessionListItem): Promise<void> {
+    setFeedback({ kind: "running", message: l("Deleting remote session...", "正在删除远程会话...") });
+    try {
+      await window.sessionSearch.deleteRemoteSession(remote.id);
+      setSessions((current) => current.filter((item) => item.id !== remote.id));
+      setFeedback({ kind: "success", message: l("Remote session deleted.", "远程会话已删除。") });
+    } catch (error) {
+      setFeedback({ kind: "error", message: error instanceof Error ? error.message : String(error) });
+    }
+  }
+
+  return (
+    <div className="dialog-backdrop" onMouseDown={onClose}>
+      <section className="command-dialog remote-sessions-dialog" onMouseDown={(event) => event.stopPropagation()}>
+        <div className="dialog-title">
+          <span>{l("Remote Sessions", "远程会话")}</span>
+          <button type="button" className="icon-button" onClick={onClose} aria-label={l("Close", "关闭")}>
+            <X size={16} />
+          </button>
+        </div>
+        <div className="remote-sessions-toolbar">
+          <div className="remote-search">
+            <Search size={15} />
+            <input value={query} onChange={(event) => setQuery(event.currentTarget.value)} placeholder={l("Search remote sessions", "搜索远程会话")} />
+          </div>
+          <div className="remote-filter-group" role="group" aria-label={l("Source filter", "来源筛选")}>
+            <span>{l("Source", "来源")}</span>
+            <div className="remote-targets compact">
+              {SOURCE_FILTERS.map((source) => (
+                <button key={source} type="button" className={sourceFilter === source ? "active" : ""} onClick={() => setSourceFilter(source)}>
+                  {source === "all" ? l("All", "全部") : migrationAgentLabel(source)}
+                </button>
+              ))}
+            </div>
+          </div>
+          <button type="button" className="settings-action-button" onClick={() => void refresh()} disabled={loading}>
+            <RefreshCw size={14} />
+            <span>{l("Refresh", "刷新")}</span>
+          </button>
+          <button type="button" className="settings-action-button" onClick={() => void copySetupSql()}>
+            <Database size={14} />
+            <span>{l("Copy SQL", "复制 SQL")}</span>
+          </button>
+        </div>
+        <div className="remote-restore-bar">
+          <div className="remote-filter-group" role="group" aria-label={l("Restore target", "恢复目标")}>
+            <span>{l("Restore to", "恢复到")}</span>
+            <div className="remote-targets">
+              {RESTORE_TARGETS.map((target) => (
+                <button key={target} type="button" className={restoreTarget === target ? "active" : ""} onClick={() => setRestoreTarget(target)}>
+                  {migrationAgentLabel(target)}
+                </button>
+              ))}
+            </div>
+          </div>
+          <button type="button" className="settings-action-button" onClick={() => void chooseProject()}>
+            <FolderOpen size={14} />
+            <span>{localProjectPath || l("Choose project", "选择项目")}</span>
+          </button>
+        </div>
+        {feedback ? <div className={`settings-feedback inline ${feedback.kind}`}>{feedback.message}</div> : null}
+        <div className="remote-session-list">
+          {loading ? <div className="remote-empty">{l("Loading remote sessions...", "正在加载远程会话...")}</div> : null}
+          {!loading && status?.kind !== "ready" ? (
+            <div className="remote-empty">
+              <Cloud size={18} />
+              <span>{status?.message ?? l("Remote sync is not configured.", "远程同步未配置。")}</span>
+            </div>
+          ) : null}
+          {!loading && status?.kind === "ready" && filtered.length === 0 ? <div className="remote-empty">{l("No remote sessions found.", "没有找到远程会话。")}</div> : null}
+          {filtered.map((remote) => (
+            <article key={remote.id} className="remote-session-row">
+              <div className="remote-session-main">
+                <strong>{remote.title}</strong>
+                <div className="session-meta">
+                  <span className={`source-badge ${sourceUiFamily(remote.sourceSource as never)}`}>
+                    {SOURCE_LABEL[remote.sourceSource as keyof typeof SOURCE_LABEL] ?? remote.sourceAgent}
+                  </span>
+                  <span>{remote.projectPath || l("No project path", "无项目路径")}</span>
+                  <span>{formatRelativeTime(remote.updatedAt)}</span>
+                  <span>{l(`${remote.messageCount} messages`, `${remote.messageCount} 条消息`)}</span>
+                  {remote.traceEventCount > 0 ? <span>{l(`${remote.traceEventCount} trace events`, `${remote.traceEventCount} 条轨迹`)}</span> : null}
+                </div>
+                {remote.aiSummary ? <p>{remote.aiSummary}</p> : null}
+                {remote.tags.length > 0 ? (
+                  <div className="row-tags">
+                    {remote.tags.slice(0, 5).map((tag) => (
+                      <span key={tag}>#{tag}</span>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+              <div className="remote-session-actions">
+                <button type="button" onClick={() => void openDetail(remote)} disabled={detailLoadingId === remote.id || restoringId === remote.id}>
+                  {detailLoadingId === remote.id ? l("Loading...", "加载中...") : l("View", "查看")}
+                </button>
+                <button type="button" onClick={() => void restore(remote)} disabled={restoringId === remote.id}>
+                  <ArrowRightLeft size={14} />
+                  {restoringId === remote.id ? l("Restoring...", "恢复中...") : l("Restore", "恢复")}
+                </button>
+                <button type="button" className="icon-button danger" onClick={() => void deleteRemote(remote)} disabled={restoringId === remote.id} aria-label={l("Delete remote session", "删除远程会话")}>
+                  <Trash2 size={14} />
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -3026,6 +3026,17 @@ select:focus-visible {
   min-width: 0;
 }
 
+.remote-sync-field {
+  display: grid;
+  grid-template-columns: minmax(160px, 220px) minmax(0, 1fr);
+  align-items: center;
+}
+
+.remote-sync-field input {
+  width: 100%;
+  min-width: 0;
+}
+
 /* A single card that stacks a toggle row with a dependent sub-row (e.g. its threshold). */
 .settings-field.settings-stack {
   flex-direction: column;
@@ -3650,6 +3661,11 @@ select:focus-visible {
     align-items: stretch;
   }
 
+  .remote-sync-field {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: stretch;
+  }
+
   .api-settings-form .settings-field {
     grid-template-columns: minmax(0, 1fr);
     align-items: stretch;
@@ -4256,4 +4272,210 @@ body.overlay-open .sidebar {
 .ai-assistant-send:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+.remote-sessions-dialog {
+  width: min(980px, calc(100vw - 48px));
+  max-height: min(760px, calc(100vh - 48px));
+}
+
+.remote-sessions-toolbar,
+.remote-restore-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.remote-sessions-toolbar {
+  flex-wrap: wrap;
+}
+
+.remote-search {
+  flex: 1 1 260px;
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  min-width: 0;
+  height: 38px;
+  padding: 0 11px;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  background: var(--panel-bg);
+  color: var(--text-muted);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.remote-search:focus-within {
+  border-color: var(--accent-line);
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+
+.remote-search svg {
+  flex: 0 0 auto;
+  color: var(--text-faint);
+}
+
+.remote-search:focus-within svg {
+  color: var(--accent);
+}
+
+.remote-search input {
+  flex: 1;
+  width: auto;
+  min-width: 0;
+  height: auto;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  box-shadow: none;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 13.5px;
+}
+
+.remote-search input:focus {
+  border: 0;
+  box-shadow: none;
+}
+
+.remote-restore-bar {
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.remote-filter-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.remote-filter-group > span {
+  flex: 0 0 auto;
+}
+
+.remote-targets {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel-bg);
+}
+
+.remote-targets button {
+  height: 28px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.remote-targets button.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.remote-targets.compact button {
+  padding: 0 8px;
+}
+
+.remote-session-list {
+  min-height: 260px;
+  max-height: 500px;
+  overflow: auto;
+  padding: 10px;
+}
+
+.remote-session-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  padding: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.remote-session-row:last-child {
+  border-bottom: 0;
+}
+
+.remote-session-main {
+  min-width: 0;
+  display: grid;
+  gap: 7px;
+}
+
+.remote-session-main strong {
+  font-size: 14px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.remote-session-main p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+
+.remote-session-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.remote-session-actions button:not(.icon-button) {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 30px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel-bg);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.remote-session-actions button:hover:not(:disabled) {
+  border-color: var(--border-strong);
+}
+
+.remote-session-actions button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.remote-empty {
+  min-height: 180px;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 10px;
+  color: var(--text-muted);
+  font-size: 13px;
+  text-align: center;
+}
+
+@media (max-width: 720px) {
+  .remote-session-row {
+    grid-template-columns: 1fr;
+  }
+
+  .remote-session-actions {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
 }


### PR DESCRIPTION
新增基于 Supabase 的远程会话同步能力，用于单人跨设备保存和恢复 Agent 会话。

本次更新支持用户将本地会话手动上传到自己的 Supabase 项目中，并在另一台设备上搜索、查看和恢复这些远程会话。远程会话会保存当前详情页支持的数据，包括会话元信息、消息内容、tool call / trace event、标签、AI 摘要，以及用于跨 Agent 恢复的 portable session 数据。

主要内容：
- 新增 Settings -> Remote sync 配置入口，支持填写 Supabase URL 和 anon key。
- 新增顶部云图标 Remote Sessions 远程会话弹窗。
- 支持复制 Supabase 初始化 SQL，用于创建远程会话表和 Storage bucket。
- 支持在本地会话详情页手动上传会话到远程。
- 支持远程会话搜索、来源筛选、只读详情查看、刷新和删除。
- 支持将远程会话恢复到 Claude Code / Codex / CodeBuddy。
- 使用内容 hash 跳过未变化的重复上传，并更新已变化的远程快照。
- 更新中英文 README，补充 Supabase 配置、上传、搜索、查看和恢复流程。

当前范围：
- 面向单人 Supabase 项目使用。
- 不做应用内登录，也不做多用户隔离。
- 仅支持手动快照同步，不支持后台自动同步。
- 同一远程会话会原地更新，不保留多版本历史。