### PR TITLE
fix: start.sh 每次启动都重新构建，避免使用过期的旧产物

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -83,13 +83,9 @@ else
 fi
 
 # ── 4. build output (out/) ─────────────────────────────────────
-if [ -f "out/main/index.js" ] && [ -f "out/renderer/index.html" ]; then
-  ok "Build output present (out/)"
-else
-  info "Building the app (npm run build) …"
-  npm run build || fail "npm run build failed"
-  ok "Build complete"
-fi
+info "Building the app (npm run build) …"
+npm run build || fail "npm run build failed"
+ok "Build complete"
 
 # ── 5. global command ──────────────────────────────────────────
 # The global binary is a symlink to this repo (npm install -g .).


### PR DESCRIPTION
- 移除 out/ 目录存在即跳过 build 的判断逻辑
- 确保 start.sh 启动时始终执行 npm run build，代码改动即时生效