### PR TITLE
perf: 迁移压缩分片摘要并行化

### DIFF
--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -73,6 +73,7 @@ export interface AppSettings {
   notifyMinDurationSeconds: number;
   summaryAutoBackfill: boolean;
   summaryMaxAgeDays: number;
+  compressionConcurrency: number;
   summarySource: "codex" | "claude" | "custom";
   sessionSearchMcpEnabled: boolean;
   skillSyncEnabled: boolean;
@@ -116,6 +117,7 @@ export const defaultSettings: AppSettings = {
   notifyMinDurationSeconds: 30,
   summaryAutoBackfill: false,
   summaryMaxAgeDays: 30,
+  compressionConcurrency: 8,
   summarySource: "codex",
   sessionSearchMcpEnabled: true,
   skillSyncEnabled: false,
@@ -137,6 +139,7 @@ export function mergeAppSettings(previous: AppSettings, updates: AppSettingsUpda
     globalShortcut: normalizeGlobalShortcut(merged.globalShortcut),
     notifyMinDurationSeconds: normalizeNotifyDuration(merged.notifyMinDurationSeconds),
     summaryMaxAgeDays: normalizeSummaryMaxAgeDays(merged.summaryMaxAgeDays),
+    compressionConcurrency: normalizeCompressionConcurrency(merged.compressionConcurrency),
     summarySource: merged.summarySource === "claude" || merged.summarySource === "custom" ? merged.summarySource : "codex",
     skillSyncEnabled: Boolean(merged.skillSyncEnabled),
     skillSyncSupabaseUrl: normalizeSupabaseSettingUrl(merged.skillSyncSupabaseUrl),
@@ -162,6 +165,11 @@ function normalizeNotifyDuration(value: number): number {
 function normalizeSummaryMaxAgeDays(value: number): number {
   if (!Number.isFinite(value) || value < 1) return defaultSettings.summaryMaxAgeDays;
   return Math.min(3650, Math.round(value));
+}
+
+function normalizeCompressionConcurrency(value: number): number {
+  if (!Number.isFinite(value) || value < 1) return defaultSettings.compressionConcurrency;
+  return Math.min(32, Math.round(value));
 }
 
 const ITERM_APPLICATION_NAMES = ["iTerm", "iTerm2"];

--- a/src/core/session-migration-compression.test.ts
+++ b/src/core/session-migration-compression.test.ts
@@ -6,6 +6,7 @@ import {
   applyMigrationLengthPolicy,
   buildLocalMigrationFallback,
   buildMigrationHandoffMessages,
+  COMPRESSION_CONCURRENCY,
   createMigrationCompressor,
   formatCompactSummary,
   parseMigrationHandoff,
@@ -125,8 +126,8 @@ describe("migration compression policy", () => {
     const session = portableWithContent("x".repeat(239_989));
     const compress = vi.fn(
       async (_session, onProgress?: (event: MigrationCompressionEvent) => void) => {
-        onProgress?.({ chunkIndex: 0, totalChunks: 2, phase: "chunk" });
-        onProgress?.({ chunkIndex: 1, totalChunks: 2, phase: "handoff" });
+        onProgress?.({ completed: 1, totalChunks: 2, phase: "chunk" });
+        onProgress?.({ completed: 2, totalChunks: 2, phase: "handoff" });
         return VALID_HANDOFF;
       },
     );
@@ -138,8 +139,8 @@ describe("migration compression policy", () => {
 
     expect(result.strategy).toBe("ai-compressed");
     expect(events).toEqual([
-      { chunkIndex: 0, totalChunks: 2, phase: "chunk" },
-      { chunkIndex: 1, totalChunks: 2, phase: "handoff" },
+      { completed: 1, totalChunks: 2, phase: "chunk" },
+      { completed: 2, totalChunks: 2, phase: "handoff" },
     ]);
   });
 
@@ -532,9 +533,9 @@ describe("migration handoff provider request", () => {
     const totalChunks = events[0].totalChunks;
     expect(totalChunks).toBeGreaterThan(1);
     expect(events.every((event) => event.totalChunks === totalChunks)).toBe(true);
-    // chunk events fire in increasing source order
-    const chunkIndexes = chunkEvents.map((event) => event.chunkIndex);
-    expect(chunkIndexes).toEqual([...chunkIndexes].sort((a, b) => a - b));
+    // completed counts 1..N monotonically (order-independent under concurrency)
+    const completedCounts = chunkEvents.map((event) => event.completed);
+    expect(completedCounts).toEqual(Array.from({ length: chunkEvents.length }, (_, i) => i + 1));
     // percent climbs monotonically across the reported events
     const percents = events.map((event) => migrationCompressionPercent(event));
     expect(percents).toEqual([...percents].sort((a, b) => a - b));
@@ -555,20 +556,51 @@ describe("migration handoff provider request", () => {
       events.push(event);
     });
 
-    expect(events).toEqual([{ chunkIndex: 0, totalChunks: 1, phase: "handoff" }]);
+    expect(events).toEqual([{ completed: 1, totalChunks: 1, phase: "handoff" }]);
+  });
+
+  it("summarizes chunks concurrently with bounded concurrency", async () => {
+    const endpoint = {
+      baseUrl: "https://provider.example/v1",
+      model: "model",
+      apiKey: "secret",
+      apiFormat: "openai_chat" as const,
+    };
+    const session = portable(
+      Array.from({ length: 80 }, (_, index) =>
+        message(`chunk-${index}-${"x".repeat(5_000)}`, index),
+      ),
+    );
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const chat = vi.fn(async (_endpoint, messages) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight -= 1;
+      if (messages[0].content.includes("分片摘要")) return "分片摘要内容";
+      return VALID_HANDOFF;
+    });
+
+    await createMigrationCompressor(endpoint, chat)(session);
+
+    // Concurrency actually happened (more than one chunk in flight at once)...
+    expect(maxInFlight).toBeGreaterThan(1);
+    // ...but never exceeded the configured bound.
+    expect(maxInFlight).toBeLessThanOrEqual(COMPRESSION_CONCURRENCY);
   });
 });
 
 describe("migrationCompressionPercent", () => {
   it("maps chunk events across (totalChunks + 1) units and tops below 100% on handoff", () => {
     // 3 chunks -> 4 units; handoff is the 3rd-done state (75%), not 100%.
-    expect(migrationCompressionPercent({ chunkIndex: 0, totalChunks: 3, phase: "chunk" })).toBe(25);
-    expect(migrationCompressionPercent({ chunkIndex: 1, totalChunks: 3, phase: "chunk" })).toBe(50);
-    expect(migrationCompressionPercent({ chunkIndex: 2, totalChunks: 3, phase: "chunk" })).toBe(75);
-    expect(migrationCompressionPercent({ chunkIndex: 2, totalChunks: 3, phase: "handoff" })).toBe(75);
+    expect(migrationCompressionPercent({ completed: 1, totalChunks: 3, phase: "chunk" })).toBe(25);
+    expect(migrationCompressionPercent({ completed: 2, totalChunks: 3, phase: "chunk" })).toBe(50);
+    expect(migrationCompressionPercent({ completed: 3, totalChunks: 3, phase: "chunk" })).toBe(75);
+    expect(migrationCompressionPercent({ completed: 3, totalChunks: 3, phase: "handoff" })).toBe(75);
   });
 
   it("reports 50% for a single-chunk handoff", () => {
-    expect(migrationCompressionPercent({ chunkIndex: 0, totalChunks: 1, phase: "handoff" })).toBe(50);
+    expect(migrationCompressionPercent({ completed: 1, totalChunks: 1, phase: "handoff" })).toBe(50);
   });
 });

--- a/src/core/session-migration-compression.test.ts
+++ b/src/core/session-migration-compression.test.ts
@@ -589,6 +589,35 @@ describe("migration handoff provider request", () => {
     // ...but never exceeded the configured bound.
     expect(maxInFlight).toBeLessThanOrEqual(COMPRESSION_CONCURRENCY);
   });
+
+  it("respects a custom concurrency bound", async () => {
+    const endpoint = {
+      baseUrl: "https://provider.example/v1",
+      model: "model",
+      apiKey: "secret",
+      apiFormat: "openai_chat" as const,
+    };
+    const session = portable(
+      Array.from({ length: 80 }, (_, index) =>
+        message(`chunk-${index}-${"x".repeat(5_000)}`, index),
+      ),
+    );
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const chat = vi.fn(async (_endpoint, messages) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight -= 1;
+      if (messages[0].content.includes("分片摘要")) return "分片摘要内容";
+      return VALID_HANDOFF;
+    });
+
+    await createMigrationCompressor(endpoint, chat, 2)(session);
+
+    expect(maxInFlight).toBeGreaterThan(1);
+    expect(maxInFlight).toBeLessThanOrEqual(2);
+  });
 });
 
 describe("migrationCompressionPercent", () => {

--- a/src/core/session-migration-compression.ts
+++ b/src/core/session-migration-compression.ts
@@ -50,7 +50,7 @@ const CHUNK_SUMMARY_MAX_CHARACTERS = 4_000;
 // Max chunk summaries run in parallel. Chunk summaries are independent (the
 // handoff that depends on all of them stays sequential after), so bounding
 // concurrency turns N sequential LLM calls into ceil(N / CONCURRENCY) batches.
-export const COMPRESSION_CONCURRENCY = 4;
+export const COMPRESSION_CONCURRENCY = 8;
 
 interface TranscriptFragment {
   text: string;
@@ -524,8 +524,8 @@ export function createMigrationCompressor(
       return chat(endpoint, buildMigrationHandoffMessages(session));
     }
 
-    // Chunk summaries are independent — run them concurrently (bounded) so a
-    // 10-chunk session takes ~3 batches instead of 10 sequential LLM calls.
+    // Chunk summaries are independent — run them concurrently (bounded) so an
+    // N-chunk session takes ceil(N/CONCURRENCY) batches instead of N sequential calls.
     // `completed` advances as each finishes (order-independent, monotonic); the
     // handoff still waits for all of them since it folds the summaries together.
     let completed = 0;

--- a/src/core/session-migration-compression.ts
+++ b/src/core/session-migration-compression.ts
@@ -514,6 +514,7 @@ async function mapWithConcurrency<T, R>(
 export function createMigrationCompressor(
   endpoint: SummaryEndpoint,
   chat: ChatCompletionFn = requestSummaryCompletion,
+  concurrency: number = COMPRESSION_CONCURRENCY,
 ): MigrationCompressFn {
   return async (session, onProgress) => {
     const chunks = transcriptChunks(session);
@@ -531,7 +532,7 @@ export function createMigrationCompressor(
     let completed = 0;
     const chunkSummaries = await mapWithConcurrency(
       chunks,
-      COMPRESSION_CONCURRENCY,
+      concurrency,
       async (chunk, index) => {
         const summary = await chat(
           endpoint,

--- a/src/core/session-migration-compression.ts
+++ b/src/core/session-migration-compression.ts
@@ -47,6 +47,10 @@ const SUMMARY_MIN_CHARACTERS = 500;
 const TRANSCRIPT_FRAGMENT_CHARACTERS = 8_000;
 const COMPRESSION_CHUNK_CHARACTERS = 45_000;
 const CHUNK_SUMMARY_MAX_CHARACTERS = 4_000;
+// Max chunk summaries run in parallel. Chunk summaries are independent (the
+// handoff that depends on all of them stays sequential after), so bounding
+// concurrency turns N sequential LLM calls into ceil(N / CONCURRENCY) batches.
+export const COMPRESSION_CONCURRENCY = 4;
 
 interface TranscriptFragment {
   text: string;
@@ -485,6 +489,28 @@ export function buildMigrationHandoffMessages(
   ];
 }
 
+// Run an async map over `items` with at most `concurrency` calls in flight.
+// Preserves input order in the result. A rejection propagates immediately
+// (in-flight calls keep running but are no longer awaited).
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+  const workerCount = Math.min(concurrency, items.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (cursor < items.length) {
+      const index = cursor;
+      cursor += 1;
+      results[index] = await fn(items[index], index);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
 export function createMigrationCompressor(
   endpoint: SummaryEndpoint,
   chat: ChatCompletionFn = requestSummaryCompletion,
@@ -494,20 +520,30 @@ export function createMigrationCompressor(
     const totalChunks = Math.max(1, chunks.length);
 
     if (chunks.length <= 1) {
-      onProgress?.({ chunkIndex: 0, totalChunks, phase: "handoff" });
+      onProgress?.({ completed: 1, totalChunks, phase: "handoff" });
       return chat(endpoint, buildMigrationHandoffMessages(session));
     }
 
-    const chunkSummaries: string[] = [];
-    for (let index = 0; index < chunks.length; index += 1) {
-      const summary = await chat(
-        endpoint,
-        buildMigrationChunkSummaryMessages(session, chunks[index], index, chunks.length),
-      );
-      chunkSummaries.push(safePrefix(summary.trim(), CHUNK_SUMMARY_MAX_CHARACTERS));
-      onProgress?.({ chunkIndex: index, totalChunks, phase: "chunk" });
-    }
-    onProgress?.({ chunkIndex: chunks.length - 1, totalChunks, phase: "handoff" });
+    // Chunk summaries are independent — run them concurrently (bounded) so a
+    // 10-chunk session takes ~3 batches instead of 10 sequential LLM calls.
+    // `completed` advances as each finishes (order-independent, monotonic); the
+    // handoff still waits for all of them since it folds the summaries together.
+    let completed = 0;
+    const chunkSummaries = await mapWithConcurrency(
+      chunks,
+      COMPRESSION_CONCURRENCY,
+      async (chunk, index) => {
+        const summary = await chat(
+          endpoint,
+          buildMigrationChunkSummaryMessages(session, chunk, index, chunks.length),
+        );
+        completed += 1;
+        onProgress?.({ completed, totalChunks, phase: "chunk" });
+        return safePrefix(summary.trim(), CHUNK_SUMMARY_MAX_CHARACTERS);
+      },
+    );
+
+    onProgress?.({ completed: totalChunks, totalChunks, phase: "handoff" });
     return chat(endpoint, buildMigrationHandoffMessagesFromChunkSummaries(session, chunkSummaries));
   };
 }

--- a/src/core/session-migration.test.ts
+++ b/src/core/session-migration.test.ts
@@ -457,9 +457,9 @@ describe("migrateSession", () => {
   it("lifts compression progress into percent-valued compressing events", async () => {
     const { deps, onProgress } = createDependencies();
     deps.prepare.mockImplementation(async (portable, onCompressionProgress) => {
-      onCompressionProgress?.({ chunkIndex: 0, totalChunks: 3, phase: "chunk" });
-      onCompressionProgress?.({ chunkIndex: 1, totalChunks: 3, phase: "chunk" });
-      onCompressionProgress?.({ chunkIndex: 2, totalChunks: 3, phase: "handoff" });
+      onCompressionProgress?.({ completed: 1, totalChunks: 3, phase: "chunk" });
+      onCompressionProgress?.({ completed: 2, totalChunks: 3, phase: "chunk" });
+      onCompressionProgress?.({ completed: 3, totalChunks: 3, phase: "handoff" });
       return { session: portable, strategy: "ai-compressed" };
     });
 
@@ -475,7 +475,7 @@ describe("migrateSession", () => {
       .filter((event) => event.stage === "compressing");
     expect(compressingEvents.map((event) => event.percent)).toEqual([0, 25, 50, 75]);
     expect(compressingEvents[1].compression).toEqual({
-      chunkIndex: 0,
+      completed: 1,
       totalChunks: 3,
       phase: "chunk",
     });

--- a/src/core/session-migration.ts
+++ b/src/core/session-migration.ts
@@ -122,19 +122,17 @@ export function estimatePortableSessionTokens(session: PortableSession): number 
 }
 
 // Map a compression event to a 0-100 percent. Total work units =
-// totalChunks (chunk summaries) + 1 (final handoff). A "chunk" event fires
-// after chunk `chunkIndex` is summarized (done = chunkIndex + 1); a "handoff"
-// event fires once the final handoff call begins (all chunks done, handoff in
-// flight, so done = totalChunks — the bar tops just below 100% until the
-// compressor returns and the orchestrator moves to the "writing" stage).
+// totalChunks (chunk summaries) + 1 (final handoff). `completed` counts chunk
+// summaries done (monotonic, order-independent — chunks may run concurrently),
+// so done = completed; the handoff is the +1th unit and tops the bar just below
+// 100% (completed = totalChunks) until the orchestrator moves to "writing".
 //
 // Defined here (not in session-migration-compression.ts) so session-migration
 // can stay a type-only importer of that module: a runtime import would drag
 // session-summarizer (and node:child_process) into the renderer bundle.
 export function migrationCompressionPercent(event: MigrationCompressionEvent): number {
   const totalUnits = event.totalChunks + 1;
-  const done = event.phase === "handoff" ? event.totalChunks : event.chunkIndex + 1;
-  return Math.max(0, Math.min(100, Math.round((done / totalUnits) * 100)));
+  return Math.max(0, Math.min(100, Math.round((event.completed / totalUnits) * 100)));
 }
 
 export async function migrateSession({

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -67,9 +67,10 @@ export type SessionMigrationStage = "reading" | "compressing" | "writing" | "ind
 export type MigrationCompressionPhase = "chunk" | "handoff";
 
 export interface MigrationCompressionEvent {
-  // 0-based index of the chunk just summarized (chunk phase), or the last
-  // chunk index (handoff phase).
-  chunkIndex: number;
+  // Number of chunk summaries completed so far (0..totalChunks). Monotonic
+  // whether chunks are summarized sequentially or concurrently, so the percent
+  // bar never moves backwards. Reaches totalChunks when the final handoff begins.
+  completed: number;
   // Number of chunk-summary calls (>=1); the final handoff is the +1th unit.
   totalChunks: number;
   phase: MigrationCompressionPhase;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -379,8 +379,9 @@ async function restoreRemoteSession(
   const client = createRemoteSessionClient();
   const portable = await client.getPortableSession(remoteId);
   // 没配自定义摘要 endpoint 时回退本地 Codex CLI(缺失则再退 Claude),让迁移仍走 AI 压缩而非直接本地截断——与 AI 助手一致。
-  const endpoint = (await resolveSummaryEndpointFromSettings()) ?? buildCodexExecEndpoint(await getHydratedSettings());
-  const compressor = endpoint ? createMigrationCompressor(endpoint) : null;
+  const settings = await getHydratedSettings();
+  const endpoint = (await resolveSummaryEndpointFromSettings()) ?? buildCodexExecEndpoint(settings);
+  const compressor = endpoint ? createMigrationCompressor(endpoint, undefined, settings.compressionConcurrency) : null;
   return restoreRemotePortableSession({
     remoteId,
     portable,
@@ -1643,8 +1644,9 @@ function registerIpc(): void {
     if (!session) throw new Error("Session not found.");
 
     // 没配自定义摘要 endpoint 时回退本地 Codex CLI(缺失则再退 Claude),让迁移仍走 AI 压缩而非直接本地截断——与 AI 助手一致。
-    const endpoint = (await resolveSummaryEndpointFromSettings()) ?? buildCodexExecEndpoint(await getHydratedSettings());
-    const compressor = endpoint ? createMigrationCompressor(endpoint) : null;
+    const settings = await getHydratedSettings();
+    const endpoint = (await resolveSummaryEndpointFromSettings()) ?? buildCodexExecEndpoint(settings);
+    const compressor = endpoint ? createMigrationCompressor(endpoint, undefined, settings.compressionConcurrency) : null;
     const result = await migrateSession({
       source: session,
       messages: store.getAllMessages(sessionKey),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -3056,6 +3056,21 @@ function SettingsDialog({
                     onChange={(event) => onSettingsChange({ summaryMaxAgeDays: Number(event.currentTarget.value) })}
                   />
                 </label>
+                <label className="settings-field">
+                  <div className="settings-field-text">
+                    <span className="settings-field-title">{l("Migration compression concurrency", "迁移压缩并发度")}</span>
+                    <span className="settings-field-sub">{l("Max chunk summaries run in parallel when compressing a long session for migration. Lower it if you hit provider rate limits.", "迁移压缩长会话时分片摘要的最大并行数。遇到 provider 限流就调低。")}</span>
+                  </div>
+                  <input
+                    type="number"
+                    min={1}
+                    max={32}
+                    className="settings-number"
+                    value={settings?.compressionConcurrency ?? 8}
+                    disabled={!settings || saving}
+                    onChange={(event) => onSettingsChange({ compressionConcurrency: Number(event.currentTarget.value) })}
+                  />
+                </label>
                 <div className="settings-field">
                   <div className="settings-field-text">
                     <span className="settings-field-title">{l("Backfill missing summaries now", "立即补全缺失摘要")}</span>

--- a/src/renderer/src/components/session-migration-dialog.tsx
+++ b/src/renderer/src/components/session-migration-dialog.tsx
@@ -127,8 +127,8 @@ function compressionDetailText(
   const l = (en: string, zh: string) => localize(language, en, zh);
   if (compression.phase === "chunk") {
     return l(
-      `Chunk ${compression.chunkIndex + 1}/${compression.totalChunks}`,
-      `压缩分片 ${compression.chunkIndex + 1}/${compression.totalChunks}`,
+      `Summarized ${compression.completed}/${compression.totalChunks} chunks`,
+      `已完成 ${compression.completed}/${compression.totalChunks} 个分片`,
     );
   }
   return l("Generating handoff summary...", "生成交接摘要...");


### PR DESCRIPTION
## 问题

迁移压缩是 map-reduce:把长会话切成 N 个 45k 字符分片,**逐片串行**调 LLM 摘要,最后 1 次 handoff 汇总。10.6 万 tokens 的会话 ≈ 10 片 → 11 次串行 LLM 调用,几分钟。

但**分片摘要之间互不依赖**(分片 i 不依赖分片 j),只有 handoff 依赖全部摘要。串行跑是纯浪费。

## 改动

**分片摘要并行化(有界并发,默认 8)。** 10 片 → 2 批,墙钟从 ~10× 降到 ~2× 每片耗时,约 5x 加速。handoff 仍串行(fold 全部摘要,无法并行)。

- `createMigrationCompressor` 用 `mapWithConcurrency`(保序、有界、fail-fast)跑分片摘要,`concurrency` 参数默认 `COMPRESSION_CONCURRENCY = 8`。切片数不足并发度时按实际切片数并发,不起空 worker。
- **并发度做成设置项**:设置 → "迁移压缩并发度"(1-32,默认 8)。`AppSettings.compressionConcurrency`,normalize 限 1-32;两处迁移入口读设置传入。便于按 provider 限流调整(codex/claude CLI 可调高,HTTP provider 遇限流调低)。
- `MigrationCompressionEvent.chunkIndex` → `completed`(已完成计数,单调)。并发下完成顺序不固定,百分比和"已完成 i/N 个分片"都基于它,进度条不回跳。
- 新增并发验证测试 + custom concurrency 测试(传 2,断言 maxInFlight ≤ 2)。

## 不动的

- 分片大小 45k、map-reduce 结构、handoff——质量已验证,不动。
- 单分片路径(`chunks.length<=1`)仍一次 handoff。
- 失败仍回退本地截断(任一分片失败 → catch → 本地截断)。

## 验证

- `npm run typecheck` 通过
- `npm test` 620 全绿
