### PR TITLE
feat: MCP Server 支持写操作(标签、收藏、可见性)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - **完整查看会话上下文**：
   详情页展示完整消息、tool call 与 Markdown / code block，并支持查看 AI 摘要和导出 Markdown。
 - **AI / Agent 辅助检索历史会话**：
-  可以使用 AI 摘要增强历史会话检索，也支持自然语言找会话；同时开放只读 MCP 能力，让 Claude Code / Codex / CodeBuddy 可以在对话里直接搜索和读取历史会话。
+  可以使用 AI 摘要增强历史会话检索，也支持自然语言找会话；同时开放 MCP 能力,让 Claude Code / Codex / CodeBuddy 可以在对话里直接搜索、读取历史会话,并对会话打标签、收藏、设置可见性。
 - **跨 Agent 迁移会话**：
   **支持把 Claude / Codex / CodeBuddy 会话迁移到Claude / Codex / CodeBuddy，并在迁移后继续工作，非常好用！！！**。
 - **远程保存和跨设备恢复会话**：

--- a/bin/agent-session-search-mcp.mjs
+++ b/bin/agent-session-search-mcp.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
-// MCP stdio server exposing the local agent-session-search database read-only,
-// so Claude Code / Codex can recall "how did I solve X before" from past sessions.
+// MCP stdio server exposing the local agent-session-search database, so
+// Claude Code / Codex can recall "how did I solve X before" from past sessions
+// and manage them (tag, favorite, visibility).
 //
-// The query functions below are exported and SDK-free so they can be unit tested;
-// the MCP wiring is loaded lazily in runServer().
+// The query and write functions below are exported and SDK-free so they can be
+// unit tested; the MCP wiring is loaded lazily in runServer().
 
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -140,8 +141,103 @@ export function listTags(db) {
   return db.prepare("SELECT name FROM tags ORDER BY lower(name)").all().map((row) => row.name);
 }
 
+// --- Write operations -----------------------------------------------------
+// These mirror the semantics of SessionStore's write methods, reimplemented in
+// raw SQL because this bin runs standalone (outside the app bundle) and can't
+// import SessionStore. All are idempotent.
+
+function sessionExists(db, sessionKey) {
+  return Boolean(db.prepare("SELECT 1 FROM sessions WHERE session_key = ?").get(sessionKey));
+}
+
+function currentTags(db, sessionKey) {
+  return db
+    .prepare(
+      `SELECT tags.name
+       FROM session_tags JOIN tags ON tags.id = session_tags.tag_id
+       WHERE session_tags.session_key = ?
+       ORDER BY lower(tags.name)`,
+    )
+    .all(sessionKey)
+    .map((row) => row.name);
+}
+
+// Drop a tag from the tags table once no session references it (matches
+// SessionStore.deleteUnusedTag), so removing the last use doesn't leave orphans.
+function deleteUnusedTag(db, tagName) {
+  db.prepare(
+    `DELETE FROM tags
+     WHERE name = ?
+       AND NOT EXISTS (SELECT 1 FROM session_tags WHERE session_tags.tag_id = tags.id)`,
+  ).run(tagName);
+}
+
+export function tagSession(db, { sessionKey, action, tag } = {}) {
+  if (!sessionKey || !sessionExists(db, sessionKey)) return { ok: false, error: "Session not found." };
+  const name = String(tag ?? "").trim();
+  if (!name) return { ok: false, error: "Tag must not be empty." };
+  if (action !== "add" && action !== "remove") return { ok: false, error: 'action must be "add" or "remove".' };
+
+  if (action === "add") {
+    db.prepare("INSERT INTO tags (name) VALUES (?) ON CONFLICT(name) DO NOTHING").run(name);
+    const row = db.prepare("SELECT id FROM tags WHERE name = ?").get(name);
+    db.prepare("INSERT INTO session_tags (session_key, tag_id) VALUES (?, ?) ON CONFLICT DO NOTHING").run(sessionKey, row.id);
+  } else {
+    db.prepare(
+      `DELETE FROM session_tags
+       WHERE session_key = ? AND tag_id = (SELECT id FROM tags WHERE name = ?)`,
+    ).run(sessionKey, name);
+    deleteUnusedTag(db, name);
+  }
+  return { ok: true, sessionKey, action, tag: name, tags: currentTags(db, sessionKey) };
+}
+
+export function toggleFavorite(db, { sessionKey, favorited } = {}) {
+  if (!sessionKey || !sessionExists(db, sessionKey)) return { ok: false, error: "Session not found." };
+  db.prepare("UPDATE sessions SET favorited = ? WHERE session_key = ?").run(favorited ? 1 : 0, sessionKey);
+  return { ok: true, sessionKey, favorited: Boolean(favorited) };
+}
+
+// Visibility is not a single column: it's derived from independent favorited /
+// pinned / hidden flags (see App.tsx ViewMode). Each call sets the requested
+// dimension and clears what would otherwise hide the session from that view,
+// without disturbing unrelated flags (e.g. favoriting doesn't unpin).
+export function setVisibility(db, { sessionKey, visibility } = {}) {
+  if (!sessionKey || !sessionExists(db, sessionKey)) return { ok: false, error: "Session not found." };
+  switch (visibility) {
+    case "default":
+      // Return to the normal list: un-hide and un-pin, leave favorite as-is.
+      db.prepare("UPDATE sessions SET hidden = 0, pinned = 0 WHERE session_key = ?").run(sessionKey);
+      break;
+    case "favorites":
+      db.prepare("UPDATE sessions SET favorited = 1, hidden = 0 WHERE session_key = ?").run(sessionKey);
+      break;
+    case "pinned":
+      db.prepare("UPDATE sessions SET pinned = 1, hidden = 0 WHERE session_key = ?").run(sessionKey);
+      break;
+    case "hidden":
+      db.prepare("UPDATE sessions SET hidden = 1 WHERE session_key = ?").run(sessionKey);
+      break;
+    default:
+      return { ok: false, error: 'visibility must be one of "default", "favorites", "hidden", "pinned".' };
+  }
+  const row = db.prepare("SELECT favorited, pinned, hidden FROM sessions WHERE session_key = ?").get(sessionKey);
+  return {
+    ok: true,
+    sessionKey,
+    visibility,
+    favorited: row.favorited === 1,
+    pinned: row.pinned === 1,
+    hidden: row.hidden === 1,
+  };
+}
+
 function jsonContent(value) {
   return { content: [{ type: "text", text: JSON.stringify(value, null, 2) }] };
+}
+
+function errorContent(message) {
+  return { content: [{ type: "text", text: message }], isError: true };
 }
 
 async function runServer() {
@@ -158,7 +254,12 @@ async function runServer() {
   const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
   const { z } = await import("zod");
 
-  const db = new DatabaseSync(dbPath, { readOnly: true });
+  // Read-write: the write tools (tag/favorite/visibility) mutate this DB. The
+  // app keeps it in WAL mode, so this separate process writes safely alongside
+  // it (SQLite serializes writers). busy_timeout tolerates brief write contention.
+  const db = new DatabaseSync(dbPath);
+  db.exec("PRAGMA busy_timeout = 5000");
+  db.exec("PRAGMA foreign_keys = ON");
   const server = new McpServer({ name: "agent-session-search", version: "0.1.0" });
 
   server.registerTool(
@@ -203,6 +304,54 @@ async function runServer() {
     "list_tags",
     { description: "List all tags, to scope a search.", inputSchema: {} },
     async () => jsonContent(listTags(db)),
+  );
+
+  server.registerTool(
+    "tag_session",
+    {
+      description:
+        "Add or remove a tag on a session. Use to mark sessions (e.g. 'important', 'review'). Idempotent. Returns the session's current tags.",
+      inputSchema: {
+        sessionKey: z.string().describe("The sessionKey from search_sessions."),
+        action: z.enum(["add", "remove"]).describe("Whether to add or remove the tag."),
+        tag: z.string().describe("Tag name, e.g. 'important'."),
+      },
+    },
+    async (args) => {
+      const result = tagSession(db, args);
+      return result.ok ? jsonContent(result) : errorContent(result.error);
+    },
+  );
+
+  server.registerTool(
+    "toggle_favorite",
+    {
+      description: "Favorite or unfavorite a session. Idempotent — set favorited to the desired final state.",
+      inputSchema: {
+        sessionKey: z.string().describe("The sessionKey from search_sessions."),
+        favorited: z.boolean().describe("true to favorite, false to unfavorite."),
+      },
+    },
+    async (args) => {
+      const result = toggleFavorite(db, args);
+      return result.ok ? jsonContent(result) : errorContent(result.error);
+    },
+  );
+
+  server.registerTool(
+    "set_visibility",
+    {
+      description:
+        "Set a session's visibility dimension. 'default' un-hides and un-pins; 'favorites' favorites it; 'pinned' pins it; 'hidden' hides it. These flags are independent (favoriting does not unpin), so this sets the chosen dimension rather than toggling exclusively.",
+      inputSchema: {
+        sessionKey: z.string().describe("The sessionKey from search_sessions."),
+        visibility: z.enum(["default", "favorites", "hidden", "pinned"]).describe("Target visibility."),
+      },
+    },
+    async (args) => {
+      const result = setVisibility(db, args);
+      return result.ok ? jsonContent(result) : errorContent(result.error);
+    },
   );
 
   await server.connect(new StdioServerTransport());

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -26,7 +26,7 @@
 - **Full session context view**:
   The detail view shows complete messages, tool calls, Markdown / code blocks, and supports AI summaries plus Markdown export.
 - **AI / Agent-assisted session retrieval**:
-  Use AI summaries to improve history search, ask for sessions in natural language, and expose read-only MCP capabilities so Claude Code / Codex / CodeBuddy can search and read session history directly in chat.
+  Use AI summaries to improve history search, ask for sessions in natural language, and expose MCP capabilities so Claude Code / Codex / CodeBuddy can search, read, tag, favorite, and set the visibility of session history directly in chat.
 - **Cross-agent session migration**:
   Migrate Claude / Codex / CodeBuddy sessions into another agent and continue from the migrated session.
 - **Remote session storage and cross-device restore**:

--- a/src/core/mcp-server.test.ts
+++ b/src/core/mcp-server.test.ts
@@ -16,6 +16,10 @@ const getSession = mcp.getSession as (
 ) => (SearchResult & { messages: Array<{ content: string }>; totalMessages: number; returned: number; nextOffset: number | null }) | null;
 const listProjects = mcp.listProjects as (db: Db) => Array<{ project: string; sessions: number }>;
 const listTags = mcp.listTags as (db: Db) => string[];
+type WriteResult = { ok: boolean; error?: string; tags?: string[]; favorited?: boolean; pinned?: boolean; hidden?: boolean };
+const tagSession = mcp.tagSession as (db: Db, args: Record<string, unknown>) => WriteResult;
+const toggleFavorite = mcp.toggleFavorite as (db: Db, args: Record<string, unknown>) => WriteResult;
+const setVisibility = mcp.setVisibility as (db: Db, args: Record<string, unknown>) => WriteResult;
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require("node:sqlite") as { DatabaseSync: new (path: string) => import("node:sqlite").DatabaseSync };
@@ -114,5 +118,96 @@ describe("MCP query functions", () => {
     const { db } = seedStore();
     expect(listProjects(db).map((p) => p.project).sort()).toEqual(["/multi", "/other", "/repo"]);
     expect(listTags(db)).toContain("auth");
+  });
+});
+
+describe("MCP write functions", () => {
+  const flags = (db: import("node:sqlite").DatabaseSync, sessionKey: string) =>
+    db.prepare("SELECT favorited, pinned, hidden FROM sessions WHERE session_key = ?").get(sessionKey) as {
+      favorited: number;
+      pinned: number;
+      hidden: number;
+    };
+
+  it("adds and removes a tag, cleaning up the orphaned tag", () => {
+    const { db } = seedStore();
+    const added = tagSession(db, { sessionKey: "codex:abc", action: "add", tag: "important" });
+    expect(added.ok).toBe(true);
+    expect(added.tags).toContain("important");
+    expect(listTags(db)).toContain("important");
+
+    const removed = tagSession(db, { sessionKey: "codex:abc", action: "remove", tag: "important" });
+    expect(removed.ok).toBe(true);
+    expect(removed.tags).not.toContain("important");
+    // "important" had no other users, so it's gone from the tags table entirely.
+    expect(listTags(db)).not.toContain("important");
+    // "auth" was seeded on this session and untouched.
+    expect(listTags(db)).toContain("auth");
+  });
+
+  it("is idempotent when adding the same tag twice", () => {
+    const { db } = seedStore();
+    tagSession(db, { sessionKey: "codex:abc", action: "add", tag: "dup" });
+    const second = tagSession(db, { sessionKey: "codex:abc", action: "add", tag: "dup" });
+    expect(second.tags?.filter((t) => t === "dup")).toHaveLength(1);
+  });
+
+  it("rejects tagging a missing session", () => {
+    const { db } = seedStore();
+    const result = tagSession(db, { sessionKey: "missing", action: "add", tag: "x" });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Session not found.");
+  });
+
+  it("rejects an empty tag and an invalid action", () => {
+    const { db } = seedStore();
+    expect(tagSession(db, { sessionKey: "codex:abc", action: "add", tag: "  " }).ok).toBe(false);
+    expect(tagSession(db, { sessionKey: "codex:abc", action: "flip", tag: "x" }).ok).toBe(false);
+  });
+
+  it("toggles favorite on and off", () => {
+    const { db } = seedStore();
+    expect(toggleFavorite(db, { sessionKey: "codex:abc", favorited: true }).favorited).toBe(true);
+    expect(flags(db, "codex:abc").favorited).toBe(1);
+    expect(toggleFavorite(db, { sessionKey: "codex:abc", favorited: false }).favorited).toBe(false);
+    expect(flags(db, "codex:abc").favorited).toBe(0);
+  });
+
+  it("rejects favoriting a missing session", () => {
+    const { db } = seedStore();
+    expect(toggleFavorite(db, { sessionKey: "missing", favorited: true }).ok).toBe(false);
+  });
+
+  it("sets each visibility dimension", () => {
+    const { db } = seedStore();
+
+    setVisibility(db, { sessionKey: "codex:abc", visibility: "hidden" });
+    expect(flags(db, "codex:abc").hidden).toBe(1);
+
+    // "default" un-hides and un-pins.
+    setVisibility(db, { sessionKey: "codex:abc", visibility: "pinned" });
+    expect(flags(db, "codex:abc").pinned).toBe(1);
+    const back = setVisibility(db, { sessionKey: "codex:abc", visibility: "default" });
+    expect(back.pinned).toBe(false);
+    expect(back.hidden).toBe(false);
+
+    const fav = setVisibility(db, { sessionKey: "codex:abc", visibility: "favorites" });
+    expect(fav.favorited).toBe(true);
+    expect(fav.hidden).toBe(false);
+  });
+
+  it("leaves unrelated flags alone (favoriting does not unpin)", () => {
+    const { db } = seedStore();
+    setVisibility(db, { sessionKey: "codex:abc", visibility: "pinned" });
+    setVisibility(db, { sessionKey: "codex:abc", visibility: "favorites" });
+    const f = flags(db, "codex:abc");
+    expect(f.pinned).toBe(1);
+    expect(f.favorited).toBe(1);
+  });
+
+  it("rejects an invalid visibility and a missing session", () => {
+    const { db } = seedStore();
+    expect(setVisibility(db, { sessionKey: "codex:abc", visibility: "bogus" }).ok).toBe(false);
+    expect(setVisibility(db, { sessionKey: "missing", visibility: "hidden" }).ok).toBe(false);
   });
 });


### PR DESCRIPTION
## 背景

实现 #52 的 **Phase 1**:当前 MCP Server(`bin/agent-session-search-mcp.mjs`)是只读的,只暴露搜索和读取会话的 tool。本 PR 让它从"查询工具"升级为可对会话做基础管理操作。

## 改动

新增 3 个写操作 tool:

| Tool | 作用 |
|------|------|
| `tag_session` | 为会话添加/移除标签,幂等;删除最后一个引用时自动清理孤儿标签 |
| `toggle_favorite` | 收藏/取消收藏 |
| `set_visibility` | 设置可见性(`default` / `favorites` / `hidden` / `pinned`) |

## 设计要点

- **数据库改为读写打开**:原本 `new DatabaseSync(dbPath, { readOnly: true })`,现改为读写并加 `PRAGMA busy_timeout = 5000` 与 `PRAGMA foreign_keys = ON`。app 侧已开启 WAL 模式,独立进程写入与 app 并发安全(SQLite 串行化写者)。
- **写函数保持 SDK-free**:直接对 `db` 执行 SQL,复刻 `SessionStore` 的写语义(不 import `SessionStore`,因为该 bin 独立运行、不进 bundle),与现有查询函数同风格,便于单测。
- **可见性语义**:可见性不是单列,而是由 `favorited` / `pinned` / `hidden` 三个独立布尔列派生。因此 `set_visibility` 采用"设置该维度、不动无关标志"的语义(例如收藏不会取消置顶),已在 tool description 中写清,避免调用方误清状态。
- **命名**:沿用仓库现有 `sessionKey`(camelCase),而非 issue 描述里的 `session_key`,保持与其它 tool 一致。

## 测试

- 新增 11 个测试用例(标签增删/幂等/孤儿清理、收藏往返、可见性四种取值及"不误清无关标志"、各类非法输入与缺失会话校验)。
- `mcp-server.test.ts` 16 个用例全过,全量 601 个测试全过,`typecheck` 干净。

## 未包含(Phase 2)

`migrate_session` 留待后续:它需要在独立进程里重建约 15 个迁移依赖(终端启动、CLI 检查、索引刷新),复杂度和风险较高,另开分支处理。
