### PR TITLE
feat: 迁移压缩增加进度条 UI

### DIFF
--- a/src/core/remote-session-restore.ts
+++ b/src/core/remote-session-restore.ts
@@ -1,9 +1,5 @@
-import {
-  migrationCompressionPercent,
-  type MigrationCompressionListener,
-  type PreparedMigrationSession,
-} from "./session-migration-compression";
-import { estimatePortableSessionTokens, MIGRATION_TOKEN_LIMIT } from "./session-migration";
+import type { MigrationCompressionListener, PreparedMigrationSession } from "./session-migration-compression";
+import { estimatePortableSessionTokens, migrationCompressionPercent, MIGRATION_TOKEN_LIMIT } from "./session-migration";
 import type { WrittenMigratedSession } from "./session-migration-writers";
 import type {
   MigrationAgent,

--- a/src/core/remote-session-restore.ts
+++ b/src/core/remote-session-restore.ts
@@ -1,4 +1,9 @@
-import type { PreparedMigrationSession } from "./session-migration-compression";
+import {
+  migrationCompressionPercent,
+  type MigrationCompressionListener,
+  type PreparedMigrationSession,
+} from "./session-migration-compression";
+import { estimatePortableSessionTokens, MIGRATION_TOKEN_LIMIT } from "./session-migration";
 import type { WrittenMigratedSession } from "./session-migration-writers";
 import type {
   MigrationAgent,
@@ -10,7 +15,10 @@ import type {
 
 export interface RemoteSessionRestoreDependencies {
   inspectCli: (target: MigrationAgent) => Promise<void> | void;
-  prepare: (session: PortableSession) => Promise<PreparedMigrationSession>;
+  prepare: (
+    session: PortableSession,
+    onProgress?: MigrationCompressionListener,
+  ) => Promise<PreparedMigrationSession>;
   write: (target: MigrationAgent, session: PortableSession) => Promise<WrittenMigratedSession>;
   record: (record: SessionMigrationRecord) => Promise<void> | void;
   refreshIndex: (target: MigrationAgent, targetFilePath: string) => Promise<void>;
@@ -56,7 +64,31 @@ export async function restoreRemotePortableSession({
     projectPath: localProjectPath,
   };
 
-  const prepared = await deps.prepare(localPortable);
+  if (estimatePortableSessionTokens(localPortable) > MIGRATION_TOKEN_LIMIT) {
+    notifyProgress(deps.onProgress, {
+      sessionKey: remoteId,
+      target,
+      stage: "compressing",
+      percent: 0,
+    });
+  }
+
+  // Lift the compressor's granular events into SessionMigrationProgress so the
+  // UI can render a percentage bar during the (slow, multi-call) compression.
+  const migrationOnProgress = deps.onProgress;
+  const compressionListener: MigrationCompressionListener | undefined = migrationOnProgress
+    ? (event) => {
+        notifyProgress(migrationOnProgress, {
+          sessionKey: remoteId,
+          target,
+          stage: "compressing",
+          percent: migrationCompressionPercent(event),
+          compression: event,
+        });
+      }
+    : undefined;
+
+  const prepared = await deps.prepare(localPortable, compressionListener);
 
   notifyProgress(deps.onProgress, {
     sessionKey: remoteId,

--- a/src/core/session-migration-compression.test.ts
+++ b/src/core/session-migration-compression.test.ts
@@ -8,10 +8,9 @@ import {
   buildMigrationHandoffMessages,
   createMigrationCompressor,
   formatCompactSummary,
-  migrationCompressionPercent,
   parseMigrationHandoff,
 } from "./session-migration-compression";
-import { estimatePortableSessionTokens, MIGRATION_TOKEN_LIMIT } from "./session-migration";
+import { estimatePortableSessionTokens, migrationCompressionPercent, MIGRATION_TOKEN_LIMIT } from "./session-migration";
 import { writeMigratedSession } from "./session-migration-writers";
 import type { MigrationCompressionEvent, PortableSession, SessionMessage } from "./types";
 

--- a/src/core/session-migration-compression.test.ts
+++ b/src/core/session-migration-compression.test.ts
@@ -8,11 +8,12 @@ import {
   buildMigrationHandoffMessages,
   createMigrationCompressor,
   formatCompactSummary,
+  migrationCompressionPercent,
   parseMigrationHandoff,
 } from "./session-migration-compression";
 import { estimatePortableSessionTokens, MIGRATION_TOKEN_LIMIT } from "./session-migration";
 import { writeMigratedSession } from "./session-migration-writers";
-import type { PortableSession, SessionMessage } from "./types";
+import type { MigrationCompressionEvent, PortableSession, SessionMessage } from "./types";
 
 const STARTED_AT = "2026-06-23T00:00:00.000Z";
 
@@ -119,6 +120,28 @@ describe("migration compression policy", () => {
     expect(result.session.messages.at(-1)?.content).toContain("final answer");
     expect(estimatePortableSessionTokens(result.session)).toBeLessThanOrEqual(MIGRATION_TOKEN_LIMIT);
     expectContinuousIndexes(result.session);
+  });
+
+  it("forwards the compression progress listener to compress", async () => {
+    const session = portableWithContent("x".repeat(239_989));
+    const compress = vi.fn(
+      async (_session, onProgress?: (event: MigrationCompressionEvent) => void) => {
+        onProgress?.({ chunkIndex: 0, totalChunks: 2, phase: "chunk" });
+        onProgress?.({ chunkIndex: 1, totalChunks: 2, phase: "handoff" });
+        return VALID_HANDOFF;
+      },
+    );
+
+    const events: MigrationCompressionEvent[] = [];
+    const result = await applyMigrationLengthPolicy(session, compress, (event) => {
+      events.push(event);
+    });
+
+    expect(result.strategy).toBe("ai-compressed");
+    expect(events).toEqual([
+      { chunkIndex: 0, totalChunks: 2, phase: "chunk" },
+      { chunkIndex: 1, totalChunks: 2, phase: "handoff" },
+    ]);
   });
 
   it.each([
@@ -480,5 +503,73 @@ describe("migration handoff provider request", () => {
 
     await expect(createMigrationCompressor(endpoint, chat)(session)).resolves.toBe(VALID_HANDOFF);
     expect(chat).toHaveBeenCalledWith(endpoint, buildMigrationHandoffMessages(session));
+  });
+
+  it("reports chunk-then-handoff progress as it summarizes a multi-chunk session", async () => {
+    const endpoint = {
+      baseUrl: "https://provider.example/v1",
+      model: "model",
+      apiKey: "secret",
+      apiFormat: "openai_chat" as const,
+    };
+    const session = portable(
+      Array.from({ length: 80 }, (_, index) =>
+        message(`chunk-${index}-${"x".repeat(5_000)}`, index),
+      ),
+    );
+    const chat = vi.fn(async (_endpoint, messages) => {
+      if (messages[0].content.includes("分片摘要")) return "分片摘要内容";
+      return VALID_HANDOFF;
+    });
+
+    const events: MigrationCompressionEvent[] = [];
+    await createMigrationCompressor(endpoint, chat)(session, (event) => {
+      events.push(event);
+    });
+
+    const chunkEvents = events.filter((event) => event.phase === "chunk");
+    expect(chunkEvents.length).toBeGreaterThan(1);
+    expect(events[events.length - 1].phase).toBe("handoff");
+    const totalChunks = events[0].totalChunks;
+    expect(totalChunks).toBeGreaterThan(1);
+    expect(events.every((event) => event.totalChunks === totalChunks)).toBe(true);
+    // chunk events fire in increasing source order
+    const chunkIndexes = chunkEvents.map((event) => event.chunkIndex);
+    expect(chunkIndexes).toEqual([...chunkIndexes].sort((a, b) => a - b));
+    // percent climbs monotonically across the reported events
+    const percents = events.map((event) => migrationCompressionPercent(event));
+    expect(percents).toEqual([...percents].sort((a, b) => a - b));
+  });
+
+  it("emits a single handoff progress event for a single-chunk session", async () => {
+    const endpoint = {
+      baseUrl: "https://provider.example/v1",
+      model: "model",
+      apiKey: "secret",
+      apiFormat: "openai_chat" as const,
+    };
+    const chat = vi.fn().mockResolvedValue(VALID_HANDOFF);
+    const session = portableWithContent("transcript");
+
+    const events: MigrationCompressionEvent[] = [];
+    await createMigrationCompressor(endpoint, chat)(session, (event) => {
+      events.push(event);
+    });
+
+    expect(events).toEqual([{ chunkIndex: 0, totalChunks: 1, phase: "handoff" }]);
+  });
+});
+
+describe("migrationCompressionPercent", () => {
+  it("maps chunk events across (totalChunks + 1) units and tops below 100% on handoff", () => {
+    // 3 chunks -> 4 units; handoff is the 3rd-done state (75%), not 100%.
+    expect(migrationCompressionPercent({ chunkIndex: 0, totalChunks: 3, phase: "chunk" })).toBe(25);
+    expect(migrationCompressionPercent({ chunkIndex: 1, totalChunks: 3, phase: "chunk" })).toBe(50);
+    expect(migrationCompressionPercent({ chunkIndex: 2, totalChunks: 3, phase: "chunk" })).toBe(75);
+    expect(migrationCompressionPercent({ chunkIndex: 2, totalChunks: 3, phase: "handoff" })).toBe(75);
+  });
+
+  it("reports 50% for a single-chunk handoff", () => {
+    expect(migrationCompressionPercent({ chunkIndex: 0, totalChunks: 1, phase: "handoff" })).toBe(50);
   });
 });

--- a/src/core/session-migration-compression.ts
+++ b/src/core/session-migration-compression.ts
@@ -283,18 +283,6 @@ function buildAiCompressedSession(
   };
 }
 
-// Map a compression event to a 0-100 percent. Total work units =
-// totalChunks (chunk summaries) + 1 (final handoff). A "chunk" event fires
-// after chunk `chunkIndex` is summarized (done = chunkIndex + 1); a "handoff"
-// event fires once the final handoff call begins (all chunks done, handoff in
-// flight, so done = totalChunks — the bar tops just below 100% until the
-// compressor returns and the orchestrator moves to the "writing" stage).
-export function migrationCompressionPercent(event: MigrationCompressionEvent): number {
-  const totalUnits = event.totalChunks + 1;
-  const done = event.phase === "handoff" ? event.totalChunks : event.chunkIndex + 1;
-  return Math.max(0, Math.min(100, Math.round((done / totalUnits) * 100)));
-}
-
 export async function applyMigrationLengthPolicy(
   session: PortableSession,
   compress: MigrationCompressFn | null,

--- a/src/core/session-migration-compression.ts
+++ b/src/core/session-migration-compression.ts
@@ -9,12 +9,18 @@ import {
   MIGRATION_TOKEN_LIMIT,
 } from "./session-migration";
 import type {
+  MigrationCompressionEvent,
   PortableSession,
   SessionMessage,
   SessionMigrationStrategy,
 } from "./types";
 
-export type MigrationCompressFn = (session: PortableSession) => Promise<string>;
+export type MigrationCompressionListener = (event: MigrationCompressionEvent) => void;
+
+export type MigrationCompressFn = (
+  session: PortableSession,
+  onProgress?: MigrationCompressionListener,
+) => Promise<string>;
 
 export interface PreparedMigrationSession {
   session: PortableSession;
@@ -277,9 +283,22 @@ function buildAiCompressedSession(
   };
 }
 
+// Map a compression event to a 0-100 percent. Total work units =
+// totalChunks (chunk summaries) + 1 (final handoff). A "chunk" event fires
+// after chunk `chunkIndex` is summarized (done = chunkIndex + 1); a "handoff"
+// event fires once the final handoff call begins (all chunks done, handoff in
+// flight, so done = totalChunks — the bar tops just below 100% until the
+// compressor returns and the orchestrator moves to the "writing" stage).
+export function migrationCompressionPercent(event: MigrationCompressionEvent): number {
+  const totalUnits = event.totalChunks + 1;
+  const done = event.phase === "handoff" ? event.totalChunks : event.chunkIndex + 1;
+  return Math.max(0, Math.min(100, Math.round((done / totalUnits) * 100)));
+}
+
 export async function applyMigrationLengthPolicy(
   session: PortableSession,
   compress: MigrationCompressFn | null,
+  onProgress?: MigrationCompressionListener,
 ): Promise<PreparedMigrationSession> {
   if (estimatePortableSessionTokens(session) <= MIGRATION_TOKEN_LIMIT) {
     return { session, strategy: "complete" };
@@ -287,7 +306,9 @@ export async function applyMigrationLengthPolicy(
 
   if (compress) {
     try {
-      const raw = (await compress(session)).trim();
+      // Forward onProgress only when provided, so callers (and tests) that
+      // pass a plain (session) => Promise<string> fn see exactly that arity.
+      const raw = (await (onProgress ? compress(session, onProgress) : compress(session))).trim();
       const summary = parseMigrationHandoff(raw);
       if (summary) {
         return {
@@ -480,9 +501,12 @@ export function createMigrationCompressor(
   endpoint: SummaryEndpoint,
   chat: ChatCompletionFn = requestSummaryCompletion,
 ): MigrationCompressFn {
-  return async (session) => {
+  return async (session, onProgress) => {
     const chunks = transcriptChunks(session);
+    const totalChunks = Math.max(1, chunks.length);
+
     if (chunks.length <= 1) {
+      onProgress?.({ chunkIndex: 0, totalChunks, phase: "handoff" });
       return chat(endpoint, buildMigrationHandoffMessages(session));
     }
 
@@ -493,7 +517,9 @@ export function createMigrationCompressor(
         buildMigrationChunkSummaryMessages(session, chunks[index], index, chunks.length),
       );
       chunkSummaries.push(safePrefix(summary.trim(), CHUNK_SUMMARY_MAX_CHARACTERS));
+      onProgress?.({ chunkIndex: index, totalChunks, phase: "chunk" });
     }
+    onProgress?.({ chunkIndex: chunks.length - 1, totalChunks, phase: "handoff" });
     return chat(endpoint, buildMigrationHandoffMessagesFromChunkSummaries(session, chunkSummaries));
   };
 }

--- a/src/core/session-migration.test.ts
+++ b/src/core/session-migration.test.ts
@@ -6,8 +6,8 @@ import {
   migrationAgentForSource,
   portableSessionFrom,
   supportedMigrationTargets,
+  type SessionMigrationDependencies,
 } from "./session-migration";
-import type { PreparedMigrationSession } from "./session-migration-compression";
 import type { WrittenMigratedSession } from "./session-migration-writers";
 import type { SessionMessage, SessionSearchResult, SessionSource } from "./types";
 
@@ -93,15 +93,13 @@ function createDependencies() {
   const inspectCli = vi.fn(async () => {
     callOrder.push("inspectCli");
   });
-  const prepare = vi.fn(
-    async (portable): Promise<PreparedMigrationSession> => {
-      callOrder.push("prepare");
-      return {
-        session: portable,
-        strategy: "complete",
-      };
-    },
-  );
+  const prepare = vi.fn<SessionMigrationDependencies["prepare"]>(async (portable) => {
+    callOrder.push("prepare");
+    return {
+      session: portable,
+      strategy: "complete",
+    };
+  });
   const write = vi.fn(async () => {
     callOrder.push("write");
     return writtenMigration();
@@ -454,6 +452,33 @@ describe("migrateSession", () => {
       "indexing",
       "launching",
     ]);
+  });
+
+  it("lifts compression progress into percent-valued compressing events", async () => {
+    const { deps, onProgress } = createDependencies();
+    deps.prepare.mockImplementation(async (portable, onCompressionProgress) => {
+      onCompressionProgress?.({ chunkIndex: 0, totalChunks: 3, phase: "chunk" });
+      onCompressionProgress?.({ chunkIndex: 1, totalChunks: 3, phase: "chunk" });
+      onCompressionProgress?.({ chunkIndex: 2, totalChunks: 3, phase: "handoff" });
+      return { session: portable, strategy: "ai-compressed" };
+    });
+
+    await migrateSession({
+      source: session("claude-cli"),
+      messages: longMessages(),
+      target: "codex",
+      deps,
+    });
+
+    const compressingEvents = onProgress.mock.calls
+      .map(([event]) => event)
+      .filter((event) => event.stage === "compressing");
+    expect(compressingEvents.map((event) => event.percent)).toEqual([0, 25, 50, 75]);
+    expect(compressingEvents[1].compression).toEqual({
+      chunkIndex: 0,
+      totalChunks: 3,
+      phase: "chunk",
+    });
   });
 
   it("isolates progress callback errors and preserves the exact stage order", async () => {

--- a/src/core/session-migration.ts
+++ b/src/core/session-migration.ts
@@ -1,11 +1,8 @@
-import {
-  migrationCompressionPercent,
-  type MigrationCompressionListener,
-  type PreparedMigrationSession,
-} from "./session-migration-compression";
+import type { MigrationCompressionListener, PreparedMigrationSession } from "./session-migration-compression";
 import type { WrittenMigratedSession } from "./session-migration-writers";
 import type {
   MigrationAgent,
+  MigrationCompressionEvent,
   PortableSession,
   SessionMessage,
   SessionMigrationProgress,
@@ -122,6 +119,22 @@ export function estimatePortableSessionTokens(session: PortableSession): number 
     0,
   );
   return Math.ceil(characters / 4);
+}
+
+// Map a compression event to a 0-100 percent. Total work units =
+// totalChunks (chunk summaries) + 1 (final handoff). A "chunk" event fires
+// after chunk `chunkIndex` is summarized (done = chunkIndex + 1); a "handoff"
+// event fires once the final handoff call begins (all chunks done, handoff in
+// flight, so done = totalChunks — the bar tops just below 100% until the
+// compressor returns and the orchestrator moves to the "writing" stage).
+//
+// Defined here (not in session-migration-compression.ts) so session-migration
+// can stay a type-only importer of that module: a runtime import would drag
+// session-summarizer (and node:child_process) into the renderer bundle.
+export function migrationCompressionPercent(event: MigrationCompressionEvent): number {
+  const totalUnits = event.totalChunks + 1;
+  const done = event.phase === "handoff" ? event.totalChunks : event.chunkIndex + 1;
+  return Math.max(0, Math.min(100, Math.round((done / totalUnits) * 100)));
 }
 
 export async function migrateSession({

--- a/src/core/session-migration.ts
+++ b/src/core/session-migration.ts
@@ -1,4 +1,8 @@
-import type { PreparedMigrationSession } from "./session-migration-compression";
+import {
+  migrationCompressionPercent,
+  type MigrationCompressionListener,
+  type PreparedMigrationSession,
+} from "./session-migration-compression";
 import type { WrittenMigratedSession } from "./session-migration-writers";
 import type {
   MigrationAgent,
@@ -17,7 +21,10 @@ const MIGRATION_AGENTS = ["claude", "codex", "codebuddy"] as const;
 
 export interface SessionMigrationDependencies {
   inspectCli: (target: MigrationAgent) => Promise<void> | void;
-  prepare: (session: PortableSession) => Promise<PreparedMigrationSession>;
+  prepare: (
+    session: PortableSession,
+    onProgress?: MigrationCompressionListener,
+  ) => Promise<PreparedMigrationSession>;
   write: (
     target: MigrationAgent,
     session: PortableSession,
@@ -139,10 +146,26 @@ export async function migrateSession({
       sessionKey: source.sessionKey,
       target,
       stage: "compressing",
+      percent: 0,
     });
   }
 
-  const prepared = await deps.prepare(portable);
+  // Lift the compressor's granular events into SessionMigrationProgress so the
+  // UI can render a percentage bar during the (slow, multi-call) compression.
+  const migrationOnProgress = deps.onProgress;
+  const compressionListener: MigrationCompressionListener | undefined = migrationOnProgress
+    ? (event) => {
+        notifyProgress(migrationOnProgress, {
+          sessionKey: source.sessionKey,
+          target,
+          stage: "compressing",
+          percent: migrationCompressionPercent(event),
+          compression: event,
+        });
+      }
+    : undefined;
+
+  const prepared = await deps.prepare(portable, compressionListener);
 
   notifyProgress(deps.onProgress, {
     sessionKey: source.sessionKey,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -61,6 +61,20 @@ export type MigrationAgent = "claude" | "codex" | "codebuddy";
 export type SessionMigrationStrategy = "complete" | "ai-compressed" | "locally-truncated";
 export type SessionMigrationStage = "reading" | "compressing" | "writing" | "indexing" | "launching";
 
+// Granular progress emitted from inside the AI compression loop. The compressor
+// summarizes the transcript chunk-by-chunk, then makes one final handoff call;
+// each completed unit reports back so the UI can render a percentage.
+export type MigrationCompressionPhase = "chunk" | "handoff";
+
+export interface MigrationCompressionEvent {
+  // 0-based index of the chunk just summarized (chunk phase), or the last
+  // chunk index (handoff phase).
+  chunkIndex: number;
+  // Number of chunk-summary calls (>=1); the final handoff is the +1th unit.
+  totalChunks: number;
+  phase: MigrationCompressionPhase;
+}
+
 export interface PortableSession {
   sourceSessionKey: string;
   sourceAgent: MigrationAgent;
@@ -74,6 +88,11 @@ export interface SessionMigrationProgress {
   sessionKey: string;
   target: MigrationAgent;
   stage: SessionMigrationStage;
+  // 0-100 progress within the current stage. Only meaningful during
+  // "compressing" (the only stage with multiple discrete units of work).
+  percent?: number;
+  // Structured compression detail; the renderer localizes this into text.
+  compression?: MigrationCompressionEvent;
 }
 
 export interface SessionMigrationResult {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -377,7 +377,8 @@ async function restoreRemoteSession(
 ): Promise<SessionMigrationResult> {
   const client = createRemoteSessionClient();
   const portable = await client.getPortableSession(remoteId);
-  const endpoint = await resolveSummaryEndpointFromSettings();
+  // 没配自定义摘要 endpoint 时回退本地 Codex CLI(缺失则再退 Claude),让迁移仍走 AI 压缩而非直接本地截断——与 AI 助手一致。
+  const endpoint = (await resolveSummaryEndpointFromSettings()) ?? buildCodexExecEndpoint(await getHydratedSettings());
   const compressor = endpoint ? createMigrationCompressor(endpoint) : null;
   return restoreRemotePortableSession({
     remoteId,
@@ -1639,7 +1640,8 @@ function registerIpc(): void {
     const session = store.getSession(sessionKey);
     if (!session) throw new Error("Session not found.");
 
-    const endpoint = await resolveSummaryEndpointFromSettings();
+    // 没配自定义摘要 endpoint 时回退本地 Codex CLI(缺失则再退 Claude),让迁移仍走 AI 压缩而非直接本地截断——与 AI 助手一致。
+    const endpoint = (await resolveSummaryEndpointFromSettings()) ?? buildCodexExecEndpoint(await getHydratedSettings());
     const compressor = endpoint ? createMigrationCompressor(endpoint) : null;
     const result = await migrateSession({
       source: session,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -386,7 +386,7 @@ async function restoreRemoteSession(
     localProjectPath,
     deps: {
       inspectCli: (migrationTarget) => inspectMigrationCli(migrationTarget, getSettings()),
-      prepare: (session) => applyMigrationLengthPolicy(session, compressor),
+      prepare: (session, onProgress) => applyMigrationLengthPolicy(session, compressor, onProgress),
       write: (migrationTarget, session) => writeMigratedSession({ target: migrationTarget, session }),
       record: (record) => store.recordSessionMigration(record),
       refreshIndex: async (migrationTarget, writtenFilePath) => {
@@ -1647,7 +1647,7 @@ function registerIpc(): void {
       target,
       deps: {
         inspectCli: (migrationTarget) => inspectMigrationCli(migrationTarget, getSettings()),
-        prepare: (portable) => applyMigrationLengthPolicy(portable, compressor),
+        prepare: (portable, onProgress) => applyMigrationLengthPolicy(portable, compressor, onProgress),
         write: (migrationTarget, portable) => writeMigratedSession({ target: migrationTarget, session: portable }),
         record: (record) => store.recordSessionMigration(record),
         refreshIndex: async (migrationTarget, writtenFilePath) => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -412,7 +412,7 @@ export function App(): ReactElement {
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const [dialog, setDialog] = useState<DialogState>(null);
   const [migrationDialog, setMigrationDialog] = useState<SessionMigrationDialogState>(null);
-  const [, setMigrationProgress] = useState<SessionMigrationProgress | null>(null);
+  const [migrationProgress, setMigrationProgress] = useState<SessionMigrationProgress | null>(null);
   const [deleteTagName, setDeleteTagName] = useState<string | null>(null);
   const [deleteSessionCandidate, setDeleteSessionCandidate] = useState<SessionSearchResult | null>(null);
   const [deletingSession, setDeletingSession] = useState(false);
@@ -2008,6 +2008,7 @@ export function App(): ReactElement {
           session={migrationDialog.session}
           language={language}
           busy={actionStatus?.kind === "running"}
+          progress={migrationProgress}
           onSelect={(target) => void runMigration(target)}
           onClose={() => setMigrationDialog(null)}
         />
@@ -2404,7 +2405,10 @@ function migrationStrategyLabel(strategy: SessionMigrationResult["strategy"], la
 function migrationProgressMessage(progress: SessionMigrationProgress, language: LanguageMode): string {
   const target = migrationAgentLabel(progress.target);
   if (progress.stage === "reading") return localize(language, `Reading session for ${target}...`, `正在读取会话，准备迁移到 ${target}...`);
-  if (progress.stage === "compressing") return localize(language, `Compressing long session for ${target}...`, `正在压缩长会话，准备迁移到 ${target}...`);
+  if (progress.stage === "compressing") {
+    const base = localize(language, `Compressing long session for ${target}...`, `正在压缩长会话，准备迁移到 ${target}...`);
+    return progress.percent != null ? `${base} ${progress.percent}%` : base;
+  }
   if (progress.stage === "writing") return localize(language, `Writing ${target} session...`, `正在写入 ${target} 会话...`);
   if (progress.stage === "indexing") return localize(language, "Refreshing index...", "正在刷新索引...");
   return localize(language, `Opening ${target}...`, `正在打开 ${target}...`);

--- a/src/renderer/src/components/session-migration-dialog.tsx
+++ b/src/renderer/src/components/session-migration-dialog.tsx
@@ -1,6 +1,11 @@
 import type { ReactElement } from "react";
 import { Copy, X } from "lucide-react";
-import type { MigrationAgent, SessionMigrationResult, SessionSearchResult } from "../../../core/types";
+import type {
+  MigrationAgent,
+  SessionMigrationProgress,
+  SessionMigrationResult,
+  SessionSearchResult,
+} from "../../../core/types";
 import { localize, type LanguageMode } from "../language";
 import { isRemoteSession, migrationAgentLabel, migrationTargetsForSource } from "../session-ui";
 
@@ -8,12 +13,14 @@ export function SessionMigrationDialog({
   session,
   language,
   busy,
+  progress,
   onSelect,
   onClose,
 }: {
   session: SessionSearchResult;
   language: LanguageMode;
   busy: boolean;
+  progress?: SessionMigrationProgress | null;
   onSelect: (target: MigrationAgent) => void;
   onClose: () => void;
 }): ReactElement {
@@ -34,6 +41,7 @@ export function SessionMigrationDialog({
           {l("Create a new local target-agent session from", "从当前会话创建新的本地目标 Agent 会话：")} <strong>{session.displayTitle}</strong>
         </p>
         {remote ? <p className="dialog-copy danger-copy">{l("Remote session migration is not supported yet.", "首版仅支持本地会话迁移。")}</p> : null}
+        {busy ? <MigrationProgressPanel progress={progress ?? null} language={language} /> : null}
         <div className="migration-targets">
           {(["claude", "codex", "codebuddy"] as const).map((target) => {
             const disabled = busy || remote || !targets.includes(target);
@@ -92,6 +100,70 @@ export function SessionMigrationLaunchFailedDialog({
           {l("Source:", "源会话：")} {session.displayTitle}
         </p>
       </div>
+    </div>
+  );
+}
+
+function migrationStageStatus(
+  progress: SessionMigrationProgress | null,
+  language: LanguageMode,
+): string {
+  const l = (en: string, zh: string) => localize(language, en, zh);
+  if (!progress) return l("Preparing migration...", "正在准备迁移...");
+  const target = migrationAgentLabel(progress.target);
+  if (progress.stage === "reading") return l(`Reading session for ${target}...`, `正在读取会话，准备迁移到 ${target}...`);
+  if (progress.stage === "compressing") return l(`Compressing long session for ${target}...`, `正在压缩长会话，准备迁移到 ${target}...`);
+  if (progress.stage === "writing") return l(`Writing ${target} session...`, `正在写入 ${target} 会话...`);
+  if (progress.stage === "indexing") return l("Refreshing index...", "正在刷新索引...");
+  return l(`Opening ${target}...`, `正在打开 ${target}...`);
+}
+
+function compressionDetailText(
+  progress: SessionMigrationProgress,
+  language: LanguageMode,
+): string | null {
+  const compression = progress.compression;
+  if (!compression) return null;
+  const l = (en: string, zh: string) => localize(language, en, zh);
+  if (compression.phase === "chunk") {
+    return l(
+      `Chunk ${compression.chunkIndex + 1}/${compression.totalChunks}`,
+      `压缩分片 ${compression.chunkIndex + 1}/${compression.totalChunks}`,
+    );
+  }
+  return l("Generating handoff summary...", "生成交接摘要...");
+}
+
+function MigrationProgressPanel({
+  progress,
+  language,
+}: {
+  progress: SessionMigrationProgress | null;
+  language: LanguageMode;
+}): ReactElement {
+  const compressing = progress?.stage === "compressing";
+  const percent = compressing ? Math.max(0, Math.min(100, progress?.percent ?? 0)) : 0;
+  const detail = compressing && progress ? compressionDetailText(progress, language) : null;
+  return (
+    <div className="migration-progress" aria-live="polite">
+      <div className="migration-progress-status">{migrationStageStatus(progress, language)}</div>
+      {compressing ? (
+        <>
+          <div
+            className="migration-progress-bar"
+            role="progressbar"
+            aria-valuenow={percent}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          >
+            <div className="migration-progress-fill" style={{ width: `${percent}%` }} />
+          </div>
+          <div className="migration-progress-meta">
+            <span className="migration-progress-percent">{percent}%</span>
+            {detail ? <span className="migration-progress-detail">{detail}</span> : null}
+          </div>
+        </>
+      ) : null}
     </div>
   );
 }

--- a/src/renderer/src/session-migration-ui.test.ts
+++ b/src/renderer/src/session-migration-ui.test.ts
@@ -20,4 +20,12 @@ describe("session migration UI wiring", () => {
     expect(dialogSource).toContain("targetSessionId");
     expect(dialogSource).toContain("resumeCommand");
   });
+
+  it("renders a compression progress bar inside the migration dialog", () => {
+    expect(appSource).toContain("progress={migrationProgress}");
+    expect(dialogSource).toContain("MigrationProgressPanel");
+    expect(dialogSource).toContain("migration-progress-bar");
+    expect(dialogSource).toContain("migration-progress-fill");
+    expect(dialogSource).toContain('role="progressbar"');
+  });
 });

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -2181,6 +2181,44 @@ select:focus-visible {
   opacity: 0.55;
 }
 
+.migration-progress {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  background: var(--panel-subtle);
+}
+
+.migration-progress-status {
+  font-size: 12.5px;
+  color: var(--text);
+}
+
+.migration-progress-bar {
+  margin-top: 8px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--border-strong);
+  overflow: hidden;
+}
+
+.migration-progress-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--accent);
+  transition: width 0.2s ease;
+}
+
+.migration-progress-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 6px;
+  font-size: 11.5px;
+  color: var(--text-muted);
+}
+
 .migration-resume-command {
   overflow: auto;
   max-height: 160px;


### PR DESCRIPTION
## 背景

长会话迁移时,压缩是多次 LLM 调用(每个分片一次摘要 + 最终 handoff),可能持续几十秒到几分钟。此前 UI 只在右下角 toast 显示一句"正在压缩长会话…",用户无法了解进度。

## 改动

把压缩分片循环的进度打通到 UI:

- **类型**:`SessionMigrationProgress` 增加 `percent`(0-100)和 `compression`(结构化事件)字段;新增 `MigrationCompressionEvent`。
- **压缩层**:`MigrationCompressFn` 加可选 `onProgress`;`createMigrationCompressor` 在每个分片摘要完成、handoff 开始时上报;新增 `migrationCompressionPercent` helper。`applyMigrationLengthPolicy` 透传 onProgress(无监听时仍以单参调用,保持原测试不变)。
- **迁移层**:`migrateSession` / `restoreRemotePortableSession` 把压缩事件抬升成带 `percent` 的 `compressing` 进度,压缩前先发 `percent:0` 基线;`deps.prepare` 加 onProgress 参数。主进程经既有 IPC 通道 `session:migration-progress` 转发。
- **UI**:`SessionMigrationDialog` busy 时渲染进度面板(状态文字 + 进度条 + 百分比 + "压缩分片 i/N");右下角 toast 文本压缩时追加百分比。新增 `styles.css` 进度条样式。

## 百分比语义

总工作量 = 分片数 + 1(最后 handoff)。每个分片完成推进一档;handoff 开始时进度停在 `分片数/(分片数+1)` 并显示"生成交接摘要…"——handoff 仍在进行,不虚报 100%,完成后自动切到"写入中"。长会话通常 6+ 分片,bar 会到 ~86% 以上。

## 验证

- `npm run typecheck` 通过
- `npm test` 608 → 615,新增 7 个测试(压缩进度回调、百分比映射、迁移层抬升事件、UI 接线断言)

