### PR TITLE
add: 新增完整会话角色过滤

### DIFF
--- a/src/renderer/src/components/detail-panel.tsx
+++ b/src/renderer/src/components/detail-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { ReactElement } from "react";
 import { ArrowRightLeft, CloudUpload, Copy, Download, Edit3, FolderOpen, Laptop, Play, Server, Sparkles, Star, Tag, Terminal as TerminalIcon, Trash2, X } from "lucide-react";
 import { formatMessageTime } from "../../../core/format-session";
@@ -22,10 +22,24 @@ type ConversationTimelineItem =
   | { kind: "message"; key: string; timestampMs: number | null; order: number; message: SessionMessage }
   | { kind: "trace"; key: string; timestampMs: number | null; order: number; event: SessionTraceEvent };
 
+type ConversationRoleFilter = "all" | SessionMessage["role"];
+
+const CONVERSATION_ROLE_FILTERS: ConversationRoleFilter[] = ["all", "user", "assistant"];
+
 function timestampMs(timestamp: string): number | null {
   if (!timestamp) return null;
   const parsed = new Date(timestamp).getTime();
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+function messageTimelineItem(message: SessionMessage): ConversationTimelineItem {
+  return {
+    kind: "message",
+    key: `message:${message.index}`,
+    timestampMs: timestampMs(message.timestamp),
+    order: message.index * 2,
+    message,
+  };
 }
 
 function conversationTimeline(messages: SessionMessage[], traceEvents: SessionTraceEvent[]): ConversationTimelineItem[] {
@@ -41,13 +55,7 @@ function conversationTimeline(messages: SessionMessage[], traceEvents: SessionTr
         });
 
   const items: ConversationTimelineItem[] = [
-    ...messages.map((message) => ({
-      kind: "message" as const,
-      key: `message:${message.index}`,
-      timestampMs: timestampMs(message.timestamp),
-      order: message.index * 2,
-      message,
-    })),
+    ...messages.map(messageTimelineItem),
     ...visibleTraceEvents.map((event) => ({
       kind: "trace" as const,
       key: `trace:${event.index}`,
@@ -65,6 +73,18 @@ function conversationTimeline(messages: SessionMessage[], traceEvents: SessionTr
     if (a.timestampMs === null && b.timestampMs !== null) return 1;
     return a.order - b.order;
   });
+}
+
+function conversationRoleFilterLabel(filter: ConversationRoleFilter, language: LanguageMode): string {
+  if (filter === "all") return localize(language, "All", "全部");
+  if (filter === "user") return localize(language, "User", "用户");
+  return localize(language, "Assistant", "助手");
+}
+
+function conversationRoleEmptyLabel(filter: Exclude<ConversationRoleFilter, "all">, language: LanguageMode): string {
+  return filter === "user"
+    ? localize(language, "No User messages in the loaded conversation.", "当前已加载内容中没有用户消息。")
+    : localize(language, "No Assistant messages in the loaded conversation.", "当前已加载内容中没有助手消息。");
 }
 
 export function DetailPanel({
@@ -146,12 +166,23 @@ export function DetailPanel({
   const l = (en: string, zh: string) => localize(language, en, zh);
   const bodyRef = useRef<HTMLDivElement>(null);
   const pendingInitialScrollRef = useRef<string | null>(session.sessionKey);
+  const [roleFilter, setRoleFilter] = useState<ConversationRoleFilter>("all");
   const timelineItems = useMemo(() => conversationTimeline(messages, traceEvents), [messages, traceEvents]);
+  const roleFilteredMessages = useMemo(
+    () => roleFilter === "all" ? messages : messages.filter((message) => message.role === roleFilter),
+    [messages, roleFilter],
+  );
+  const visibleTimelineItems = useMemo(
+    () => roleFilter === "all" ? timelineItems : roleFilteredMessages.map(messageTimelineItem),
+    [roleFilter, roleFilteredMessages, timelineItems],
+  );
+  const roleFilterEmpty = !loading && messages.length > 0 && roleFilter !== "all" && roleFilteredMessages.length === 0;
   const localOnlyDisabled = isRemoteSession(session);
   const revealTitle = localOnlyDisabled ? remoteRevealTitle(language) : l(`Show in ${revealLabel}`, `在${revealLabel}中显示`);
 
   useEffect(() => {
     pendingInitialScrollRef.current = session.sessionKey;
+    setRoleFilter("all");
   }, [session.sessionKey]);
 
   useEffect(() => {
@@ -321,7 +352,21 @@ export function DetailPanel({
             </section>
           ) : null}
           <section className="conversation">
-            <h3>{l("Full Conversation", "完整会话")}</h3>
+            <div className="conversation-header">
+              <h3>{l("Full Conversation", "完整会话")}</h3>
+              <div className="conversation-role-filter" role="group" aria-label={l("Conversation role filter", "会话角色过滤")}>
+                {CONVERSATION_ROLE_FILTERS.map((filter) => (
+                  <button
+                    key={filter}
+                    className={roleFilter === filter ? "active" : ""}
+                    onClick={() => setRoleFilter(filter)}
+                    aria-pressed={roleFilter === filter}
+                  >
+                    {conversationRoleFilterLabel(filter, language)}
+                  </button>
+                ))}
+              </div>
+            </div>
             {loading ? <div className="loading-state">{l("Loading conversation...", "正在加载会话...")}</div> : null}
             {!loading && messages.length === 0 ? <div className="loading-state">{l("No visible messages indexed for this session.", "这个会话没有可见消息被索引。")}</div> : null}
             {!loading && olderMessageCount > 0 ? (
@@ -329,7 +374,10 @@ export function DetailPanel({
                 {l(`Show ${Math.min(messagePageSize, olderMessageCount)} older messages`, `再显示 ${Math.min(messagePageSize, olderMessageCount)} 条更早消息`)}
               </button>
             ) : null}
-            {timelineItems.map((item) => (
+            {roleFilter !== "all" && roleFilterEmpty ? (
+              <div className="conversation-empty">{conversationRoleEmptyLabel(roleFilter, language)}</div>
+            ) : null}
+            {visibleTimelineItems.map((item) => (
               item.kind === "message" ? (
                 <MessageBlock key={item.key} message={item.message} query={query} language={language} />
               ) : (

--- a/src/renderer/src/detail-panel-actions.test.ts
+++ b/src/renderer/src/detail-panel-actions.test.ts
@@ -63,6 +63,22 @@ describe("detail panel actions", () => {
     expect(detailPanelSource).toContain("Show ${Math.min(messagePageSize, olderMessageCount)} older messages");
   });
 
+  it("filters the loaded full conversation by role while keeping pagination available", () => {
+    const showOlderIndex = detailPanelSource.indexOf("olderMessageCount > 0");
+    const visibleItemsIndex = detailPanelSource.indexOf("visibleTimelineItems.map");
+
+    expect(detailPanelSource).toContain('type ConversationRoleFilter = "all" | SessionMessage["role"]');
+    expect(detailPanelSource).toContain('const CONVERSATION_ROLE_FILTERS: ConversationRoleFilter[] = ["all", "user", "assistant"]');
+    expect(detailPanelSource).toContain('roleFilter === "all" ? messages : messages.filter((message) => message.role === roleFilter)');
+    expect(detailPanelSource).toContain('roleFilter === "all" ? timelineItems : roleFilteredMessages.map(messageTimelineItem)');
+    expect(detailPanelSource).toContain('setRoleFilter("all");');
+    expect(detailPanelSource).toContain("conversation-role-filter");
+    expect(detailPanelSource).toContain("No User messages in the loaded conversation.");
+    expect(detailPanelSource).toContain("No Assistant messages in the loaded conversation.");
+    expect(showOlderIndex).toBeGreaterThanOrEqual(0);
+    expect(visibleItemsIndex).toBeGreaterThan(showOlderIndex);
+  });
+
   it("loads the visible message window before trace events when opening detail", () => {
     const openDetail = appSource.slice(appSource.indexOf("async function openDetail"), appSource.indexOf("function closeDetail"));
     const freshIndex = openDetail.indexOf("const fresh = await window.sessionSearch.getSession(sessionKey)");

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1838,6 +1838,49 @@ select:focus-visible {
   color: var(--accent);
 }
 
+.conversation-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 14px 0 8px;
+}
+
+.conversation-header h3 {
+  margin: 0;
+}
+
+.conversation-role-filter {
+  display: inline-flex;
+  flex: 0 0 auto;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 7px;
+  background: var(--panel-subtle);
+}
+
+.conversation-role-filter button {
+  min-width: 40px;
+  height: 23px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 5px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.conversation-role-filter button:hover {
+  color: var(--text);
+}
+
+.conversation-role-filter button.active {
+  background: var(--panel-bg);
+  color: var(--text);
+  box-shadow: inset 0 0 0 1px var(--border-subtle);
+}
+
 .detail-body {
   min-height: 0;
   flex: 1;
@@ -2003,6 +2046,18 @@ select:focus-visible {
   background: var(--panel-subtle);
   color: var(--text-muted);
   font-size: 12.5px;
+}
+
+.conversation-empty {
+  display: grid;
+  place-items: center;
+  min-height: 46px;
+  margin-bottom: 10px;
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  background: var(--panel-subtle);
+  color: var(--text-muted);
+  font-size: 12px;
 }
 
 .show-more {


### PR DESCRIPTION
关联 issue：Closes #55

在长会话详情中，FULL CONVERSATION 消息较多时，用户消息和助手消息混在一起，复盘或只查看某一方内容时需要反复滚动，不太方便区分和浏览。

本次更新在会话详情的 FULL CONVERSATION 区域增加 All / User / Assistant 角色过滤，用于在已加载的会话窗口中快速聚焦用户侧或助手侧内容。

主要内容：
- 新增 FULL CONVERSATION 的 All / User / Assistant 切换控件。
- User / Assistant 模式只显示当前已加载消息中对应角色的内容。
- 点击 Show older messages 加载更早消息后，会继续沿用当前角色过滤。
- All 模式保留原有完整时间线，包括 trace / tool event。
- 过滤结果为空时显示轻量空状态提示。
- 补充详情面板行为测试。

当前范围：
- 仅作用于详情页已加载消息，不主动拉取整段会话。
- 不影响搜索、导出、AI 摘要、迁移、上传和 Resume 行为。