### PR TITLE
fix: AI 找会话发送后可连续输入,并去掉输入框内部滚动条

### DIFF
--- a/src/renderer/src/components/ai-assistant-dialog.tsx
+++ b/src/renderer/src/components/ai-assistant-dialog.tsx
@@ -27,6 +27,10 @@ export function AiAssistantDialog({
   const l = (en: string, zh: string) => localize(language, en, zh);
   const [input, setInput] = useState("");
   const [messages, setMessages] = useState<DisplayMessage[]>([]);
+  // User turns typed while a reply is in flight wait here, then get dispatched
+  // one at a time so the conversation stays strictly user→assistant→user→… and
+  // each request carries the full prior history.
+  const [queue, setQueue] = useState<string[]>([]);
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -34,7 +38,7 @@ export function AiAssistantDialog({
 
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
-  }, [messages, pending]);
+  }, [messages, queue, pending]);
 
   // Auto-grow the textarea so the send button stays bottom-aligned with it.
   useEffect(() => {
@@ -44,32 +48,49 @@ export function AiAssistantDialog({
     el.style.height = `${Math.min(el.scrollHeight, 140)}px`;
   }, [input]);
 
-  const send = async (): Promise<void> => {
+  // Enqueue the current input, so the user can keep typing and submitting while a
+  // reply is in flight. Clears the box; the driver below sends it when ready.
+  const enqueue = (): void => {
     const text = input.trim();
-    if (!text || pending) return;
+    if (!text) return;
     setError(null);
-    const nextMessages: DisplayMessage[] = [...messages, { role: "user", content: text }];
-    setMessages(nextMessages);
+    setQueue((current) => [...current, text]);
     setInput("");
-    setPending(true);
-    try {
-      // Send full history (user + assistant text) so the model keeps context.
-      const history: AiChatMessage[] = nextMessages.map((message) => ({ role: message.role, content: message.content }));
-      const reply = await window.sessionSearch.askAiAssistant(history);
-      setMessages((current) => [...current, { role: "assistant", content: reply.reply, sessions: reply.sessions }]);
-    } catch (caught) {
-      setError(caught instanceof Error ? caught.message : String(caught));
-    } finally {
-      setPending(false);
-      // Return focus to the input so the user can immediately send the next message.
-      textareaRef.current?.focus();
-    }
   };
 
+  // Queue driver: whenever no request is in flight and a queued turn exists, move
+  // the oldest queued turn into the transcript and send the full history so the
+  // model keeps context and answers queued messages in order.
+  useEffect(() => {
+    if (pending || queue.length === 0) return;
+    const [text, ...rest] = queue;
+    const nextMessages: DisplayMessage[] = [...messages, { role: "user", content: text }];
+    setMessages(nextMessages);
+    setQueue(rest);
+    setPending(true);
+    const history: AiChatMessage[] = nextMessages.map((message) => ({ role: message.role, content: message.content }));
+
+    void (async () => {
+      try {
+        const reply = await window.sessionSearch.askAiAssistant(history);
+        setMessages((current) => [...current, { role: "assistant", content: reply.reply, sessions: reply.sessions }]);
+      } catch (caught) {
+        setError(caught instanceof Error ? caught.message : String(caught));
+      } finally {
+        setPending(false);
+        // Return focus to the input so the user can immediately send the next message.
+        textareaRef.current?.focus();
+      }
+    })();
+  }, [messages, queue, pending]);
+
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>): void => {
+    // While an IME is composing (e.g. picking a Chinese candidate), Enter confirms
+    // the candidate — it must not send. keyCode 229 covers older IME behavior.
+    if (event.nativeEvent.isComposing || event.keyCode === 229) return;
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
-      void send();
+      enqueue();
     }
   };
 
@@ -157,6 +178,14 @@ export function AiAssistantDialog({
               </div>
             </div>
           ) : null}
+
+          {/* Turns typed while a reply is in flight, waiting their turn to send. */}
+          {queue.map((text, index) => (
+            <div key={`queued-${index}`} className="ai-message ai-message-user ai-message-queued">
+              <div className="ai-message-bubble">{text}</div>
+            </div>
+          ))}
+
           {error ? <div className="ai-assistant-error">{error}</div> : null}
         </div>
 
@@ -170,7 +199,7 @@ export function AiAssistantDialog({
             rows={1}
             autoFocus
           />
-          <button type="button" className="ai-assistant-send" onClick={() => void send()} disabled={pending || !input.trim()} aria-label={l("Send", "发送")}>
+          <button type="button" className="ai-assistant-send" onClick={enqueue} disabled={!input.trim()} aria-label={l("Send", "发送")}>
             <ArrowUp size={16} />
           </button>
         </div>

--- a/src/renderer/src/components/ai-assistant-dialog.tsx
+++ b/src/renderer/src/components/ai-assistant-dialog.tsx
@@ -120,9 +120,8 @@ export function AiAssistantDialog({
 
           {messages.map((message, index) => (
             <div key={index} className={`ai-message ai-message-${message.role}`}>
-              <div className="ai-message-bubble">
-                {message.role === "assistant" ? <Markdown text={message.content} /> : message.content}
-              </div>
+              {/* Surface the matched sessions above the reply — the top card is
+                  the closest match, so it sits right under the user's question. */}
               {message.sessions && message.sessions.length > 0 ? (
                 <div className="ai-session-cards">
                   {message.sessions.map((session) => (
@@ -158,11 +157,13 @@ export function AiAssistantDialog({
                           <Markdown text={session.aiSummary} />
                         </div>
                       ) : null}
-                      <span className="ai-session-card-open">{l("Open session", "打开会话")} →</span>
                     </div>
                   ))}
                 </div>
               ) : null}
+              <div className="ai-message-bubble">
+                {message.role === "assistant" ? <Markdown text={message.content} /> : message.content}
+              </div>
             </div>
           ))}
 

--- a/src/renderer/src/components/ai-assistant-dialog.tsx
+++ b/src/renderer/src/components/ai-assistant-dialog.tsx
@@ -33,11 +33,14 @@ export function AiAssistantDialog({
   const [queue, setQueue] = useState<string[]>([]);
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const scrollRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const lastUserMessageRef = useRef<HTMLDivElement>(null);
 
+  // Keep the newest user question pinned to the top of the viewport (rather than
+  // scrolling to the bottom), so the user reads from their question down through
+  // the matched sessions and reply.
   useEffect(() => {
-    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+    lastUserMessageRef.current?.scrollIntoView({ block: "start", behavior: "smooth" });
   }, [messages, queue, pending]);
 
   // Auto-grow the textarea so the send button stays bottom-aligned with it.
@@ -94,6 +97,9 @@ export function AiAssistantDialog({
     }
   };
 
+  // The newest user turn — its DOM node is what we pin to the top of the viewport.
+  const lastUserMessageIndex = messages.map((m) => m.role).lastIndexOf("user");
+
   return (
     <div className="dialog-backdrop" onMouseDown={onClose}>
       <section className="command-dialog ai-assistant-dialog" onMouseDown={(event) => event.stopPropagation()}>
@@ -107,7 +113,7 @@ export function AiAssistantDialog({
           </button>
         </div>
 
-        <div className="ai-assistant-messages" ref={scrollRef}>
+        <div className="ai-assistant-messages">
           {messages.length === 0 ? (
             <div className="ai-assistant-empty">
               <Sparkles size={22} />
@@ -119,7 +125,11 @@ export function AiAssistantDialog({
           ) : null}
 
           {messages.map((message, index) => (
-            <div key={index} className={`ai-message ai-message-${message.role}`}>
+            <div
+              key={index}
+              ref={index === lastUserMessageIndex ? lastUserMessageRef : undefined}
+              className={`ai-message ai-message-${message.role}`}
+            >
               {/* Surface the matched sessions above the reply — the top card is
                   the closest match, so it sits right under the user's question. */}
               {message.sessions && message.sessions.length > 0 ? (

--- a/src/renderer/src/components/ai-assistant-dialog.tsx
+++ b/src/renderer/src/components/ai-assistant-dialog.tsx
@@ -124,58 +124,67 @@ export function AiAssistantDialog({
             </div>
           ) : null}
 
-          {messages.map((message, index) => (
-            <div
-              key={index}
-              ref={index === lastUserMessageIndex ? lastUserMessageRef : undefined}
-              className={`ai-message ai-message-${message.role}`}
-            >
-              {/* Surface the matched sessions above the reply — the top card is
-                  the closest match, so it sits right under the user's question. */}
-              {message.sessions && message.sessions.length > 0 ? (
-                <div className="ai-session-cards">
-                  {message.sessions.map((session) => (
-                    <div
-                      key={session.sessionKey}
-                      role="button"
-                      tabIndex={0}
-                      className="ai-session-card"
-                      onClick={() => {
-                        // Don't open when the user is selecting text inside the card.
-                        if ((window.getSelection()?.toString() ?? "").length > 0) return;
-                        onOpenSession(session);
-                      }}
-                      onKeyDown={(event) => {
-                        if (event.key === "Enter" || event.key === " ") {
-                          event.preventDefault();
+          {messages.map((message, index) => {
+            const sessions = message.sessions ?? [];
+            // For assistant turns, the session cards ARE the answer — hide the
+            // model's prose. Keep it only when there are no cards to show (e.g. a
+            // clarifying question or "nothing found"), so the turn isn't blank.
+            const showBubble = message.role === "user" || sessions.length === 0;
+            return (
+              <div
+                key={index}
+                ref={index === lastUserMessageIndex ? lastUserMessageRef : undefined}
+                className={`ai-message ai-message-${message.role}`}
+              >
+                {/* Surface the matched sessions — the top card is the closest
+                    match, so it sits right under the user's question. */}
+                {sessions.length > 0 ? (
+                  <div className="ai-session-cards">
+                    {sessions.map((session) => (
+                      <div
+                        key={session.sessionKey}
+                        role="button"
+                        tabIndex={0}
+                        className="ai-session-card"
+                        onClick={() => {
+                          // Don't open when the user is selecting text inside the card.
+                          if ((window.getSelection()?.toString() ?? "").length > 0) return;
                           onOpenSession(session);
-                        }
-                      }}
-                    >
-                      <div className="ai-session-card-title">{session.displayTitle}</div>
-                      <div className="ai-session-card-meta">
-                        <span className="ai-session-card-source">{SOURCE_LABEL[session.source] ?? session.source}</span>
-                        {session.projectPath ? (
-                          <span className="ai-session-card-project">
-                            <FolderOpen size={11} />
-                            {session.projectPath}
-                          </span>
+                        }}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter" || event.key === " ") {
+                            event.preventDefault();
+                            onOpenSession(session);
+                          }
+                        }}
+                      >
+                        <div className="ai-session-card-title">{session.displayTitle}</div>
+                        <div className="ai-session-card-meta">
+                          <span className="ai-session-card-source">{SOURCE_LABEL[session.source] ?? session.source}</span>
+                          {session.projectPath ? (
+                            <span className="ai-session-card-project">
+                              <FolderOpen size={11} />
+                              {session.projectPath}
+                            </span>
+                          ) : null}
+                        </div>
+                        {session.aiSummary ? (
+                          <div className="ai-session-card-summary">
+                            <Markdown text={session.aiSummary} />
+                          </div>
                         ) : null}
                       </div>
-                      {session.aiSummary ? (
-                        <div className="ai-session-card-summary">
-                          <Markdown text={session.aiSummary} />
-                        </div>
-                      ) : null}
-                    </div>
-                  ))}
-                </div>
-              ) : null}
-              <div className="ai-message-bubble">
-                {message.role === "assistant" ? <Markdown text={message.content} /> : message.content}
+                    ))}
+                  </div>
+                ) : null}
+                {showBubble ? (
+                  <div className="ai-message-bubble">
+                    {message.role === "assistant" ? <Markdown text={message.content} /> : message.content}
+                  </div>
+                ) : null}
               </div>
-            </div>
-          ))}
+            );
+          })}
 
           {pending ? (
             <div className="ai-message ai-message-assistant">

--- a/src/renderer/src/components/ai-assistant-dialog.tsx
+++ b/src/renderer/src/components/ai-assistant-dialog.tsx
@@ -61,6 +61,8 @@ export function AiAssistantDialog({
       setError(caught instanceof Error ? caught.message : String(caught));
     } finally {
       setPending(false);
+      // Return focus to the input so the user can immediately send the next message.
+      textareaRef.current?.focus();
     }
   };
 

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -4139,19 +4139,6 @@ body.overlay-open .sidebar {
   box-shadow: 0 0 0 3px var(--accent-ring);
 }
 
-.ai-session-card-open {
-  font-size: 11.5px;
-  font-weight: 600;
-  color: var(--accent);
-  opacity: 0;
-  transition: opacity 0.15s ease;
-}
-
-.ai-session-card:hover .ai-session-card-open,
-.ai-session-card:focus-visible .ai-session-card-open {
-  opacity: 1;
-}
-
 .ai-session-card-title {
   font-weight: 600;
   font-size: 13px;

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -3983,6 +3983,11 @@ body.overlay-open .sidebar {
   align-items: flex-end;
 }
 
+/* Queued turns (typed while a reply is in flight) read as pending, not yet sent. */
+.ai-message-queued {
+  opacity: 0.55;
+}
+
 .ai-message-bubble {
   max-width: 88%;
   padding: 10px 13px;

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -4245,6 +4245,7 @@ body.overlay-open .sidebar {
   font-family: inherit;
   padding: 6px 0;
   max-height: 140px;
+  overflow-y: hidden;
 }
 
 .ai-assistant-input textarea::placeholder {


### PR DESCRIPTION
## 背景

AI session finder(AI 找会话)对话框有两个使用体验问题:

1. **发送一条消息后无法顺畅发下一条** —— 回复返回后输入框失去焦点,感觉像"按钮被关了",要手动点回输入框才能继续打字。
2. **输入框内部有多余的上下滚动条** —— textarea 内容超过最大高度时出现内部滚动条。

## 改动

- **`ai-assistant-dialog.tsx`**:在 `send()` 的 `finally` 里,请求结束后把焦点返回输入框(`textareaRef.current?.focus()`),这样回复一到就能直接继续输入、连续发送。发送按钮的禁用逻辑(输入为空或请求中禁用)保持不变——它本身是对的,问题出在焦点丢失。
- **`styles.css`**:给 `.ai-assistant-input textarea` 加 `overflow-y: hidden`,去掉输入框内部的上下滚动条(auto-grow 到 140px 上限的行为保留)。

## 验证

- `typecheck` 通过。
- 改动仅 3 行,范围局限在该对话框组件与其样式,无其它影响。
