### PR TITLE
feat: add expand/collapse for truncated messages and trace events

### DIFF
--- a/src/renderer/src/components/detail-panel.tsx
+++ b/src/renderer/src/components/detail-panel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { ReactElement } from "react";
-import { ArrowRightLeft, CloudUpload, Copy, Download, Edit3, FolderOpen, Laptop, Play, Server, Sparkles, Star, Tag, Terminal as TerminalIcon, Trash2, X } from "lucide-react";
+import { ArrowRightLeft, ChevronDown, ChevronUp, CloudUpload, Copy, Download, Edit3, FolderOpen, Laptop, Play, Server, Sparkles, Star, Tag, Terminal as TerminalIcon, Trash2, X } from "lucide-react";
 import { formatMessageTime } from "../../../core/format-session";
 import type { SessionMessage, SessionSearchResult, SessionTraceEvent } from "../../../core/types";
 import { formatTokenCount } from "../format-count";
@@ -391,15 +391,15 @@ export function DetailPanel({
   );
 }
 
+const MESSAGE_TRUNCATE_LIMIT = 3000;
+
 function MessageBlock({ message, query, language }: { message: SessionMessage; query: string; language: LanguageMode }): ReactElement {
+  const truncated = message.content.length > MESSAGE_TRUNCATE_LIMIT;
+  const [expanded, setExpanded] = useState(false);
   const content = useMemo(() => {
-    const text =
-      message.content.length > 3000
-        ? `${message.content.slice(0, 3000)}\n\n${localize(language, "...(truncated)", "...（已截断）")}`
-        : message.content;
-    if (!query) return text;
-    return text;
-  }, [message.content, query, language]);
+    if (!truncated || expanded) return message.content;
+    return `${message.content.slice(0, MESSAGE_TRUNCATE_LIMIT)}\n\n${localize(language, "...(truncated)", "...（已截断）")}`;
+  }, [message.content, truncated, expanded, language]);
 
   return (
     <div className={`message ${message.role}`}>
@@ -408,6 +408,12 @@ function MessageBlock({ message, query, language }: { message: SessionMessage; q
         <span>{formatMessageTime(message.timestamp)}</span>
       </div>
       <pre>{content}</pre>
+      {truncated ? (
+        <button className="expand-toggle" onClick={() => setExpanded((prev) => !prev)}>
+          {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+          {expanded ? localize(language, "Collapse", "收起") : localize(language, "Show full content", "展开全文")}
+        </button>
+      ) : null}
     </div>
   );
 }
@@ -419,13 +425,16 @@ function traceStatusSymbol(event: SessionTraceEvent): string {
   return "•";
 }
 
+const TRACE_TRUNCATE_LIMIT = 2400;
+
 function TraceEventBlock({ event, language }: { event: SessionTraceEvent; language: LanguageMode }): ReactElement {
+  const truncated = Boolean(event.detail) && event.detail.length > TRACE_TRUNCATE_LIMIT;
+  const [expanded, setExpanded] = useState(false);
   const detail = useMemo(() => {
     if (!event.detail) return localize(language, "No detail captured.", "没有记录详情。");
-    return event.detail.length > 2400
-      ? `${event.detail.slice(0, 2400)}\n\n${localize(language, "...(truncated)", "...（已截断）")}`
-      : event.detail;
-  }, [event.detail, language]);
+    if (!truncated || expanded) return event.detail;
+    return `${event.detail.slice(0, TRACE_TRUNCATE_LIMIT)}\n\n${localize(language, "...(truncated)", "...（已截断）")}`;
+  }, [event.detail, truncated, expanded, language]);
 
   return (
     <details className={`trace-event ${event.kind} ${event.status || "unknown"}`}>
@@ -441,6 +450,12 @@ function TraceEventBlock({ event, language }: { event: SessionTraceEvent; langua
         {event.callId ? <span>{event.callId}</span> : null}
       </div>
       <pre>{detail}</pre>
+      {truncated ? (
+        <button className="expand-toggle" onClick={() => setExpanded((prev) => !prev)}>
+          {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+          {expanded ? localize(language, "Collapse", "收起") : localize(language, "Show full detail", "展开详情")}
+        </button>
+      ) : null}
     </details>
   );
 }

--- a/src/renderer/src/components/detail-panel.tsx
+++ b/src/renderer/src/components/detail-panel.tsx
@@ -393,7 +393,7 @@ export function DetailPanel({
 
 const MESSAGE_TRUNCATE_LIMIT = 3000;
 
-function MessageBlock({ message, query, language }: { message: SessionMessage; query: string; language: LanguageMode }): ReactElement {
+function MessageBlock({ message, query: _query, language }: { message: SessionMessage; query: string; language: LanguageMode }): ReactElement {
   const truncated = message.content.length > MESSAGE_TRUNCATE_LIMIT;
   const [expanded, setExpanded] = useState(false);
   const content = useMemo(() => {
@@ -409,7 +409,7 @@ function MessageBlock({ message, query, language }: { message: SessionMessage; q
       </div>
       <pre>{content}</pre>
       {truncated ? (
-        <button className="expand-toggle" onClick={() => setExpanded((prev) => !prev)}>
+        <button className="expand-toggle" aria-expanded={expanded} onClick={() => setExpanded((prev) => !prev)}>
           {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
           {expanded ? localize(language, "Collapse", "收起") : localize(language, "Show full content", "展开全文")}
         </button>
@@ -451,7 +451,7 @@ function TraceEventBlock({ event, language }: { event: SessionTraceEvent; langua
       </div>
       <pre>{detail}</pre>
       {truncated ? (
-        <button className="expand-toggle" onClick={() => setExpanded((prev) => !prev)}>
+        <button className="expand-toggle" aria-expanded={expanded} onClick={() => setExpanded((prev) => !prev)}>
           {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
           {expanded ? localize(language, "Collapse", "收起") : localize(language, "Show full detail", "展开详情")}
         </button>

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -2078,6 +2078,27 @@ select:focus-visible {
   background: var(--accent-soft);
 }
 
+.expand-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 28px;
+  margin: 4px 10px 8px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--panel-subtle);
+  color: var(--accent);
+  font-size: 11.5px;
+  font-weight: 600;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+
+.expand-toggle:hover {
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
+}
+
 /* ============================================================ MENUS / DIALOGS */
 .context-menu {
   position: fixed;


### PR DESCRIPTION
## 问题描述

在查看历史会话详情时，较长的消息（>3000 字符）和 trace event 详情（>2400 字符）会被硬截断，只显示"...（已截断）"，没有任何方式查看完整内容。用户如果需要查看被截断的部分，只能去原始 JSONL 文件中查找，体验断裂。

## 改动内容

为 MessageBlock 和 TraceEventBlock 添加了展开/收起按钮：

- **消息块 (MessageBlock)**：超过 3000 字符时，底部显示"展开全文"/"收起"按钮，带 ChevronDown/ChevronUp 图标
- **轨迹事件块 (TraceEventBlock)**：超过 2400 字符时，底部显示"展开详情"/"收起"按钮
- 截断阈值提取为命名常量 `MESSAGE_TRUNCATE_LIMIT` 和 `TRACE_TRUNCATE_LIMIT`，便于后续调整
- 按钮使用中英双语，跟随应用语言设置
- 新增 `.expand-toggle` CSS 样式，使用 accent 主题色，hover 时有视觉反馈

## 验证方式

- 打开一个包含长消息的会话详情，确认截断消息底部出现展开按钮
- 点击"展开全文"后显示完整内容，按钮文字变为"收起"
- 短消息不显示展开按钮
- trace event 同理
