### PR TITLE
修复 Supabase 同步上传反馈问题

### DIFF
--- a/src/core/remote-session-sync.test.ts
+++ b/src/core/remote-session-sync.test.ts
@@ -9,6 +9,7 @@ import {
   parsePortableSession,
   remoteSessionContentHash,
   remoteSessionId,
+  SupabaseRemoteSessionClient,
 } from "./remote-session-sync";
 import type { PortableSession, SessionSearchResult } from "./types";
 
@@ -172,5 +173,25 @@ describe("remote session sync model", () => {
     ];
     expect(filterRemoteSessions(sessions, "oauth")).toHaveLength(1);
     expect(filterRemoteSessions(sessions, "missing")).toHaveLength(0);
+  });
+
+  it("reports the latest setup SQL when source environment columns are missing", async () => {
+    const detail = buildRemoteSessionSnapshot(SESSION, MESSAGES, [], 10_000);
+    const { payload, detailJson, portableJson } = buildRemoteSessionPayload({ session: SESSION, detail, portable: PORTABLE, now: 11_000 });
+    const missingColumn = {
+      code: "PGRST204",
+      message: "Could not find the 'source_environment_id' column of 'agent_session_remote_sessions' in the schema cache",
+    };
+    const client = new SupabaseRemoteSessionClient({
+      url: "https://example.supabase.co",
+      anonKey: "anon",
+      fetchImpl: async (url, init) => {
+        if (String(url).includes("/storage/v1/object/")) return new Response("{}", { status: 200 });
+        if (init?.method === "POST") return new Response(JSON.stringify(missingColumn), { status: 400 });
+        return new Response(JSON.stringify(missingColumn), { status: 400 });
+      },
+    });
+
+    await expect(client.uploadSession(payload, detailJson, portableJson)).rejects.toThrow(/latest Supabase remote sessions setup SQL/i);
   });
 });

--- a/src/core/remote-session-sync.ts
+++ b/src/core/remote-session-sync.ts
@@ -338,7 +338,7 @@ export class SupabaseRemoteSessionClient {
 
   async checkStatus(): Promise<RemoteSessionStatus> {
     const setupSql = buildRemoteSessionSetupSql();
-    const response = await this.restRequest(`/${REMOTE_SESSION_TABLE}?select=id&limit=1`, { method: "GET" });
+    const response = await this.restRequest(`/${REMOTE_SESSION_TABLE}?select=${REMOTE_SESSION_COLUMNS}&limit=1`, { method: "GET" });
     if (response.ok) return { kind: "ready", setupSql };
     const body = await readResponseBody(response);
     if (isMissingTableError(response.status, body)) {
@@ -347,6 +347,9 @@ export class SupabaseRemoteSessionClient {
         setupSql,
         message: `Supabase table ${REMOTE_SESSION_TABLE} was not found.`,
       };
+    }
+    if (isMissingSchemaColumnError(body)) {
+      return { kind: "error", setupSql, message: latestRemoteSessionSetupSqlMessage(body) };
     }
     return { kind: "error", setupSql, message: supabaseErrorMessage(response.status, body) };
   }
@@ -357,7 +360,10 @@ export class SupabaseRemoteSessionClient {
       { method: "GET" },
     );
     const body = await readResponseBody(response);
-    if (!response.ok) throw new Error(supabaseErrorMessage(response.status, body));
+    if (!response.ok) {
+      if (isMissingSchemaColumnError(body)) throw new Error(latestRemoteSessionSetupSqlMessage(body));
+      throw new Error(supabaseErrorMessage(response.status, body));
+    }
     return filterRemoteSessions(parseRows(body), query);
   }
 
@@ -367,7 +373,10 @@ export class SupabaseRemoteSessionClient {
       { method: "GET" },
     );
     const body = await readResponseBody(response);
-    if (!response.ok) throw new Error(supabaseErrorMessage(response.status, body));
+    if (!response.ok) {
+      if (isMissingSchemaColumnError(body)) throw new Error(latestRemoteSessionSetupSqlMessage(body));
+      throw new Error(supabaseErrorMessage(response.status, body));
+    }
     const [session] = parseRows(body);
     if (!session) throw new Error("Remote session was not found.");
     return session;
@@ -386,7 +395,10 @@ export class SupabaseRemoteSessionClient {
       body: JSON.stringify(payload),
     });
     const body = await readResponseBody(response);
-    if (!response.ok) throw new Error(supabaseErrorMessage(response.status, body));
+    if (!response.ok) {
+      if (isMissingSchemaColumnError(body)) throw new Error(latestRemoteSessionSetupSqlMessage(body));
+      throw new Error(supabaseErrorMessage(response.status, body));
+    }
     const [remoteSession] = parseRows(body);
     if (!remoteSession) throw new Error("Supabase did not return the uploaded remote session.");
     return { status: existing ? "updated" : "uploaded", remoteSession };
@@ -422,7 +434,8 @@ export class SupabaseRemoteSessionClient {
   private async getRemoteSessionOrNull(remoteId: string): Promise<RemoteSessionListItem | null> {
     try {
       return await this.getRemoteSession(remoteId);
-    } catch {
+    } catch (error) {
+      if (error instanceof Error && /latest Supabase remote sessions setup SQL/i.test(error.message)) throw error;
       return null;
     }
   }
@@ -675,6 +688,28 @@ function isMissingTableError(status: number, body: unknown): boolean {
     code === "PGRST205" ||
     (typeof message === "string" && /table|relation/i.test(message) && /not found|does not exist/i.test(message))
   );
+}
+
+function isMissingSchemaColumnError(body: unknown): boolean {
+  if (!body || typeof body !== "object") return false;
+  const code = (body as { code?: unknown }).code;
+  const message = (body as { message?: unknown }).message;
+  return (
+    code === "PGRST204" &&
+    typeof message === "string" &&
+    /source_environment_(id|kind|label)|schema cache|could not find/i.test(message)
+  );
+}
+
+function latestRemoteSessionSetupSqlMessage(body: unknown): string {
+  const message = supabaseErrorMessage(400, body);
+  return [
+    message,
+    "",
+    "Run the latest Supabase remote sessions setup SQL, then try again:",
+    "",
+    buildRemoteSessionSetupSql(),
+  ].join("\n");
 }
 
 function normalizeSupabaseUrl(url: string): string {

--- a/src/core/skill-sync.test.ts
+++ b/src/core/skill-sync.test.ts
@@ -77,6 +77,8 @@ describe("skill sync", () => {
     expect(sql).toContain(`drop index if exists ${AGENT_SESSION_SEARCH_SKILLS_TABLE}_fingerprint_idx;`);
     expect(sql).toContain(`${AGENT_SESSION_SEARCH_SKILLS_TABLE}_fingerprint_version_idx`);
     expect(sql).toContain("(local_fingerprint, version)");
+    expect(sql).toContain("storage.buckets");
+    expect(sql).toContain("agent-session-skills");
     expect(sql).toContain("enable row level security");
     expect(sql).not.toContain("service_role");
   });
@@ -183,6 +185,37 @@ describe("skill sync", () => {
 
     const result = await client.insertSkillVersion(base, 2);
     expect(result).toMatchObject({ id: "remote-9", version: 2, contentHash, markdown: localSkill().markdown });
+  });
+
+  it("stores large skill file bundles in Supabase Storage instead of the table row", async () => {
+    const largeFile = {
+      relativePath: "references/large.md",
+      contentBase64: Buffer.alloc(1_200_000, "a").toString("base64"),
+      mode: 0o644,
+    };
+    const { base } = buildSkillVersionBasePayload(localSkill());
+    base.metadata = { ...base.metadata, skillFiles: [largeFile] };
+    const calls: Array<{ url: string; method: string; body?: string }> = [];
+    const client = new SupabaseSkillSyncClient({
+      url: "https://example.supabase.co",
+      anonKey: "anon",
+      fetchImpl: async (url, init) => {
+        calls.push({ url: String(url), method: init?.method ?? "GET", body: typeof init?.body === "string" ? init.body : undefined });
+        if (String(url).includes("/storage/v1/object/")) return new Response("{}", { status: 200 });
+        const body = JSON.parse(String(init?.body));
+        expect(body.metadata.skillFiles).toEqual([]);
+        expect(body.metadata.skillFilesObjectKey).toMatch(/^skills\/[0-9a-f]{64}\/v2\/files\.json$/);
+        expect(body.metadata.skillFilesSha256).toMatch(/^[0-9a-f]{64}$/);
+        return new Response(JSON.stringify([{ ...body, id: "remote-large", created_at: "x", updated_at: "y" }]), { status: 201 });
+      },
+    });
+
+    const result = await client.insertSkillVersion(base, 2);
+
+    expect(result.id).toBe("remote-large");
+    expect(calls[0].url).toContain("/storage/v1/object/agent-session-skills/skills/");
+    expect(calls[0].body).toContain("references/large.md");
+    expect(calls.some((call) => call.url.includes(`/rest/v1/${AGENT_SESSION_SEARCH_SKILLS_TABLE}`))).toBe(true);
   });
 
   it("retries a version insert with a fresh number after a unique conflict", async () => {

--- a/src/core/skill-sync.ts
+++ b/src/core/skill-sync.ts
@@ -5,8 +5,10 @@ import type { SkillSyncBinding } from "./session-store";
 import type { InstalledSkill } from "./skill-manager";
 
 export const AGENT_SESSION_SEARCH_SKILLS_TABLE = "agent_session_search_skills";
+export const AGENT_SESSION_SKILLS_BUCKET = "agent-session-skills";
 const REMOTE_SKILL_VERSION_COLUMNS =
   "id,name,description,agent,source,local_fingerprint,content_hash,uploaded_from_path,version,created_at,updated_at";
+const SKILL_FILES_STORAGE_THRESHOLD_BYTES = 512 * 1024;
 
 // Full row (markdown + bundled files) fetched on demand for preview/install.
 export interface RemoteSkill {
@@ -55,6 +57,11 @@ export interface SkillSyncFile {
   relativePath: string;
   contentBase64: string;
   mode?: number;
+}
+
+interface SkillFilesSnapshot {
+  schemaVersion: 1;
+  files: SkillSyncFile[];
 }
 
 export type SkillSyncStatus =
@@ -146,6 +153,11 @@ export function buildSkillSyncSetupSql(tableName = AGENT_SESSION_SEARCH_SKILLS_T
     "-- Upgrade an existing table created before version history was added.",
     `alter table public.${tableName} add column if not exists content_hash text not null default '';`,
     "",
+    "-- Create the private Storage bucket used for large bundled skill files.",
+    "insert into storage.buckets (id, name, public)",
+    `values ('${AGENT_SESSION_SKILLS_BUCKET}', '${AGENT_SESSION_SKILLS_BUCKET}', false)`,
+    "on conflict (id) do nothing;",
+    "",
     "-- Version history keeps one row per (skill, version); drop the old one-row-per-skill unique index.",
     `drop index if exists ${tableName}_fingerprint_idx;`,
     `create unique index if not exists ${tableName}_fingerprint_version_idx`,
@@ -176,6 +188,14 @@ export function buildSkillSyncSetupSql(tableName = AGENT_SESSION_SEARCH_SKILLS_T
     "  to anon",
     "  using (true)",
     "  with check (true);",
+    "",
+    `drop policy if exists "${AGENT_SESSION_SKILLS_BUCKET}_objects_personal_sync" on storage.objects;`,
+    `create policy "${AGENT_SESSION_SKILLS_BUCKET}_objects_personal_sync"`,
+    "  on storage.objects",
+    "  for all",
+    "  to anon",
+    `  using (bucket_id = '${AGENT_SESSION_SKILLS_BUCKET}')`,
+    `  with check (bucket_id = '${AGENT_SESSION_SKILLS_BUCKET}');`,
   ].join("\n");
 }
 
@@ -306,14 +326,15 @@ export class SupabaseSkillSyncClient {
     if (!response.ok) throw new Error(supabaseErrorMessage(response.status, body));
     const [skill] = parseFullRows(body);
     if (!skill) throw new Error("Remote skill was not found.");
-    return skill;
+    return this.hydrateRemoteSkillFiles(skill);
   }
 
   async insertSkillVersion(base: SkillVersionBasePayload, version: number): Promise<RemoteSkill> {
+    const prepared = await this.prepareSkillVersionPayload(base, version);
     const response = await this.request(`/${AGENT_SESSION_SEARCH_SKILLS_TABLE}`, {
       method: "POST",
       headers: { Prefer: "return=representation" },
-      body: JSON.stringify({ ...base, version }),
+      body: JSON.stringify({ ...prepared, version }),
     });
     const body = await readResponseBody(response);
     if (!response.ok) {
@@ -345,7 +366,8 @@ export class SupabaseSkillSyncClient {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.timeoutMs);
     try {
-      return await this.fetchImpl(`${this.baseUrl}/rest/v1${path}`, {
+      const url = path.startsWith("/storage/v1/") ? `${this.baseUrl}${path}` : `${this.baseUrl}/rest/v1${path}`;
+      return await this.fetchImpl(url, {
         ...init,
         signal: controller.signal,
         headers: {
@@ -364,6 +386,94 @@ export class SupabaseSkillSyncClient {
       clearTimeout(timer);
     }
   }
+
+  private async prepareSkillVersionPayload(base: SkillVersionBasePayload, version: number): Promise<SkillVersionBasePayload> {
+    const files = skillSyncFilesFromMetadata(base.metadata ?? {});
+    if (files.length === 0) return base;
+    const filesJson = stableJson({ schemaVersion: 1, files } satisfies SkillFilesSnapshot);
+    if (Buffer.byteLength(filesJson, "utf8") <= SKILL_FILES_STORAGE_THRESHOLD_BYTES) return base;
+
+    const objectKey = `skills/${base.local_fingerprint}/v${version}/files.json`;
+    await this.uploadStorageObject(objectKey, filesJson);
+    return {
+      ...base,
+      metadata: {
+        ...(base.metadata ?? {}),
+        skillFiles: [],
+        skillFilesObjectKey: objectKey,
+        skillFilesSha256: sha256(filesJson),
+        skillFilesCount: files.length,
+        skillFilesBytes: Buffer.byteLength(filesJson, "utf8"),
+      },
+    };
+  }
+
+  private async hydrateRemoteSkillFiles(skill: RemoteSkill): Promise<RemoteSkill> {
+    if (skillSyncFilesFromMetadata(skill.metadata).length > 0) return skill;
+    const objectKey = skill.metadata.skillFilesObjectKey;
+    if (typeof objectKey !== "string" || !objectKey.trim()) return skill;
+    const filesJson = await this.downloadStorageObject(objectKey);
+    const expectedSha = skill.metadata.skillFilesSha256;
+    if (typeof expectedSha === "string" && expectedSha && sha256(filesJson) !== expectedSha) {
+      throw new Error("Remote skill files checksum mismatch.");
+    }
+    const snapshot = parseSkillFilesSnapshot(JSON.parse(filesJson));
+    return {
+      ...skill,
+      metadata: {
+        ...skill.metadata,
+        skillFiles: snapshot.files,
+      },
+    };
+  }
+
+  private async uploadStorageObject(key: string, body: string): Promise<void> {
+    const response = await this.storageRequest(key, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-cache",
+        "x-upsert": "true",
+      },
+      body,
+    });
+    const responseBody = await readResponseBody(response);
+    if (!response.ok) throw new Error(skillSyncStorageErrorMessage(response.status, responseBody));
+  }
+
+  private async downloadStorageObject(key: string): Promise<string> {
+    const response = await this.storageRequest(key, { method: "GET" });
+    const text = await response.text();
+    if (!response.ok) throw new Error(skillSyncStorageErrorMessage(response.status, text));
+    return text;
+  }
+
+  private async storageRequest(path: string, init: RequestInit): Promise<Response> {
+    return this.request(`/storage/v1/object/${AGENT_SESSION_SKILLS_BUCKET}/${path}`, {
+      ...init,
+      headers: {
+        apikey: this.anonKey,
+        Authorization: `Bearer ${this.anonKey}`,
+        ...(init.headers ?? {}),
+      },
+    });
+  }
+}
+
+function parseSkillFilesSnapshot(value: unknown): SkillFilesSnapshot {
+  if (!value || typeof value !== "object") throw new Error("Remote skill files snapshot is invalid.");
+  const snapshot = value as Partial<SkillFilesSnapshot>;
+  if (snapshot.schemaVersion !== 1 || !Array.isArray(snapshot.files)) throw new Error("Remote skill files snapshot is invalid.");
+  return {
+    schemaVersion: 1,
+    files: snapshot.files.flatMap((item) => {
+      if (!item || typeof item !== "object") return [];
+      const file = item as Partial<SkillSyncFile>;
+      if (typeof file.relativePath !== "string" || typeof file.contentBase64 !== "string") return [];
+      const mode = typeof file.mode === "number" && Number.isFinite(file.mode) ? file.mode : undefined;
+      return [{ relativePath: file.relativePath, contentBase64: file.contentBase64, ...(mode === undefined ? {} : { mode }) }];
+    }),
+  };
 }
 
 function parseFullRows(body: unknown): RemoteSkill[] {
@@ -476,6 +586,28 @@ function supabaseErrorMessage(status: number, body: unknown): string {
   }
   if (typeof body === "string" && body.trim()) return body;
   return `Supabase request failed with status ${status}.`;
+}
+
+function skillSyncStorageErrorMessage(status: number, body: unknown): string {
+  const message = supabaseErrorMessage(status, body);
+  if (/bucket|storage/i.test(message) || status === 404) {
+    return `${message} Run the latest Supabase skill sync setup SQL from Settings, then try again.`;
+  }
+  return message;
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(sortJson(value));
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b)).map(([key, item]) => [key, sortJson(item)]));
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
 }
 
 function isMissingTableError(status: number, body: unknown): boolean {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -9,7 +9,6 @@ import {
   ChevronRight,
   Clipboard,
   Cloud,
-  CloudUpload,
   Code2,
   Copy,
   Download,
@@ -670,16 +669,16 @@ export function App(): ReactElement {
     [loadSkills, t],
   );
 
-  const uploadVisibleSkillsToSync = useCallback(
+  const uploadSelectedSkillsToSync = useCallback(
     async (skills: InstalledSkill[]): Promise<void> => {
       const uploadable = skills.filter((skill) => skill.source !== "codex-system");
       if (uploadable.length === 0) {
-        setSkillsFeedback({ kind: "error", message: t("No visible non-system skills to upload.", "没有可上传的非系统 Skill。") });
+        setSkillsFeedback({ kind: "error", message: t("No selected non-system skills to upload.", "没有选中可上传的非系统 Skill。") });
         return;
       }
 
       setSkillsLoading(true);
-      setSkillsFeedback({ kind: "running", message: t(`Uploading ${uploadable.length} visible skills...`, `正在上传 ${uploadable.length} 个当前可见 Skill...`) });
+      setSkillsFeedback({ kind: "running", message: t(`Uploading ${uploadable.length} selected skills...`, `正在上传 ${uploadable.length} 个选中 Skill...`) });
       let uploaded = 0;
       let skipped = 0;
       let conflicts = 0;
@@ -697,8 +696,8 @@ export function App(): ReactElement {
         }
         await loadSkills({ silent: true });
         const message = t(
-          `Visible skills upload finished: ${uploaded} uploaded, ${skipped} skipped, ${conflicts} need confirmation, ${failed} failed.`,
-          `当前可见 Skills 上传完成：${uploaded} 个已上传，${skipped} 个已跳过，${conflicts} 个需要确认，${failed} 个失败。`,
+          `Selected skills upload finished: ${uploaded} uploaded, ${skipped} skipped, ${conflicts} need confirmation, ${failed} failed.`,
+          `选中 Skills 上传完成：${uploaded} 个已上传，${skipped} 个已跳过，${conflicts} 个需要确认，${failed} 个失败。`,
         );
         setSkillsFeedback({ kind: failed > 0 ? "error" : "success", message });
         window.setTimeout(() => {
@@ -1864,15 +1863,6 @@ export function App(): ReactElement {
               <Cloud size={15} />
             </button>
             <button
-              className="icon-button toolbar-icon-button"
-              onClick={() => void uploadVisibleRemoteSessions()}
-              disabled={actionStatus?.kind === "running" || !displayedResults.some((session) => supportsMigrationSource(session.source))}
-              title={t("Save visible to remote", "保存当前可见到远程")}
-              aria-label={t("Save visible to remote", "保存当前可见到远程")}
-            >
-              <CloudUpload size={15} />
-            </button>
-            <button
               className={`icon-button toolbar-icon-button ${apiConfigOpen ? "active" : ""}`}
               onClick={() => {
                 setSkillsOpen(false);
@@ -2206,7 +2196,7 @@ export function App(): ReactElement {
           revealLabel={FILE_MANAGER_LABEL}
           onRefresh={() => void loadSkills({ refreshUsage: true })}
           onUpload={(skill, force) => uploadSkillToSync(skill, force)}
-          onUploadVisible={(skills) => uploadVisibleSkillsToSync(skills)}
+          onUploadSelected={(skills) => uploadSelectedSkillsToSync(skills)}
           onInstallRemote={(remoteSkillId) => installSyncedSkill(remoteSkillId)}
           onFetchVersion={(remoteSkillId) => fetchSyncedSkillVersion(remoteSkillId)}
           onRefreshRemote={() => void loadSkills({ silent: true })}
@@ -2230,6 +2220,8 @@ export function App(): ReactElement {
             void Promise.all([load(), loadSidebarMetadata()]);
           }}
           onOpenDetail={openRemoteDetail}
+          onUploadVisible={uploadVisibleRemoteSessions}
+          visibleUploadCount={displayedResults.filter((session) => supportsMigrationSource(session.source)).length}
           onClose={() => setRemoteSessionsOpen(false)}
         />
       ) : null}

--- a/src/renderer/src/components/remote-sessions-dialog.tsx
+++ b/src/renderer/src/components/remote-sessions-dialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import type { ReactElement } from "react";
-import { ArrowRightLeft, Cloud, Database, FolderOpen, RefreshCw, Search, Trash2, X } from "lucide-react";
+import { ArrowRightLeft, Cloud, CloudUpload, Database, FolderOpen, RefreshCw, Search, Trash2, X } from "lucide-react";
 import type { RemoteSessionDetailSnapshot, RemoteSessionListItem, RemoteSessionStatus } from "../../../core/remote-session-sync";
 import type { MigrationAgent, SessionMigrationResult } from "../../../core/types";
 import { formatRelativeTime } from "../../../core/format-session";
@@ -17,11 +17,15 @@ export function RemoteSessionsDialog({
   onClose,
   onRestored,
   onOpenDetail,
+  onUploadVisible,
+  visibleUploadCount,
 }: {
   language: LanguageMode;
   onClose: () => void;
   onRestored: (result: SessionMigrationResult) => void;
   onOpenDetail: (detail: RemoteSessionDetailSnapshot, query: string) => void;
+  onUploadVisible: () => Promise<void>;
+  visibleUploadCount: number;
 }): ReactElement {
   const l = (en: string, zh: string) => localize(language, en, zh);
   const [status, setStatus] = useState<RemoteSessionStatus | null>(null);
@@ -76,6 +80,16 @@ export function RemoteSessionsDialog({
     try {
       await window.sessionSearch.copyRemoteSessionSetupSql();
       setFeedback({ kind: "success", message: l("Supabase setup SQL copied.", "Supabase 初始化 SQL 已复制。") });
+    } catch (error) {
+      setFeedback({ kind: "error", message: error instanceof Error ? error.message : String(error) });
+    }
+  }
+
+  async function uploadVisible(): Promise<void> {
+    setFeedback({ kind: "running", message: l(`Saving ${visibleUploadCount} visible sessions...`, `正在保存 ${visibleUploadCount} 个当前可见会话...`) });
+    try {
+      await onUploadVisible();
+      await refresh();
     } catch (error) {
       setFeedback({ kind: "error", message: error instanceof Error ? error.message : String(error) });
     }
@@ -172,6 +186,10 @@ export function RemoteSessionsDialog({
           <button type="button" className="settings-action-button" onClick={() => void refresh()} disabled={loading}>
             <RefreshCw size={14} />
             <span>{l("Refresh", "刷新")}</span>
+          </button>
+          <button type="button" className="settings-action-button" onClick={() => void uploadVisible()} disabled={loading || visibleUploadCount === 0}>
+            <CloudUpload size={14} />
+            <span>{l(`Save visible (${visibleUploadCount})`, `保存当前可见（${visibleUploadCount}）`)}</span>
           </button>
           <button type="button" className="settings-action-button" onClick={() => void copySetupSql()}>
             <Database size={14} />

--- a/src/renderer/src/components/skills-dialog.tsx
+++ b/src/renderer/src/components/skills-dialog.tsx
@@ -18,7 +18,7 @@ export function SkillsDialog({
   revealLabel,
   onRefresh,
   onUpload,
-  onUploadVisible,
+  onUploadSelected,
   onInstallRemote,
   onFetchVersion,
   onRefreshRemote,
@@ -36,7 +36,7 @@ export function SkillsDialog({
   revealLabel: string;
   onRefresh: () => void;
   onUpload: (skill: InstalledSkill, force?: boolean) => Promise<SkillSyncUploadOutcome | null>;
-  onUploadVisible: (skills: InstalledSkill[]) => Promise<void>;
+  onUploadSelected: (skills: InstalledSkill[]) => Promise<void>;
   onInstallRemote: (remoteSkillId: string) => Promise<void>;
   onFetchVersion: (remoteSkillId: string) => Promise<RemoteSkill>;
   onRefreshRemote: () => void;
@@ -52,6 +52,7 @@ export function SkillsDialog({
   const [sourceFilter, setSourceFilter] = useState<SkillSourceFilter>("all");
   const [sortKey, setSortKey] = useState<SkillSortKey>("usage");
   const [selectedSkillId, setSelectedSkillId] = useState<string | null>(null);
+  const [selectedSkillIds, setSelectedSkillIds] = useState<Set<string>>(() => new Set());
   const [selectedGroupFingerprint, setSelectedGroupFingerprint] = useState<string | null>(null);
   const [selectedVersionId, setSelectedVersionId] = useState<string | null>(null);
   const [versionContent, setVersionContent] = useState<Record<string, string>>({});
@@ -79,11 +80,13 @@ export function SkillsDialog({
     selectedGroup?.versions.find((version) => version.id === selectedVersionId) ?? selectedGroup?.latest ?? null;
   const selectedSkillBinding = selectedSkill ? syncSnapshot.bindings.find((binding) => binding.localSkillPath === selectedSkill.path) : null;
   const selectedGroupBinding = selectedGroup ? bindingForGroup(syncSnapshot, selectedGroup) : null;
-  const uploadableVisibleSkills = filteredSkills.filter((skill) => skill.source !== "codex-system");
+  const uploadableVisibleSkills = useMemo(() => filteredSkills.filter((skill) => skill.source !== "codex-system"), [filteredSkills]);
+  const selectedUploadableSkills = useMemo(() => uploadableVisibleSkills.filter((skill) => selectedSkillIds.has(skill.id)), [selectedSkillIds, uploadableVisibleSkills]);
+  const allUploadableVisibleSelected = uploadableVisibleSkills.length > 0 && selectedUploadableSkills.length === uploadableVisibleSkills.length;
   const syncReady = syncSnapshot.status.kind === "ready";
   const codexCount = snapshot.skills.filter((skill) => skill.agent === "codex").length;
   const claudeCount = snapshot.skills.filter((skill) => skill.agent === "claude").length;
-  const activeItemRef = useRef<HTMLButtonElement>(null);
+  const activeItemRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!filteredSkills.length) {
@@ -96,6 +99,14 @@ export function SkillsDialog({
   useEffect(() => {
     activeItemRef.current?.scrollIntoView({ block: "nearest" });
   }, [selectedSkill?.id]);
+
+  useEffect(() => {
+    const uploadableIds = new Set(uploadableVisibleSkills.map((skill) => skill.id));
+    setSelectedSkillIds((current) => {
+      const next = new Set([...current].filter((id) => uploadableIds.has(id)));
+      return next.size === current.size ? current : next;
+    });
+  }, [uploadableVisibleSkills]);
 
   useEffect(() => {
     if (!remoteGroups.length) {
@@ -181,6 +192,28 @@ export function SkillsDialog({
     if (outcome && outcome.status === "needs-confirmation") setUploadConfirm({ skill, conflict: outcome.conflict });
   };
 
+  const toggleSkillSelection = (skill: InstalledSkill) => {
+    if (skill.source === "codex-system") return;
+    setSelectedSkillIds((current) => {
+      const next = new Set(current);
+      if (next.has(skill.id)) next.delete(skill.id);
+      else next.add(skill.id);
+      return next;
+    });
+  };
+
+  const toggleVisibleSelection = () => {
+    setSelectedSkillIds((current) => {
+      const next = new Set(current);
+      if (allUploadableVisibleSelected) {
+        for (const skill of uploadableVisibleSkills) next.delete(skill.id);
+      } else {
+        for (const skill of uploadableVisibleSkills) next.add(skill.id);
+      }
+      return next;
+    });
+  };
+
   const confirmUpload = async () => {
     if (!uploadConfirm) return;
     const { skill } = uploadConfirm;
@@ -242,12 +275,23 @@ export function SkillsDialog({
             <button
               type="button"
               className="settings-action-button"
-              onClick={() => void onUploadVisible(uploadableVisibleSkills)}
-              disabled={!syncReady || loading || uploadableVisibleSkills.length === 0}
-              title={!syncReady ? syncDisabledTitle(syncSnapshot, language) : l("Upload visible non-system skills", "上传当前可见的非系统 Skills")}
+              onClick={toggleVisibleSelection}
+              disabled={loading || uploadableVisibleSkills.length === 0}
+              title={l("Select visible non-system skills", "选择当前可见的非系统 Skills")}
+            >
+              <span>{allUploadableVisibleSelected ? l("Clear selected", "清空选择") : l("Select visible", "选择当前可见")}</span>
+            </button>
+          ) : null}
+          {syncView === "local" ? (
+            <button
+              type="button"
+              className="settings-action-button"
+              onClick={() => void onUploadSelected(selectedUploadableSkills)}
+              disabled={!syncReady || loading || selectedUploadableSkills.length === 0}
+              title={!syncReady ? syncDisabledTitle(syncSnapshot, language) : l("Upload selected non-system skills", "上传选中的非系统 Skills")}
             >
               <Upload size={13} />
-              <span>{l("Upload visible", "上传当前可见")}</span>
+              <span>{l(`Upload selected (${selectedUploadableSkills.length})`, `上传选中（${selectedUploadableSkills.length}）`)}</span>
             </button>
           ) : null}
           <button className="stats-refresh" onClick={syncView === "local" ? onRefresh : onRefreshRemote} disabled={loading} title={l("Refresh skills", "刷新 Skills")} aria-label={l("Refresh skills", "刷新 Skills")}>
@@ -272,12 +316,19 @@ export function SkillsDialog({
             {!loading && syncView === "remote" && remoteGroups.length === 0 ? <div className="skills-empty">{remoteEmptyLabel(syncSnapshot, language)}</div> : null}
             {!loading && syncView === "local"
               ? filteredSkills.map((skill) => (
-                  <button
+                  <div
                     key={skill.id}
                     ref={selectedSkill?.id === skill.id ? activeItemRef : undefined}
-                    type="button"
+                    role="button"
+                    tabIndex={0}
                     className={`skill-item ${selectedSkill?.id === skill.id ? "active" : ""}`}
                     onClick={() => setSelectedSkillId(skill.id)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        setSelectedSkillId(skill.id);
+                      }
+                    }}
                     onContextMenu={(event) => {
                       event.preventDefault();
                       setSelectedSkillId(skill.id);
@@ -285,13 +336,23 @@ export function SkillsDialog({
                     }}
                   >
                     <span className="skill-item-head">
+                      <label className="skill-select" title={skill.source === "codex-system" ? l("System skills are excluded from upload", "系统内置 Skills 不参与上传") : l("Select for upload", "选择上传")}>
+                        <input
+                          type="checkbox"
+                          checked={selectedSkillIds.has(skill.id)}
+                          disabled={skill.source === "codex-system"}
+                          onClick={(event) => event.stopPropagation()}
+                          onChange={() => toggleSkillSelection(skill)}
+                          aria-label={l(`Select ${skill.name}`, `选择 ${skill.name}`)}
+                        />
+                      </label>
                       <strong>{skill.name}</strong>
                       {skill.usageCount ? <span className="skill-usage-count" title={l("Times used", "使用次数")}>{formatCompactNumber(skill.usageCount)}</span> : null}
                       <SkillSourceBadge source={skill.source} language={language} />
                     </span>
                     <span className="skill-item-desc">{skill.description || l("No description", "无描述")}</span>
                     <span className="skill-item-path">{skill.path}</span>
-                  </button>
+                  </div>
                 ))
               : null}
             {!loading && syncView === "remote"

--- a/src/renderer/src/detail-panel-actions.test.ts
+++ b/src/renderer/src/detail-panel-actions.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 const appSource = readFileSync(new URL("./App.tsx", import.meta.url), "utf8");
 const detailPanelSource = readFileSync(new URL("./components/detail-panel.tsx", import.meta.url), "utf8");
+const remoteSessionsDialogSource = readFileSync(new URL("./components/remote-sessions-dialog.tsx", import.meta.url), "utf8");
 const sessionUiSource = readFileSync(new URL("./session-ui.ts", import.meta.url), "utf8");
 const preloadSource = readFileSync(new URL("../../preload/index.ts", import.meta.url), "utf8");
 const mainSource = readFileSync(new URL("../../main/index.ts", import.meta.url), "utf8");
@@ -197,7 +198,9 @@ describe("detail panel actions", () => {
 
   it("exposes visible session bulk remote upload and remote-environment restore actions", () => {
     expect(appSource).toContain("uploadVisibleRemoteSessions");
-    expect(appSource).toContain("Save visible to remote");
+    expect(appSource).not.toContain("CloudUpload");
+    expect(remoteSessionsDialogSource).toContain("onUploadVisible");
+    expect(remoteSessionsDialogSource).toContain("Save visible");
     expect(preloadSource).toContain("restoreRemoteSessionToSourceEnvironment");
     expect(preloadSource).toContain("remote-session:restore-to-source-environment");
     expect(mainSource).toContain('ipcMain.handle("remote-session:restore-to-source-environment"');

--- a/src/renderer/src/skills-dialog-actions.test.ts
+++ b/src/renderer/src/skills-dialog-actions.test.ts
@@ -39,8 +39,9 @@ describe("skills dialog actions", () => {
     expect(supabaseSettings.match(/settings-field skills-sync-field/g)).toHaveLength(2);
     expect(skillsDialogSource).toContain("syncView");
     expect(skillsDialogSource).toContain("onUpload");
-    expect(skillsDialogSource).toContain("onUploadVisible");
-    expect(skillsDialogSource).toContain("Upload visible");
+    expect(skillsDialogSource).toContain("selectedSkillIds");
+    expect(skillsDialogSource).toContain('type="checkbox"');
+    expect(skillsDialogSource).toContain("Upload selected");
     expect(skillsDialogSource).toContain("onInstallRemote");
     expect(skillsDialogSource).toContain("onCopySetupSql");
   });

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -2345,7 +2345,7 @@ select:focus-visible {
 
 .skills-toolbar {
   display: grid;
-  grid-template-columns: minmax(180px, 1fr) auto auto auto;
+  grid-template-columns: minmax(180px, 1fr) auto auto auto auto;
   gap: 10px;
   padding: 12px 14px;
   border-bottom: 1px solid var(--border-subtle);
@@ -2574,6 +2574,7 @@ select:focus-visible {
   border: 1px solid transparent;
   border-radius: 8px;
   background: transparent;
+  cursor: pointer;
   text-align: left;
 }
 
@@ -2592,6 +2593,21 @@ select:focus-visible {
   align-items: center;
   gap: 8px;
   min-width: 0;
+}
+
+.skill-select {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+}
+
+.skill-select input {
+  width: 14px;
+  height: 14px;
+  margin: 0;
 }
 
 .skill-item-head strong {


### PR DESCRIPTION
## 背景

#60 已合并后，又根据试用反馈追加两个修复提交。本 PR 只包含这些后续修正。

反馈点：

- `skills:sync-upload` 上传 `bytedcli` 时出现 `canceling statement due to statement timeout`。
- `remote-session:upload` 遇到 `source_environment_id` 缺列时，不需要旧表兼容，应直接给最新 SQL。
- Skills 需要选择部分上传，而不是只能上传当前可见。
- 会话一键上传入口不应该放在主工具栏外面。

## 改动

### Supabase SQL 和上传稳定性

- Skill sync setup SQL 新增私有 Storage bucket：`agent-session-skills`，并创建 anon policy。
- 大 Skill 的 bundled files 超过阈值后写入 Supabase Storage，表行只保存 object key、sha、数量和大小，避免大 JSONB 单行写入导致 statement timeout。
- 安装/读取远程 Skill 时会按需读取 Storage 文件清单并校验 sha。
- Remote Sessions status 会检查完整列集合；缺 `source_environment_id/source_environment_kind/source_environment_label` 时返回包含最新 setup SQL 的错误提示。
- 按要求不做旧 schema 降级写入，执行最新 SQL 后再上传。

### 上传入口 UI

- Skills 本地列表增加 checkbox，可选择部分 Skill 上传。
- 新增 “Select visible / 选择当前可见” 和 “Upload selected / 上传选中”。
- 系统内置 `codex-system` Skill 不可选，默认排除上传。
- 移除主工具栏外部的会话批量上传按钮。
- Remote Sessions 弹窗内新增 “Save visible / 保存当前可见”，上传范围仍是主列表当前可见且支持迁移的会话。

## 验证

- `npm test`：60 个测试文件、618 个测试全部通过。
- `npm run typecheck`：通过。
- `git diff --check HEAD`：通过。

## 使用说明

- 如果远程会话报 `source_environment_id` 缺列，复制并执行 Settings / Remote Sessions 里的最新 setup SQL。
- 如果大 Skill 上传报 Storage bucket/policy 相关错误，复制并执行 Settings / Skills 里的最新 setup SQL。
