### PR TITLE
修复 Supabase 同步 follow-up 问题

### DIFF
--- a/src/core/remote-session-sync.test.ts
+++ b/src/core/remote-session-sync.test.ts
@@ -175,23 +175,64 @@ describe("remote session sync model", () => {
     expect(filterRemoteSessions(sessions, "missing")).toHaveLength(0);
   });
 
-  it("reports the latest setup SQL when source environment columns are missing", async () => {
+  it("falls back to legacy remote session rows when source environment columns are missing", async () => {
     const detail = buildRemoteSessionSnapshot(SESSION, MESSAGES, [], 10_000);
     const { payload, detailJson, portableJson } = buildRemoteSessionPayload({ session: SESSION, detail, portable: PORTABLE, now: 11_000 });
+    const calls: Array<{ url: string; method: string; body?: Record<string, unknown> }> = [];
     const missingColumn = {
       code: "PGRST204",
       message: "Could not find the 'source_environment_id' column of 'agent_session_remote_sessions' in the schema cache",
+    };
+    const legacyRow = {
+      id: payload.id,
+      source_session_key: payload.source_session_key,
+      source_agent: payload.source_agent,
+      source_source: payload.source_source,
+      title: payload.title,
+      project_path: payload.project_path,
+      started_at: payload.started_at,
+      updated_at: payload.updated_at,
+      content_hash: payload.content_hash,
+      message_count: payload.message_count,
+      trace_event_count: payload.trace_event_count,
+      ai_summary: payload.ai_summary,
+      tags: payload.tags,
+      search_text: payload.search_text,
+      detail_object_key: payload.detail_object_key,
+      portable_object_key: payload.portable_object_key,
+      detail_sha256: payload.detail_sha256,
+      portable_sha256: payload.portable_sha256,
+      created_at: payload.created_at,
+      synced_at: payload.synced_at,
     };
     const client = new SupabaseRemoteSessionClient({
       url: "https://example.supabase.co",
       anonKey: "anon",
       fetchImpl: async (url, init) => {
+        calls.push({
+          url: String(url),
+          method: init?.method ?? "GET",
+          body: init?.body ? JSON.parse(String(init.body)) : undefined,
+        });
         if (String(url).includes("/storage/v1/object/")) return new Response("{}", { status: 200 });
-        if (init?.method === "POST") return new Response(JSON.stringify(missingColumn), { status: 400 });
+        if (init?.method === "POST") {
+          const body = JSON.parse(String(init.body));
+          if ("source_environment_id" in body) return new Response(JSON.stringify(missingColumn), { status: 400 });
+          return new Response(JSON.stringify([legacyRow]), { status: 201 });
+        }
+        if (String(url).includes("source_environment_id")) return new Response(JSON.stringify(missingColumn), { status: 400 });
+        if (String(url).includes("select=id")) return new Response(JSON.stringify([]), { status: 200 });
         return new Response(JSON.stringify(missingColumn), { status: 400 });
       },
     });
 
-    await expect(client.uploadSession(payload, detailJson, portableJson)).rejects.toThrow(/latest Supabase remote sessions setup SQL/i);
+    const result = await client.uploadSession(payload, detailJson, portableJson);
+
+    expect(result.status).toBe("uploaded");
+    expect(result.remoteSession.sourceEnvironmentKind).toBe("local");
+    const postBodies = calls.filter((call) => call.method === "POST" && call.url.includes("/rest/v1/")).map((call) => call.body);
+    expect(postBodies).toHaveLength(2);
+    expect(postBodies[0]).toHaveProperty("source_environment_id", "local");
+    expect(postBodies[1]).not.toHaveProperty("source_environment_id");
   });
 });

--- a/src/core/remote-session-sync.ts
+++ b/src/core/remote-session-sync.ts
@@ -7,6 +7,8 @@ export const REMOTE_SESSION_TABLE = "agent_session_remote_sessions";
 export const REMOTE_SESSION_BUCKET = "agent-session-remote";
 const REMOTE_SESSION_COLUMNS =
   "id,source_session_key,source_agent,source_source,source_environment_id,source_environment_kind,source_environment_label,title,project_path,started_at,updated_at,content_hash,message_count,trace_event_count,ai_summary,tags,search_text,detail_object_key,portable_object_key,detail_sha256,portable_sha256,created_at,synced_at";
+const REMOTE_SESSION_LEGACY_COLUMNS =
+  "id,source_session_key,source_agent,source_source,title,project_path,started_at,updated_at,content_hash,message_count,trace_event_count,ai_summary,tags,search_text,detail_object_key,portable_object_key,detail_sha256,portable_sha256,created_at,synced_at";
 
 export interface RemoteSessionDetailSnapshot {
   schemaVersion: 1;
@@ -306,6 +308,19 @@ export function remotePortableSessionFrom(session: SessionSearchResult, messages
   };
 }
 
+function legacyRemoteSessionPayload(payload: RemoteSessionUploadPayload): Omit<
+  RemoteSessionUploadPayload,
+  "source_environment_id" | "source_environment_kind" | "source_environment_label"
+> {
+  const {
+    source_environment_id: _sourceEnvironmentId,
+    source_environment_kind: _sourceEnvironmentKind,
+    source_environment_label: _sourceEnvironmentLabel,
+    ...legacy
+  } = payload;
+  return legacy;
+}
+
 export function filterRemoteSessions(sessions: RemoteSessionListItem[], query: string): RemoteSessionListItem[] {
   const normalized = query.trim().toLowerCase();
   if (!normalized) return sessions;
@@ -349,34 +364,21 @@ export class SupabaseRemoteSessionClient {
       };
     }
     if (isMissingSchemaColumnError(body)) {
-      return { kind: "error", setupSql, message: latestRemoteSessionSetupSqlMessage(body) };
+      const legacyResponse = await this.restRequest(`/${REMOTE_SESSION_TABLE}?select=id&limit=1`, { method: "GET" });
+      if (legacyResponse.ok) return { kind: "ready", setupSql };
+      const legacyBody = await readResponseBody(legacyResponse);
+      return { kind: "error", setupSql, message: supabaseErrorMessage(legacyResponse.status, legacyBody) };
     }
     return { kind: "error", setupSql, message: supabaseErrorMessage(response.status, body) };
   }
 
   async listRemoteSessions(query = ""): Promise<RemoteSessionListItem[]> {
-    const response = await this.restRequest(
-      `/${REMOTE_SESSION_TABLE}?select=${REMOTE_SESSION_COLUMNS}&order=updated_at.desc`,
-      { method: "GET" },
-    );
-    const body = await readResponseBody(response);
-    if (!response.ok) {
-      if (isMissingSchemaColumnError(body)) throw new Error(latestRemoteSessionSetupSqlMessage(body));
-      throw new Error(supabaseErrorMessage(response.status, body));
-    }
+    const { body } = await this.selectRemoteSessionRows(`order=updated_at.desc`);
     return filterRemoteSessions(parseRows(body), query);
   }
 
   async getRemoteSession(remoteId: string): Promise<RemoteSessionListItem> {
-    const response = await this.restRequest(
-      `/${REMOTE_SESSION_TABLE}?id=eq.${encodeURIComponent(remoteId)}&select=${REMOTE_SESSION_COLUMNS}&limit=1`,
-      { method: "GET" },
-    );
-    const body = await readResponseBody(response);
-    if (!response.ok) {
-      if (isMissingSchemaColumnError(body)) throw new Error(latestRemoteSessionSetupSqlMessage(body));
-      throw new Error(supabaseErrorMessage(response.status, body));
-    }
+    const { body } = await this.selectRemoteSessionRows(`id=eq.${encodeURIComponent(remoteId)}&limit=1`);
     const [session] = parseRows(body);
     if (!session) throw new Error("Remote session was not found.");
     return session;
@@ -396,7 +398,9 @@ export class SupabaseRemoteSessionClient {
     });
     const body = await readResponseBody(response);
     if (!response.ok) {
-      if (isMissingSchemaColumnError(body)) throw new Error(latestRemoteSessionSetupSqlMessage(body));
+      if (isMissingSchemaColumnError(body)) {
+        return this.uploadLegacySession(payload, existing);
+      }
       throw new Error(supabaseErrorMessage(response.status, body));
     }
     const [remoteSession] = parseRows(body);
@@ -434,10 +438,43 @@ export class SupabaseRemoteSessionClient {
   private async getRemoteSessionOrNull(remoteId: string): Promise<RemoteSessionListItem | null> {
     try {
       return await this.getRemoteSession(remoteId);
-    } catch (error) {
-      if (error instanceof Error && /latest Supabase remote sessions setup SQL/i.test(error.message)) throw error;
+    } catch {
       return null;
     }
+  }
+
+  private async selectRemoteSessionRows(params: string): Promise<{ body: unknown }> {
+    const response = await this.restRequest(
+      `/${REMOTE_SESSION_TABLE}?select=${REMOTE_SESSION_COLUMNS}&${params}`,
+      { method: "GET" },
+    );
+    const body = await readResponseBody(response);
+    if (response.ok) return { body };
+    if (!isMissingSchemaColumnError(body)) throw new Error(supabaseErrorMessage(response.status, body));
+
+    const legacyResponse = await this.restRequest(
+      `/${REMOTE_SESSION_TABLE}?select=${REMOTE_SESSION_LEGACY_COLUMNS}&${params}`,
+      { method: "GET" },
+    );
+    const legacyBody = await readResponseBody(legacyResponse);
+    if (!legacyResponse.ok) throw new Error(supabaseErrorMessage(legacyResponse.status, legacyBody));
+    return { body: legacyBody };
+  }
+
+  private async uploadLegacySession(
+    payload: RemoteSessionUploadPayload,
+    existing: RemoteSessionListItem | null,
+  ): Promise<RemoteSessionUploadResult> {
+    const response = await this.restRequest(`/${REMOTE_SESSION_TABLE}?on_conflict=id`, {
+      method: "POST",
+      headers: { Prefer: "resolution=merge-duplicates,return=representation" },
+      body: JSON.stringify(legacyRemoteSessionPayload(payload)),
+    });
+    const body = await readResponseBody(response);
+    if (!response.ok) throw new Error(supabaseErrorMessage(response.status, body));
+    const [remoteSession] = parseRows(body);
+    if (!remoteSession) throw new Error("Supabase did not return the uploaded remote session.");
+    return { status: existing ? "updated" : "uploaded", remoteSession };
   }
 
   private async restRequest(path: string, init: RequestInit): Promise<Response> {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -356,6 +356,7 @@ async function getRemoteSessionStatus(): Promise<RemoteSessionStatus> {
 
 async function uploadSessionToRemote(sessionKey: string): Promise<RemoteSessionUploadResult> {
   const client = createRemoteSessionClient();
+  await ensureRemoteSessionDetailsLoaded(sessionKey);
   const { payload, detailJson, portableJson } = buildRemoteSessionUploadFromStore(store, sessionKey);
   return client.uploadSession(payload, detailJson, portableJson);
 }

--- a/src/renderer/src/components/remote-sessions-dialog.tsx
+++ b/src/renderer/src/components/remote-sessions-dialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import type { ReactElement } from "react";
-import { ArrowRightLeft, Cloud, CloudUpload, Database, FolderOpen, RefreshCw, Search, Trash2, X } from "lucide-react";
+import { ArrowRightLeft, Cloud, CloudUpload, Copy, Eye, FolderOpen, RefreshCw, Search, Server, Trash2, X } from "lucide-react";
 import type { RemoteSessionDetailSnapshot, RemoteSessionListItem, RemoteSessionStatus } from "../../../core/remote-session-sync";
 import type { MigrationAgent, SessionMigrationResult } from "../../../core/types";
 import { formatRelativeTime } from "../../../core/format-session";
@@ -191,10 +191,6 @@ export function RemoteSessionsDialog({
             <CloudUpload size={14} />
             <span>{l(`Save visible (${visibleUploadCount})`, `保存当前可见（${visibleUploadCount}）`)}</span>
           </button>
-          <button type="button" className="settings-action-button" onClick={() => void copySetupSql()}>
-            <Database size={14} />
-            <span>{l("Copy SQL", "复制 SQL")}</span>
-          </button>
         </div>
         <div className="remote-restore-bar">
           <div className="remote-filter-group" role="group" aria-label={l("Restore target", "恢复目标")}>
@@ -219,6 +215,12 @@ export function RemoteSessionsDialog({
             <div className="remote-empty">
               <Cloud size={18} />
               <span>{status?.message ?? l("Remote sync is not configured.", "远程同步未配置。")}</span>
+              {status && status.kind !== "unconfigured" ? (
+                <button type="button" className="setup-copy-button" onClick={() => void copySetupSql()}>
+                  <Copy size={13} />
+                  <span>{l("Copy setup SQL", "复制初始化 SQL")}</span>
+                </button>
+              ) : null}
             </div>
           ) : null}
           {!loading && status?.kind === "ready" && filtered.length === 0 ? <div className="remote-empty">{l("No remote sessions found.", "没有找到远程会话。")}</div> : null}
@@ -245,20 +247,21 @@ export function RemoteSessionsDialog({
                 ) : null}
               </div>
               <div className="remote-session-actions">
-                <button type="button" onClick={() => void openDetail(remote)} disabled={detailLoadingId === remote.id || restoringId === remote.id}>
-                  {detailLoadingId === remote.id ? l("Loading...", "加载中...") : l("View", "查看")}
+                <button type="button" className="remote-session-action" onClick={() => void openDetail(remote)} disabled={detailLoadingId === remote.id || restoringId === remote.id}>
+                  <Eye size={14} />
+                  <span>{detailLoadingId === remote.id ? l("Loading...", "加载中...") : l("View", "查看")}</span>
                 </button>
-                <button type="button" onClick={() => void restore(remote)} disabled={restoringId === remote.id}>
+                <button type="button" className="remote-session-action" onClick={() => void restore(remote)} disabled={restoringId === remote.id}>
                   <ArrowRightLeft size={14} />
-                  {restoringId === remote.id ? l("Restoring...", "恢复中...") : l("Restore", "恢复")}
+                  <span>{restoringId === remote.id ? l("Restoring...", "恢复中...") : l("Restore", "恢复")}</span>
                 </button>
                 {remote.sourceEnvironmentKind === "ssh" ? (
-                  <button type="button" onClick={() => void restoreToSourceRemote(remote)} disabled={restoringId === remote.id} title={l("Restore to the original SSH environment", "恢复到原 SSH 环境")}>
-                    <ArrowRightLeft size={14} />
-                    {l("Restore SSH", "恢复 SSH")}
+                  <button type="button" className="remote-session-action" onClick={() => void restoreToSourceRemote(remote)} disabled={restoringId === remote.id} title={l("Restore to the original SSH environment", "恢复到原 SSH 环境")}>
+                    <Server size={14} />
+                    <span>{l("Restore SSH", "恢复 SSH")}</span>
                   </button>
                 ) : null}
-                <button type="button" className="icon-button danger" onClick={() => void deleteRemote(remote)} disabled={restoringId === remote.id} aria-label={l("Delete remote session", "删除远程会话")}>
+                <button type="button" className="remote-session-action icon-only danger" onClick={() => void deleteRemote(remote)} disabled={restoringId === remote.id} aria-label={l("Delete remote session", "删除远程会话")}>
                   <Trash2 size={14} />
                 </button>
               </div>

--- a/src/renderer/src/components/skills-dialog.tsx
+++ b/src/renderer/src/components/skills-dialog.tsx
@@ -641,7 +641,7 @@ function SkillSyncStatusPanel({
     <div className={`skill-sync-panel ${snapshot.status.kind}`}>
       <span>{snapshot.status.message}</span>
       {snapshot.status.kind === "missing-table" ? (
-        <button type="button" onClick={onCopySetupSql}>
+        <button type="button" className="setup-copy-button" onClick={onCopySetupSql}>
           <Copy size={14} />
           {l("Copy setup SQL", "复制初始化 SQL")}
         </button>

--- a/src/renderer/src/detail-panel-actions.test.ts
+++ b/src/renderer/src/detail-panel-actions.test.ts
@@ -201,9 +201,20 @@ describe("detail panel actions", () => {
     expect(appSource).not.toContain("CloudUpload");
     expect(remoteSessionsDialogSource).toContain("onUploadVisible");
     expect(remoteSessionsDialogSource).toContain("Save visible");
+    expect(remoteSessionsDialogSource).not.toContain("Database");
+    expect(remoteSessionsDialogSource).toContain("setup-copy-button");
     expect(preloadSource).toContain("restoreRemoteSessionToSourceEnvironment");
     expect(preloadSource).toContain("remote-session:restore-to-source-environment");
     expect(mainSource).toContain('ipcMain.handle("remote-session:restore-to-source-environment"');
+  });
+
+  it("hydrates remote session details before uploading them to Supabase", () => {
+    const uploadFunction = mainSource.slice(mainSource.indexOf("async function uploadSessionToRemote"), mainSource.indexOf("function listRemoteSessions"));
+
+    expect(uploadFunction).toContain("await ensureRemoteSessionDetailsLoaded(sessionKey)");
+    expect(uploadFunction.indexOf("await ensureRemoteSessionDetailsLoaded(sessionKey)")).toBeLessThan(
+      uploadFunction.indexOf("buildRemoteSessionUploadFromStore"),
+    );
   });
 
   it("preflights remote resume before opening terminals", () => {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -4559,9 +4559,10 @@ body.overlay-open .sidebar {
   gap: 6px;
 }
 
-.remote-session-actions button:not(.icon-button) {
+.remote-session-action {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 5px;
   height: 30px;
   padding: 0 10px;
@@ -4570,6 +4571,15 @@ body.overlay-open .sidebar {
   background: var(--panel-bg);
   color: var(--text);
   cursor: pointer;
+}
+
+.remote-session-action.icon-only {
+  width: 34px;
+  padding: 0;
+}
+
+.remote-session-action.danger {
+  color: var(--danger);
 }
 
 .remote-session-actions button:hover:not(:disabled) {
@@ -4590,6 +4600,26 @@ body.overlay-open .sidebar {
   color: var(--text-muted);
   font-size: 13px;
   text-align: center;
+}
+
+.setup-copy-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 9px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 7px;
+  background: var(--panel-bg);
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.setup-copy-button:hover {
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## 背景

这是 #60 / #61 合并后的 follow-up 修复，针对实际试用反馈继续收敛 Supabase Skills 和远程会话同步体验。

用户反馈的问题包括：

- `skills:sync-upload` 上传 `bytedcli` 这类大 Skill 时出现 Supabase `statement timeout`。
- `remote-session:upload` 在旧版 `agent_session_remote_sessions` 表上会因为缺少 `source_environment_id` schema cache 列直接失败。
- 远程会话预览里部分会话显示 `0 messages`。
- Skills 需要明确选择部分上传。
- Remote Sessions 弹窗里常驻 `Copy SQL` 按钮太突兀，右侧操作按钮风格不统一。

## 改动说明

### 1. 远程会话旧 schema 兼容上传

- `SupabaseRemoteSessionClient` 读取远程会话时会优先使用新列集合。
- 如果 Supabase 返回 `source_environment_*` 缺列，会自动降级到旧列集合读取。
- 上传时如果新 payload 因旧表缺列失败，会自动重试旧 schema payload，避免用户还没执行最新 SQL 时完全无法上传。
- 旧 schema 下会丢失来源 SSH 环境字段，因此“恢复回来源 SSH”仍建议执行最新 setup SQL 后使用；但上传和查看不再被阻断。

### 2. 远程会话上传前补齐详情

- `remote-session:upload` 在构建 Supabase snapshot 前会先调用 `ensureRemoteSessionDetailsLoaded(sessionKey)`。
- 这样 SSH 远程会话即使本地索引只有轻量列表，也会先按需拉取完整 messages，再上传到云端。
- 修复云端预览出现 `0 messages` 的根因。

### 3. SQL 复制入口弱化

- Remote Sessions 顶部工具栏移除常驻 `Copy SQL` 按钮。
- 只有在缺表/错误状态下，空态区域才显示轻量的 `Copy setup SQL` 引导。
- Skills 的 setup SQL 入口也统一使用轻量按钮样式，避免和主要操作冲突。

### 4. Remote Sessions 操作按钮统一

- `View`、`Restore`、`Restore SSH`、删除按钮统一使用同一套 `remote-session-action` 样式。
- `View` 增加图标，`Restore SSH` 使用 server 图标，删除按钮保持危险色但尺寸和边框一致。

## 说明

- 大 Skill 的 Storage bucket/policy 修复已经在 #61 中合入；这次保留并验证相关测试。
- 本次新增旧 schema 降级路径，是为了让已有表用户无需立刻手动升级也能继续上传/查看。
- 如果需要完整 SSH 来源恢复能力，仍然应该执行最新 Remote Sessions setup SQL，补齐 `source_environment_id/source_environment_kind/source_environment_label`。

## 验证

- `npm test`：60 个测试文件、613 个测试全部通过。
- `npm run typecheck`：通过。
- `git diff --check`：通过。
