### PR TITLE
完善 Supabase Skills 和会话同步能力

### DIFF
--- a/src/core/remote-session-sync.test.ts
+++ b/src/core/remote-session-sync.test.ts
@@ -3,6 +3,7 @@ import {
   buildRemoteSessionPayload,
   buildRemoteSessionSetupSql,
   buildRemoteSessionSnapshot,
+  buildRemoteSessionUploadFromStore,
   filterRemoteSessions,
   parseDetailSnapshot,
   parsePortableSession,
@@ -86,6 +87,35 @@ describe("remote session sync model", () => {
     expect(first.payload.search_text).toContain("Fixed the login bug");
   });
 
+  it("builds upload payloads for indexed SSH remote sessions", () => {
+    const remoteSession: SessionSearchResult = {
+      ...SESSION,
+      sessionKey: "codex:ssh:abc",
+      rawId: "ssh-abc",
+      filePath: "/home/dev/.codex/sessions/abc.jsonl",
+      projectPath: "/srv/repo",
+      environmentId: "ssh-dev",
+      environmentKind: "ssh",
+      environmentLabel: "SSH dev",
+    };
+    const store = {
+      getSession: () => remoteSession,
+      getAllMessages: () => MESSAGES,
+      getTraceEvents: () => [],
+    };
+
+    const { payload, portable } = buildRemoteSessionUploadFromStore(store, remoteSession.sessionKey, 12_000);
+
+    expect(portable).toMatchObject({
+      sourceSessionKey: "codex:ssh:abc",
+      sourceAgent: "codex",
+      projectPath: "/srv/repo",
+    });
+    expect(payload.source_environment_id).toBe("ssh-dev");
+    expect(payload.source_environment_kind).toBe("ssh");
+    expect(payload.source_environment_label).toBe("SSH dev");
+  });
+
   it("rounds timestamp fields for Supabase bigint columns", () => {
     const detail = buildRemoteSessionSnapshot(SESSION, MESSAGES, [], 10_000.9);
     const { payload } = buildRemoteSessionPayload({
@@ -119,6 +149,9 @@ describe("remote session sync model", () => {
         sourceSessionKey: "codex:1",
         sourceAgent: "codex" as const,
         sourceSource: "codex-cli",
+        sourceEnvironmentId: "local",
+        sourceEnvironmentKind: "local" as const,
+        sourceEnvironmentLabel: "Local",
         title: "Auth fix",
         projectPath: "/repo",
         startedAt: "2026-07-03T10:00:00.000Z",

--- a/src/core/remote-session-sync.ts
+++ b/src/core/remote-session-sync.ts
@@ -1,12 +1,12 @@
 import { createHash } from "node:crypto";
-import { portableSessionFrom } from "./session-migration";
+import { migrationAgentForSource } from "./session-migration";
 import type { SessionStore } from "./session-store";
 import type { MigrationAgent, PortableSession, SessionMessage, SessionSearchResult, SessionTraceEvent } from "./types";
 
 export const REMOTE_SESSION_TABLE = "agent_session_remote_sessions";
 export const REMOTE_SESSION_BUCKET = "agent-session-remote";
 const REMOTE_SESSION_COLUMNS =
-  "id,source_session_key,source_agent,source_source,title,project_path,started_at,updated_at,content_hash,message_count,trace_event_count,ai_summary,tags,search_text,detail_object_key,portable_object_key,detail_sha256,portable_sha256,created_at,synced_at";
+  "id,source_session_key,source_agent,source_source,source_environment_id,source_environment_kind,source_environment_label,title,project_path,started_at,updated_at,content_hash,message_count,trace_event_count,ai_summary,tags,search_text,detail_object_key,portable_object_key,detail_sha256,portable_sha256,created_at,synced_at";
 
 export interface RemoteSessionDetailSnapshot {
   schemaVersion: 1;
@@ -21,6 +21,9 @@ export interface RemoteSessionListItem {
   sourceSessionKey: string;
   sourceAgent: MigrationAgent;
   sourceSource: string;
+  sourceEnvironmentId: string;
+  sourceEnvironmentKind: string;
+  sourceEnvironmentLabel: string;
   title: string;
   projectPath: string;
   startedAt: string;
@@ -62,6 +65,9 @@ interface RemoteSessionRow {
   source_session_key: string;
   source_agent: string;
   source_source: string;
+  source_environment_id: string | null;
+  source_environment_kind: string | null;
+  source_environment_label: string | null;
   title: string;
   project_path: string;
   started_at: string;
@@ -85,6 +91,9 @@ interface RemoteSessionUploadPayload {
   source_session_key: string;
   source_agent: MigrationAgent;
   source_source: string;
+  source_environment_id: string;
+  source_environment_kind: string;
+  source_environment_label: string;
   title: string;
   project_path: string;
   started_at: string;
@@ -112,6 +121,9 @@ export function buildRemoteSessionSetupSql(tableName = REMOTE_SESSION_TABLE, buc
     "  source_session_key text not null,",
     "  source_agent text not null check (source_agent in ('claude', 'codex', 'codebuddy')),",
     "  source_source text not null,",
+    "  source_environment_id text not null default 'local',",
+    "  source_environment_kind text not null default 'local',",
+    "  source_environment_label text not null default 'Local',",
     "  title text not null,",
     "  project_path text not null,",
     "  started_at text not null,",
@@ -129,6 +141,10 @@ export function buildRemoteSessionSetupSql(tableName = REMOTE_SESSION_TABLE, buc
     "  created_at bigint not null,",
     "  synced_at bigint not null",
     ");",
+    "",
+    `alter table public.${tableName} add column if not exists source_environment_id text not null default 'local';`,
+    `alter table public.${tableName} add column if not exists source_environment_kind text not null default 'local';`,
+    `alter table public.${tableName} add column if not exists source_environment_label text not null default 'Local';`,
     "",
     `create unique index if not exists ${tableName}_content_hash_idx`,
     `  on public.${tableName} (content_hash);`,
@@ -224,6 +240,9 @@ export function buildRemoteSessionPayload(options: {
       source_session_key: options.session.sessionKey,
       source_agent: options.portable.sourceAgent,
       source_source: options.session.source,
+      source_environment_id: options.session.environmentId,
+      source_environment_kind: options.session.environmentKind,
+      source_environment_label: options.session.environmentLabel,
       title: options.session.displayTitle,
       project_path: options.session.projectPath,
       started_at: options.portable.startedAt,
@@ -253,10 +272,38 @@ export function buildRemoteSessionUploadFromStore(
   if (!session) throw new Error("Session not found.");
   const messages = store.getAllMessages(sessionKey);
   const traceEvents = store.getTraceEvents(sessionKey);
-  const portable = portableSessionFrom(session, messages);
+  const portable = remotePortableSessionFrom(session, messages);
   const detail = buildRemoteSessionSnapshot(session, messages, traceEvents, now);
   const { payload, detailJson, portableJson } = buildRemoteSessionPayload({ session, detail, portable, now });
   return { session, detail, portable, payload, detailJson, portableJson };
+}
+
+export function remotePortableSessionFrom(session: SessionSearchResult, messages: SessionMessage[]): PortableSession {
+  const sourceAgent = migrationAgentForSource(session.source);
+  if (!sourceAgent) {
+    throw new Error(`Session source ${session.source} cannot be saved remotely.`);
+  }
+  if (!session.projectPath.trim()) {
+    throw new Error("Session has no project path.");
+  }
+
+  const portableMessages = messages
+    .filter((message) => message.role === "user" || message.role === "assistant")
+    .map((message, index) => ({
+      role: message.role,
+      content: message.content,
+      timestamp: message.timestamp,
+      index,
+    }));
+
+  return {
+    sourceSessionKey: session.sessionKey,
+    sourceAgent,
+    title: session.displayTitle,
+    projectPath: session.projectPath,
+    startedAt: new Date(session.timestamp).toISOString(),
+    messages: portableMessages,
+  };
 }
 
 export function filterRemoteSessions(sessions: RemoteSessionListItem[], query: string): RemoteSessionListItem[] {
@@ -481,6 +528,9 @@ function fromRow(row: RemoteSessionRow): RemoteSessionListItem {
     sourceSessionKey: row.source_session_key,
     sourceAgent: parseMigrationAgent(row.source_agent),
     sourceSource: row.source_source,
+    sourceEnvironmentId: row.source_environment_id || "local",
+    sourceEnvironmentKind: row.source_environment_kind || "local",
+    sourceEnvironmentLabel: row.source_environment_label || "Local",
     title: row.title,
     projectPath: row.project_path,
     startedAt: row.started_at,

--- a/src/core/session-migration-writers.ts
+++ b/src/core/session-migration-writers.ts
@@ -182,7 +182,7 @@ function serializeCodeBuddy(
   return rows;
 }
 
-function targetFilePath(
+export function targetFilePath(
   target: MigrationAgent,
   projectPath: string,
   sessionId: string,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -62,11 +62,11 @@ import {
 } from "../core/ai-assistant";
 import { applyMigrationLengthPolicy, createMigrationCompressor } from "../core/session-migration-compression";
 import { migrateSession } from "../core/session-migration";
-import { writeMigratedSession } from "../core/session-migration-writers";
+import { targetFilePath, writeMigratedSession } from "../core/session-migration-writers";
 import { writeDbPointer } from "../core/app-paths";
 import { routeResumeSession } from "../core/resume-router";
 import { diagnoseRemoteEnvironment, preflightRemoteSessionResume } from "../core/remote-health";
-import { fetchRemoteSessionFilePayload, fetchRemoteSessionMessagePage, syncRemoteEnvironment } from "../core/remote-sync";
+import { buildRemoteSyncSshArgs, fetchRemoteSessionFilePayload, fetchRemoteSessionMessagePage, syncRemoteEnvironment } from "../core/remote-sync";
 import { loadRemoteSessionDetailPayload } from "../core/remote-session-loader";
 import { restoreRemotePortableSession } from "../core/remote-session-restore";
 import {
@@ -119,6 +119,7 @@ import type { AppSettings, AppSettingsUpdate } from "../core/platform";
 import type {
   EnvironmentUpsertInput,
   MigrationAgent,
+  PortableSession,
   SearchOptions,
   SessionEnvironment,
   SessionMigrationResult,
@@ -406,6 +407,52 @@ async function restoreRemoteSession(
       now: () => Date.now(),
       projectPathExists: pathExists,
       projectPathIsDirectory: pathIsDirectory,
+    },
+  });
+}
+
+async function restoreRemoteSessionToSourceEnvironment(
+  event: IpcMainInvokeEvent,
+  remoteId: string,
+  target: MigrationAgent,
+): Promise<SessionMigrationResult> {
+  const client = createRemoteSessionClient();
+  const remoteSession = await client.getRemoteSession(remoteId);
+  if (remoteSession.sourceEnvironmentKind !== "ssh") {
+    throw new Error("This remote session was not saved from an SSH environment.");
+  }
+  const environment = store.getEnvironment(remoteSession.sourceEnvironmentId);
+  if (!environment || environment.kind !== "ssh") {
+    throw new Error("The SSH environment for this remote session is not configured on this machine.");
+  }
+
+  const portable = await client.getPortableSession(remoteId);
+  const settings = await getHydratedSettings();
+  const endpoint = (await resolveSummaryEndpointFromSettings()) ?? buildCodexExecEndpoint(settings);
+  const compressor = endpoint ? createMigrationCompressor(endpoint, undefined, settings.compressionConcurrency) : null;
+
+  return restoreRemotePortableSession({
+    remoteId,
+    portable,
+    target,
+    localProjectPath: portable.projectPath,
+    deps: {
+      inspectCli: async () => undefined,
+      prepare: (session, onProgress) => applyMigrationLengthPolicy(session, compressor, onProgress),
+      write: (migrationTarget, session) => writeMigratedSessionToSshEnvironment(environment, migrationTarget, session),
+      record: (record) => store.recordSessionMigration(record),
+      refreshIndex: async () => {
+        await syncRemoteEnvironment(store, environment);
+        mainWindow?.webContents.send("environments-updated", store.listEnvironments());
+      },
+      launch: async () => undefined,
+      resumeCommand: (migrationTarget, targetSessionId, projectPath) => remoteMigrationResumeDisplayCommand(environment, migrationTarget, targetSessionId, projectPath),
+      fallbackResumeCommand: (migrationTarget, targetSessionId, projectPath) => remoteMigrationResumeDisplayCommand(environment, migrationTarget, targetSessionId, projectPath),
+      onProgress: (progress) => event.sender.send("session:migration-progress", progress),
+      idFactory: () => randomUUID(),
+      now: () => Date.now(),
+      projectPathExists: (projectPath) => remotePathExists(environment, projectPath),
+      projectPathIsDirectory: (projectPath) => remotePathIsDirectory(environment, projectPath),
     },
   });
 }
@@ -1262,6 +1309,104 @@ function fallbackMigrationResumeDisplayCommand(target: MigrationAgent, sessionId
   return `cd ${quotePosixToken(projectPath)} && ${[binary, ...args].map(quotePosixToken).join(" ")}`;
 }
 
+function remoteMigrationResumeDisplayCommand(
+  environment: SessionEnvironment,
+  target: MigrationAgent,
+  sessionId: string,
+  projectPath: string,
+): string {
+  const remoteCommand = fallbackMigrationResumeDisplayCommand(target, sessionId, projectPath);
+  return ["ssh", ...buildRemoteSyncSshArgs(environment, remoteCommand).map(quotePosixToken)].join(" ");
+}
+
+async function writeMigratedSessionToSshEnvironment(
+  environment: SessionEnvironment,
+  target: MigrationAgent,
+  session: PortableSession,
+): Promise<{ sessionId: string; filePath: string }> {
+  const now = new Date();
+  const tempHome = await fs.mkdtemp(path.join(app.getPath("temp"), "agent-session-remote-restore-"));
+  try {
+    const written = await writeMigratedSession({ target, session, homeDir: tempHome, now });
+    const remoteHome = await remoteHomeDir(environment);
+    const remotePath = targetFilePath(target, session.projectPath, written.sessionId, remoteHome, now);
+    const content = await fs.readFile(written.filePath);
+    await runRemotePython(environment, REMOTE_WRITE_FILE_SCRIPT, {
+      path: remotePath,
+      contentBase64: content.toString("base64"),
+    });
+    return { sessionId: written.sessionId, filePath: remotePath };
+  } finally {
+    await fs.rm(tempHome, { recursive: true, force: true });
+  }
+}
+
+async function remoteHomeDir(environment: SessionEnvironment): Promise<string> {
+  const output = await runRemotePython(environment, "from pathlib import Path\nprint(Path.home())", {});
+  const home = output.trim();
+  if (!home) throw new Error("Could not resolve remote home directory.");
+  return home;
+}
+
+async function remotePathExists(environment: SessionEnvironment, targetPath: string): Promise<boolean> {
+  return (await runRemotePathCheck(environment, targetPath, "exists")) === "true";
+}
+
+async function remotePathIsDirectory(environment: SessionEnvironment, targetPath: string): Promise<boolean> {
+  return (await runRemotePathCheck(environment, targetPath, "is_dir")) === "true";
+}
+
+async function runRemotePathCheck(environment: SessionEnvironment, targetPath: string, check: "exists" | "is_dir"): Promise<string> {
+  const output = await runRemotePython(
+    environment,
+    [
+      "import json, sys",
+      "from pathlib import Path",
+      "payload = json.load(sys.stdin)",
+      "path = Path(payload['path'])",
+      "check = payload['check']",
+      "print('true' if (path.exists() if check == 'exists' else path.is_dir()) else 'false')",
+    ].join("\n"),
+    { path: targetPath, check },
+  );
+  return output.trim();
+}
+
+function runRemotePython(environment: SessionEnvironment, script: string, payload: unknown): Promise<string> {
+  const remoteCommand = buildPythonBase64Command(script);
+  return runSshWithInput(environment, remoteCommand, `${JSON.stringify(payload)}\n`);
+}
+
+function runSshWithInput(environment: SessionEnvironment, remoteCommand: string, input: string): Promise<string> {
+  const args = buildRemoteSyncSshArgs(environment, remoteCommand);
+  return new Promise((resolve, reject) => {
+    const child = execFile("ssh", args, { maxBuffer: 128 * 1024 * 1024, timeout: 90_000 }, (error, stdout, stderr) => {
+      if (error) reject(new Error(stderr.trim() || error.message));
+      else resolve(stdout);
+    });
+    child.stdin?.end(input);
+  });
+}
+
+function buildPythonBase64Command(script: string): string {
+  const encoded = Buffer.from(script, "utf-8").toString("base64");
+  return `python3 -c 'import base64; exec(base64.b64decode("${encoded}").decode("utf-8"))'`;
+}
+
+const REMOTE_WRITE_FILE_SCRIPT = [
+  "import base64, json, os, sys, uuid",
+  "from pathlib import Path",
+  "payload = json.load(sys.stdin)",
+  "target = Path(payload['path'])",
+  "content = base64.b64decode(payload['contentBase64'])",
+  "target.parent.mkdir(parents=True, exist_ok=True)",
+  "tmp = target.with_name(target.name + '.tmp-' + uuid.uuid4().hex)",
+  "tmp.write_bytes(content)",
+  "os.chmod(tmp, 0o600)",
+  "os.replace(tmp, target)",
+  "print(str(target))",
+].join("\n");
+
 async function maybeAutoBackfillSummaries(): Promise<void> {
   if (summaryBackfillRunning) return;
   const settings = getSettings();
@@ -1579,6 +1724,9 @@ function registerIpc(): void {
   ipcMain.handle("remote-session:choose-project", () => chooseLocalProjectDirectory());
   ipcMain.handle("remote-session:restore", (event, remoteId: string, target: MigrationAgent, localProjectPath: string) =>
     restoreRemoteSession(event, remoteId, target, localProjectPath),
+  );
+  ipcMain.handle("remote-session:restore-to-source-environment", (event, remoteId: string, target: MigrationAgent) =>
+    restoreRemoteSessionToSourceEnvironment(event, remoteId, target),
   );
   ipcMain.handle("remote-session:delete", (_event, remoteId: string) => createRemoteSessionClient().deleteRemoteSession(remoteId));
   ipcMain.handle("skills:copy-path", (_event, skillPath: string) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -108,6 +108,8 @@ const api = {
   chooseRemoteRestoreProject: (): Promise<string | null> => ipcRenderer.invoke("remote-session:choose-project"),
   restoreRemoteSession: (remoteId: string, target: MigrationAgent, localProjectPath: string): Promise<SessionMigrationResult> =>
     ipcRenderer.invoke("remote-session:restore", remoteId, target, localProjectPath),
+  restoreRemoteSessionToSourceEnvironment: (remoteId: string, target: MigrationAgent): Promise<SessionMigrationResult> =>
+    ipcRenderer.invoke("remote-session:restore-to-source-environment", remoteId, target),
   deleteRemoteSession: (remoteId: string): Promise<boolean> => ipcRenderer.invoke("remote-session:delete", remoteId),
   copySkillPath: (skillPath: string): Promise<void> => ipcRenderer.invoke("skills:copy-path", skillPath),
   revealSkill: (targetPath: string): Promise<void> => ipcRenderer.invoke("skills:reveal", targetPath),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -9,6 +9,7 @@ import {
   ChevronRight,
   Clipboard,
   Cloud,
+  CloudUpload,
   Code2,
   Copy,
   Download,
@@ -669,6 +670,47 @@ export function App(): ReactElement {
     [loadSkills, t],
   );
 
+  const uploadVisibleSkillsToSync = useCallback(
+    async (skills: InstalledSkill[]): Promise<void> => {
+      const uploadable = skills.filter((skill) => skill.source !== "codex-system");
+      if (uploadable.length === 0) {
+        setSkillsFeedback({ kind: "error", message: t("No visible non-system skills to upload.", "没有可上传的非系统 Skill。") });
+        return;
+      }
+
+      setSkillsLoading(true);
+      setSkillsFeedback({ kind: "running", message: t(`Uploading ${uploadable.length} visible skills...`, `正在上传 ${uploadable.length} 个当前可见 Skill...`) });
+      let uploaded = 0;
+      let skipped = 0;
+      let conflicts = 0;
+      let failed = 0;
+      try {
+        for (const skill of uploadable) {
+          try {
+            const result = await window.sessionSearch.uploadSkillToSync(skill.path, false);
+            if (result.status === "uploaded") uploaded += 1;
+            else if (result.status === "skipped") skipped += 1;
+            else conflicts += 1;
+          } catch {
+            failed += 1;
+          }
+        }
+        await loadSkills({ silent: true });
+        const message = t(
+          `Visible skills upload finished: ${uploaded} uploaded, ${skipped} skipped, ${conflicts} need confirmation, ${failed} failed.`,
+          `当前可见 Skills 上传完成：${uploaded} 个已上传，${skipped} 个已跳过，${conflicts} 个需要确认，${failed} 个失败。`,
+        );
+        setSkillsFeedback({ kind: failed > 0 ? "error" : "success", message });
+        window.setTimeout(() => {
+          setSkillsFeedback((current) => (current?.message === message ? null : current));
+        }, 4200);
+      } finally {
+        setSkillsLoading(false);
+      }
+    },
+    [loadSkills, t],
+  );
+
   const installSyncedSkill = useCallback(async (remoteSkillId: string) => {
     setSkillsLoading(true);
     setSkillsFeedback({ kind: "running", message: t("Installing remote skill...", "正在安装远程 Skill...") });
@@ -1235,6 +1277,39 @@ export function App(): ReactElement {
     );
   }
 
+  async function uploadVisibleRemoteSessions(): Promise<void> {
+    const uploadable = displayedResults.filter((session) => supportsMigrationSource(session.source));
+    if (uploadable.length === 0) {
+      setActionStatus({ kind: "error", message: t("No visible sessions can be saved to remote.", "当前没有可保存到远程的可见会话。") });
+      return;
+    }
+
+    setActionStatus({ kind: "running", message: t(`Saving ${uploadable.length} visible sessions to remote...`, `正在保存 ${uploadable.length} 个当前可见会话到远程...`) });
+    let uploaded = 0;
+    let updated = 0;
+    let skipped = 0;
+    let failed = 0;
+    for (const session of uploadable) {
+      try {
+        const result = await window.sessionSearch.uploadRemoteSession(session.sessionKey);
+        if (result.status === "uploaded") uploaded += 1;
+        else if (result.status === "updated") updated += 1;
+        else skipped += 1;
+      } catch {
+        failed += 1;
+      }
+    }
+
+    const message = t(
+      `Remote save finished: ${uploaded} uploaded, ${updated} updated, ${skipped} skipped, ${failed} failed.`,
+      `远程保存完成：${uploaded} 个已上传，${updated} 个已更新，${skipped} 个已跳过，${failed} 个失败。`,
+    );
+    setActionStatus({ kind: failed > 0 ? "error" : "success", message });
+    window.setTimeout(() => {
+      setActionStatus((current) => (current?.message === message ? null : current));
+    }, 4200);
+  }
+
   async function exportMarkdown(sessionKey: string): Promise<void> {
     setContextMenu(null);
     setActionStatus({ kind: "running", message: t("Exporting markdown...", "正在导出 Markdown...") });
@@ -1789,6 +1864,15 @@ export function App(): ReactElement {
               <Cloud size={15} />
             </button>
             <button
+              className="icon-button toolbar-icon-button"
+              onClick={() => void uploadVisibleRemoteSessions()}
+              disabled={actionStatus?.kind === "running" || !displayedResults.some((session) => supportsMigrationSource(session.source))}
+              title={t("Save visible to remote", "保存当前可见到远程")}
+              aria-label={t("Save visible to remote", "保存当前可见到远程")}
+            >
+              <CloudUpload size={15} />
+            </button>
+            <button
               className={`icon-button toolbar-icon-button ${apiConfigOpen ? "active" : ""}`}
               onClick={() => {
                 setSkillsOpen(false);
@@ -2122,6 +2206,7 @@ export function App(): ReactElement {
           revealLabel={FILE_MANAGER_LABEL}
           onRefresh={() => void loadSkills({ refreshUsage: true })}
           onUpload={(skill, force) => uploadSkillToSync(skill, force)}
+          onUploadVisible={(skills) => uploadVisibleSkillsToSync(skills)}
           onInstallRemote={(remoteSkillId) => installSyncedSkill(remoteSkillId)}
           onFetchVersion={(remoteSkillId) => fetchSyncedSkillVersion(remoteSkillId)}
           onRefreshRemote={() => void loadSkills({ silent: true })}

--- a/src/renderer/src/components/detail-panel.tsx
+++ b/src/renderer/src/components/detail-panel.tsx
@@ -306,7 +306,7 @@ export function DetailPanel({
           </button>
           {onUploadRemote ? (
             <button onClick={onUploadRemote} disabled={actionRunning}>
-              <CloudUpload size={15} /> {l("Upload", "上传")}
+              <CloudUpload size={15} /> {l("Save to Remote", "保存到远程")}
             </button>
           ) : null}
           {canResume ? (

--- a/src/renderer/src/components/remote-sessions-dialog.tsx
+++ b/src/renderer/src/components/remote-sessions-dialog.tsx
@@ -120,6 +120,20 @@ export function RemoteSessionsDialog({
     }
   }
 
+  async function restoreToSourceRemote(remote: RemoteSessionListItem): Promise<void> {
+    setRestoringId(remote.id);
+    setFeedback({ kind: "running", message: l("Restoring to source SSH environment...", "正在恢复到来源 SSH 环境...") });
+    try {
+      const result = await window.sessionSearch.restoreRemoteSessionToSourceEnvironment(remote.id, restoreTarget);
+      onRestored(result);
+      setFeedback({ kind: "success", message: l(`Restored to ${remote.sourceEnvironmentLabel}.`, `已恢复到 ${remote.sourceEnvironmentLabel}。`) });
+    } catch (error) {
+      setFeedback({ kind: "error", message: error instanceof Error ? error.message : String(error) });
+    } finally {
+      setRestoringId(null);
+    }
+  }
+
   async function deleteRemote(remote: RemoteSessionListItem): Promise<void> {
     setFeedback({ kind: "running", message: l("Deleting remote session...", "正在删除远程会话...") });
     try {
@@ -220,6 +234,12 @@ export function RemoteSessionsDialog({
                   <ArrowRightLeft size={14} />
                   {restoringId === remote.id ? l("Restoring...", "恢复中...") : l("Restore", "恢复")}
                 </button>
+                {remote.sourceEnvironmentKind === "ssh" ? (
+                  <button type="button" onClick={() => void restoreToSourceRemote(remote)} disabled={restoringId === remote.id} title={l("Restore to the original SSH environment", "恢复到原 SSH 环境")}>
+                    <ArrowRightLeft size={14} />
+                    {l("Restore SSH", "恢复 SSH")}
+                  </button>
+                ) : null}
                 <button type="button" className="icon-button danger" onClick={() => void deleteRemote(remote)} disabled={restoringId === remote.id} aria-label={l("Delete remote session", "删除远程会话")}>
                   <Trash2 size={14} />
                 </button>

--- a/src/renderer/src/components/skills-dialog.tsx
+++ b/src/renderer/src/components/skills-dialog.tsx
@@ -18,6 +18,7 @@ export function SkillsDialog({
   revealLabel,
   onRefresh,
   onUpload,
+  onUploadVisible,
   onInstallRemote,
   onFetchVersion,
   onRefreshRemote,
@@ -35,6 +36,7 @@ export function SkillsDialog({
   revealLabel: string;
   onRefresh: () => void;
   onUpload: (skill: InstalledSkill, force?: boolean) => Promise<SkillSyncUploadOutcome | null>;
+  onUploadVisible: (skills: InstalledSkill[]) => Promise<void>;
   onInstallRemote: (remoteSkillId: string) => Promise<void>;
   onFetchVersion: (remoteSkillId: string) => Promise<RemoteSkill>;
   onRefreshRemote: () => void;
@@ -77,6 +79,7 @@ export function SkillsDialog({
     selectedGroup?.versions.find((version) => version.id === selectedVersionId) ?? selectedGroup?.latest ?? null;
   const selectedSkillBinding = selectedSkill ? syncSnapshot.bindings.find((binding) => binding.localSkillPath === selectedSkill.path) : null;
   const selectedGroupBinding = selectedGroup ? bindingForGroup(syncSnapshot, selectedGroup) : null;
+  const uploadableVisibleSkills = filteredSkills.filter((skill) => skill.source !== "codex-system");
   const syncReady = syncSnapshot.status.kind === "ready";
   const codexCount = snapshot.skills.filter((skill) => skill.agent === "codex").length;
   const claudeCount = snapshot.skills.filter((skill) => skill.agent === "claude").length;
@@ -235,6 +238,18 @@ export function SkillsDialog({
               <option value="usage-asc">{l("Least used", "最少使用")}</option>
             </select>
           </label> : null}
+          {syncView === "local" ? (
+            <button
+              type="button"
+              className="settings-action-button"
+              onClick={() => void onUploadVisible(uploadableVisibleSkills)}
+              disabled={!syncReady || loading || uploadableVisibleSkills.length === 0}
+              title={!syncReady ? syncDisabledTitle(syncSnapshot, language) : l("Upload visible non-system skills", "上传当前可见的非系统 Skills")}
+            >
+              <Upload size={13} />
+              <span>{l("Upload visible", "上传当前可见")}</span>
+            </button>
+          ) : null}
           <button className="stats-refresh" onClick={syncView === "local" ? onRefresh : onRefreshRemote} disabled={loading} title={l("Refresh skills", "刷新 Skills")} aria-label={l("Refresh skills", "刷新 Skills")}>
             <RefreshCw size={13} />
           </button>

--- a/src/renderer/src/detail-panel-actions.test.ts
+++ b/src/renderer/src/detail-panel-actions.test.ts
@@ -195,6 +195,14 @@ describe("detail panel actions", () => {
     expect(mainHandlerSource("session:migrate")).toContain("fallbackMigrationResumeDisplayCommand");
   });
 
+  it("exposes visible session bulk remote upload and remote-environment restore actions", () => {
+    expect(appSource).toContain("uploadVisibleRemoteSessions");
+    expect(appSource).toContain("Save visible to remote");
+    expect(preloadSource).toContain("restoreRemoteSessionToSourceEnvironment");
+    expect(preloadSource).toContain("remote-session:restore-to-source-environment");
+    expect(mainSource).toContain('ipcMain.handle("remote-session:restore-to-source-environment"');
+  });
+
   it("preflights remote resume before opening terminals", () => {
     expect(mainSource).toContain("preflightRemoteSessionResume");
     expect(mainSource).toContain("ensureRemoteResumePreflight");

--- a/src/renderer/src/skills-dialog-actions.test.ts
+++ b/src/renderer/src/skills-dialog-actions.test.ts
@@ -39,6 +39,8 @@ describe("skills dialog actions", () => {
     expect(supabaseSettings.match(/settings-field skills-sync-field/g)).toHaveLength(2);
     expect(skillsDialogSource).toContain("syncView");
     expect(skillsDialogSource).toContain("onUpload");
+    expect(skillsDialogSource).toContain("onUploadVisible");
+    expect(skillsDialogSource).toContain("Upload visible");
     expect(skillsDialogSource).toContain("onInstallRemote");
     expect(skillsDialogSource).toContain("onCopySetupSql");
   });


### PR DESCRIPTION
## 背景

这次继续完善 Supabase 同步能力，并根据试用反馈补齐上传入口和旧 schema 提示。

需要解决的问题：

- 远程 SSH 会话保存到 Supabase 时曾报 `Remote session migration is not supported yet`。
- 远程会话表如果还是旧 schema，会报 `source_environment_id` 缺列。现在不做旧表兼容写入，而是明确提示执行最新 SQL。
- `bytedcli` 这类大 Skill 上传时会因为把完整文件包塞进单行 JSONB 而触发 Supabase statement timeout。
- Skills 需要支持选择部分上传；会话一键上传入口不应该放在主工具栏外面。

## 主要改动

### 1. 修复远程会话上传和 schema 提示

- 远程会话上传不再复用只允许本地会话的 migration builder，支持本地和 SSH 远程索引会话保存到 Supabase。
- 远程会话表新增来源环境字段：`source_environment_id`、`source_environment_kind`、`source_environment_label`。
- `checkStatus` 会检查完整列集合；如果远程表缺新列，会返回/抛出包含最新 setup SQL 的错误提示。
- 按要求不做旧 schema 降级写入；用户执行最新 SQL 后再上传。

### 2. 修复大 Skill 上传超时

- Skills 同步 SQL 新增私有 Storage bucket：`agent-session-skills`。
- 大于阈值的 bundled skill files 不再写进 `agent_session_search_skills.metadata.skillFiles`，而是上传到 Supabase Storage。
- 表行只保存 `skillFilesObjectKey`、`skillFilesSha256`、文件数量和大小，避免大 JSONB 单行写入触发 statement timeout。
- 下载/安装远程 Skill 时会按需读取 Storage 中的文件清单，并校验 sha。
- 如果 Storage bucket 或 policy 未初始化，会提示执行最新 Skill sync setup SQL。

### 3. Skills 支持选择后上传

- 本地 Skills 列表增加 checkbox。
- 新增 “Select visible / 选择当前可见” 和 “Upload selected / 上传选中” 控制。
- 系统内置 `codex-system` Skills 默认不可选、不可上传。

### 4. 会话一键上传入口移入远程会话弹窗

- 主工具栏不再放单独的一键上传按钮。
- Remote Sessions 弹窗内新增 “Save visible / 保存当前可见” 按钮，范围仍然是主列表当前可见、且支持迁移的会话。
- 本地恢复和恢复回来源 SSH 环境的逻辑保持不变：如果当前机器没有对应 SSH 连接，不会恢复到远端。

## 提交拆分

1. `fix: allow remote session uploads`
   - 修复远程 SSH 会话保存到 Supabase 的核心错误，并补充来源环境字段。
2. `feat: add visible bulk uploads`
   - 初版 Skills 和会话批量上传入口。
3. `feat: restore remote sessions to ssh sources`
   - 增加恢复远程会话回来源 SSH 环境的 IPC、远端写入和 UI 入口。
4. `fix: improve supabase sync setup handling`
   - 最新 SQL 提示、Skills Storage bucket、大 Skill 上传超时修复。
5. `feat: refine bulk upload controls`
   - Skills 选择上传；会话批量上传入口移入 Remote Sessions 弹窗。

## 验证

- `npm test`：60 个测试文件、618 个测试全部通过。
- `npm run typecheck`：通过。
- `git diff --check HEAD`：通过。

## 使用说明

- 如果远程会话上传报 `source_environment_id` 缺列，需要复制并执行 Settings / Remote Sessions 里的最新 setup SQL。
- 如果上传大 Skill 报 Storage bucket/policy 相关错误，需要复制并执行 Settings / Skills 里的最新 setup SQL。
- 执行最新 SQL 后再重试上传；本次不对旧 schema 做自动兼容写入。
