### PR TITLE
feat: 支持扩展 CLI 会话迁移

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 - **AI / Agent 辅助检索历史会话**：
   可以使用 AI 摘要增强历史会话检索，也支持自然语言找会话；同时开放 MCP 能力,让 Claude Code / Codex / CodeBuddy 可以在对话里直接搜索、读取历史会话,并对会话打标签、收藏、设置可见性。
 - **跨 Agent 迁移会话**：
-  **支持把 Claude / Codex / CodeBuddy 会话迁移到Claude / Codex / CodeBuddy，并在迁移后继续工作，非常好用！！！**。
+  支持把 Claude Code、Codex、CodeBuddy、TClaude、TCodex、Claude Code Internal 和 Codex Internal 的本地会话迁移到任一上述本地 Agent，并在迁移后继续工作。四个扩展 CLI 的迁移按钮仅在 Settings -> Optional sources 中启用对应开关后显示，同一开关也会启用索引。迁移仅支持本地会话；远程恢复目标仍为 Claude Code、Codex 和 CodeBuddy。
 - **远程保存和跨设备恢复会话**：
   支持使用自己的 Supabase 项目手动上传会话快照，在另一台设备搜索远程会话、查看完整详情，并恢复到 Claude Code / Codex / CodeBuddy 中继续工作。
 - **统一查看 Agent 用量和额度**：

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 - **AI / Agent 辅助检索历史会话**：
   可以使用 AI 摘要增强历史会话检索，也支持自然语言找会话；同时开放 MCP 能力,让 Claude Code / Codex / CodeBuddy 可以在对话里直接搜索、读取历史会话,并对会话打标签、收藏、设置可见性。
 - **跨 Agent 迁移会话**：
-  支持把 Claude Code、Codex、CodeBuddy、TClaude、TCodex、Claude Code Internal 和 Codex Internal 的本地会话迁移到任一上述本地 Agent，并在迁移后继续工作。四个扩展 CLI 的迁移按钮仅在 Settings -> Optional sources 中启用对应开关后显示，同一开关也会启用索引。迁移仅支持本地会话；远程恢复目标仍为 Claude Code、Codex 和 CodeBuddy。
+  支持把 Claude Code、Codex、CodeBuddy、TClaude、TCodex、Claude Code Internal 和 Codex Internal 的本地会话迁移到任一上述本地 Agent，并在迁移后继续工作。四个扩展 CLI 的迁移按钮仅在 Settings -> Optional sources 中启用对应开关后显示，同一开关也会启用索引。迁移仅支持本地会话；远程恢复目标仍为 Claude Code、Codex 和 CodeBuddy。原会话不会改变，迁移会创建新的目标会话且仅携带 user / assistant 消息；超过 60k token 会尝试压缩，provider 不可用时本地截断。
 - **远程保存和跨设备恢复会话**：
   支持使用自己的 Supabase 项目手动上传会话快照，在另一台设备搜索远程会话、查看完整详情，并恢复到 Claude Code / Codex / CodeBuddy 中继续工作。
 - **统一查看 Agent 用量和额度**：
@@ -48,6 +48,8 @@
 | Claude Desktop app | `~/Library/Application Support/Claude/claude-code-sessions/**/local_*.json`，以及 Claude Code 项目日志 |
 | TClaude CLI | 可在设置中开启，读取 `~/.tclaude/projects/*/*.jsonl`（Claude Code 分支，格式一致），支持 Resume |
 | TCodex CLI | 可在设置中开启，读取 `~/.tcodex/sessions/**/*.jsonl`（Codex 分支，格式一致），支持 Resume |
+| Claude Code Internal | 可在设置中开启，读取 `~/.claude-internal/projects/*/*.jsonl` |
+| Codex Internal | 可在设置中开启，读取 `~/.codex-internal/sessions/**/*.jsonl` |
 | CodeBuddy CLI | 可在设置中开启，读取 `~/.codebuddy/projects/**/*.jsonl` |
 | OpenClaw | 可在设置中开启，读取 `~/.openclaw/agents/*/sessions/*.jsonl`，兼容 `~/.clawdbot/agents/*/sessions/*.jsonl`，排除 `*.trajectory.jsonl` |
 | Hermes | 可在设置中开启，读取 `~/.hermes/state.db` |
@@ -58,7 +60,7 @@
 
 当 `~/.codex/session_index.jsonl` 存在时，应用会读取 Codex 的标题元数据。没有上游标题时，会使用第一个有效用户问题作为默认标题。
 
-CodeBuddy CLI、TClaude、TCodex、OpenClaw、Hermes、OpenCode、Cursor Agent 和 Trae 默认关闭，可在 Settings -> Optional sources 里选择监测。开启后支持本地只读索引、搜索、详情查看和来源过滤；其中 TClaude / TCodex 因为与 Claude Code / Codex 格式一致，额外支持 Resume 和一键启动（分别调用 `tclaude` / `tcodex` 命令）。OpenClaw 等其他来源的 Resume、远程 SSH 同步和专属用量统计会后续按来源单独补齐。Trae 额外支持打开状态检测。
+CodeBuddy CLI、TClaude、TCodex、Claude Code Internal、Codex Internal、OpenClaw、Hermes、OpenCode、Cursor Agent 和 Trae 默认关闭，可在 Settings -> Optional sources 里选择监测。开启后支持本地只读索引、搜索、详情查看和来源过滤；其中 TClaude / TCodex 因为与 Claude Code / Codex 格式一致，额外支持 Resume 和一键启动（分别调用 `tclaude` / `tcodex` 命令）。OpenClaw 等其他来源的 Resume、远程 SSH 同步和专属用量统计会后续按来源单独补齐。Trae 额外支持打开状态检测。
 
 ## 远程会话同步
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 - **AI / Agent 辅助检索历史会话**：
   可以使用 AI 摘要增强历史会话检索，也支持自然语言找会话；同时开放 MCP 能力,让 Claude Code / Codex / CodeBuddy 可以在对话里直接搜索、读取历史会话,并对会话打标签、收藏、设置可见性。
 - **跨 Agent 迁移会话**：
-  支持把 Claude Code、Codex、CodeBuddy、TClaude、TCodex、Claude Code Internal 和 Codex Internal 的本地会话迁移到任一上述本地 Agent，并在迁移后继续工作。四个扩展 CLI 的迁移按钮仅在 Settings -> Optional sources 中启用对应开关后显示，同一开关也会启用索引。迁移仅支持本地会话；远程恢复目标仍为 Claude Code、Codex 和 CodeBuddy。原会话不会改变，迁移会创建新的目标会话且仅携带 user / assistant 消息；超过 60k token 会尝试压缩，provider 不可用时本地截断。
+  支持在 Claude Code、Codex、CodeBuddy 及已启用的扩展 CLI 间迁移本地会话；远程恢复仍支持 Claude Code、Codex 和 CodeBuddy。
 - **远程保存和跨设备恢复会话**：
   支持使用自己的 Supabase 项目手动上传会话快照，在另一台设备搜索远程会话、查看完整详情，并恢复到 Claude Code / Codex / CodeBuddy 中继续工作。
 - **统一查看 Agent 用量和额度**：

--- a/bin/agent-session-search-mcp.mjs
+++ b/bin/agent-session-search-mcp.mjs
@@ -289,11 +289,10 @@ export async function migrateSession(db, { sessionKey, target } = {}) {
   if (!sessionKey || typeof sessionKey !== "string") {
     return { ok: false, error: "sessionKey is required." };
   }
-  const targets = ["claude", "codex", "codebuddy"];
-  if (!targets.includes(target)) {
-    return { ok: false, error: 'target must be one of "claude", "codex", "codebuddy".' };
-  }
   const bundle = await loadMigrationBundle();
+  if (!bundle.isMigrationTarget(target)) {
+    return { ok: false, error: `target must be one of ${bundle.MIGRATION_TARGET_IDS.map((value) => `"${value}"`).join(", ")}.` };
+  }
   const store = new bundle.SessionStore(db);
   try {
     const result = await bundle.migrateSessionForMcp(
@@ -304,6 +303,14 @@ export async function migrateSession(db, { sessionKey, target } = {}) {
   } catch (error) {
     return { ok: false, error: error instanceof Error ? error.message : String(error) };
   }
+}
+
+// This is the same schema used by runServer's migrate_session registration.
+// Its values come from the bundled core registry, keeping the standalone MCP
+// boundary in lock-step with the typed migration facade.
+export async function migrationTargetSchema(zod) {
+  const bundle = await loadMigrationBundle();
+  return zod.enum(bundle.MIGRATION_TARGET_IDS);
 }
 
 function jsonContent(value) {
@@ -335,6 +342,7 @@ async function runServer() {
   db.exec("PRAGMA busy_timeout = 5000");
   db.exec("PRAGMA foreign_keys = ON");
   const server = new McpServer({ name: "agent-session-search", version: "0.1.0" });
+  const migrateTargetSchema = await migrationTargetSchema(z);
 
   server.registerTool(
     "search_sessions",
@@ -454,10 +462,11 @@ async function runServer() {
         "典型场景：用户说「把这个会话迁移到 Claude/Codex/CodeBuddy」「把当前对话搬过去」「迁移会话」时调用此工具。" +
         "流程：先用 search_sessions 找到源会话的 sessionKey，再调用本工具传入 sessionKey 和 target。" +
         "迁移完成后返回 resumeCommand（如 cd /repo && claude --resume <id>），launched 恒为 false，需要用户自行在终端执行该命令。" +
+        "四个可选目标 tclaude、tcodex、claude-internal、codex-internal 必须先在 Settings > Optional sources 中启用。" +
         "仅支持本地会话（environmentKind=local），远程会话不可迁移。",
       inputSchema: {
         sessionKey: z.string().describe("要迁移的源会话 sessionKey，可通过 search_sessions 获取。"),
-        target: z.enum(["claude", "codex", "codebuddy"]).describe("目标 Agent：迁移到 claude（Claude Code）、codex（Codex）还是 codebuddy（CodeBuddy）。"),
+        target: migrateTargetSchema.describe("目标 Agent：claude、codex、codebuddy、tclaude、tcodex、claude-internal 或 codex-internal。四个可选目标需先在 Settings > Optional sources 启用。"),
       },
     },
     async (args) => {

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -30,7 +30,7 @@
 - **AI / Agent-assisted session retrieval**:
   Use AI summaries to improve history search, ask for sessions in natural language, and expose MCP capabilities so Claude Code / Codex / CodeBuddy can search, read, tag, favorite, and set the visibility of session history directly in chat.
 - **Cross-agent session migration**:
-  Migrate Claude / Codex / CodeBuddy sessions into another agent and continue from the migrated session.
+  Migrate local sessions from Claude Code, Codex, CodeBuddy, TClaude, TCodex, Claude Code Internal, or Codex Internal into any of those local agents and continue working. Migration buttons for the four extended CLIs appear only when their corresponding switches are enabled under Settings -> Optional sources; the same switches also enable indexing. Migration is local-only; remote restore targets remain Claude Code, Codex, and CodeBuddy.
 - **Remote session storage and cross-device restore**:
   Upload session snapshots manually to your own Supabase project, search and inspect them on another device, and restore them into Claude Code / Codex / CodeBuddy.
 - **Unified agent usage and quota view**:

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -30,7 +30,7 @@
 - **AI / Agent-assisted session retrieval**:
   Use AI summaries to improve history search, ask for sessions in natural language, and expose MCP capabilities so Claude Code / Codex / CodeBuddy can search, read, tag, favorite, and set the visibility of session history directly in chat.
 - **Cross-agent session migration**:
-  Migrate local sessions from Claude Code, Codex, CodeBuddy, TClaude, TCodex, Claude Code Internal, or Codex Internal into any of those local agents and continue working. Migration buttons for the four extended CLIs appear only when their corresponding switches are enabled under Settings -> Optional sources; the same switches also enable indexing. Migration is local-only; remote restore targets remain Claude Code, Codex, and CodeBuddy.
+  Migrate local sessions from Claude Code, Codex, CodeBuddy, TClaude, TCodex, Claude Code Internal, or Codex Internal into any of those local agents and continue working. Migration buttons for the four extended CLIs appear only when their corresponding switches are enabled under Settings -> Optional sources; the same switches also enable indexing. Migration is local-only; remote restore targets remain Claude Code, Codex, and CodeBuddy. The original session is unchanged; migration creates a new target session containing only user / assistant messages. Sessions over 60k tokens are compressed when possible and locally truncated if the provider is unavailable.
 - **Remote session storage and cross-device restore**:
   Upload session snapshots manually to your own Supabase project, search and inspect them on another device, and restore them into Claude Code / Codex / CodeBuddy.
 - **Unified agent usage and quota view**:
@@ -48,6 +48,8 @@
 | Claude Desktop app | `~/Library/Application Support/Claude/claude-code-sessions/**/local_*.json` plus Claude Code project logs |
 | TClaude CLI | Optional in settings; reads `~/.tclaude/projects/*/*.jsonl` (a Claude Code fork sharing the same format); supports Resume |
 | TCodex CLI | Optional in settings; reads `~/.tcodex/sessions/**/*.jsonl` (a Codex fork sharing the same format); supports Resume |
+| Claude Code Internal | Optional in settings; reads `~/.claude-internal/projects/*/*.jsonl` |
+| Codex Internal | Optional in settings; reads `~/.codex-internal/sessions/**/*.jsonl` |
 | CodeBuddy CLI | Optional in settings; reads `~/.codebuddy/projects/**/*.jsonl` |
 | OpenClaw | Optional in settings; reads `~/.openclaw/agents/*/sessions/*.jsonl`, legacy `~/.clawdbot/agents/*/sessions/*.jsonl`, excluding `*.trajectory.jsonl` |
 | Hermes | Optional in settings; reads `~/.hermes/state.db` |
@@ -58,7 +60,7 @@
 
 Codex title metadata is read from `~/.codex/session_index.jsonl` when that file exists. If no upstream title is available, the app uses the first meaningful user question as the default title.
 
-CodeBuddy CLI, TClaude, TCodex, OpenClaw, Hermes, OpenCode, Cursor Agent, and Trae are off by default and can be selected from Settings -> Optional sources. Once enabled, they support local read-only indexing, search, details, and source filtering. Because TClaude / TCodex share the Claude Code / Codex formats, they additionally support Resume and one-click launch (invoking the `tclaude` / `tcodex` commands respectively). For the other sources, Resume, SSH remote sync, and provider-specific usage stats are intentionally separate follow-up work. Trae also supports open-state detection.
+CodeBuddy CLI, TClaude, TCodex, Claude Code Internal, Codex Internal, OpenClaw, Hermes, OpenCode, Cursor Agent, and Trae are off by default and can be selected from Settings -> Optional sources. Once enabled, they support local read-only indexing, search, details, and source filtering. Because TClaude / TCodex share the Claude Code / Codex formats, they additionally support Resume and one-click launch (invoking the `tclaude` / `tcodex` commands respectively). For the other sources, Resume, SSH remote sync, and provider-specific usage stats are intentionally separate follow-up work. Trae also supports open-state detection.
 
 ## Remote Session Sync
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -30,7 +30,7 @@
 - **AI / Agent-assisted session retrieval**:
   Use AI summaries to improve history search, ask for sessions in natural language, and expose MCP capabilities so Claude Code / Codex / CodeBuddy can search, read, tag, favorite, and set the visibility of session history directly in chat.
 - **Cross-agent session migration**:
-  Migrate local sessions from Claude Code, Codex, CodeBuddy, TClaude, TCodex, Claude Code Internal, or Codex Internal into any of those local agents and continue working. Migration buttons for the four extended CLIs appear only when their corresponding switches are enabled under Settings -> Optional sources; the same switches also enable indexing. Migration is local-only; remote restore targets remain Claude Code, Codex, and CodeBuddy. The original session is unchanged; migration creates a new target session containing only user / assistant messages. Sessions over 60k tokens are compressed when possible and locally truncated if the provider is unavailable.
+  Migrate local sessions between Claude Code, Codex, CodeBuddy, and enabled optional CLIs; remote restore remains available for Claude Code, Codex, and CodeBuddy.
 - **Remote session storage and cross-device restore**:
   Upload session snapshots manually to your own Supabase project, search and inspect them on another device, and restore them into Claude Code / Codex / CodeBuddy.
 - **Unified agent usage and quota view**:

--- a/docs/superpowers/plans/2026-07-10-extended-cli-session-migration.md
+++ b/docs/superpowers/plans/2026-07-10-extended-cli-session-migration.md
@@ -1,0 +1,924 @@
+# Extended CLI Session Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make TClaude, TCodex, Claude Code Internal, and Codex Internal first-class bidirectional local session-migration environments in the desktop UI and MCP tool, gated by the existing optional-source settings.
+
+**Architecture:** Keep `MigrationAgent` as the three portable JSONL format families and add `MigrationTarget` for the seven concrete runtime environments. A renderer-safe target registry owns labels, family/source mappings, and Settings gates; writer, indexer, platform, UI, IPC, and MCP resolve all target-specific behavior through that registry while remote restore remains on the three base agents.
+
+**Tech Stack:** TypeScript, Electron, React, Vitest, Node.js filesystem/process APIs, SQLite, MCP SDK/Zod
+
+---
+
+## File Structure
+
+- Create `src/core/migration-targets.ts`: renderer-safe target registry, labels, family/source mapping, Settings gates.
+- Create `src/core/migration-targets.test.ts`: registry and four-switch matrix tests.
+- Modify `src/core/types.ts`: add `MigrationTarget`; use it in local migration progress/result/record types.
+- Modify `src/core/session-migration.ts` and tests: enable TClaude/TCodex/Internal sources and concrete targets.
+- Modify `src/core/session-migration-writers.ts` and tests: family-based serialization plus target-specific roots and round-trip sources.
+- Modify `src/core/indexer.ts` and tests: incrementally index into the concrete target source namespace.
+- Modify `src/core/platform.ts` and tests: target binaries, multi-line version checks, scoped `CODEX_HOME`, shell-safe resume commands.
+- Modify `src/main/index.ts`, `src/preload/index.ts`, renderer UI and tests: Settings-gated buttons, IPC validation, consistent Internal labels.
+- Modify `src/core/mcp-migration.ts`, `src/mcp/migration-entry.ts`, `bin/agent-session-search-mcp.mjs`, and tests: seven MCP targets with backend Settings enforcement.
+- Modify `README.md` and `docs/README.en.md`: document the enabled-target behavior and local-only boundary.
+
+### Task 1: Target Registry And Settings Model
+
+**Files:**
+- Create: `src/core/migration-targets.ts`
+- Create: `src/core/migration-targets.test.ts`
+- Modify: `src/core/types.ts:60-117`
+- Modify: `src/core/platform.ts:50-110`
+
+- [ ] **Step 1: Write failing registry tests**
+
+Create `src/core/migration-targets.test.ts` with the complete expected matrix:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  BASE_MIGRATION_TARGETS,
+  MIGRATION_TARGETS,
+  enabledMigrationTargets,
+  migrationTargetDescriptor,
+} from "./migration-targets";
+
+describe("migration target registry", () => {
+  it("defines seven unique targets in display order", () => {
+    expect(MIGRATION_TARGETS.map((item) => item.id)).toEqual([
+      "claude", "codex", "codebuddy", "tclaude", "tcodex",
+      "claude-internal", "codex-internal",
+    ]);
+    expect(new Set(MIGRATION_TARGETS.map((item) => item.id)).size).toBe(7);
+    expect(BASE_MIGRATION_TARGETS).toEqual(["claude", "codex", "codebuddy"]);
+  });
+
+  it.each([
+    ["tclaude", "TClaude", "claude", "tclaude-cli", "includeTclaude"],
+    ["tcodex", "TCodex", "codex", "tcodex-cli", "includeTcodex"],
+    ["claude-internal", "Claude Code Internal", "claude", "claude-internal", "includeClaudeInternal"],
+    ["codex-internal", "Codex Internal", "codex", "codex-internal", "includeCodexInternal"],
+  ] as const)("maps %s", (id, label, family, source, gate) => {
+    expect(migrationTargetDescriptor(id)).toMatchObject({ id, label, family, source, enabledSetting: gate });
+  });
+
+  it("enables each optional target only through its own setting", () => {
+    const off = {
+      includeTclaude: false,
+      includeTcodex: false,
+      includeClaudeInternal: false,
+      includeCodexInternal: false,
+    };
+    expect(enabledMigrationTargets(off)).toEqual(BASE_MIGRATION_TARGETS);
+    expect(enabledMigrationTargets({ ...off, includeTclaude: true })).toEqual([...BASE_MIGRATION_TARGETS, "tclaude"]);
+    expect(enabledMigrationTargets({ ...off, includeTcodex: true })).toEqual([...BASE_MIGRATION_TARGETS, "tcodex"]);
+    expect(enabledMigrationTargets({ ...off, includeClaudeInternal: true })).toEqual([...BASE_MIGRATION_TARGETS, "claude-internal"]);
+    expect(enabledMigrationTargets({ ...off, includeCodexInternal: true })).toEqual([...BASE_MIGRATION_TARGETS, "codex-internal"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the registry test to verify RED**
+
+Run:
+
+```bash
+npm test -- src/core/migration-targets.test.ts --run
+```
+
+Expected: FAIL because `migration-targets.ts` and `MigrationTarget` do not exist.
+
+- [ ] **Step 3: Add the target type and registry**
+
+Add to `src/core/types.ts`:
+
+```ts
+export type MigrationAgent = "claude" | "codex" | "codebuddy";
+export type MigrationTarget =
+  | MigrationAgent
+  | "tclaude"
+  | "tcodex"
+  | "claude-internal"
+  | "codex-internal";
+```
+
+Create `src/core/migration-targets.ts`:
+
+```ts
+import type { MigrationAgent, MigrationTarget, SessionSource } from "./types";
+
+export type OptionalMigrationTargetSetting =
+  | "includeTclaude"
+  | "includeTcodex"
+  | "includeClaudeInternal"
+  | "includeCodexInternal";
+
+export type MigrationTargetSettings = Record<OptionalMigrationTargetSetting, boolean>;
+
+export interface MigrationTargetDescriptor {
+  id: MigrationTarget;
+  label: string;
+  family: MigrationAgent;
+  source: SessionSource;
+  enabledSetting: OptionalMigrationTargetSetting | null;
+}
+
+export const MIGRATION_TARGETS = [
+  { id: "claude", label: "Claude Code", family: "claude", source: "claude-cli", enabledSetting: null },
+  { id: "codex", label: "Codex", family: "codex", source: "codex-cli", enabledSetting: null },
+  { id: "codebuddy", label: "CodeBuddy", family: "codebuddy", source: "codebuddy-cli", enabledSetting: null },
+  { id: "tclaude", label: "TClaude", family: "claude", source: "tclaude-cli", enabledSetting: "includeTclaude" },
+  { id: "tcodex", label: "TCodex", family: "codex", source: "tcodex-cli", enabledSetting: "includeTcodex" },
+  { id: "claude-internal", label: "Claude Code Internal", family: "claude", source: "claude-internal", enabledSetting: "includeClaudeInternal" },
+  { id: "codex-internal", label: "Codex Internal", family: "codex", source: "codex-internal", enabledSetting: "includeCodexInternal" },
+] as const satisfies readonly MigrationTargetDescriptor[];
+
+export const MIGRATION_TARGET_IDS = [
+  "claude", "codex", "codebuddy", "tclaude", "tcodex", "claude-internal", "codex-internal",
+] as const satisfies readonly MigrationTarget[];
+export const BASE_MIGRATION_TARGETS = ["claude", "codex", "codebuddy"] as const;
+
+export function migrationTargetDescriptor(target: MigrationTarget): MigrationTargetDescriptor {
+  const descriptor = MIGRATION_TARGETS.find((item) => item.id === target);
+  if (!descriptor) throw new Error(`Unsupported migration target: ${target}`);
+  return descriptor;
+}
+
+export function enabledMigrationTargets(settings: MigrationTargetSettings): MigrationTarget[] {
+  return MIGRATION_TARGETS
+    .filter((item) => item.enabledSetting === null || settings[item.enabledSetting])
+    .map((item) => item.id);
+}
+
+export function assertMigrationTargetEnabled(target: MigrationTarget, settings: MigrationTargetSettings): void {
+  const descriptor = migrationTargetDescriptor(target);
+  if (descriptor.enabledSetting && !settings[descriptor.enabledSetting]) {
+    throw new Error(`${descriptor.label} migration target is disabled in Settings.`);
+  }
+}
+```
+
+Add `claudeInternalBinary: string` to `AppSettings` and default it to `"claude-internal"`. Keep the existing four include flags unchanged.
+
+- [ ] **Step 4: Run tests and typecheck to verify GREEN**
+
+Run:
+
+```bash
+npm test -- src/core/migration-targets.test.ts --run
+npm run typecheck
+```
+
+Expected: registry tests and typecheck pass. Task 1 adds the new type without changing existing local migration signatures.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add src/core/types.ts src/core/migration-targets.ts src/core/migration-targets.test.ts src/core/platform.ts
+git commit -m "feat: define extended migration targets"
+```
+
+### Task 2: Migration Source Families And Generic Target Discovery
+
+**Files:**
+- Modify: `src/core/session-migration.ts:1-140`
+- Modify: `src/core/session-migration.test.ts:150-220`
+
+- [ ] **Step 1: Write failing source/target tests**
+
+Extend `src/core/session-migration.test.ts`:
+
+```ts
+it.each([
+  ["tclaude-cli", "claude"],
+  ["tcodex-cli", "codex"],
+] as const)("maps %s to %s", (source, expected) => {
+  expect(migrationAgentForSource(source)).toBe(expected);
+});
+
+it.each([
+  "claude-cli", "claude-app", "claude-internal", "tclaude-cli",
+  "codex-cli", "codex-app", "codex-internal", "tcodex-cli", "codebuddy-cli",
+] as const)("allows %s to migrate to every enabled concrete target", (source) => {
+  expect(supportedMigrationTargets(source, [
+    "claude", "codex", "codebuddy", "tclaude", "tcodex", "claude-internal", "codex-internal",
+  ])).toHaveLength(7);
+});
+
+```
+
+- [ ] **Step 2: Run the domain tests to verify RED**
+
+Run:
+
+```bash
+npm test -- src/core/session-migration.test.ts --run
+```
+
+Expected: FAIL because TClaude/TCodex are unsupported sources and target discovery is fixed to the three base agents.
+
+- [ ] **Step 3: Add source mappings and generic target discovery**
+
+In `session-migration.ts`, keep orchestration target signatures on `MigrationAgent` until Task 6. Add the source mappings and make discovery generic so existing callers still infer the three-value type:
+
+```ts
+export function migrationAgentForSource(source: SessionSource): MigrationAgent | null {
+  switch (source) {
+    case "claude-cli":
+    case "claude-app":
+    case "claude-internal":
+    case "tclaude-cli":
+      return "claude";
+    case "codex-cli":
+    case "codex-app":
+    case "codex-internal":
+    case "tcodex-cli":
+      return "codex";
+    case "codebuddy-cli":
+      return "codebuddy";
+    default:
+      return null;
+  }
+}
+
+export function supportedMigrationTargets(source: SessionSource): MigrationAgent[];
+export function supportedMigrationTargets<T extends MigrationTarget>(
+  source: SessionSource,
+  enabledTargets: readonly T[],
+): T[];
+export function supportedMigrationTargets(
+  source: SessionSource,
+  enabledTargets: readonly MigrationTarget[] = BASE_MIGRATION_TARGETS,
+): MigrationTarget[] {
+  return migrationAgentForSource(source) ? [...enabledTargets] : [];
+}
+```
+
+- [ ] **Step 4: Run source-domain tests and typecheck**
+
+Run:
+
+```bash
+npm test -- src/core/migration-targets.test.ts src/core/session-migration.test.ts --run
+npm run typecheck
+```
+
+Expected: source-domain tests and typecheck pass; existing callers continue to infer `MigrationAgent[]` when they omit the second argument.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add src/core/session-migration.ts src/core/session-migration.test.ts
+git commit -m "feat: support extended migration sources"
+```
+
+### Task 3: Target-Specific Writers And Round-Trip Validation
+
+**Files:**
+- Modify: `src/core/session-migration-writers.ts:1-460`
+- Modify: `src/core/session-migration-writers.test.ts:1-430`
+
+- [ ] **Step 1: Write failing seven-target path and round-trip tests**
+
+Add this table to `session-migration-writers.test.ts`:
+
+```ts
+import {
+  loadClaudeCliSessionRows,
+  loadCodeBuddyCliSessionFile,
+  loadCodexSessionRows,
+  parseJsonlText,
+} from "./session-loader";
+import type { LoadedSession, MigrationTarget, SessionSource } from "./types";
+
+function loadForExpectedSource(source: SessionSource, filePath: string): LoadedSession | null {
+  const rows = parseJsonlText(fs.readFileSync(filePath, "utf8"));
+  if (source === "codebuddy-cli") return loadCodeBuddyCliSessionFile(filePath);
+  if (source === "codex-cli" || source === "tcodex-cli" || source === "codex-internal") {
+    return loadCodexSessionRows(filePath, rows, { sourceOverride: source });
+  }
+  return loadClaudeCliSessionRows(filePath, rows, { source });
+}
+
+it.each([
+  ["claude", ".claude", "claude-cli"],
+  ["tclaude", ".tclaude", "tclaude-cli"],
+  ["claude-internal", ".claude-internal", "claude-internal"],
+  ["codex", ".codex", "codex-cli"],
+  ["tcodex", ".tcodex", "tcodex-cli"],
+  ["codex-internal", ".codex-internal", "codex-internal"],
+  ["codebuddy", ".codebuddy", "codebuddy-cli"],
+] as const)("writes %s under %s and validates as %s", async (target, root, source) => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), `migration-writer-${target}-`));
+  const family = migrationTargetDescriptor(target).family;
+  try {
+    const written = await writeMigratedSession({
+      target,
+      session: portable(),
+      homeDir,
+      now: NOW,
+      idFactory: idFactory(family === "codex" ? [SESSION_ID] : [SESSION_ID, ...MESSAGE_IDS]),
+    });
+    expect(path.relative(homeDir, written.filePath).split(path.sep)[0]).toBe(root);
+    expect(loadForExpectedSource(source, written.filePath)?.session).toMatchObject({
+      source,
+      rawId: written.sessionId,
+      originalTitle: "迁移标题 🚀",
+    });
+  } finally {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+```
+
+Change `expectRoundTrip`'s target parameter from `MigrationAgent` to `MigrationTarget`, route it through `loadForExpectedSource`, and add the four new targets to the existing mode/cleanup tables that exercise `beforeValidate`.
+
+- [ ] **Step 2: Run writer tests to verify RED**
+
+Run:
+
+```bash
+npm test -- src/core/session-migration-writers.test.ts --run
+```
+
+Expected: FAIL because `targetFilePath`, serialization, structure validation, and Loader validation only understand three targets.
+
+- [ ] **Step 3: Resolve family and source through the registry**
+
+Update writer signatures to `MigrationTarget`. Use:
+
+```ts
+const descriptor = migrationTargetDescriptor(target);
+const family = descriptor.family;
+```
+
+Dispatch serializer and native structure validation by `family`, not target id. Implement roots:
+
+```ts
+const CLAUDE_ROOT: Record<"claude" | "tclaude" | "claude-internal", string> = {
+  claude: ".claude",
+  tclaude: ".tclaude",
+  "claude-internal": ".claude-internal",
+};
+const CODEX_ROOT: Record<"codex" | "tcodex" | "codex-internal", string> = {
+  codex: ".codex",
+  tcodex: ".tcodex",
+  "codex-internal": ".codex-internal",
+};
+```
+
+`loadWrittenSession` must pass `descriptor.source` to the Claude/Codex Loader APIs so the returned session key/source match the concrete environment. Keep the existing title, timestamp, parent-chain, `0600`, fsync, atomic rename, and failure cleanup behavior unchanged.
+
+- [ ] **Step 4: Run writer and loader tests**
+
+Run:
+
+```bash
+npm test -- src/core/session-migration-writers.test.ts src/core/session-loader.test.ts --run
+```
+
+Expected: all writer/loader tests pass for seven targets.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add src/core/session-migration-writers.ts src/core/session-migration-writers.test.ts
+git commit -m "feat: write sessions to extended cli targets"
+```
+
+### Task 4: Concrete-Source Incremental Indexing
+
+**Files:**
+- Modify: `src/core/indexer.ts:155-185`
+- Modify: `src/core/indexer.test.ts:110-145`
+
+- [ ] **Step 1: Expand the incremental-index test to seven targets**
+
+Replace the three-value table with:
+
+```ts
+it.each([
+  ["claude", "claude-cli"],
+  ["tclaude", "tclaude-cli"],
+  ["claude-internal", "claude-internal"],
+  ["codex", "codex-cli"],
+  ["tcodex", "tcodex-cli"],
+  ["codex-internal", "codex-internal"],
+  ["codebuddy", "codebuddy-cli"],
+] as const)("indexes one migrated %s file as %s", async (target, source) => {
+  const store = createInMemoryStore();
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), `agent-session-search-index-${target}-`));
+  try {
+    const written = await writeMigratedSession({
+      target,
+      homeDir,
+      now: new Date("2026-06-23T06:07:08.901Z"),
+      session: portableSession(),
+    });
+    const status = indexMigratedSessionFile(store, target, written.filePath);
+    expect(status).toMatchObject({ indexed: 1, total: 1, error: null });
+    expect(store.searchSessions({ source })).toEqual([expect.objectContaining({ source })]);
+  } finally {
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+```
+
+- [ ] **Step 2: Run the indexer test to verify RED**
+
+Run:
+
+```bash
+npm test -- src/core/indexer.test.ts --run
+```
+
+Expected: FAIL because `loadMigratedSessionFile` treats every non-Codex/non-CodeBuddy target as ordinary Claude.
+
+- [ ] **Step 3: Load via descriptor family/source**
+
+Change target types to `MigrationTarget` and implement:
+
+```ts
+function loadMigratedSessionFile(target: MigrationTarget, filePath: string): LoadedSession | null {
+  const descriptor = migrationTargetDescriptor(target);
+  const rows = parseJsonlText(fs.readFileSync(filePath, "utf8"));
+  if (descriptor.family === "codex") {
+    return loadCodexSessionRows(filePath, rows, { sourceOverride: descriptor.source });
+  }
+  if (descriptor.family === "codebuddy") return loadCodeBuddyCliSessionFile(filePath);
+  return loadClaudeCliSessionRows(filePath, rows, { source: descriptor.source });
+}
+```
+
+- [ ] **Step 4: Run indexer tests to verify GREEN**
+
+Run:
+
+```bash
+npm test -- src/core/indexer.test.ts src/core/session-migration-writers.test.ts --run
+```
+
+Expected: all migrated files are indexed under their concrete source.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add src/core/indexer.ts src/core/indexer.test.ts
+git commit -m "feat: index extended migration targets"
+```
+
+### Task 5: Target CLI Preflight And Resume Commands
+
+**Files:**
+- Modify: `src/core/platform.ts:40-110,185-335,780-1010`
+- Modify: `src/core/platform.test.ts:720-970`
+
+- [ ] **Step 1: Write failing binary/process/version tests**
+
+Add configured binaries and expected process specs:
+
+```ts
+const extendedSettings = {
+  ...defaultSettings,
+  tclaudeBinary: "/opt/TClaude/tclaude",
+  tcodexBinary: "/opt/TCodex/tcodex",
+  claudeInternalBinary: "/opt/Claude Internal/claude-internal",
+  codexBinary: "/opt/Codex/codex",
+};
+
+expect(migrationBinary("tclaude", extendedSettings)).toBe("/opt/TClaude/tclaude");
+expect(migrationBinary("tcodex", extendedSettings)).toBe("/opt/TCodex/tcodex");
+expect(migrationBinary("claude-internal", extendedSettings)).toBe("/opt/Claude Internal/claude-internal");
+expect(migrationBinary("codex-internal", extendedSettings)).toBe("/opt/Codex/codex");
+
+expect(getMigrationResumeProcessSpec("codex-internal", "id-1", "/repo", extendedSettings, { homeDir: "/home/me" })).toMatchObject({
+  command: "/opt/Codex/codex",
+  args: ["resume", "id-1"],
+  cwd: "/repo",
+  env: { CODEX_HOME: "/home/me/.codex-internal" },
+  displayCommand: "cd /repo && CODEX_HOME=/home/me/.codex-internal /opt/Codex/codex resume id-1",
+});
+```
+
+Add wrapper version fixtures using the exact verified outputs and assert missing wrapper/upstream lines and low versions fail with target-specific messages.
+
+- [ ] **Step 2: Run platform tests to verify RED**
+
+Run:
+
+```bash
+npm test -- src/core/platform.test.ts --run
+```
+
+Expected: FAIL because binaries, resume specs, env, and wrapper version parsing support only three targets.
+
+- [ ] **Step 3: Implement target-specific process specs**
+
+Change platform migration APIs to `MigrationTarget`. Add `env?: Record<string, string>` to the process spec and an optional `{ homeDir?: string; platform?: NodeJS.Platform }` argument.
+
+Map binaries/args as follows:
+
+```ts
+function migrationBinary(target: MigrationTarget, settings: AppSettings): string {
+  if (target === "claude") return settings.claudeBinary;
+  if (target === "tclaude") return settings.tclaudeBinary;
+  if (target === "claude-internal") return settings.claudeInternalBinary;
+  if (target === "codebuddy") return settings.codeBuddyBinary;
+  if (target === "tcodex") return settings.tcodexBinary;
+  return settings.codexBinary;
+}
+
+function migrationResumeArgs(target: MigrationTarget, sessionId: string): string[] {
+  return migrationTargetDescriptor(target).family === "codex"
+    ? ["resume", sessionId]
+    : ["--resume", sessionId];
+}
+```
+
+Only `codex-internal` receives `{ CODEX_HOME: path.join(homeDir, ".codex-internal") }`. Generate POSIX inline env assignment, PowerShell `try/finally` restoration, and cmd `setlocal`/`endlocal` from the same process spec. Do not leave a second fallback target switch in `src/main/index.ts` or `src/core/mcp-migration.ts`.
+
+- [ ] **Step 4: Implement target-specific version rules**
+
+Represent each target as required labelled version lines:
+
+```ts
+const TARGET_VERSION_RULES: Record<MigrationTarget, readonly VersionRule[]> = {
+  claude: [{ label: "Claude Code", pattern: /(?:Claude Code\s+)?(\d+\.\d+(?:\.\d+)?)/i, minimum: "2.1.186" }],
+  codex: [{ label: "Codex", pattern: /(?:codex(?:-cli)?\s+)?(\d+\.\d+(?:\.\d+)?)/i, minimum: "0.141.0" }],
+  codebuddy: [{ label: "CodeBuddy", pattern: /(?:CodeBuddy\s+)?(\d+\.\d+(?:\.\d+)?)/i, minimum: "2.109.1" }],
+  tclaude: [
+    { label: "@tencent/tclaude", pattern: /@tencent\/tclaude\s+(\d+\.\d+\.\d+)/, minimum: "0.0.9" },
+    { label: "@anthropic-ai/claude-code", pattern: /@anthropic-ai\/claude-code\s+(\d+\.\d+\.\d+)/, minimum: "2.1.154" },
+  ],
+  tcodex: [
+    { label: "@tencent/tcodex", pattern: /@tencent\/tcodex\s+(\d+\.\d+\.\d+)/, minimum: "0.0.13" },
+    { label: "@openai/codex", pattern: /@openai\/codex\s+(\d+\.\d+\.\d+)/, minimum: "0.142.4" },
+  ],
+  "claude-internal": [
+    { label: "claude-internal", pattern: /claude-internal:\s*(\d+\.\d+\.\d+)/, minimum: "1.1.9" },
+    { label: "claude", pattern: /^claude:\s*(\d+\.\d+\.\d+)/m, minimum: "2.1.154" },
+  ],
+  "codex-internal": [{ label: "Codex", pattern: /(?:codex-cli\s+)?(\d+\.\d+\.\d+)/i, minimum: "0.141.0" }],
+};
+```
+
+Extend `CliVersionRunner` to accept an optional env and use scoped `CODEX_HOME` for the internal target. Preserve clear ENOENT, empty, unparseable, and too-old messages.
+
+- [ ] **Step 5: Run platform tests and typecheck**
+
+Run:
+
+```bash
+npm test -- src/core/platform.test.ts --run
+npm run typecheck
+```
+
+Expected: target process/version tests and typecheck pass. Existing three-target callers remain valid because `MigrationAgent` is a subset of `MigrationTarget`.
+
+- [ ] **Step 6: Commit Task 5**
+
+```bash
+git add src/core/platform.ts src/core/platform.test.ts
+git commit -m "feat: launch extended migration targets"
+```
+
+### Task 6: Desktop Settings, UI, IPC, And Labels
+
+**Files:**
+- Modify: `src/core/types.ts:60-117`
+- Modify: `src/core/session-migration.ts:1-340`
+- Modify: `src/core/session-migration.test.ts:250-780`
+- Modify: `src/core/session-store.ts:150-165,1020-1070`
+- Modify: `src/core/session-store.test.ts:570-700`
+- Modify: `src/main/index.ts:1250-1300,1745-1790`
+- Modify: `src/preload/index.ts:1-135`
+- Modify: `src/renderer/src/session-ui.ts:1-85`
+- Modify: `src/renderer/src/session-ui.test.ts:1-80`
+- Modify: `src/renderer/src/components/session-migration-dialog.tsx:1-130`
+- Modify: `src/renderer/src/App.tsx:1350-1410,2135-2150,2940-3030`
+- Modify: `src/renderer/src/session-migration-ui.test.ts`
+- Modify: `src/renderer/src/detail-panel-actions.test.ts`
+- Modify: `src/core/format-session.ts:1-20`
+
+- [ ] **Step 1: Write failing concrete-target orchestration and record tests**
+
+Add to `session-migration.test.ts`:
+
+```ts
+it("orchestrates and records a concrete target", async () => {
+  const fixture = createDependencies();
+  const result = await migrateSession({
+    source: session("tclaude-cli"),
+    messages,
+    target: "codex-internal",
+    deps: fixture.deps,
+  });
+  expect(result.target).toBe("codex-internal");
+  expect(fixture.seenRecords).toEqual([
+    expect.objectContaining({ sourceAgent: "claude", targetAgent: "codex-internal" }),
+  ]);
+});
+```
+
+Add a `session-store.test.ts` round trip using `targetAgent: "tcodex"` and assert the same value is returned.
+
+- [ ] **Step 2: Write failing UI availability and naming tests**
+
+Extend `session-ui.test.ts`:
+
+```ts
+it("shows Internal names and Settings-gated migration targets", () => {
+  expect(sourceFilters({
+    ...defaultSettings,
+    includeTclaude: true,
+    includeTcodex: true,
+    includeClaudeInternal: true,
+    includeCodexInternal: true,
+  }).map((item) => item.label)).toEqual(expect.arrayContaining([
+    "TClaude", "TCodex", "Claude Code Internal", "Codex Internal",
+  ]));
+
+  expect(migrationTargetsForSource("tclaude-cli", defaultSettings)).toEqual(["claude", "codex", "codebuddy"]);
+  expect(migrationTargetsForSource("tclaude-cli", { ...defaultSettings, includeTclaude: true })).toEqual([
+    "claude", "codex", "codebuddy", "tclaude",
+  ]);
+});
+```
+
+Add source-contract assertions that the dialog receives `targets`, renders `targets.map`, and no longer hardcodes `(["claude", "codex", "codebuddy"] as const)`.
+
+- [ ] **Step 3: Run domain/renderer tests to verify RED**
+
+Run:
+
+```bash
+npm test -- src/core/session-migration.test.ts src/core/session-store.test.ts src/renderer/src/session-ui.test.ts src/renderer/src/session-migration-ui.test.ts src/renderer/src/detail-panel-actions.test.ts --run
+```
+
+Expected: FAIL because orchestration/result/record types still use `MigrationAgent`, labels are `Extra`, and the dialog hardcodes three buttons.
+
+- [ ] **Step 4: Promote local migration flow to `MigrationTarget`**
+
+Keep `PortableSession.sourceAgent: MigrationAgent`, but change progress, result, record target, orchestrator options/dependencies, and safe/fallback target parameters to `MigrationTarget`:
+
+```ts
+export interface SessionMigrationProgress {
+  sessionKey: string;
+  target: MigrationTarget;
+  stage: SessionMigrationStage;
+  percent?: number;
+  compression?: MigrationCompressionEvent;
+}
+export interface SessionMigrationResult {
+  target: MigrationTarget;
+  targetSessionId: string;
+  targetFilePath: string;
+  strategy: SessionMigrationStrategy;
+  resumeCommand: string;
+  indexed: boolean;
+  launched: boolean;
+  warning?: string;
+}
+export interface SessionMigrationRecord {
+  id: string;
+  sourceSessionKey: string;
+  sourceAgent: MigrationAgent;
+  targetAgent: MigrationTarget;
+  targetSessionId: string;
+  targetFilePath: string;
+  strategy: SessionMigrationStrategy;
+  createdAt: number;
+}
+```
+
+Replace the old `MIGRATION_AGENTS.includes(target)` validation with `migrationTargetDescriptor(target)`. SQLite remains `TEXT`; update its row types only.
+
+- [ ] **Step 5: Drive UI targets from Settings and registry**
+
+In `session-ui.ts`:
+
+```ts
+export function migrationTargetsForSource(source: SessionSource, settings: MigrationTargetSettings): MigrationTarget[] {
+  return supportedMigrationTargets(source, enabledMigrationTargets(settings));
+}
+
+export function migrationAgentLabel(target: MigrationTarget): string {
+  return migrationTargetDescriptor(target).label;
+}
+```
+
+Rename every `Claude Extra` / `Codex Extra` label. Change `SessionMigrationDialog` to accept `targets: readonly MigrationTarget[]` and render only those values. In `App.tsx`, compute targets with the current settings and pass them into the dialog.
+
+Update the four Settings subtitles to say the toggle indexes the source and enables the migration target. Do not add another toggle.
+
+- [ ] **Step 6: Enforce Settings again in the main process**
+
+Before `migrateSession` in `ipcMain.handle("session:migrate", ...)`, call:
+
+```ts
+assertMigrationTargetEnabled(target, getSettings());
+```
+
+Change IPC/preload types to `MigrationTarget`. Delete the local fallback binary/argument switch and use the platform helper that builds a safe target-specific display command from the shared process spec.
+
+- [ ] **Step 7: Run desktop/domain tests and typecheck**
+
+Run:
+
+```bash
+npm test -- src/core/session-migration.test.ts src/core/session-store.test.ts src/renderer/src/session-ui.test.ts src/renderer/src/session-migration-ui.test.ts src/renderer/src/detail-panel-actions.test.ts src/core/platform.test.ts --run
+npm run typecheck
+```
+
+Expected: UI/IPC tests pass and no desktop migration type errors remain.
+
+- [ ] **Step 8: Commit Task 6**
+
+```bash
+git add src/core/types.ts src/core/session-migration.ts src/core/session-migration.test.ts src/core/session-store.ts src/core/session-store.test.ts src/main/index.ts src/preload/index.ts src/renderer/src/App.tsx src/renderer/src/session-ui.ts src/renderer/src/session-ui.test.ts src/renderer/src/components/session-migration-dialog.tsx src/renderer/src/session-migration-ui.test.ts src/renderer/src/detail-panel-actions.test.ts src/core/format-session.ts
+git commit -m "feat: expose settings-gated migration targets"
+```
+
+### Task 7: MCP Seven-Target Support
+
+**Files:**
+- Modify: `src/core/mcp-migration.ts:1-230`
+- Modify: `src/core/mcp-migration.test.ts:1-410`
+- Modify: `src/mcp/migration-entry.ts:1-45`
+- Modify: `bin/agent-session-search-mcp.mjs:285-315,430-485`
+- Modify: `src/core/mcp-server.test.ts:240-285`
+
+- [ ] **Step 1: Write failing MCP target/gate tests**
+
+Add to `mcp-migration.test.ts`:
+
+```ts
+it("migrates a TClaude source to enabled Codex Internal", async () => {
+  const settings = { ...defaultSettings, includeCodexInternal: true };
+  const store = createInMemoryStore();
+  const { sessionKey, projectPath } = seedLocalSession(store, {
+    source: "tclaude-cli",
+    sessionKey: "tclaude:source-1",
+  });
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-mig-home-"));
+  try {
+    const result = await migrateSessionForMcp(
+      { sessionKey, target: "codex-internal" },
+      { store, settings, homeDir, inspectCli: noOpInspect },
+    );
+    expect(result).toMatchObject({ target: "codex-internal", launched: false });
+    expect(store.getSession(`codex-internal:${result.targetSessionId}`)?.source).toBe("codex-internal");
+  } finally {
+    store.close();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    fs.rmSync(projectPath, { recursive: true, force: true });
+  }
+});
+
+it("rejects a disabled optional MCP target before CLI inspection", async () => {
+  const store = createInMemoryStore();
+  const { sessionKey, projectPath } = seedLocalSession(store);
+  const inspectCli = vi.fn(noOpInspect);
+  try {
+    await expect(migrateSessionForMcp(
+      { sessionKey, target: "tcodex" },
+      { store, settings: defaultSettings, inspectCli },
+    )).rejects.toThrow("TCodex migration target is disabled in Settings");
+    expect(inspectCli).not.toHaveBeenCalled();
+  } finally {
+    store.close();
+    fs.rmSync(projectPath, { recursive: true, force: true });
+  }
+});
+```
+
+Update `mcp-server.test.ts` to accept `target: "tclaude"` and continue rejecting `"gemini"`.
+
+- [ ] **Step 2: Run MCP tests to verify RED**
+
+Run:
+
+```bash
+npm test -- src/core/mcp-migration.test.ts src/core/mcp-server.test.ts --run
+```
+
+Expected: FAIL because input types/schema only accept three targets and MCP does not enforce Settings.
+
+- [ ] **Step 3: Use shared target/gate/platform helpers in MCP**
+
+Change `McpMigrateSessionInput.target` and dependency callbacks to `MigrationTarget`. Immediately after loading settings, run:
+
+```ts
+assertMigrationTargetEnabled(input.target, settings);
+```
+
+Use `writeMigratedSession`, `indexMigratedSessionFile`, `inspectMigrationCli`, and the shared process-spec display command with the concrete target. Remove MCP's local `target === "claude" ? ...` fallback switch.
+
+Export required registry/target helpers from `src/mcp/migration-entry.ts`. Update the server schema:
+
+```ts
+target: z.enum([
+  "claude", "codex", "codebuddy", "tclaude", "tcodex",
+  "claude-internal", "codex-internal",
+])
+```
+
+Update the MCP description with the four optional targets and Settings requirement.
+
+- [ ] **Step 4: Rebuild and run MCP tests**
+
+Run:
+
+```bash
+npm run build:mcp
+npm test -- src/core/mcp-migration.test.ts src/core/mcp-server.test.ts --run
+npm run typecheck
+```
+
+Expected: MCP core/server/settings tests pass; the generated bundle loads seven-target code.
+
+- [ ] **Step 5: Commit Task 7**
+
+```bash
+git add src/core/mcp-migration.ts src/core/mcp-migration.test.ts src/mcp/migration-entry.ts bin/agent-session-search-mcp.mjs src/core/mcp-server.test.ts
+git commit -m "feat: extend mcp session migration targets"
+```
+
+### Task 8: Documentation, Local Smoke Tests, And Final Verification
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/README.en.md`
+- Modify: tests touched by any final compatibility correction
+
+- [ ] **Step 1: Update user documentation**
+
+Document:
+
+```markdown
+- Optional TClaude, TCodex, Claude Code Internal, and Codex Internal sources can also be migration sources and targets.
+- Their migration buttons appear only when the matching Optional sources switch is enabled.
+- Migration remains local-only; remote restore still targets Claude Code, Codex, or CodeBuddy.
+```
+
+Use the equivalent Chinese wording in `README.md` and English wording in `docs/README.en.md`.
+
+- [ ] **Step 2: Run real read-only CLI preflight**
+
+Run without starting sessions:
+
+```bash
+tclaude --version
+tcodex --version
+claude-internal --version
+CODEX_HOME="$HOME/.codex-internal" codex --version
+```
+
+Expected: outputs match or exceed the target-specific baselines. Do not print config/auth file contents.
+
+- [ ] **Step 3: Run temporary-home writer/indexer smoke tests**
+
+Run the focused tests that write only under test-created temp homes:
+
+```bash
+npm test -- src/core/migration-targets.test.ts src/core/session-migration-writers.test.ts src/core/indexer.test.ts src/core/platform.test.ts src/core/mcp-migration.test.ts --run
+```
+
+Expected: all four new targets write, round-trip, and index without touching real CLI session directories.
+
+- [ ] **Step 4: Run complete verification**
+
+Run:
+
+```bash
+npm run typecheck
+npm test -- --run
+npm run build
+git diff --check
+```
+
+Expected: typecheck, all tests, and production build pass; no whitespace errors.
+
+- [ ] **Step 5: Verify scope and compatibility**
+
+Run:
+
+```bash
+git diff --stat 0b8f52f..HEAD
+git status -sb
+```
+
+Confirm remote restore still declares `RESTORE_TARGETS: MigrationAgent[] = ["claude", "codex", "codebuddy"]`, portable `sourceAgent` remains a three-value family, and no real `~/.tclaude` / `~/.tcodex` / Internal session file was created.
+
+- [ ] **Step 6: Commit documentation**
+
+```bash
+git add README.md docs/README.en.md
+git commit -m "docs: document extended cli migration"
+```
+
+- [ ] **Step 7: Request code review**
+
+Review the complete range from design commit `0b8f52f` to `HEAD`, fix every Critical/Important issue, rerun the focused tests plus complete verification, verify `git status -sb` is clean, then use `superpowers:finishing-a-development-branch` to choose merge/PR/keep behavior.

--- a/docs/superpowers/specs/2026-07-10-extended-cli-session-migration-design.md
+++ b/docs/superpowers/specs/2026-07-10-extended-cli-session-migration-design.md
@@ -1,0 +1,323 @@
+# Extended CLI Session Migration Design
+
+## 目标
+
+在现有 Claude Code、Codex、CodeBuddy 三目标会话迁移基础上，增加以下本地 CLI 环境：
+
+- TClaude
+- TCodex
+- Claude Code Internal
+- Codex Internal
+
+四种环境既可作为迁移源，也可作为迁移目标。桌面 UI 与 MCP `migrate_session` 共用同一套目标解析、Settings 门控、写入、校验、索引和启动逻辑。远程会话恢复保持现有 Claude、Codex、CodeBuddy 三目标，不扩展本机专用环境。
+
+## 已验证的本机环境
+
+设计基于 2026-07-10 的本机只读检查：
+
+| 环境 | CLI / 版本 | 会话根目录 | Resume 能力 |
+| --- | --- | --- | --- |
+| TClaude | `@tencent/tclaude 0.0.9`，上游 Claude Code `2.1.154` | `~/.tclaude/projects` | wrapper 将 `--resume` 转发给 Claude Code |
+| TCodex | `@tencent/tcodex 0.0.13`，上游 Codex `0.142.4` | `~/.tcodex/sessions` | wrapper 将 `resume` 转发给 Codex |
+| Claude Code Internal | `claude-internal 1.1.9`，上游 Claude Code `2.1.154` | `~/.claude-internal/projects` | `claude-internal --resume <id>` |
+| Codex Internal | 普通 Codex `0.144.1` 配合独立 `CODEX_HOME` | `~/.codex-internal/sessions` | `CODEX_HOME=~/.codex-internal codex resume <id>` |
+
+这些目录中已有可被当前 Loader 读取的真实 JSONL：TClaude 与 Claude Code Internal 使用 Claude 格式，TCodex 与 Codex Internal 使用 Codex 格式。
+
+## 范围
+
+### 包含
+
+- 四种新环境作为迁移源与迁移目标。
+- Settings 开关控制可选迁移目标是否出现。
+- UI、IPC、主进程和 MCP 支持七种迁移目标。
+- 目标专属 CLI 预检、写入目录、回读来源、增量索引和 Resume 命令。
+- `Claude Extra` / `Codex Extra` 统一改名为 `Claude Code Internal` / `Codex Internal`。
+- 本地迁移记录保存具体目标环境。
+- macOS、Windows PowerShell 与 cmd 的目标启动命令。
+
+### 不包含
+
+- SSH 远程环境直接迁移。
+- 远程会话恢复到 TClaude、TCodex 或 Internal 环境。
+- 自动安装、升级或登录目标 CLI。
+- 实际启动交互会话或调用模型的自动化 smoke test。
+- 为可选 CLI 新增单独的设置页面或账号管理。
+
+## 核心建模
+
+当前 `MigrationAgent` 同时承担“原生文件格式族”和“运行目标”两个职责。新增环境后必须拆开这两个维度。
+
+保留三种可移植格式族：
+
+```ts
+export type MigrationAgent = "claude" | "codex" | "codebuddy";
+```
+
+新增实际运行目标：
+
+```ts
+export type MigrationTarget =
+  | "claude"
+  | "codex"
+  | "codebuddy"
+  | "tclaude"
+  | "tcodex"
+  | "claude-internal"
+  | "codex-internal";
+```
+
+`PortableSession.sourceAgent`、远程 portable JSON 的 `sourceAgent` 继续使用 `MigrationAgent`，保持现有远程数据兼容。下列本地流程字段改用 `MigrationTarget`：
+
+- `SessionMigrationProgress.target`
+- `SessionMigrationResult.target`
+- `SessionMigrationRecord.targetAgent`
+- `migrateSession(...).target`
+- IPC / preload 的迁移目标参数
+- MCP `migrate_session.target`
+
+SQLite `session_migrations.target_agent` 已是无约束 `TEXT`，无需数据库迁移；读取类型扩展为 `MigrationTarget`。
+
+## 目标注册表
+
+建立单一、纯数据的目标注册表，避免 UI、writer、platform 和 MCP 各自维护分支列表。注册表至少描述：
+
+```ts
+type OptionalMigrationTargetSetting =
+  | "includeTclaude"
+  | "includeTcodex"
+  | "includeClaudeInternal"
+  | "includeCodexInternal";
+
+interface MigrationTargetDescriptor {
+  id: MigrationTarget;
+  label: string;
+  family: MigrationAgent;
+  source: SessionSource;
+  enabledSetting: null | OptionalMigrationTargetSetting;
+}
+```
+
+目标矩阵：
+
+| Target | Label | Family | Indexed source | Settings gate |
+| --- | --- | --- | --- | --- |
+| `claude` | Claude Code | `claude` | `claude-cli` | 始终可用 |
+| `codex` | Codex | `codex` | `codex-cli` | 始终可用 |
+| `codebuddy` | CodeBuddy | `codebuddy` | `codebuddy-cli` | 保持现状，始终作为迁移目标 |
+| `tclaude` | TClaude | `claude` | `tclaude-cli` | `includeTclaude` |
+| `tcodex` | TCodex | `codex` | `tcodex-cli` | `includeTcodex` |
+| `claude-internal` | Claude Code Internal | `claude` | `claude-internal` | `includeClaudeInternal` |
+| `codex-internal` | Codex Internal | `codex` | `codex-internal` | `includeCodexInternal` |
+
+注册表及其 Settings key union 放在 renderer 可安全导入的核心模块中，不导入 `AppSettings` 或 `node:*`。目标的二进制、目录和环境变量由 platform/writer 根据 descriptor 的 `id` / `family` 解析。
+
+## 来源支持与 Settings 门控
+
+`migrationAgentForSource` 增加：
+
+```text
+tclaude-cli -> claude
+tcodex-cli  -> codex
+```
+
+`claude-internal`、`codex-internal` 继续映射到已有 family。由此以下本地来源都可迁移：
+
+- `claude-cli`、`claude-app`、`claude-internal`、`tclaude-cli`
+- `codex-cli`、`codex-app`、`codex-internal`、`tcodex-cli`
+- `codebuddy-cli`
+
+`enabledMigrationTargets(settings)` 返回三个基础目标加已开启的可选目标。UI 只渲染该列表，不渲染灰色占位按钮。主进程和 MCP 在写文件前重新调用同一门控函数，防止 Settings 在弹窗打开后变化或调用方绕过 UI。
+
+关闭可选来源开关后：
+
+- 对应来源停止索引，保持当前行为。
+- 对应迁移目标按钮立即消失。
+- IPC / MCP 直接指定该目标时返回 `<Target> migration target is disabled in Settings.`。
+
+Settings 的四个开关副标题改为同时说明“索引来源并启用迁移目标”。不增加新的开关。TClaude/TCodex 继续使用现有 `tclaudeBinary` / `tcodexBinary` 设置值；新增 `claudeInternalBinary`，默认 `claude-internal`。Codex Internal 复用 `codexBinary` 并注入独立 `CODEX_HOME`。
+
+## 写入、校验与增量索引
+
+serializer 只由 `family` 决定：
+
+- `claude` family 使用现有 Claude JSONL serializer。
+- `codex` family 使用现有 Codex JSONL serializer。
+- `codebuddy` family 使用现有 CodeBuddy JSONL serializer。
+
+最终路径由具体 target 决定：
+
+| Target | 输出路径 |
+| --- | --- |
+| `claude` | `~/.claude/projects/<encoded-project>/<id>.jsonl` |
+| `tclaude` | `~/.tclaude/projects/<encoded-project>/<id>.jsonl` |
+| `claude-internal` | `~/.claude-internal/projects/<encoded-project>/<id>.jsonl` |
+| `codex` | `~/.codex/sessions/YYYY/MM/DD/rollout-<timestamp>-<id>.jsonl` |
+| `tcodex` | `~/.tcodex/sessions/YYYY/MM/DD/rollout-<timestamp>-<id>.jsonl` |
+| `codex-internal` | `~/.codex-internal/sessions/YYYY/MM/DD/rollout-<timestamp>-<id>.jsonl` |
+| `codebuddy` | `~/.codebuddy/projects/<encoded-project>/<id>.jsonl` |
+
+临时文件仍在最终目录同级创建，使用 `wx`、`0600`、fsync、结构校验、Loader 回读和原子 rename。Loader 回读及增量索引必须使用 descriptor 中的具体 `source`，避免把 TClaude 新文件错误索引为普通 Claude。
+
+`indexMigratedSessionFile(target, filePath)` 根据 target registry 选择：
+
+- Claude family：`loadClaudeCliSessionFile`，传入具体 `SessionSource`。
+- Codex family：`loadCodexSessionFile`，传入具体 `SessionSource`。
+- CodeBuddy：现有 Loader。
+
+## CLI 预检
+
+现有逻辑只解析 `--version` 输出中的第一个版本号。wrapper 输出包含 wrapper 和上游两个版本，因此改为目标专属解析：
+
+| Target | 必须识别的版本行 | 支持基线 |
+| --- | --- | --- |
+| `claude` | Claude Code | 保持 `2.1.186` |
+| `codex` | Codex | 保持 `0.141.0` |
+| `codebuddy` | CodeBuddy | 保持 `2.109.1` |
+| `tclaude` | `@tencent/tclaude` + `@anthropic-ai/claude-code` | wrapper `0.0.9`，upstream `2.1.154` |
+| `tcodex` | `@tencent/tcodex` + `@openai/codex` | wrapper `0.0.13`，upstream `0.142.4` |
+| `claude-internal` | `claude-internal` + `claude` | wrapper `1.1.9`，upstream `2.1.154` |
+| `codex-internal` | Codex，且设置独立 `CODEX_HOME` | Codex `0.141.0` |
+
+基线是本机只读验证通过的已知组合。错误信息明确指出 target、binary、实际版本和要求版本。预检 runner 支持可选环境变量，以验证 Codex Internal 时只对该子进程设置 `CODEX_HOME`。
+
+## Resume 命令与打开方式
+
+| Target | Process spec |
+| --- | --- |
+| `claude` | `claude --resume <id>` |
+| `tclaude` | `tclaude --resume <id>` |
+| `claude-internal` | `claude-internal --resume <id>` |
+| `codex` | `codex resume <id>` |
+| `tcodex` | `tcodex resume <id>` |
+| `codex-internal` | `CODEX_HOME=<absolute ~/.codex-internal> codex resume <id>` |
+| `codebuddy` | `codebuddy --resume <id>` |
+
+Codex Internal 的环境变量只附着在目标命令上：
+
+- POSIX：`cd <project> && CODEX_HOME=<path> codex resume <id>`
+- PowerShell：在 `try/finally` 中临时设置 `$env:CODEX_HOME`，Codex 退出后恢复原值或删除该环境变量。
+- cmd：使用 `setlocal` 临时设置 `CODEX_HOME`，Codex 退出后执行 `endlocal`。
+
+终端启动继续复用 Terminal、iTerm、Ghostty、WezTerm、Warp 和 Windows 终端分支。display/fallback command 必须由同一 process spec 生成，不能在主进程另写三元表达式退化为基础目标；Codex Internal 命令结束后不得改变该终端后续命令使用的 `CODEX_HOME`。
+
+## UI
+
+`SessionMigrationDialog` 接收当前 `AppSettings` 或预计算后的 `MigrationTarget[]`。按钮由 registry 顺序渲染：
+
+```text
+Claude Code, Codex, CodeBuddy,
+TClaude?, TCodex?, Claude Code Internal?, Codex Internal?
+```
+
+问号目标只在对应开关开启时出现。现有同目标迁移行为保留，例如 TClaude 会话仍可迁移为新的 TClaude 会话。
+
+所有用户可见文本统一使用 registry label：
+
+- 来源筛选
+- Settings 标题和副标题
+- 迁移按钮
+- 迁移进度
+- 成功通知
+- 自动启动失败弹窗
+- MCP 错误
+
+原 `Claude Extra` / `Codex Extra` 全部替换为 `Claude Code Internal` / `Codex Internal`。
+
+## IPC 与 MCP
+
+IPC/preload 的目标参数与进度/结果改用 `MigrationTarget`。主进程在执行迁移前按当前 Settings 校验 target。
+
+MCP `migrate_session` schema 接受：
+
+```text
+claude | codex | codebuddy | tclaude | tcodex |
+claude-internal | codex-internal
+```
+
+示例：
+
+```json
+{
+  "sessionKey": "tclaude:517015a8-eb5c-41e6-b1f7-e8c54efbef53",
+  "target": "codex-internal"
+}
+```
+
+MCP 通过 `readMcpAppSettings()` 获取与桌面应用一致的开关和 binary 设置。它调用与 UI 相同的 `migrateSession`、writer、indexer 和 platform helpers。MCP bundle 在实现后重新生成并通过现有 bundle-loading 测试。
+
+远程恢复的 `RESTORE_TARGETS` 继续使用 `MigrationAgent[]`，不接受 `MigrationTarget` 扩展值。
+
+## 数据兼容性
+
+- 远程 portable JSON 不变。
+- Supabase schema 与远程来源过滤不变。
+- 旧迁移记录的 `target_agent` 值仍是新 union 的合法子集。
+- 新记录可以保存具体 target；SQLite 无需 ALTER TABLE。
+- 现有 Claude/Codex/CodeBuddy 文件路径、序列化结果和启动命令保持不变。
+
+## 失败语义
+
+1. 非本地来源、无项目路径、不支持来源、未知 target 或 disabled target：任何写入前拒绝。
+2. CLI 缺失、版本输出为空/不可解析、wrapper/upstream 版本低于基线：任何写入前拒绝。
+3. 临时写入、原生结构校验或目标 Loader 回读失败：删除临时文件，不记录、不索引、不启动。
+4. 最终文件写入后，迁移记录失败：保留文件，追加 warning，继续索引和启动。
+5. 增量索引失败：保留文件，`indexed=false`，追加 warning，继续启动。
+6. CLI 启动失败：保留文件，`launched=false`，返回目标专属可复制命令。
+7. Settings 在弹窗打开后被关闭：主进程重新校验并拒绝，不依赖 UI 快照。
+
+## 测试策略
+
+### 领域与 Settings
+
+- target registry 的 7 个 id、label、family、source 与 gate 完整且唯一。
+- 所有 Claude/Codex/TClaude/TCodex/Internal/CodeBuddy 来源映射到正确 family。
+- 四个开关的所有组合只产生预期目标。
+- UI 与主进程对 disabled target 使用同一判断。
+
+### Writer 与 Loader
+
+- 7 个目标逐一验证最终目录。
+- 三个 Claude family 目标序列化结果等价并由具体 Claude source 回读。
+- 三个 Codex family 目标序列化结果等价并由具体 Codex source 回读。
+- CodeBuddy 保持原测试。
+- 每个新目标覆盖 Unicode 标题、时间戳、父链、权限、原子 rename 和失败清理。
+
+### 编排矩阵
+
+- 所有受支持来源均可迁移到 7 个目标。
+- 每个目标验证 `inspect -> prepare -> write -> record -> index -> launch` 顺序。
+- disabled、unknown、remote、无路径、CLI 缺失、write/index/launch 失败语义。
+- 长会话压缩策略与 target 无关，复用已有 complete / ai-compressed / locally-truncated 测试。
+
+### Platform
+
+- 多行 wrapper/upstream 版本解析及每项目标基线。
+- 7 个目标的 binary、args、environment。
+- POSIX、PowerShell、cmd 的 cwd、引号与 `CODEX_HOME` 隔离。
+- Terminal、iTerm、Ghostty、WezTerm、Warp 启动路径不回归。
+
+### UI / IPC / MCP
+
+- Settings 开关打开后按钮出现，关闭后消失。
+- Internal 命名在筛选、设置和迁移 UI 中一致。
+- preload / IPC 传递具体 target。
+- MCP schema 接受 7 个目标，拒绝未知或 disabled target。
+- MCP 实际迁移 TClaude source 到 Codex Internal 的参数化测试。
+
+### 最终验证
+
+- 本机四种环境执行只读 `--version` / `--help` 预检。
+- 在临时 home 中完成四个新目标的写入和 Loader 回读 smoke test。
+- 不启动真实交互会话，不调用模型，不消耗额度。
+- 运行迁移相关定向测试、完整 `npm test -- --run`、`npm run typecheck` 和 `npm run build`。
+
+## 验收标准
+
+1. 四个可选开关分别控制同名迁移目标按钮与后端授权。
+2. 现有及四种新增来源都可迁移到当前启用的七目标子集。
+3. 每个目标写入自己的真实会话目录，并能被同来源 Loader 立即索引。
+4. 每个目标使用正确 binary、resume syntax 和必要环境变量。
+5. UI 和 MCP 支持相同目标与错误语义。
+6. 远程恢复及现有三目标行为不回归。
+7. 本机只读预检和临时目录 smoke test 通过，完整测试与构建通过。

--- a/docs/superpowers/specs/2026-07-11-migration-readme-copy-design.md
+++ b/docs/superpowers/specs/2026-07-11-migration-readme-copy-design.md
@@ -1,0 +1,16 @@
+# Migration README Copy Simplification
+
+## Scope
+
+Replace the verbose cross-Agent migration overview in the Chinese and English READMEs with one concise sentence.
+
+## Approved Copy
+
+- Chinese: `支持在 Claude Code、Codex、CodeBuddy 及已启用的扩展 CLI 间迁移本地会话；远程恢复仍支持 Claude Code、Codex 和 CodeBuddy。`
+- English: `Migrate local sessions between Claude Code, Codex, CodeBuddy, and enabled optional CLIs; remote restore remains available for Claude Code, Codex, and CodeBuddy.`
+
+## Constraints
+
+- Change only the migration overview line in `README.md` and `docs/README.en.md`.
+- Keep the existing source table and detailed migration notes unchanged.
+- Do not change product behavior, tests, or generated artifacts.

--- a/docs/superpowers/specs/2026-07-11-migration-readme-copy-design.md
+++ b/docs/superpowers/specs/2026-07-11-migration-readme-copy-design.md
@@ -12,5 +12,6 @@ Replace the verbose cross-Agent migration overview in the Chinese and English RE
 ## Constraints
 
 - Change only the migration overview line in `README.md` and `docs/README.en.md`.
-- Keep the existing source table and detailed migration notes unchanged.
+- Keep the existing source table and Optional source notes unchanged.
+- Intentionally remove the long-session compression and data-retention detail from this feature overview so the bullet stays concise.
 - Do not change product behavior, tests, or generated artifacts.

--- a/src/core/format-session.ts
+++ b/src/core/format-session.ts
@@ -3,10 +3,10 @@ import type { IndexedSession, SessionMessage, SessionSearchResult, SessionTraceE
 const SOURCE_LABEL: Record<string, string> = {
   "claude-cli": "Claude Code",
   "claude-app": "Claude Code",
-  "claude-internal": "Claude Extra",
+  "claude-internal": "Claude Code Internal",
   "codex-cli": "Codex",
   "codex-app": "Codex",
-  "codex-internal": "Codex Extra",
+  "codex-internal": "Codex Internal",
   "tclaude-cli": "TClaude",
   "tcodex-cli": "TCodex",
   "codebuddy-cli": "CodeBuddy CLI",

--- a/src/core/indexer.test.ts
+++ b/src/core/indexer.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import { indexMigratedSessionFile, syncDefaultSessionsInBatches, syncLoadedSessionsInBatches } from "./indexer";
 import { createInMemoryStore } from "./session-store";
 import { writeMigratedSession } from "./session-migration-writers";
-import type { IndexedSession, LoadedSession, MigrationAgent, PortableSession } from "./types";
+import type { IndexedSession, LoadedSession, MigrationTarget, PortableSession, SessionSource } from "./types";
 
 function session(index: number): LoadedSession {
   const id = `session-${index}`;
@@ -115,25 +115,42 @@ describe("indexer", () => {
     }
   });
 
-  it.each(["claude", "codex", "codebuddy"] as const)("indexes one migrated %s session file without a full scan", async (target: MigrationAgent) => {
-    const store = createInMemoryStore();
-    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-session-search-index-migration-"));
-    try {
-      const written = await writeMigratedSession({
-        target,
-        homeDir,
-        now: new Date("2026-06-24T10:00:00.000Z"),
-        session: portableSession(),
-      });
+  it.each([
+    { target: "claude", source: "claude-cli" },
+    { target: "tclaude", source: "tclaude-cli" },
+    { target: "claude-internal", source: "claude-internal" },
+    { target: "codex", source: "codex-cli" },
+    { target: "tcodex", source: "tcodex-cli" },
+    { target: "codex-internal", source: "codex-internal" },
+    { target: "codebuddy", source: "codebuddy-cli" },
+  ] as const satisfies readonly { target: MigrationTarget; source: SessionSource }[])(
+    "indexes one migrated $target session file as its concrete source without a full scan",
+    async ({ target, source }) => {
+      const store = createInMemoryStore();
+      const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), `agent-session-search-index-migration-${target}-`));
+      try {
+        const written = await writeMigratedSession({
+          target,
+          homeDir,
+          now: new Date("2026-06-24T10:00:00.000Z"),
+          session: portableSession(),
+        });
 
-      const status = indexMigratedSessionFile(store, target, written.filePath);
+        const status = indexMigratedSessionFile(store, target, written.filePath);
 
-      expect(status).toMatchObject({ running: false, indexed: 1, total: 1, error: null });
-      expect(store.searchSessions({ query: "migrated question", limit: 10 })).toHaveLength(1);
-    } finally {
-      fs.rmSync(homeDir, { recursive: true, force: true });
-    }
-  });
+        expect(status).toMatchObject({ running: false, indexed: 1, total: 1, error: null });
+        const indexed = store.searchSessions({ source, limit: 10 });
+        expect(indexed).toHaveLength(1);
+        expect(indexed[0]).toMatchObject({
+          source,
+          sessionKey: `${target}:${written.sessionId}`,
+        });
+      } finally {
+        store.close();
+        fs.rmSync(homeDir, { recursive: true, force: true });
+      }
+    },
+  );
 });
 
 function writeCodexSession(homeDir: string, id: string, question: string, title: string): string {

--- a/src/core/indexer.test.ts
+++ b/src/core/indexer.test.ts
@@ -145,6 +145,26 @@ describe("indexer", () => {
           source,
           sessionKey: `${target}:${written.sessionId}`,
         });
+        expect(store.searchSessions({ query: "migrated question", source, limit: 10 })).toMatchObject([
+          { sessionKey: `${target}:${written.sessionId}` },
+        ]);
+      } finally {
+        store.close();
+        fs.rmSync(homeDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each(["claude", "codex", "codebuddy"] as const)(
+    "reports a stable domain error when a migrated %s session file is missing",
+    (target) => {
+      const store = createInMemoryStore();
+      const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), `agent-session-search-index-missing-${target}-`));
+      const filePath = path.join(homeDir, "missing.jsonl");
+      try {
+        expect(() => indexMigratedSessionFile(store, target, filePath)).toThrow(
+          `Migrated ${target} session could not be loaded from ${filePath}.`,
+        );
       } finally {
         store.close();
         fs.rmSync(homeDir, { recursive: true, force: true });

--- a/src/core/indexer.ts
+++ b/src/core/indexer.ts
@@ -2,14 +2,15 @@ import * as fs from "node:fs";
 import {
   loadClaudeCliSessionRows,
   loadCodeBuddyCliSessionFile,
-  loadCodexSessionFile,
+  loadCodexSessionRows,
   loadDefaultSessions,
   loadDefaultSessionsIterator,
   parseJsonlText,
   type SessionLoadOptions,
 } from "./session-loader";
+import { migrationTargetDescriptor } from "./migration-targets";
 import type { SessionStore } from "./session-store";
-import type { LoadedSession, MigrationAgent } from "./types";
+import type { LoadedSession, MigrationTarget } from "./types";
 
 export interface IndexStatus {
   running: boolean;
@@ -158,7 +159,7 @@ function findSessionFileSnapshot(
 
 export function indexMigratedSessionFile(
   store: SessionStore,
-  target: MigrationAgent,
+  target: MigrationTarget,
   filePath: string,
 ): IndexStatus {
   const loaded = loadMigratedSessionFile(target, filePath);
@@ -176,8 +177,12 @@ export function indexMigratedSessionFile(
   };
 }
 
-function loadMigratedSessionFile(target: MigrationAgent, filePath: string): LoadedSession | null {
-  if (target === "codex") return loadCodexSessionFile(filePath);
-  if (target === "codebuddy") return loadCodeBuddyCliSessionFile(filePath);
-  return loadClaudeCliSessionRows(filePath, parseJsonlText(fs.readFileSync(filePath, "utf8")));
+function loadMigratedSessionFile(target: MigrationTarget, filePath: string): LoadedSession | null {
+  const descriptor = migrationTargetDescriptor(target);
+  const rows = parseJsonlText(fs.readFileSync(filePath, "utf8"));
+  if (descriptor.family === "codex") {
+    return loadCodexSessionRows(filePath, rows, { sourceOverride: descriptor.source });
+  }
+  if (descriptor.family === "codebuddy") return loadCodeBuddyCliSessionFile(filePath);
+  return loadClaudeCliSessionRows(filePath, rows, { source: descriptor.source });
 }

--- a/src/core/indexer.ts
+++ b/src/core/indexer.ts
@@ -179,10 +179,16 @@ export function indexMigratedSessionFile(
 
 function loadMigratedSessionFile(target: MigrationTarget, filePath: string): LoadedSession | null {
   const descriptor = migrationTargetDescriptor(target);
-  const rows = parseJsonlText(fs.readFileSync(filePath, "utf8"));
+  if (descriptor.family === "codebuddy") return loadCodeBuddyCliSessionFile(filePath);
+
+  let rows: unknown[];
+  try {
+    rows = parseJsonlText(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
   if (descriptor.family === "codex") {
     return loadCodexSessionRows(filePath, rows, { sourceOverride: descriptor.source });
   }
-  if (descriptor.family === "codebuddy") return loadCodeBuddyCliSessionFile(filePath);
   return loadClaudeCliSessionRows(filePath, rows, { source: descriptor.source });
 }

--- a/src/core/mcp-migration.test.ts
+++ b/src/core/mcp-migration.test.ts
@@ -10,7 +10,7 @@ import {
 import { createInMemoryStore } from "./session-store";
 import { loadCodexSessionFile, loadClaudeCliSessionRows, loadCodeBuddyCliSessionFile, parseJsonlText } from "./session-loader";
 import { defaultSettings } from "./platform";
-import type { IndexedSession, MigrationAgent, SessionMessage, SessionMigrationStrategy } from "./types";
+import type { IndexedSession, MigrationTarget, SessionMessage, SessionMigrationStrategy, SessionSource } from "./types";
 
 function makeProjectDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "mcp-mig-project-"));
@@ -47,17 +47,35 @@ function seedLocalSession(
 
 const noOpInspect = async () => undefined;
 
+const allMigrationTargetsEnabled = {
+  ...defaultSettings,
+  includeTclaude: true,
+  includeTcodex: true,
+  includeClaudeInternal: true,
+  includeCodexInternal: true,
+};
+
+const targetSources: Record<MigrationTarget, SessionSource> = {
+  claude: "claude-cli",
+  codex: "codex-cli",
+  codebuddy: "codebuddy-cli",
+  tclaude: "tclaude-cli",
+  tcodex: "tcodex-cli",
+  "claude-internal": "claude-internal",
+  "codex-internal": "codex-internal",
+};
+
 describe("migrateSessionForMcp — happy path", () => {
-  it.each(["claude", "codex", "codebuddy"] as const)(
+  it.each(Object.keys(targetSources) as MigrationTarget[])(
     "migrates a local session to %s, writes a loadable file, indexes it, and returns launched=false",
-    async (target: MigrationAgent) => {
+    async (target) => {
       const store = createInMemoryStore();
       const { sessionKey, projectPath } = seedLocalSession(store);
       const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-mig-home-"));
       try {
         const result = await migrateSessionForMcp(
           { sessionKey, target },
-          { store, settings: defaultSettings, inspectCli: noOpInspect, homeDir },
+          { store, settings: allMigrationTargetsEnabled, inspectCli: noOpInspect, homeDir },
         );
 
         // launched must always be false: the MCP server never opens a terminal.
@@ -72,9 +90,9 @@ describe("migrateSessionForMcp — happy path", () => {
 
         // The target file must be readable by the existing loaders.
         const loaded =
-          target === "codex"
+          targetSources[target] === "codex-cli" || targetSources[target] === "tcodex-cli" || targetSources[target] === "codex-internal"
             ? loadCodexSessionFile(result.targetFilePath)
-            : target === "claude"
+            : targetSources[target] === "claude-cli" || targetSources[target] === "tclaude-cli" || targetSources[target] === "claude-internal"
               ? loadClaudeCliSessionRows(result.targetFilePath, parseJsonlText(fs.readFileSync(result.targetFilePath, "utf8")))
               : loadCodeBuddyCliSessionFile(result.targetFilePath);
         expect(loaded?.messages.length).toBeGreaterThan(0);
@@ -82,12 +100,69 @@ describe("migrateSessionForMcp — happy path", () => {
         // The migrated session is immediately searchable in the DB.
         const found = store.getSession(`${target}:${result.targetSessionId}`);
         expect(found).not.toBeNull();
-        expect(found?.source).toBe(target === "codex" ? "codex-cli" : target === "claude" ? "claude-cli" : "codebuddy-cli");
+        expect(found?.source).toBe(targetSources[target]);
       } finally {
+        store.close();
         fs.rmSync(homeDir, { recursive: true, force: true });
+        fs.rmSync(projectPath, { recursive: true, force: true });
       }
     },
   );
+
+  it("migrates a TClaude source to Codex Internal with a scoped safe resume command", async () => {
+    const store = createInMemoryStore();
+    const projectPath = makeProjectDir();
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-mig-home-"));
+    const { sessionKey } = seedLocalSession(store, {
+      sessionKey: "tclaude:source-1",
+      rawId: "source-1",
+      source: "tclaude-cli",
+      projectPath,
+    });
+    try {
+      const result = await migrateSessionForMcp(
+        { sessionKey, target: "codex-internal" },
+        { store, settings: allMigrationTargetsEnabled, inspectCli: noOpInspect, homeDir },
+      );
+
+      expect(result).toMatchObject({ target: "codex-internal", launched: false, indexed: true });
+      expect(result.targetFilePath).toContain(path.join(homeDir, ".codex-internal"));
+      const indexed = store.getSession(`codex-internal:${result.targetSessionId}`);
+      expect(indexed?.source).toBe("codex-internal");
+      expect(store.listSessionMigrations(sessionKey)[0]).toMatchObject({
+        sourceAgent: "claude",
+        targetAgent: "codex-internal",
+      });
+      expect(result.resumeCommand).toContain(`CODEX_HOME=${path.join(homeDir, ".codex-internal")}`);
+      expect(result.resumeCommand).toContain(result.targetSessionId);
+    } finally {
+      store.close();
+      fs.rmSync(homeDir, { recursive: true, force: true });
+      fs.rmSync(projectPath, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a disabled optional target before CLI inspection or file writes", async () => {
+    const store = createInMemoryStore();
+    const { sessionKey, projectPath } = seedLocalSession(store);
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-mig-home-"));
+    const inspectCli = vi.fn(noOpInspect);
+    try {
+      await expect(
+        migrateSessionForMcp(
+          { sessionKey, target: "tcodex" },
+          { store, settings: defaultSettings, inspectCli, homeDir },
+        ),
+      ).rejects.toThrow("TCodex migration target is disabled in Settings.");
+      expect(inspectCli).not.toHaveBeenCalled();
+      expect(fs.existsSync(path.join(homeDir, ".tcodex"))).toBe(false);
+      expect(store.listSessionMigrations(sessionKey)).toEqual([]);
+    } finally {
+      store.close();
+      fs.rmSync(homeDir, { recursive: true, force: true });
+      fs.rmSync(projectPath, { recursive: true, force: true });
+    }
+  });
 
   it("records a session_migrations row", async () => {
     const store = createInMemoryStore();

--- a/src/core/mcp-migration.ts
+++ b/src/core/mcp-migration.ts
@@ -1,10 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { existsSync, statSync } from "node:fs";
 import {
-  getMigrationResumeProcessSpec,
+  getSafeMigrationResumeCommand,
   inspectMigrationCli,
   type AppSettings,
 } from "./platform";
+import { assertMigrationTargetEnabled, isMigrationTarget } from "./migration-targets";
 import {
   hydrateMcpSummaryApiKey,
   readMcpAppSettings,
@@ -20,7 +21,7 @@ import { indexMigratedSessionFile } from "./indexer";
 import { resolveSummaryEndpointFromSettings } from "./summary-endpoint";
 import type { SessionStore } from "./session-store";
 import type {
-  MigrationAgent,
+  MigrationTarget,
   SessionMessage,
   SessionMigrationRecord,
   SessionMigrationResult,
@@ -29,13 +30,13 @@ import type {
 
 export interface McpMigrateSessionInput {
   sessionKey: string;
-  target: MigrationAgent;
+  target: MigrationTarget;
 }
 
 export interface McpMigrationDeps {
   store: SessionStore;
   settings?: AppSettings;
-  inspectCli?: (target: MigrationAgent, settings: AppSettings) => Promise<void> | void;
+  inspectCli?: (target: MigrationTarget, settings: AppSettings) => Promise<void> | void;
   now?: () => number;
   idFactory?: () => string;
   // Override the home directory used when writing the target session file, so
@@ -51,7 +52,7 @@ export interface McpMigrationDeps {
 // caller gets the exact `resumeCommand` to run themselves. This mirrors the
 // desktop migration result shape so clients can treat both uniformly.
 export interface McpMigrationResult {
-  target: MigrationAgent;
+  target: MigrationTarget;
   targetSessionId: string;
   targetFilePath: string;
   strategy: SessionMigrationResult["strategy"];
@@ -106,31 +107,15 @@ function pathIsDirectory(targetPath: string): boolean {
 }
 
 function buildResumeCommand(
-  target: MigrationAgent,
+  target: MigrationTarget,
   sessionId: string,
   projectPath: string,
   settings: AppSettings,
+  homeDir?: string,
 ): string {
-  try {
-    return getMigrationResumeProcessSpec(target, sessionId, projectPath, settings).displayCommand;
-  } catch {
-    return fallbackResumeCommand(target, sessionId, projectPath, settings);
-  }
-}
-
-function fallbackResumeCommand(
-  target: MigrationAgent,
-  sessionId: string,
-  projectPath: string,
-  settings: AppSettings,
-): string {
-  const binary = target === "claude" ? settings.claudeBinary : target === "codex" ? settings.codexBinary : settings.codeBuddyBinary;
-  const args = target === "codex" ? ["resume", sessionId] : ["--resume", sessionId];
-  return `cd ${quotePosix(projectPath)} && ${[binary, ...args].map(quotePosix).join(" ")}`;
-}
-
-function quotePosix(value: string): string {
-  return /^[A-Za-z0-9_\-./]+$/.test(value) ? value : `'${value.replace(/'/g, "'\\''")}'`;
+  return getSafeMigrationResumeCommand(target, sessionId, projectPath, settings, {
+    ...(homeDir ? { homeDir } : {}),
+  });
 }
 
 // Returns the temporary-session cleaner used by the MCP migration endpoint.
@@ -152,7 +137,11 @@ export async function migrateSessionForMcp(
 ): Promise<McpMigrationResult> {
   const { store } = deps;
   const settings = deps.settings ?? loadMcpAppSettings(store);
+  if (!isMigrationTarget(input.target)) {
+    throw new Error(`Migration target ${String(input.target)} is not supported.`);
+  }
   const target = input.target;
+  assertMigrationTargetEnabled(target, settings);
 
   // Load + validate before touching the CLI or any AI provider.
   const { source, messages } = loadMcpSourceSession(store, input.sessionKey);
@@ -165,7 +154,9 @@ export async function migrateSessionForMcp(
     throw new Error(`Session project path is not a directory: ${portable.projectPath}`);
   }
 
-  const inspect = deps.inspectCli ?? ((t, s) => inspectMigrationCli(t, s));
+  const inspect = deps.inspectCli ?? ((t, s) => inspectMigrationCli(t, s, undefined, {
+    ...(deps.homeDir ? { homeDir: deps.homeDir } : {}),
+  }));
   await inspect(target, settings);
 
   // Build the compressor: prefer the configured custom endpoint, otherwise fall
@@ -218,6 +209,7 @@ export async function migrateSessionForMcp(
     written.sessionId,
     prepared.session.projectPath,
     settings,
+    deps.homeDir,
   );
 
   return {
@@ -231,4 +223,3 @@ export async function migrateSessionForMcp(
     ...(warnings.length > 0 ? { warning: warnings.join("\n") } : {}),
   };
 }
-

--- a/src/core/mcp-server.test.ts
+++ b/src/core/mcp-server.test.ts
@@ -1,4 +1,7 @@
 import { createRequire } from "node:module";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { SessionStore } from "./session-store";
@@ -23,6 +26,24 @@ type WriteResult = { ok: boolean; error?: string; tags?: string[]; favorited?: b
 const tagSession = mcp.tagSession as (db: Db, args: Record<string, unknown>) => WriteResult;
 const toggleFavorite = mcp.toggleFavorite as (db: Db, args: Record<string, unknown>) => WriteResult;
 const setVisibility = mcp.setVisibility as (db: Db, args: Record<string, unknown>) => WriteResult;
+
+async function withMcpConfig(
+  config: Record<string, unknown>,
+  run: (root: string) => Promise<void>,
+): Promise<void> {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-server-config-"));
+  const configPath = path.join(root, "config.json");
+  fs.writeFileSync(configPath, JSON.stringify(config), "utf8");
+  const previous = process.env.AGENT_SESSION_SEARCH_CONFIG;
+  process.env.AGENT_SESSION_SEARCH_CONFIG = configPath;
+  try {
+    await run(root);
+  } finally {
+    if (previous === undefined) delete process.env.AGENT_SESSION_SEARCH_CONFIG;
+    else process.env.AGENT_SESSION_SEARCH_CONFIG = previous;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require("node:sqlite") as { DatabaseSync: new (path: string) => import("node:sqlite").DatabaseSync };
@@ -267,12 +288,33 @@ describe("MCP migrate_session tool", () => {
     ]);
   });
 
-  it("accepts tclaude at the handler boundary and reaches the core migration facade", async () => {
-    const { db } = seedStore();
-    const result = await migrateSession(db, { sessionKey: "codex:abc", target: "tclaude" });
-    expect(result.ok).toBe(false);
-    expect(result.error).not.toContain("target must be one of");
-    expect(result.error).toContain("project path does not exist");
+  it("reads an isolated enabled TClaude setting and reaches CLI inspection", async () => {
+    await withMcpConfig({ includeTclaude: true, tclaudeBinary: "/missing/test-tclaude" }, async (root) => {
+      const { db, store } = seedStore();
+      const projectPath = path.join(root, "project");
+      fs.mkdirSync(projectPath);
+      db.prepare("UPDATE sessions SET project_path = ? WHERE session_key = ?").run(projectPath, "codex:abc");
+      try {
+        const result = await migrateSession(db, { sessionKey: "codex:abc", target: "tclaude" });
+        expect(result.ok).toBe(false);
+        expect(result.error).toBe("TClaude CLI binary not found: /missing/test-tclaude");
+      } finally {
+        store.close();
+      }
+    });
+  });
+
+  it("reads an isolated disabled TClaude setting and rejects before CLI inspection", async () => {
+    await withMcpConfig({ includeTclaude: false, tclaudeBinary: "/missing/test-tclaude" }, async () => {
+      const { db, store } = seedStore();
+      try {
+        const result = await migrateSession(db, { sessionKey: "codex:abc", target: "tclaude" });
+        expect(result.ok).toBe(false);
+        expect(result.error).toBe("TClaude migration target is disabled in Settings.");
+      } finally {
+        store.close();
+      }
+    });
   });
 
   it("rejects a missing sessionKey before touching the bundle", async () => {

--- a/src/core/mcp-server.test.ts
+++ b/src/core/mcp-server.test.ts
@@ -1,5 +1,6 @@
 import { createRequire } from "node:module";
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 import { SessionStore } from "./session-store";
 import type { IndexedSession, SessionMessage } from "./types";
 // The MCP server runs standalone; we exercise its SDK-free query functions here.
@@ -249,6 +250,30 @@ describe("MCP migrate_session tool", () => {
     launched?: boolean;
   };
   const migrateSession = mcp.migrateSession as (db: Db, args: Record<string, unknown>) => Promise<MigrationResult>;
+  const migrationTargetSchema = mcp.migrationTargetSchema as (zod: typeof z) => Promise<ReturnType<typeof z.enum>>;
+
+  it("uses the seven-target schema for the real migrate_session tool contract", async () => {
+    const schema = await migrationTargetSchema(z);
+    expect(schema.parse("tclaude")).toBe("tclaude");
+    expect(() => schema.parse("gemini")).toThrow();
+    expect(schema.options).toEqual([
+      "claude",
+      "codex",
+      "codebuddy",
+      "tclaude",
+      "tcodex",
+      "claude-internal",
+      "codex-internal",
+    ]);
+  });
+
+  it("accepts tclaude at the handler boundary and reaches the core migration facade", async () => {
+    const { db } = seedStore();
+    const result = await migrateSession(db, { sessionKey: "codex:abc", target: "tclaude" });
+    expect(result.ok).toBe(false);
+    expect(result.error).not.toContain("target must be one of");
+    expect(result.error).toContain("project path does not exist");
+  });
 
   it("rejects a missing sessionKey before touching the bundle", async () => {
     const { db } = seedStore();

--- a/src/core/mcp-settings.test.ts
+++ b/src/core/mcp-settings.test.ts
@@ -1,0 +1,74 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readMcpAppSettings, resolveMcpConfigPath } from "./mcp-settings";
+
+describe("resolveMcpConfigPath", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-settings-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  function touch(filePath: string, contents = "{}") {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, contents, "utf8");
+  }
+
+  it("always prefers an explicit config override", () => {
+    const override = path.join(root, "explicit.json");
+    expect(resolveMcpConfigPath({
+      platform: "linux",
+      home: root,
+      env: { AGENT_SESSION_SEARCH_CONFIG: `  ${override}  `, XDG_CONFIG_HOME: path.join(root, "xdg") },
+    })).toBe(override);
+  });
+
+  it("resolves the packaged macOS Electron userData directory before the legacy name", () => {
+    const packaged = path.join(root, "Library", "Application Support", "Agent-Session-Search", "config.json");
+    const legacy = path.join(root, "Library", "Application Support", "agent-session-search", "config.json");
+    touch(legacy);
+    touch(packaged);
+    expect(resolveMcpConfigPath({ platform: "darwin", home: root, env: {} })).toBe(packaged);
+  });
+
+  it("resolves the packaged Electron app name under Windows APPDATA", () => {
+    const appData = path.join(root, "Roaming");
+    const packaged = path.join(appData, "Agent-Session-Search", "config.json");
+    touch(packaged);
+    expect(resolveMcpConfigPath({ platform: "win32", home: root, env: { APPDATA: appData } })).toBe(packaged);
+  });
+
+  it("falls back from empty or missing Windows APPDATA to home AppData/Roaming", () => {
+    const home = path.join(root, "user");
+    const packaged = path.join(home, "AppData", "Roaming", "Agent-Session-Search", "config.json");
+    touch(packaged);
+    expect(resolveMcpConfigPath({ platform: "win32", home, env: { APPDATA: "  " } })).toBe(packaged);
+  });
+
+  it("resolves Linux XDG_CONFIG_HOME and falls back to ~/.config when its config is absent", () => {
+    const xdg = path.join(root, "xdg");
+    const fallback = path.join(root, ".config", "Agent-Session-Search", "config.json");
+    touch(fallback);
+    expect(resolveMcpConfigPath({ platform: "linux", home: root, env: { XDG_CONFIG_HOME: xdg } })).toBe(fallback);
+    const xdgConfig = path.join(xdg, "Agent-Session-Search", "config.json");
+    touch(xdgConfig);
+    expect(resolveMcpConfigPath({ platform: "linux", home: root, env: { XDG_CONFIG_HOME: xdg } })).toBe(xdgConfig);
+  });
+
+  it("returns null when no platform candidate exists", () => {
+    expect(resolveMcpConfigPath({ platform: "linux", home: root, env: {} })).toBeNull();
+  });
+
+  it("loads a Windows GUI optional-source switch from APPDATA", () => {
+    const appData = path.join(root, "Roaming");
+    const configPath = path.join(appData, "Agent-Session-Search", "config.json");
+    touch(configPath, JSON.stringify({ includeTcodex: true }));
+    expect(readMcpAppSettings({ platform: "win32", home: root, env: { APPDATA: appData } }).includeTcodex).toBe(true);
+  });
+});

--- a/src/core/mcp-settings.ts
+++ b/src/core/mcp-settings.ts
@@ -16,20 +16,30 @@ const CONFIG_CANDIDATE_DIRS = ["Agent-Session-Search", "agent-session-search"];
 export interface McpSettingsOptions {
   env?: Record<string, string | undefined>;
   home?: string;
+  platform?: NodeJS.Platform;
 }
 
 export function resolveMcpConfigPath(options: McpSettingsOptions = {}): string | null {
   const env = options.env ?? process.env;
   const home = options.home ?? homedir();
+  const platform = options.platform ?? process.platform;
 
   // An explicit override always wins, so tests and alternate installs can point
   // at a specific config without searching.
   const override = env.AGENT_SESSION_SEARCH_CONFIG?.trim();
   if (override) return override;
 
-  for (const dir of CONFIG_CANDIDATE_DIRS) {
-    const candidate = path.join(home, "Library", "Application Support", dir, "config.json");
-    if (existsSync(candidate)) return candidate;
+  const roots = platform === "darwin"
+    ? [path.join(home, "Library", "Application Support")]
+    : platform === "win32"
+      ? [env.APPDATA?.trim(), path.join(home, "AppData", "Roaming")]
+      : [env.XDG_CONFIG_HOME?.trim(), path.join(home, ".config")];
+
+  for (const root of new Set(roots.filter((value): value is string => Boolean(value)))) {
+    for (const dir of CONFIG_CANDIDATE_DIRS) {
+      const candidate = path.join(root, dir, "config.json");
+      if (existsSync(candidate)) return candidate;
+    }
   }
   return null;
 }
@@ -39,7 +49,7 @@ export function resolveMcpConfigPath(options: McpSettingsOptions = {}): string |
 // Returns null when no config file exists (the MCP server then uses defaults).
 export function readMcpAppSettings(options: McpSettingsOptions = {}): AppSettings {
   const env = options.env ?? process.env;
-  const configPath = resolveMcpConfigPath({ env, home: options.home });
+  const configPath = resolveMcpConfigPath({ env, home: options.home, platform: options.platform });
   let raw: Record<string, unknown> = {};
   if (configPath) {
     try {

--- a/src/core/migration-targets.test.ts
+++ b/src/core/migration-targets.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  BASE_MIGRATION_TARGETS,
+  MIGRATION_TARGET_IDS,
+  MIGRATION_TARGETS,
+  assertMigrationTargetEnabled,
+  enabledMigrationTargets,
+  migrationTargetDescriptor,
+  type MigrationTargetSettings,
+} from "./migration-targets";
+
+const allDisabled: MigrationTargetSettings = {
+  includeTclaude: false,
+  includeTcodex: false,
+  includeClaudeInternal: false,
+  includeCodexInternal: false,
+};
+
+describe("migration target registry", () => {
+  it("defines the renderer display order with unique ids", () => {
+    expect(MIGRATION_TARGET_IDS).toEqual([
+      "claude",
+      "codex",
+      "codebuddy",
+      "tclaude",
+      "tcodex",
+      "claude-internal",
+      "codex-internal",
+    ]);
+    expect(new Set(MIGRATION_TARGET_IDS).size).toBe(MIGRATION_TARGET_IDS.length);
+    expect(MIGRATION_TARGETS.map(({ id }) => id)).toEqual(MIGRATION_TARGET_IDS);
+  });
+
+  it("defines the three base migration targets", () => {
+    expect(BASE_MIGRATION_TARGETS).toEqual(["claude", "codex", "codebuddy"]);
+  });
+
+  it("maps the four optional migration targets", () => {
+    expect(MIGRATION_TARGETS.slice(3)).toEqual([
+      {
+        id: "tclaude",
+        label: "TClaude",
+        family: "claude",
+        source: "tclaude-cli",
+        enabledSetting: "includeTclaude",
+      },
+      {
+        id: "tcodex",
+        label: "TCodex",
+        family: "codex",
+        source: "tcodex-cli",
+        enabledSetting: "includeTcodex",
+      },
+      {
+        id: "claude-internal",
+        label: "Claude Code Internal",
+        family: "claude",
+        source: "claude-internal",
+        enabledSetting: "includeClaudeInternal",
+      },
+      {
+        id: "codex-internal",
+        label: "Codex Internal",
+        family: "codex",
+        source: "codex-internal",
+        enabledSetting: "includeCodexInternal",
+      },
+    ]);
+  });
+
+  it("always enables base targets and gates each optional target independently", () => {
+    expect(enabledMigrationTargets(allDisabled)).toEqual(BASE_MIGRATION_TARGETS);
+
+    for (const descriptor of MIGRATION_TARGETS.slice(3)) {
+      const settings = { ...allDisabled, [descriptor.enabledSetting!]: true };
+      expect(enabledMigrationTargets(settings)).toEqual([...BASE_MIGRATION_TARGETS, descriptor.id]);
+    }
+
+    expect(enabledMigrationTargets({
+      includeTclaude: true,
+      includeTcodex: true,
+      includeClaudeInternal: true,
+      includeCodexInternal: true,
+    })).toEqual(MIGRATION_TARGET_IDS);
+  });
+
+  it("looks up registered targets and rejects unsupported ids", () => {
+    expect(migrationTargetDescriptor("tcodex")).toEqual(MIGRATION_TARGETS[4]);
+    expect(() => migrationTargetDescriptor("unsupported" as never)).toThrow("Unsupported migration target");
+  });
+
+  it("rejects disabled optional targets with their display label", () => {
+    expect(() => assertMigrationTargetEnabled("claude-internal", allDisabled)).toThrow(
+      "Claude Code Internal migration target is disabled in Settings.",
+    );
+    expect(() => assertMigrationTargetEnabled("claude", allDisabled)).not.toThrow();
+  });
+});

--- a/src/core/migration-targets.test.ts
+++ b/src/core/migration-targets.test.ts
@@ -33,6 +33,29 @@ describe("migration target registry", () => {
 
   it("defines the three base migration targets", () => {
     expect(BASE_MIGRATION_TARGETS).toEqual(["claude", "codex", "codebuddy"]);
+    expect(MIGRATION_TARGETS.slice(0, 3)).toEqual([
+      {
+        id: "claude",
+        label: "Claude Code",
+        family: "claude",
+        source: "claude-cli",
+        enabledSetting: null,
+      },
+      {
+        id: "codex",
+        label: "Codex",
+        family: "codex",
+        source: "codex-cli",
+        enabledSetting: null,
+      },
+      {
+        id: "codebuddy",
+        label: "CodeBuddy",
+        family: "codebuddy",
+        source: "codebuddy-cli",
+        enabledSetting: null,
+      },
+    ]);
   });
 
   it("maps the four optional migration targets", () => {

--- a/src/core/migration-targets.ts
+++ b/src/core/migration-targets.ts
@@ -1,0 +1,82 @@
+import type { MigrationAgent, MigrationTarget, SessionSource } from "./types";
+
+export type OptionalMigrationTargetSetting =
+  | "includeTclaude"
+  | "includeTcodex"
+  | "includeClaudeInternal"
+  | "includeCodexInternal";
+
+export type MigrationTargetSettings = Record<OptionalMigrationTargetSetting, boolean>;
+
+export interface MigrationTargetDescriptor {
+  id: MigrationTarget;
+  label: string;
+  family: MigrationAgent;
+  source: SessionSource;
+  enabledSetting?: OptionalMigrationTargetSetting;
+}
+
+export const MIGRATION_TARGETS: readonly MigrationTargetDescriptor[] = [
+  { id: "claude", label: "Claude Code", family: "claude", source: "claude-cli" },
+  { id: "codex", label: "Codex", family: "codex", source: "codex-cli" },
+  { id: "codebuddy", label: "CodeBuddy", family: "codebuddy", source: "codebuddy-cli" },
+  {
+    id: "tclaude",
+    label: "TClaude",
+    family: "claude",
+    source: "tclaude-cli",
+    enabledSetting: "includeTclaude",
+  },
+  {
+    id: "tcodex",
+    label: "TCodex",
+    family: "codex",
+    source: "tcodex-cli",
+    enabledSetting: "includeTcodex",
+  },
+  {
+    id: "claude-internal",
+    label: "Claude Code Internal",
+    family: "claude",
+    source: "claude-internal",
+    enabledSetting: "includeClaudeInternal",
+  },
+  {
+    id: "codex-internal",
+    label: "Codex Internal",
+    family: "codex",
+    source: "codex-internal",
+    enabledSetting: "includeCodexInternal",
+  },
+] as const satisfies readonly MigrationTargetDescriptor[];
+
+export const MIGRATION_TARGET_IDS = [
+  "claude",
+  "codex",
+  "codebuddy",
+  "tclaude",
+  "tcodex",
+  "claude-internal",
+  "codex-internal",
+] as const satisfies readonly MigrationTarget[];
+
+export const BASE_MIGRATION_TARGETS = ["claude", "codex", "codebuddy"] as const satisfies readonly MigrationTarget[];
+
+export function migrationTargetDescriptor(target: MigrationTarget): MigrationTargetDescriptor {
+  const descriptor = MIGRATION_TARGETS.find(({ id }) => id === target);
+  if (!descriptor) throw new Error(`Unsupported migration target: ${target}`);
+  return descriptor;
+}
+
+export function enabledMigrationTargets(settings: MigrationTargetSettings): MigrationTarget[] {
+  return MIGRATION_TARGETS
+    .filter(({ enabledSetting }) => !enabledSetting || settings[enabledSetting])
+    .map(({ id }) => id);
+}
+
+export function assertMigrationTargetEnabled(target: MigrationTarget, settings: MigrationTargetSettings): void {
+  const descriptor = migrationTargetDescriptor(target);
+  if (descriptor.enabledSetting && !settings[descriptor.enabledSetting]) {
+    throw new Error(`${descriptor.label} migration target is disabled in Settings.`);
+  }
+}

--- a/src/core/migration-targets.ts
+++ b/src/core/migration-targets.ts
@@ -13,13 +13,19 @@ export interface MigrationTargetDescriptor {
   label: string;
   family: MigrationAgent;
   source: SessionSource;
-  enabledSetting?: OptionalMigrationTargetSetting;
+  enabledSetting: OptionalMigrationTargetSetting | null;
 }
 
 export const MIGRATION_TARGETS: readonly MigrationTargetDescriptor[] = [
-  { id: "claude", label: "Claude Code", family: "claude", source: "claude-cli" },
-  { id: "codex", label: "Codex", family: "codex", source: "codex-cli" },
-  { id: "codebuddy", label: "CodeBuddy", family: "codebuddy", source: "codebuddy-cli" },
+  { id: "claude", label: "Claude Code", family: "claude", source: "claude-cli", enabledSetting: null },
+  { id: "codex", label: "Codex", family: "codex", source: "codex-cli", enabledSetting: null },
+  {
+    id: "codebuddy",
+    label: "CodeBuddy",
+    family: "codebuddy",
+    source: "codebuddy-cli",
+    enabledSetting: null,
+  },
   {
     id: "tclaude",
     label: "TClaude",

--- a/src/core/migration-targets.ts
+++ b/src/core/migration-targets.ts
@@ -68,7 +68,11 @@ export const MIGRATION_TARGET_IDS = [
 
 export const BASE_MIGRATION_TARGETS = ["claude", "codex", "codebuddy"] as const satisfies readonly MigrationTarget[];
 
-export function migrationTargetDescriptor(target: MigrationTarget): MigrationTargetDescriptor {
+export function isMigrationTarget(value: unknown): value is MigrationTarget {
+  return typeof value === "string" && (MIGRATION_TARGET_IDS as readonly string[]).includes(value);
+}
+
+export function migrationTargetDescriptor(target: unknown): MigrationTargetDescriptor {
   const descriptor = MIGRATION_TARGETS.find(({ id }) => id === target);
   if (!descriptor) throw new Error(`Unsupported migration target: ${target}`);
   return descriptor;

--- a/src/core/platform.test.ts
+++ b/src/core/platform.test.ts
@@ -731,11 +731,40 @@ describe("migration cli process specs", () => {
       claudeBinary: "/opt/Claude CLI/claude",
       codexBinary: "/opt/Codex CLI/codex",
       codeBuddyBinary: "/opt/CodeBuddy CLI/codebuddy",
+      tclaudeBinary: "/opt/Tencent CLI/tclaude",
+      tcodexBinary: "/opt/Tencent CLI/tcodex",
+      claudeInternalBinary: "/opt/Internal CLI/claude-internal",
     };
 
     expect(migrationBinary("claude", settings)).toBe("/opt/Claude CLI/claude");
     expect(migrationBinary("codex", settings)).toBe("/opt/Codex CLI/codex");
     expect(migrationBinary("codebuddy", settings)).toBe("/opt/CodeBuddy CLI/codebuddy");
+    expect(migrationBinary("tclaude", settings)).toBe("/opt/Tencent CLI/tclaude");
+    expect(migrationBinary("tcodex", settings)).toBe("/opt/Tencent CLI/tcodex");
+    expect(migrationBinary("claude-internal", settings)).toBe("/opt/Internal CLI/claude-internal");
+    expect(migrationBinary("codex-internal", settings)).toBe("/opt/Codex CLI/codex");
+  });
+
+  it("uses Codex resume args for the Codex family and Claude resume args for the other targets", () => {
+    const settings = {
+      ...defaultSettings,
+      claudeBinary: "/cli/claude",
+      codexBinary: "/cli/codex",
+      codeBuddyBinary: "/cli/codebuddy",
+      tclaudeBinary: "/cli/tclaude",
+      tcodexBinary: "/cli/tcodex",
+      claudeInternalBinary: "/cli/claude-internal",
+    };
+
+    for (const target of ["codex", "tcodex", "codex-internal"] as const) {
+      expect(getMigrationResumeProcessSpec(target, "id", "/repo", settings, { homeDir: "/home/me" }).args).toEqual([
+        "resume",
+        "id",
+      ]);
+    }
+    for (const target of ["claude", "tclaude", "claude-internal", "codebuddy"] as const) {
+      expect(getMigrationResumeProcessSpec(target, "id", "/repo", settings).args).toEqual(["--resume", "id"]);
+    }
   });
 
   it("builds a POSIX migration resume process spec with safe display quoting", () => {
@@ -800,9 +829,65 @@ describe("migration cli process specs", () => {
     });
   });
 
+  it.each(["darwin", "linux"] as const)("scopes Codex Internal CODEX_HOME in its %s process spec and POSIX display command", (platform) => {
+    const settings = { ...defaultSettings, codexBinary: "/opt/Codex CLI/codex" };
+
+    expect(
+      getMigrationResumeProcessSpec(
+        "codex-internal",
+        "session 'one'; echo nope",
+        "/repo it's safe",
+        settings,
+        { homeDir: "/Users/a user", platform },
+      ),
+    ).toEqual({
+      command: "/opt/Codex CLI/codex",
+      args: ["resume", "session 'one'; echo nope"],
+      cwd: "/repo it's safe",
+      env: { CODEX_HOME: "/Users/a user/.codex-internal" },
+      displayCommand:
+        "cd '/repo it'\\''s safe' && CODEX_HOME='/Users/a user/.codex-internal' '/opt/Codex CLI/codex' resume 'session '\\''one'\\''; echo nope'",
+    });
+    expect(getMigrationResumeProcessSpec("codex", "id", "/repo", settings, { homeDir: "/Users/a user" }).env).toBeUndefined();
+  });
+
+  it("restores or removes CODEX_HOME after the Codex Internal PowerShell command", () => {
+    const settings = {
+      ...defaultSettings,
+      defaultTerminal: "PowerShell" as const,
+      codexBinary: "C:\\Program Files\\Codex CLI\\codex.exe",
+    };
+
+    expect(
+      getMigrationResumeProcessSpec("codex-internal", "id 'quoted'", "C:\\repo & tools", settings, {
+        homeDir: "C:\\Users\\A User",
+        platform: "win32",
+      }).displayCommand,
+    ).toBe(
+      "$__assHadCodexHome = Test-Path Env:CODEX_HOME; $__assCodexHome = $env:CODEX_HOME; try { $env:CODEX_HOME = 'C:\\Users\\A User/.codex-internal'; cd 'C:\\repo & tools'; & 'C:\\Program Files\\Codex CLI\\codex.exe' resume 'id ''quoted''' } finally { if ($__assHadCodexHome) { $env:CODEX_HOME = $__assCodexHome } else { Remove-Item Env:CODEX_HOME -ErrorAction SilentlyContinue } }",
+    );
+  });
+
+  it("uses cmd setlocal/endlocal for Codex Internal without leaking CODEX_HOME", () => {
+    const settings = {
+      ...defaultSettings,
+      defaultTerminal: "Cmd" as const,
+      codexBinary: "C:\\Program Files\\Codex CLI\\codex.exe",
+    };
+
+    expect(
+      getMigrationResumeProcessSpec("codex-internal", "id & next", "C:\\repo with spaces", settings, {
+        homeDir: "C:\\Users\\A User",
+        platform: "win32",
+      }).displayCommand,
+    ).toBe(
+      'setlocal & set "CODEX_HOME=C:\\Users\\A User/.codex-internal" & cd /d "C:\\repo with spaces" && "C:\\Program Files\\Codex CLI\\codex.exe" resume "id & next" & endlocal',
+    );
+  });
+
   it("rejects old, empty, and unparseable migration CLI versions", async () => {
     await expect(
-      inspectMigrationCli("claude", defaultSettings, async () => "2.1.185"),
+      inspectMigrationCli("claude", defaultSettings, async () => "2.1.185 (Claude Code)"),
     ).rejects.toThrow("Claude CLI 2.1.185 is too old");
     await expect(
       inspectMigrationCli("codex", defaultSettings, async () => "   "),
@@ -810,6 +895,19 @@ describe("migration cli process specs", () => {
     await expect(
       inspectMigrationCli("codebuddy", defaultSettings, async () => "version banana"),
     ).rejects.toThrow("CodeBuddy CLI returned an unparseable version");
+  });
+
+  it("does not echo potentially sensitive unparseable version output", async () => {
+    const failure = inspectMigrationCli("codex", defaultSettings, async () => "API_TOKEN=do-not-leak");
+    await expect(failure).rejects.toThrow("Codex CLI returned an unparseable version for codex from codex --version");
+    await expect(failure).rejects.not.toThrow("do-not-leak");
+  });
+
+  it("identifies the required version label in empty and too-old errors", async () => {
+    await expect(inspectMigrationCli("claude", defaultSettings, async () => " ")).rejects.toThrow("Claude Code");
+    await expect(
+      inspectMigrationCli("claude", defaultSettings, async () => "2.1.185 (Claude Code)"),
+    ).rejects.toThrow("Claude Code");
   });
 
   it("formats missing binary and non-zero runner failures clearly", async () => {
@@ -833,16 +931,83 @@ describe("migration cli process specs", () => {
     ).rejects.toThrow("Codex CLI --version failed for");
   });
 
+  it("does not echo version command stdout or stderr when the command fails", async () => {
+    const failure = inspectMigrationCli("codex", defaultSettings, async () => {
+      throw Object.assign(new Error("exit 1"), {
+        stdout: "API_TOKEN=stdout-secret",
+        stderr: "API_TOKEN=stderr-secret",
+      });
+    });
+    await expect(failure).rejects.toThrow(new Error("Codex CLI --version failed for codex."));
+    await expect(failure).rejects.not.toThrow("stdout-secret");
+    await expect(failure).rejects.not.toThrow("stderr-secret");
+  });
+
   it("accepts the current and newer supported migration CLI versions", async () => {
     await expect(
-      inspectMigrationCli("claude", defaultSettings, async () => "Claude Code 2.1.186"),
+      inspectMigrationCli("claude", defaultSettings, async () => "2.1.186 (Claude Code)"),
     ).resolves.toBeUndefined();
     await expect(
       inspectMigrationCli("codex", defaultSettings, async () => "codex 0.150.0"),
     ).resolves.toBeUndefined();
     await expect(
-      inspectMigrationCli("codebuddy", defaultSettings, async () => "CodeBuddy 2.109.2"),
+      inspectMigrationCli("codebuddy", defaultSettings, async () => "2.109.2"),
     ).resolves.toBeUndefined();
+  });
+
+  it("validates every wrapper and upstream version rule regardless of line order or extra text", async () => {
+    await expect(
+      inspectMigrationCli("tclaude", defaultSettings, async () => [
+        "diagnostic build 99.88.77",
+        "@anthropic-ai/claude-code 2.1.154",
+        "@tencent/tclaude 0.0.9",
+      ].join("\n")),
+    ).resolves.toBeUndefined();
+    await expect(
+      inspectMigrationCli("tcodex", defaultSettings, async () => [
+        "@openai/codex 0.142.4",
+        "extra 300.0.0",
+        "@tencent/tcodex 0.0.13",
+      ].join("\n")),
+    ).resolves.toBeUndefined();
+    await expect(
+      inspectMigrationCli("claude-internal", defaultSettings, async () => [
+        "claude: 2.1.154",
+        "claude-internal: 1.1.9",
+      ].join("\n")),
+    ).resolves.toBeUndefined();
+    await expect(inspectMigrationCli("codex-internal", defaultSettings, async () => "codex-cli 0.141.0")).resolves.toBeUndefined();
+  });
+
+  it("rejects a new wrapper with an old upstream and reports missing required lines", async () => {
+    await expect(
+      inspectMigrationCli("tclaude", defaultSettings, async () => [
+        "@tencent/tclaude 9.0.0",
+        "@anthropic-ai/claude-code 2.1.153",
+      ].join("\n")),
+    ).rejects.toThrow("@anthropic-ai/claude-code 2.1.153 is too old for tclaude");
+    await expect(
+      inspectMigrationCli("tcodex", defaultSettings, async () => "@tencent/tcodex 0.0.13"),
+    ).rejects.toThrow("@openai/codex version");
+    await expect(
+      inspectMigrationCli("claude-internal", defaultSettings, async () => "claude: 2.1.154"),
+    ).rejects.toThrow("claude-internal version");
+  });
+
+  it("passes a scoped CODEX_HOME only to Codex Internal version inspection", async () => {
+    const calls: Array<{ command: string; args: string[]; env?: Record<string, string> }> = [];
+    const runner = async (command: string, args: string[], env?: Record<string, string>) => {
+      calls.push({ command, args, env });
+      return "Codex CLI 0.141.0";
+    };
+
+    await inspectMigrationCli("codex-internal", defaultSettings, runner, { homeDir: "/Users/a user" });
+    await inspectMigrationCli("codex", defaultSettings, runner, { homeDir: "/Users/a user" });
+
+    expect(calls).toEqual([
+      { command: "codex", args: ["--version"], env: { CODEX_HOME: "/Users/a user/.codex-internal" } },
+      { command: "codex", args: ["--version"], env: undefined },
+    ]);
   });
 });
 

--- a/src/core/platform.test.ts
+++ b/src/core/platform.test.ts
@@ -193,7 +193,7 @@ describe("resume commands", () => {
     );
   });
 
-  it("keeps local Windows Cmd quoting unchanged for cmd metacharacters", () => {
+  it("encodes local Windows Cmd resume values containing environment syntax", () => {
     const session = {
       source: "claude-cli",
       rawId: "abc",
@@ -201,8 +201,10 @@ describe("resume commands", () => {
     } as SessionSearchResult;
     const settings = { ...defaultSettings, defaultTerminal: "Cmd" as const };
 
-    expect(getResumeCommand(session, settings, { platform: "win32" })).toBe(
-      'cd /d "C:\\repo %USERNAME% & tools" && claude --resume abc',
+    const command = getResumeCommand(session, settings, { platform: "win32" });
+    expect(command).toMatch(/^setlocal DisableDelayedExpansion & powershell\.exe -NoLogo -NoProfile -EncodedCommand [A-Za-z0-9+/=]+ & endlocal$/);
+    expect(decodeEncodedCmdPowerShell(command)).toBe(
+      "$ErrorActionPreference = 'Stop'; Set-Location -LiteralPath 'C:\\repo %USERNAME% & tools'; & claude --resume abc",
     );
   });
 
@@ -654,6 +656,91 @@ describe("reveal in file manager", () => {
 });
 
 describe("resume process specs", () => {
+  it("uses the concrete Claude Internal binary for ordinary resume", () => {
+    const session = {
+      source: "claude-internal",
+      rawId: "internal-claude-1",
+      projectPath: "/repo",
+    } as SessionSearchResult;
+    const settings = { ...defaultSettings, claudeInternalBinary: "/opt/Internal CLI/claude-internal" };
+
+    expect(getResumeProcessSpec(session, settings, { platform: "darwin" })).toMatchObject({
+      command: "/opt/Internal CLI/claude-internal",
+      args: ["--resume", "internal-claude-1"],
+      cwd: "/repo",
+      env: undefined,
+      displayCommand: "cd /repo && '/opt/Internal CLI/claude-internal' --resume internal-claude-1",
+    });
+  });
+
+  it("keeps ordinary Codex Internal resume in its scoped CODEX_HOME", () => {
+    const session = {
+      source: "codex-internal",
+      rawId: "internal-codex-1",
+      projectPath: "/repo with spaces",
+    } as SessionSearchResult;
+    const settings = { ...defaultSettings, codexBinary: "/opt/Codex CLI/codex" };
+    const options = { platform: "darwin" as const, homeDir: "/Users/internal user" };
+
+    expect(getResumeProcessSpec(session, settings, options)).toEqual({
+      command: "/opt/Codex CLI/codex",
+      args: ["resume", "internal-codex-1"],
+      cwd: "/repo with spaces",
+      env: { CODEX_HOME: "/Users/internal user/.codex-internal" },
+      displayCommand:
+        "cd '/repo with spaces' && CODEX_HOME='/Users/internal user/.codex-internal' '/opt/Codex CLI/codex' resume internal-codex-1",
+    });
+  });
+
+  it("scopes ordinary Codex Internal display commands in POSIX, PowerShell, and Cmd", () => {
+    const session = {
+      source: "codex-internal",
+      rawId: "internal id",
+      projectPath: "C:\\repo & tools",
+    } as SessionSearchResult;
+    const homeDir = "C:\\Users\\Internal User";
+    const options = { platform: "win32" as const, homeDir };
+    const powershell = getResumeCommand(session, { ...defaultSettings, defaultTerminal: "PowerShell" }, options);
+    const cmd = getResumeCommand(session, { ...defaultSettings, defaultTerminal: "Cmd" }, options);
+    const posix = getResumeCommand(
+      { ...session, projectPath: "/repo with spaces" },
+      defaultSettings,
+      { platform: "linux", homeDir: "/home/internal user" },
+    );
+
+    expect(posix).toBe(
+      "cd '/repo with spaces' && CODEX_HOME='/home/internal user/.codex-internal' codex resume 'internal id'",
+    );
+    expect(powershell).toContain("try { $env:CODEX_HOME = 'C:\\Users\\Internal User\\.codex-internal'");
+    expect(powershell).toContain("codex resume 'internal id'");
+    expect(cmd).toContain('setlocal & set "CODEX_HOME=C:\\Users\\Internal User\\.codex-internal"');
+    expect(cmd).toContain('cd /d "C:\\repo & tools" && codex resume "internal id" & endlocal');
+  });
+
+  it("keeps dangerous ordinary Codex Internal values encoded in the Windows launch chain", () => {
+    const session = {
+      source: "codex-internal",
+      rawId: "id-%PATH%-!TEMP!-&|<>^\"",
+      projectPath: "C:\\repo\\%PATH%\\!TEMP! & source",
+    } as SessionSearchResult;
+    const settings = {
+      ...defaultSettings,
+      defaultTerminal: "Cmd" as const,
+      codexBinary: "C:\\Tools\\%PATH%\\!TEMP!\\codex & helper.exe",
+    };
+    const plan = buildWindowsResumeLaunchPlan(session, settings, {
+      terminal: "Cmd",
+      platform: "win32",
+      homeDir: "C:\\Users\\%PATH%\\!TEMP!",
+    });
+
+    const command = plan[0].args.at(-1) ?? "";
+    expect(command).toMatch(/^setlocal DisableDelayedExpansion & powershell\.exe -NoLogo -NoProfile -EncodedCommand [A-Za-z0-9+/=]+ & endlocal$/);
+    expect(decodeEncodedCmdPowerShell(command)).toBe(
+      "$ErrorActionPreference = 'Stop'; $env:CODEX_HOME = 'C:\\Users\\%PATH%\\!TEMP!\\.codex-internal'; & 'C:\\Tools\\%PATH%\\!TEMP!\\codex & helper.exe' resume 'id-%PATH%-!TEMP!-&|<>^\"'",
+    );
+  });
+
   it("builds Codex resume as binary args with cwd instead of shell text", () => {
     const session = {
       source: "codex-cli",

--- a/src/core/platform.test.ts
+++ b/src/core/platform.test.ts
@@ -13,6 +13,7 @@ import {
   getResumeCommand,
   getResumeProcessSpec,
   inspectMigrationCli,
+  mergeProcessEnvOverrides,
   mergeAppSettings,
   normalizeApiConfig,
   normalizeClaudeApiConfig,
@@ -869,7 +870,7 @@ describe("migration cli process specs", () => {
         platform: "win32",
       }).displayCommand,
     ).toBe(
-      "$__assHadCodexHome = Test-Path Env:CODEX_HOME; $__assCodexHome = $env:CODEX_HOME; try { $env:CODEX_HOME = 'C:\\Users\\A User/.codex-internal'; cd 'C:\\repo & tools'; & 'C:\\Program Files\\Codex CLI\\codex.exe' resume 'id ''quoted''' } finally { if ($__assHadCodexHome) { $env:CODEX_HOME = $__assCodexHome } else { Remove-Item Env:CODEX_HOME -ErrorAction SilentlyContinue } }",
+      "$__assHadCodexHome = Test-Path Env:CODEX_HOME; $__assCodexHome = $env:CODEX_HOME; try { $env:CODEX_HOME = 'C:\\Users\\A User\\.codex-internal'; cd 'C:\\repo & tools'; & 'C:\\Program Files\\Codex CLI\\codex.exe' resume 'id ''quoted''' } finally { if ($__assHadCodexHome) { $env:CODEX_HOME = $__assCodexHome } else { Remove-Item Env:CODEX_HOME -ErrorAction SilentlyContinue } }",
     );
   });
 
@@ -886,7 +887,7 @@ describe("migration cli process specs", () => {
         platform: "win32",
       }).displayCommand,
     ).toBe(
-      'setlocal & set "CODEX_HOME=C:\\Users\\A User/.codex-internal" & cd /d "C:\\repo with spaces" && "C:\\Program Files\\Codex CLI\\codex.exe" resume "id & next" & endlocal',
+      'setlocal & set "CODEX_HOME=C:\\Users\\A User\\.codex-internal" & cd /d "C:\\repo with spaces" && "C:\\Program Files\\Codex CLI\\codex.exe" resume "id & next" & endlocal',
     );
   });
 
@@ -913,7 +914,7 @@ describe("migration cli process specs", () => {
       codexBinary: "C:\\Tools\\%PATH%\\!TEMP!\\codex ^ internal.exe",
     };
     const expectedScript =
-      "$ErrorActionPreference = 'Stop'; $env:CODEX_HOME = 'C:\\Users\\%PATH%\\!TEMP!/.codex-internal'; Set-Location -LiteralPath 'C:\\repo\\%PATH%\\!TEMP! | source'; & 'C:\\Tools\\%PATH%\\!TEMP!\\codex ^ internal.exe' resume 'id-%PATH%-!TEMP!-<next>'";
+      "$ErrorActionPreference = 'Stop'; $env:CODEX_HOME = 'C:\\Users\\%PATH%\\!TEMP!\\.codex-internal'; Set-Location -LiteralPath 'C:\\repo\\%PATH%\\!TEMP! | source'; & 'C:\\Tools\\%PATH%\\!TEMP!\\codex ^ internal.exe' resume 'id-%PATH%-!TEMP!-<next>'";
 
     expect(
       getMigrationResumeProcessSpec(
@@ -1020,6 +1021,18 @@ describe("migration cli process specs", () => {
     await expect(inspectMigrationCli("codex-internal", defaultSettings, async () => "codex-cli 0.141.0")).resolves.toBeUndefined();
   });
 
+  it.each([
+    ["codex", "codex 0.141.0junk"],
+    ["codex", "codex-cli 0.141.0-not-a-release"],
+    ["codex", "codex 0.141"],
+    ["tclaude", "@tencent/tclaude 0.0.9garbage\n@anthropic-ai/claude-code 2.1.154"],
+    ["tclaude", "@tencent/tclaude 0.0.9\n@anthropic-ai/claude-code 2.1.154-preview"],
+    ["claude-internal", "claude-internal: 1.1.9junk\nclaude: 2.1.154"],
+    ["claude-internal", "claude-internal: 1.1.9\nclaude: 2.1.154-preview"],
+  ] as const)("rejects non-release version text for %s", async (target, output) => {
+    await expect(inspectMigrationCli(target, defaultSettings, async () => output)).rejects.toThrow(/version/i);
+  });
+
   it("rejects a new wrapper with an old upstream and reports missing required lines", async () => {
     await expect(
       inspectMigrationCli("tclaude", defaultSettings, async () => [
@@ -1050,6 +1063,35 @@ describe("migration cli process specs", () => {
       { command: "codex", args: ["--version"], env: undefined },
     ]);
   });
+
+  it("uses Windows path semantics for the Codex Internal version environment", async () => {
+    const calls: Array<{ env?: Record<string, string> }> = [];
+    await inspectMigrationCli(
+      "codex-internal",
+      defaultSettings,
+      async (_command, _args, env) => {
+        calls.push({ env });
+        return "codex-cli 0.141.0";
+      },
+      { homeDir: "C:\\Users\\A User", platform: "win32" },
+    );
+    expect(calls).toEqual([{ env: { CODEX_HOME: "C:\\Users\\A User\\.codex-internal" } }]);
+  });
+
+  it("merges child process env overrides without dropping the parent environment", () => {
+    const previous = process.env.AGENT_SESSION_SEARCH_ENV_CONTRACT;
+    process.env.AGENT_SESSION_SEARCH_ENV_CONTRACT = "parent";
+    try {
+      const merged = mergeProcessEnvOverrides({ CODEX_HOME: "/custom/home" });
+      expect(merged.AGENT_SESSION_SEARCH_ENV_CONTRACT).toBe("parent");
+      expect(merged.CODEX_HOME).toBe("/custom/home");
+      expect(merged).not.toBe(process.env);
+    } finally {
+      if (previous === undefined) delete process.env.AGENT_SESSION_SEARCH_ENV_CONTRACT;
+      else process.env.AGENT_SESSION_SEARCH_ENV_CONTRACT = previous;
+    }
+  });
+
 });
 
 describe("migration resume terminal launch", () => {

--- a/src/core/platform.test.ts
+++ b/src/core/platform.test.ts
@@ -71,6 +71,12 @@ function encodedCmdPowerShell(script: string): string {
   return `setlocal DisableDelayedExpansion & powershell.exe -NoLogo -NoProfile -EncodedCommand ${encoded} & endlocal`;
 }
 
+function decodeEncodedCmdPowerShell(command: string): string {
+  const encoded = command.match(/-EncodedCommand ([A-Za-z0-9+/=]+) & endlocal$/)?.[1];
+  if (!encoded) throw new Error(`Missing encoded PowerShell payload: ${command}`);
+  return Buffer.from(encoded, "base64").toString("utf16le");
+}
+
 describe("platform application resolution", () => {
   it("hides subagent sessions by default and preserves the default for older saved settings", () => {
     expect(defaultSettings.hideSubagentSessions).toBe(true);
@@ -779,6 +785,42 @@ describe("migration cli process specs", () => {
     expect(posix).toContain("CODEX_HOME=/home/me/.codex-internal");
     expect(powershell).toContain("try { $env:CODEX_HOME = 'C:\\Users\\me\\.codex-internal'");
     expect(cmd).toContain('setlocal & set "CODEX_HOME=C:\\Users\\me\\.codex-internal"');
+  });
+
+  it("encodes dangerous safe-fallback Cmd command, argv, and cwd values as literal PowerShell payload", () => {
+    const settings = {
+      ...defaultSettings,
+      defaultTerminal: "Cmd" as const,
+      codexBinary: "C:\\Tools\\%PATH%\\!TEMP!\\codex \"quoted\" &|<>^\r\n.exe",
+    };
+    const projectPath = "C:\\repo\\%PATH%\\!TEMP! &|<>^\"\r\nsource";
+    const sessionId = "id-%PATH%-!TEMP!-&|<>^\"\r\nnext";
+    const command = getSafeMigrationResumeCommand("codex", sessionId, projectPath, settings, { platform: "win32" });
+
+    expect(command).toMatch(/^setlocal DisableDelayedExpansion & powershell\.exe -NoLogo -NoProfile -EncodedCommand [A-Za-z0-9+/=]+ & endlocal$/);
+    expect(command).not.toContain("%PATH%");
+    expect(command).not.toContain("!TEMP!");
+    expect(decodeEncodedCmdPowerShell(command)).toBe(
+      "$ErrorActionPreference = 'Stop'; Set-Location -LiteralPath 'C:\\repo\\%PATH%\\!TEMP! &|<>^\"\r\nsource'; & 'C:\\Tools\\%PATH%\\!TEMP!\\codex \"quoted\" &|<>^\r\n.exe' 'resume' 'id-%PATH%-!TEMP!-&|<>^\"\r\nnext'",
+    );
+  });
+
+  it("encodes dangerous Codex Internal CODEX_HOME only inside the PowerShell child payload", () => {
+    const settings = {
+      ...defaultSettings,
+      defaultTerminal: "Cmd" as const,
+      codexBinary: "C:\\Tools\\codex.exe",
+    };
+    const command = getSafeMigrationResumeCommand("codex-internal", "id", "C:\\repo", settings, {
+      platform: "win32",
+      homeDir: "C:\\Users\\%PATH%\\!TEMP!\\\"quoted\" &|<>^\r\nme",
+    });
+
+    expect(command).toMatch(/^setlocal DisableDelayedExpansion & powershell\.exe -NoLogo -NoProfile -EncodedCommand [A-Za-z0-9+/=]+ & endlocal$/);
+    expect(command).not.toContain("CODEX_HOME=");
+    expect(decodeEncodedCmdPowerShell(command)).toBe(
+      "$ErrorActionPreference = 'Stop'; $env:CODEX_HOME = 'C:\\Users\\%PATH%\\!TEMP!\\\"quoted\" &|<>^\r\nme\\.codex-internal'; Set-Location -LiteralPath 'C:\\repo'; & 'C:\\Tools\\codex.exe' 'resume' 'id'",
+    );
   });
   it("maps each migration target to its configured binary", () => {
     const settings = {

--- a/src/core/platform.test.ts
+++ b/src/core/platform.test.ts
@@ -63,6 +63,11 @@ function withShell<T>(shell: string, fn: () => T | Promise<T>): T | Promise<T> {
   }
 }
 
+function encodedCmdPowerShell(script: string): string {
+  const encoded = Buffer.from(script, "utf16le").toString("base64");
+  return `setlocal DisableDelayedExpansion & powershell.exe -NoLogo -NoProfile -EncodedCommand ${encoded} & endlocal`;
+}
+
 describe("platform application resolution", () => {
   it("hides subagent sessions by default and preserves the default for older saved settings", () => {
     expect(defaultSettings.hideSubagentSessions).toBe(true);
@@ -883,6 +888,42 @@ describe("migration cli process specs", () => {
     ).toBe(
       'setlocal & set "CODEX_HOME=C:\\Users\\A User/.codex-internal" & cd /d "C:\\repo with spaces" && "C:\\Program Files\\Codex CLI\\codex.exe" resume "id & next" & endlocal',
     );
+  });
+
+  it("encodes ordinary Cmd migration values so percent and delayed expansion cannot rewrite them", () => {
+    const settings = {
+      ...defaultSettings,
+      defaultTerminal: "Cmd" as const,
+      codexBinary: "C:\\Tools\\%PATH%\\!TEMP!\\codex & helper.exe",
+    };
+    const projectPath = "C:\\repo\\%PATH%\\!TEMP! & source";
+    const sessionId = "id-%PATH%-!TEMP!-&|<>^\"";
+    const expectedScript =
+      "$ErrorActionPreference = 'Stop'; Set-Location -LiteralPath 'C:\\repo\\%PATH%\\!TEMP! & source'; & 'C:\\Tools\\%PATH%\\!TEMP!\\codex & helper.exe' resume 'id-%PATH%-!TEMP!-&|<>^\"'";
+
+    expect(
+      getMigrationResumeProcessSpec("codex", sessionId, projectPath, settings, { platform: "win32" }).displayCommand,
+    ).toBe(encodedCmdPowerShell(expectedScript));
+  });
+
+  it("encodes Codex Internal Cmd values while keeping CODEX_HOME child-scoped", () => {
+    const settings = {
+      ...defaultSettings,
+      defaultTerminal: "Cmd" as const,
+      codexBinary: "C:\\Tools\\%PATH%\\!TEMP!\\codex ^ internal.exe",
+    };
+    const expectedScript =
+      "$ErrorActionPreference = 'Stop'; $env:CODEX_HOME = 'C:\\Users\\%PATH%\\!TEMP!/.codex-internal'; Set-Location -LiteralPath 'C:\\repo\\%PATH%\\!TEMP! | source'; & 'C:\\Tools\\%PATH%\\!TEMP!\\codex ^ internal.exe' resume 'id-%PATH%-!TEMP!-<next>'";
+
+    expect(
+      getMigrationResumeProcessSpec(
+        "codex-internal",
+        "id-%PATH%-!TEMP!-<next>",
+        "C:\\repo\\%PATH%\\!TEMP! | source",
+        settings,
+        { homeDir: "C:\\Users\\%PATH%\\!TEMP!", platform: "win32" },
+      ).displayCommand,
+    ).toBe(encodedCmdPowerShell(expectedScript));
   });
 
   it("rejects old, empty, and unparseable migration CLI versions", async () => {

--- a/src/core/platform.test.ts
+++ b/src/core/platform.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
 import { mergeApiConfigWithProfileDefaults, mergeClaudeApiConfigWithProfileDefaults } from "./api-config";
 import {
   buildGhosttyOpenArgs,
@@ -10,6 +11,7 @@ import {
   defaultSettings,
   defaultTerminalFor,
   getMigrationResumeProcessSpec,
+  getSafeMigrationResumeCommand,
   getResumeCommand,
   getResumeProcessSpec,
   inspectMigrationCli,
@@ -731,6 +733,53 @@ describe("resume process specs", () => {
 });
 
 describe("migration cli process specs", () => {
+  it("keeps the safe formatter independent from the primary formatter chain", () => {
+    const source = readFileSync(new URL("./platform.ts", import.meta.url), "utf8");
+    const safeFormatter = source.slice(
+      source.indexOf("export function getSafeMigrationResumeCommand"),
+      source.indexOf("// Ghostty has no", source.indexOf("export function getSafeMigrationResumeCommand")),
+    );
+    expect(safeFormatter).not.toContain("getMigrationResumeProcessSpec");
+    expect(safeFormatter).not.toContain("buildMigrationResumeShellCommand");
+    expect(safeFormatter).not.toContain("buildMigrationResumeCommands");
+  });
+  it("builds an independent safe resume command for all migration targets", () => {
+    const settings = {
+      ...defaultSettings,
+      claudeBinary: "/cli/claude safe",
+      codexBinary: "/cli/codex safe",
+      codeBuddyBinary: "/cli/codebuddy safe",
+      tclaudeBinary: "/cli/tclaude safe",
+      tcodexBinary: "/cli/tcodex safe",
+      claudeInternalBinary: "/cli/claude-internal safe",
+    };
+
+    for (const target of ["claude", "codex", "codebuddy", "tclaude", "tcodex", "claude-internal", "codex-internal"] as const) {
+      const command = getSafeMigrationResumeCommand(target, "id with space", "/repo with space", settings, {
+        platform: "linux",
+        homeDir: "/home/me",
+      });
+      expect(command).toContain("cd '/repo with space' &&");
+      expect(command).toContain("'id with space'");
+      expect(command).toContain(["codex", "tcodex", "codex-internal"].includes(target) ? " resume " : " --resume ");
+    }
+  });
+
+  it("keeps Codex Internal CODEX_HOME scoped in safe POSIX, PowerShell, and Cmd commands", () => {
+    const posix = getSafeMigrationResumeCommand("codex-internal", "id", "/repo", defaultSettings, {
+      platform: "linux", homeDir: "/home/me",
+    });
+    const powershell = getSafeMigrationResumeCommand("codex-internal", "id", "C:\\repo", {
+      ...defaultSettings, defaultTerminal: "PowerShell",
+    }, { platform: "win32", homeDir: "C:\\Users\\me" });
+    const cmd = getSafeMigrationResumeCommand("codex-internal", "id", "C:\\repo", {
+      ...defaultSettings, defaultTerminal: "Cmd",
+    }, { platform: "win32", homeDir: "C:\\Users\\me" });
+
+    expect(posix).toContain("CODEX_HOME=/home/me/.codex-internal");
+    expect(powershell).toContain("try { $env:CODEX_HOME = 'C:\\Users\\me\\.codex-internal'");
+    expect(cmd).toContain('setlocal & set "CODEX_HOME=C:\\Users\\me\\.codex-internal"');
+  });
   it("maps each migration target to its configured binary", () => {
     const settings = {
       ...defaultSettings,

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -1,5 +1,7 @@
 import { execFile, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
 import {
   defaultApiConfig,
   defaultClaudeApiConfig,
@@ -15,7 +17,7 @@ import {
   normalizeTerminal,
   terminalOptionsFor,
 } from "./terminal-options";
-import type { MigrationAgent, SessionSearchResult, SessionSource } from "./types";
+import type { MigrationTarget, SessionSearchResult, SessionSource } from "./types";
 
 export { type TerminalChoice, defaultTerminalFor, normalizeTerminal, terminalOptionsFor } from "./terminal-options";
 export {
@@ -36,6 +38,7 @@ export interface ResumeProcessSpec {
   command: string;
   args: string[];
   cwd?: string;
+  env?: Record<string, string>;
   displayCommand: string;
 }
 
@@ -195,20 +198,29 @@ export function sourceFamily(source: SessionSource): SourceFamily {
   return source === "claude-cli" || source === "claude-app" || source === "claude-internal" ? "claude" : "codex";
 }
 
-export function migrationBinary(target: MigrationAgent, settings: AppSettings): string {
+export function migrationBinary(target: MigrationTarget, settings: AppSettings): string {
   if (target === "claude") return settings.claudeBinary;
+  if (target === "tclaude") return settings.tclaudeBinary;
+  if (target === "tcodex") return settings.tcodexBinary;
+  if (target === "claude-internal") return settings.claudeInternalBinary;
   if (target === "codebuddy") return settings.codeBuddyBinary;
   return settings.codexBinary;
 }
 
-function migrationTargetDisplayName(target: MigrationAgent): string {
+function migrationTargetDisplayName(target: MigrationTarget): string {
   if (target === "claude") return "Claude";
+  if (target === "tclaude") return "TClaude";
+  if (target === "tcodex") return "TCodex";
+  if (target === "claude-internal") return "Claude Internal";
+  if (target === "codex-internal") return "Codex Internal";
   if (target === "codebuddy") return "CodeBuddy";
   return "Codex";
 }
 
-function migrationResumeArgs(target: MigrationAgent, sessionId: string): string[] {
-  return target === "codex" ? ["resume", sessionId] : ["--resume", sessionId];
+function migrationResumeArgs(target: MigrationTarget, sessionId: string): string[] {
+  return target === "codex" || target === "tcodex" || target === "codex-internal"
+    ? ["resume", sessionId]
+    : ["--resume", sessionId];
 }
 
 interface ShellCommands {
@@ -229,10 +241,33 @@ interface MigrationCliVersion {
   text: string;
 }
 
-const MIN_MIGRATION_CLI_VERSIONS: Record<MigrationAgent, MigrationCliVersion> = {
-  claude: { major: 2, minor: 1, patch: 186, text: "2.1.186" },
-  codex: { major: 0, minor: 141, patch: 0, text: "0.141.0" },
-  codebuddy: { major: 2, minor: 109, patch: 1, text: "2.109.1" },
+interface VersionRule {
+  label: string;
+  pattern: RegExp;
+  minimum: MigrationCliVersion;
+}
+
+function version(major: number, minor: number, patch: number): MigrationCliVersion {
+  return { major, minor, patch, text: `${major}.${minor}.${patch}` };
+}
+
+const MIGRATION_CLI_VERSION_RULES: Record<MigrationTarget, VersionRule[]> = {
+  claude: [{ label: "Claude Code", pattern: /^\s*v?(\d+\.\d+(?:\.\d+)?)\s+\(Claude Code\)\s*$/im, minimum: version(2, 1, 186) }],
+  codex: [{ label: "codex", pattern: /^\s*(?:codex(?:-cli)?|Codex(?: CLI)?)\s*:?[ \t]*v?(\d+\.\d+(?:\.\d+)?)/im, minimum: version(0, 141, 0) }],
+  codebuddy: [{ label: "CodeBuddy", pattern: /^\s*v?(\d+\.\d+(?:\.\d+)?)\s*$/im, minimum: version(2, 109, 1) }],
+  tclaude: [
+    { label: "@tencent/tclaude", pattern: /^\s*@tencent\/tclaude\s*:?[ \t]*v?(\d+\.\d+(?:\.\d+)?)/im, minimum: version(0, 0, 9) },
+    { label: "@anthropic-ai/claude-code", pattern: /^\s*@anthropic-ai\/claude-code\s*:?[ \t]*v?(\d+\.\d+(?:\.\d+)?)/im, minimum: version(2, 1, 154) },
+  ],
+  tcodex: [
+    { label: "@tencent/tcodex", pattern: /^\s*@tencent\/tcodex\s*:?[ \t]*v?(\d+\.\d+(?:\.\d+)?)/im, minimum: version(0, 0, 13) },
+    { label: "@openai/codex", pattern: /^\s*@openai\/codex\s*:?[ \t]*v?(\d+\.\d+(?:\.\d+)?)/im, minimum: version(0, 142, 4) },
+  ],
+  "claude-internal": [
+    { label: "claude-internal", pattern: /^\s*claude-internal\s*:?[ \t]*v?(\d+\.\d+(?:\.\d+)?)/im, minimum: version(1, 1, 9) },
+    { label: "claude", pattern: /^\s*claude\s*:?[ \t]*v?(\d+\.\d+(?:\.\d+)?)/im, minimum: version(2, 1, 154) },
+  ],
+  "codex-internal": [{ label: "codex", pattern: /^\s*(?:codex(?:-cli)?|Codex(?: CLI)?)\s*:?[ \t]*v?(\d+\.\d+(?:\.\d+)?)/im, minimum: version(0, 141, 0) }],
 };
 
 function buildResumeProcessArgs(
@@ -319,30 +354,40 @@ function buildResumeShellCommand(
 }
 
 function buildMigrationResumeShellCommand(
-  target: MigrationAgent,
-  sessionId: string,
+  spec: Omit<ResumeProcessSpec, "displayCommand">,
   projectPath: string,
-  settings: AppSettings,
   shell: ShellKind,
   withCwd = true,
 ): string {
-  return buildShellCommand(migrationBinary(target, settings), migrationResumeArgs(target, sessionId), projectPath, {
+  const invocation = buildShellCommand(spec.command, spec.args, projectPath, {
     shell,
-    withCwd,
+    withCwd: withCwd && !spec.env?.CODEX_HOME,
   });
+  const codexHome = spec.env?.CODEX_HOME;
+  if (!codexHome) return invocation;
+
+  if (shell === "posix") {
+    const scopedInvocation = `CODEX_HOME=${shellTokenQuote(codexHome, shell)} ${buildShellCommand(spec.command, spec.args, projectPath, { shell, withCwd: false })}`;
+    return withCwd && projectPath ? `${buildCdPrefix(projectPath, shell)}${scopedInvocation}` : scopedInvocation;
+  }
+  if (shell === "powershell") {
+    const command = buildShellCommand(spec.command, spec.args, projectPath, { shell, withCwd });
+    return `$__assHadCodexHome = Test-Path Env:CODEX_HOME; $__assCodexHome = $env:CODEX_HOME; try { $env:CODEX_HOME = ${powershellQuote(codexHome)}; ${command} } finally { if ($__assHadCodexHome) { $env:CODEX_HOME = $__assCodexHome } else { Remove-Item Env:CODEX_HOME -ErrorAction SilentlyContinue } }`;
+  }
+
+  const command = buildShellCommand(spec.command, spec.args, projectPath, { shell, withCwd });
+  return `setlocal & set "CODEX_HOME=${codexHome.replace(/"/g, '""')}" & ${command} & endlocal`;
 }
 
 function buildMigrationResumeCommands(
-  target: MigrationAgent,
-  sessionId: string,
+  spec: Omit<ResumeProcessSpec, "displayCommand">,
   projectPath: string,
-  settings: AppSettings,
   withCwd = true,
 ): ShellCommands {
   return {
-    posix: buildMigrationResumeShellCommand(target, sessionId, projectPath, settings, "posix", withCwd),
-    cmd: buildMigrationResumeShellCommand(target, sessionId, projectPath, settings, "cmd", withCwd),
-    powershell: buildMigrationResumeShellCommand(target, sessionId, projectPath, settings, "powershell", withCwd),
+    posix: buildMigrationResumeShellCommand(spec, projectPath, "posix", withCwd),
+    cmd: buildMigrationResumeShellCommand(spec, projectPath, "cmd", withCwd),
+    powershell: buildMigrationResumeShellCommand(spec, projectPath, "powershell", withCwd),
   };
 }
 
@@ -550,20 +595,28 @@ export function getResumeProcessSpec(
 }
 
 export function getMigrationResumeProcessSpec(
-  target: MigrationAgent,
+  target: MigrationTarget,
   sessionId: string,
   projectPath: string,
   settings: AppSettings = defaultSettings,
+  options: { homeDir?: string; platform?: NodeJS.Platform } = {},
 ): ResumeProcessSpec {
-  const platform = process.platform;
+  const platform = options.platform ?? process.platform;
   const shell = localShellKind(platform, settings);
-  const commands = buildMigrationResumeCommands(target, sessionId, projectPath, settings, true);
-  const displayCommand = shell === "powershell" ? commands.powershell : shell === "cmd" ? commands.cmd : commands.posix;
-
-  return {
+  const env = target === "codex-internal"
+    ? { CODEX_HOME: path.join(options.homeDir ?? homedir(), ".codex-internal") }
+    : undefined;
+  const spec = {
     command: migrationBinary(target, settings),
     args: migrationResumeArgs(target, sessionId),
     cwd: projectPath || undefined,
+    env,
+  };
+  const commands = buildMigrationResumeCommands(spec, projectPath, true);
+  const displayCommand = shell === "powershell" ? commands.powershell : shell === "cmd" ? commands.cmd : commands.posix;
+
+  return {
+    ...spec,
     displayCommand,
   };
 }
@@ -783,7 +836,7 @@ end tell`, run);
 }
 
 export async function openMigrationResumeInTerminal(
-  target: MigrationAgent,
+  target: MigrationTarget,
   sessionId: string,
   projectPath: string,
   settings: AppSettings,
@@ -795,7 +848,14 @@ export async function openMigrationResumeInTerminal(
   } = {},
 ): Promise<void> {
   const platform = deps.platform ?? process.platform;
-  const commands = buildMigrationResumeCommands(target, sessionId, projectPath, settings, platform !== "win32");
+  const { displayCommand: _displayCommand, ...spec } = getMigrationResumeProcessSpec(
+    target,
+    sessionId,
+    projectPath,
+    settings,
+    { platform },
+  );
+  const commands = buildMigrationResumeCommands(spec, projectPath, platform !== "win32");
   const run = deps.runProcess ?? runProcess;
 
   if (platform === "darwin" && settings.defaultTerminal === "Warp") {
@@ -935,11 +995,11 @@ function runProcessIgnoringExit(command: string, args: string[]): Promise<void> 
   });
 }
 
-type CliVersionRunner = (command: string, args: string[]) => Promise<string>;
+type CliVersionRunner = (command: string, args: string[], env?: Record<string, string>) => Promise<string>;
 
-function runCliVersion(command: string, args: string[]): Promise<string> {
+function runCliVersion(command: string, args: string[], env?: Record<string, string>): Promise<string> {
   return new Promise((resolve, reject) => {
-    execFile(command, args, (error, stdout, stderr) => {
+    execFile(command, args, { env: env ? { ...process.env, ...env } : process.env }, (error, stdout, stderr) => {
       if (!error) {
         resolve(stdout);
         return;
@@ -950,8 +1010,8 @@ function runCliVersion(command: string, args: string[]): Promise<string> {
   });
 }
 
-function parseMigrationCliVersion(output: string): MigrationCliVersion | null {
-  const match = output.match(/(?:^|[^\d])(\d+)\.(\d+)(?:\.(\d+))?(?:[^\d]|$)/);
+function parseMigrationCliVersion(value: string): MigrationCliVersion | null {
+  const match = value.match(/^(\d+)\.(\d+)(?:\.(\d+))?$/);
   if (!match) return null;
   return {
     major: Number(match[1]),
@@ -967,45 +1027,62 @@ function compareMigrationCliVersions(left: MigrationCliVersion, right: Migration
   return left.patch - right.patch;
 }
 
-function migrationCliVersionPrefix(target: MigrationAgent): string {
+function migrationCliVersionPrefix(target: MigrationTarget): string {
   return `${migrationTargetDisplayName(target)} CLI`;
 }
 
-function migrationCliVersionErrorMessage(target: MigrationAgent, binary: string, error: unknown): string {
+function migrationCliVersionErrorMessage(target: MigrationTarget, binary: string, error: unknown): string {
   const prefix = migrationCliVersionPrefix(target);
-  const err = error as NodeJS.ErrnoException & { stdout?: string; stderr?: string };
-  const detail = [err.stderr?.trim(), err.stdout?.trim(), err.message].find((value) => Boolean(value)) ?? "unknown error";
+  const err = error as NodeJS.ErrnoException;
   if (err.code === "ENOENT") return `${prefix} binary not found: ${binary}`;
-  return `${prefix} --version failed for ${binary}: ${detail}`;
+  return `${prefix} --version failed for ${binary}.`;
 }
 
 export async function inspectMigrationCli(
-  target: MigrationAgent,
+  target: MigrationTarget,
   settings: AppSettings,
   runner: CliVersionRunner = runCliVersion,
+  options: { homeDir?: string } = {},
 ): Promise<void> {
   const binary = migrationBinary(target, settings);
+  const env = target === "codex-internal"
+    ? { CODEX_HOME: path.join(options.homeDir ?? homedir(), ".codex-internal") }
+    : undefined;
   let versionOutput: string;
   try {
-    versionOutput = await runner(binary, ["--version"]);
+    versionOutput = await runner(binary, ["--version"], env);
   } catch (error) {
     throw new Error(migrationCliVersionErrorMessage(target, binary, error));
   }
 
   const trimmed = versionOutput.trim();
+  const rules = MIGRATION_CLI_VERSION_RULES[target];
+  const requiredLabels = rules.map((rule) => rule.label).join(", ");
   if (!trimmed) {
-    throw new Error(`${migrationCliVersionPrefix(target)} returned no version information from ${binary} --version.`);
-  }
-
-  const parsed = parseMigrationCliVersion(trimmed);
-  if (!parsed) {
-    throw new Error(`${migrationCliVersionPrefix(target)} returned an unparseable version from ${binary} --version: ${trimmed}`);
-  }
-
-  const minimum = MIN_MIGRATION_CLI_VERSIONS[target];
-  if (compareMigrationCliVersions(parsed, minimum) < 0) {
     throw new Error(
-      `${migrationCliVersionPrefix(target)} ${parsed.text} is too old for ${binary}; require at least ${minimum.text}.`,
+      `${migrationCliVersionPrefix(target)} returned no version information for ${requiredLabels} from ${binary} --version.`,
     );
+  }
+
+  for (const rule of rules) {
+    const match = rule.pattern.exec(trimmed);
+    const parsed = match ? parseMigrationCliVersion(match[1]) : null;
+    if (!parsed) {
+      if (rules.length === 1) {
+        throw new Error(
+          `${migrationCliVersionPrefix(target)} returned an unparseable version for ${rule.label} from ${binary} --version.`,
+        );
+      }
+      throw new Error(
+        `${migrationCliVersionPrefix(target)} returned no parseable ${rule.label} version from ${binary} --version.`,
+      );
+    }
+    if (compareMigrationCliVersions(parsed, rule.minimum) < 0) {
+      const label = rules.length === 1 ? "" : `${rule.label} `;
+      const labelSuffix = rules.length === 1 ? ` (${rule.label})` : "";
+      throw new Error(
+        `${migrationCliVersionPrefix(target)} ${label}${parsed.text} is too old for ${binary}${labelSuffix}; require at least ${rule.minimum.text}.`,
+      );
+    }
   }
 }

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -48,11 +48,12 @@ interface ResumeOptions {
   withCwd?: boolean;
   skipPermissions?: boolean;
   platform?: NodeJS.Platform;
+  homeDir?: string;
   sshTarget?: string;
   sshArgs?: string[];
 }
 
-type ResumeOpenOptions = Pick<ResumeOptions, "skipPermissions" | "platform" | "sshTarget" | "sshArgs">;
+type ResumeOpenOptions = Pick<ResumeOptions, "skipPermissions" | "platform" | "homeDir" | "sshTarget" | "sshArgs">;
 
 export interface AppSettings {
   defaultTerminal: TerminalChoice;
@@ -277,37 +278,44 @@ function migrationCodexHome(homeDir: string, platform: NodeJS.Platform): string 
   return platformPath.join(homeDir, ".codex-internal");
 }
 
-function buildResumeProcessArgs(
+function migrationTargetForResumeSource(source: SessionSource): MigrationTarget | null {
+  if (source === "claude-cli" || source === "claude-app") return "claude";
+  if (source === "claude-internal") return "claude-internal";
+  if (source === "codex-cli" || source === "codex-app") return "codex";
+  if (source === "codex-internal") return "codex-internal";
+  if (source === "tclaude-cli") return "tclaude";
+  if (source === "tcodex-cli") return "tcodex";
+  if (source === "codebuddy-cli") return "codebuddy";
+  return null;
+}
+
+function buildResumeRuntimeProcessSpec(
   session: SessionSearchResult,
   settings: AppSettings,
   skipPermissions: boolean,
-): { command: string; args: string[] } {
-  const family = sourceFamily(session.source);
-  if (family === "claude") {
-    const args = ["--resume", session.rawId];
-    if (skipPermissions) args.push("--dangerously-skip-permissions");
-    return { command: settings.claudeBinary, args };
-  }
-  if (family === "tclaude") {
-    const args = ["--resume", session.rawId];
-    if (skipPermissions) args.push("--dangerously-skip-permissions");
-    return { command: settings.tclaudeBinary, args };
-  }
-  if (family === "codebuddy") {
-    return { command: settings.codeBuddyBinary, args: ["--resume", session.rawId] };
-  }
-  if (family === "tcodex") {
-    const args = ["resume", session.rawId];
-    if (skipPermissions) args.push("--dangerously-bypass-approvals-and-sandbox");
-    return { command: settings.tcodexBinary, args };
-  }
-  if (family !== "codex") {
+  platform: NodeJS.Platform,
+  homeDir: string,
+): Omit<ResumeProcessSpec, "displayCommand"> {
+  const target = migrationTargetForResumeSource(session.source);
+  if (!target) {
     throw new Error(`Resume is not supported for ${sourceDisplayName(session.source)} sessions yet.`);
   }
 
-  const args = ["resume", session.rawId];
-  if (skipPermissions) args.push("--dangerously-bypass-approvals-and-sandbox");
-  return { command: settings.codexBinary, args };
+  const args = migrationResumeArgs(target, session.rawId);
+  if (skipPermissions) {
+    if (target === "claude" || target === "tclaude" || target === "claude-internal") {
+      args.push("--dangerously-skip-permissions");
+    } else if (target === "codex" || target === "tcodex" || target === "codex-internal") {
+      args.push("--dangerously-bypass-approvals-and-sandbox");
+    }
+  }
+
+  return {
+    command: migrationBinary(target, settings),
+    args,
+    cwd: session.projectPath || undefined,
+    env: target === "codex-internal" ? { CODEX_HOME: migrationCodexHome(homeDir, platform) } : undefined,
+  };
 }
 
 // Which shell the displayed/copied command is meant to be pasted into. The
@@ -354,10 +362,10 @@ function buildShellCommand(
 function buildResumeShellCommand(
   session: SessionSearchResult,
   settings: AppSettings,
-  opts: Required<Pick<ResumeOptions, "withCwd" | "skipPermissions">> & { shell: ShellKind },
+  opts: Required<Pick<ResumeOptions, "withCwd" | "skipPermissions" | "platform">> & { shell: ShellKind; homeDir?: string },
 ): string {
-  const { command, args } = buildResumeProcessArgs(session, settings, opts.skipPermissions);
-  return buildShellCommand(command, args, session.projectPath, opts);
+  const spec = buildResumeRuntimeProcessSpec(session, settings, opts.skipPermissions, opts.platform, opts.homeDir ?? homedir());
+  return buildMigrationResumeShellCommand(spec, session.projectPath ?? "", opts.shell, opts.withCwd);
 }
 
 function buildMigrationResumeShellCommand(
@@ -438,17 +446,19 @@ export function getResumeCommand(
   settings: AppSettings = defaultSettings,
   opts: ResumeOptions = {},
 ): string {
-  const { withCwd = true, skipPermissions = false, platform = process.platform } = opts;
+  const { withCwd = true, skipPermissions = false, platform = process.platform, homeDir = homedir() } = opts;
   const sshArgs = resolveSshArgs(opts);
   const shell = localShellKind(platform, settings);
+  const runtimePlatform = sshArgs ? "linux" : platform;
+  const spec = buildResumeRuntimeProcessSpec(session, settings, skipPermissions, runtimePlatform, homeDir);
   if (sshArgs) {
     // The remote command body always targets a POSIX shell; only the outer ssh
     // invocation is quoted for the local terminal (cmd carets vs PowerShell).
-    const innerCommand = buildResumeShellCommand(session, settings, { withCwd, skipPermissions, shell: "posix" });
+    const innerCommand = buildMigrationResumeShellCommand(spec, session.projectPath ?? "", "posix", withCwd);
     if (shell === "powershell") return formatPowershellSshDisplay(sshArgs, innerCommand);
     return formatSshDisplayCommand(sshArgs, innerCommand, platform);
   }
-  return buildResumeShellCommand(session, settings, { withCwd, skipPermissions, shell });
+  return buildMigrationResumeShellCommand(spec, session.projectPath ?? "", shell, withCwd);
 }
 
 function formatPowershellSshDisplay(sshArgs: string[], innerCommand: string): string {
@@ -541,6 +551,7 @@ export function buildWindowsResumeLaunchPlan(
     withCwd: Boolean(sshArgs),
     skipPermissions: opts.skipPermissions,
     platform,
+    homeDir: opts.homeDir,
     sshTarget: opts.sshTarget,
     sshArgs: opts.sshArgs,
   });
@@ -550,6 +561,7 @@ export function buildWindowsResumeLaunchPlan(
         withCwd: true,
         skipPermissions: opts.skipPermissions,
         platform,
+        homeDir: opts.homeDir,
       });
   const terminal = normalizeTerminal(opts.terminal ?? settings.defaultTerminal, "win32");
   const cwd = sshArgs ? "" : existingDirectory(session.projectPath);
@@ -602,18 +614,15 @@ function spawnDetached(command: string, args: string[], cwd?: string): Promise<v
 export function getResumeProcessSpec(
   session: SessionSearchResult,
   settings: AppSettings = defaultSettings,
-  opts: { skipPermissions?: boolean; platform?: NodeJS.Platform; sshTarget?: string; sshArgs?: string[] } = {},
+  opts: Pick<ResumeOptions, "skipPermissions" | "platform" | "homeDir" | "sshTarget" | "sshArgs"> = {},
 ): ResumeProcessSpec {
-  const { skipPermissions = false, platform = process.platform } = opts;
-  const { command, args } = buildResumeProcessArgs(session, settings, skipPermissions);
+  const { skipPermissions = false, platform = process.platform, homeDir = homedir() } = opts;
   const sshArgs = resolveSshArgs(opts);
+  const runtimePlatform = sshArgs ? "linux" : platform;
+  const spec = buildResumeRuntimeProcessSpec(session, settings, skipPermissions, runtimePlatform, homeDir);
 
   if (sshArgs) {
-    const innerCommand = buildResumeShellCommand(session, settings, {
-      withCwd: true,
-      skipPermissions,
-      shell: "posix",
-    });
+    const innerCommand = buildMigrationResumeShellCommand(spec, session.projectPath ?? "", "posix", true);
     return {
       command: "ssh",
       args: [...sshArgs, innerCommand],
@@ -629,10 +638,8 @@ export function getResumeProcessSpec(
   }
 
   return {
-    command,
-    args,
-    cwd: session.projectPath || undefined,
-    displayCommand: getResumeCommand(session, settings, { withCwd: true, skipPermissions, platform }),
+    ...spec,
+    displayCommand: getResumeCommand(session, settings, { withCwd: true, skipPermissions, platform, homeDir }),
   };
 }
 
@@ -1041,6 +1048,8 @@ function getResumePowerShellCommand(
     withCwd: true,
     skipPermissions: opts.skipPermissions ?? false,
     shell: "posix",
+    platform: "linux",
+    homeDir: opts.homeDir,
   });
   return formatPowershellSshDisplay(opts.sshArgs, innerCommand);
 }

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -57,6 +57,7 @@ export interface AppSettings {
   codeBuddyBinary: string;
   tclaudeBinary: string;
   tcodexBinary: string;
+  claudeInternalBinary: string;
   includeClaudeInternal: boolean;
   includeCodexInternal: boolean;
   includeTclaude: boolean;
@@ -100,6 +101,7 @@ export const defaultSettings: AppSettings = {
   codeBuddyBinary: "codebuddy",
   tclaudeBinary: "tclaude",
   tcodexBinary: "tcodex",
+  claudeInternalBinary: "claude-internal",
   includeClaudeInternal: false,
   includeCodexInternal: false,
   includeTclaude: false,

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -38,6 +38,8 @@ export interface ResumeProcessSpec {
   command: string;
   args: string[];
   cwd?: string;
+  // Child-process environment overrides only. Execution boundaries must merge
+  // this map over process.env rather than treating it as a complete env.
   env?: Record<string, string>;
   displayCommand: string;
 }
@@ -252,23 +254,28 @@ function version(major: number, minor: number, patch: number): MigrationCliVersi
 }
 
 const MIGRATION_CLI_VERSION_RULES: Record<MigrationTarget, VersionRule[]> = {
-  claude: [{ label: "Claude Code", pattern: /^\s*v?(\d+\.\d+(?:\.\d+)?)\s+\(Claude Code\)\s*$/im, minimum: version(2, 1, 186) }],
-  codex: [{ label: "codex", pattern: /^\s*(?:codex(?:-cli)?|Codex(?: CLI)?)\s*:?[ \t]*v?(\d+\.\d+(?:\.\d+)?)/im, minimum: version(0, 141, 0) }],
-  codebuddy: [{ label: "CodeBuddy", pattern: /^\s*v?(\d+\.\d+(?:\.\d+)?)\s*$/im, minimum: version(2, 109, 1) }],
+  claude: [{ label: "Claude Code", pattern: /^\s*v?(\d+\.\d+\.\d+)\s+\(Claude Code\)\s*$/im, minimum: version(2, 1, 186) }],
+  codex: [{ label: "codex", pattern: /^\s*(?:codex(?:-cli)?|Codex(?: CLI)?)\s*:?[ \t]*v?(\d+\.\d+\.\d+)[ \t]*$/im, minimum: version(0, 141, 0) }],
+  codebuddy: [{ label: "CodeBuddy", pattern: /^\s*v?(\d+\.\d+\.\d+)\s*$/im, minimum: version(2, 109, 1) }],
   tclaude: [
-    { label: "@tencent/tclaude", pattern: /^\s*@tencent\/tclaude\s*:?[ \t]*v?(\d+\.\d+(?:\.\d+)?)/im, minimum: version(0, 0, 9) },
-    { label: "@anthropic-ai/claude-code", pattern: /^\s*@anthropic-ai\/claude-code\s*:?[ \t]*v?(\d+\.\d+(?:\.\d+)?)/im, minimum: version(2, 1, 154) },
+    { label: "@tencent/tclaude", pattern: /^\s*@tencent\/tclaude\s*:?[ \t]*v?(\d+\.\d+\.\d+)[ \t]*$/im, minimum: version(0, 0, 9) },
+    { label: "@anthropic-ai/claude-code", pattern: /^\s*@anthropic-ai\/claude-code\s*:?[ \t]*v?(\d+\.\d+\.\d+)[ \t]*$/im, minimum: version(2, 1, 154) },
   ],
   tcodex: [
-    { label: "@tencent/tcodex", pattern: /^\s*@tencent\/tcodex\s*:?[ \t]*v?(\d+\.\d+(?:\.\d+)?)/im, minimum: version(0, 0, 13) },
-    { label: "@openai/codex", pattern: /^\s*@openai\/codex\s*:?[ \t]*v?(\d+\.\d+(?:\.\d+)?)/im, minimum: version(0, 142, 4) },
+    { label: "@tencent/tcodex", pattern: /^\s*@tencent\/tcodex\s*:?[ \t]*v?(\d+\.\d+\.\d+)[ \t]*$/im, minimum: version(0, 0, 13) },
+    { label: "@openai/codex", pattern: /^\s*@openai\/codex\s*:?[ \t]*v?(\d+\.\d+\.\d+)[ \t]*$/im, minimum: version(0, 142, 4) },
   ],
   "claude-internal": [
-    { label: "claude-internal", pattern: /^\s*claude-internal\s*:?[ \t]*v?(\d+\.\d+(?:\.\d+)?)/im, minimum: version(1, 1, 9) },
-    { label: "claude", pattern: /^\s*claude\s*:?[ \t]*v?(\d+\.\d+(?:\.\d+)?)/im, minimum: version(2, 1, 154) },
+    { label: "claude-internal", pattern: /^\s*claude-internal\s*:?[ \t]*v?(\d+\.\d+\.\d+)[ \t]*$/im, minimum: version(1, 1, 9) },
+    { label: "claude", pattern: /^\s*claude\s*:?[ \t]*v?(\d+\.\d+\.\d+)[ \t]*$/im, minimum: version(2, 1, 154) },
   ],
-  "codex-internal": [{ label: "codex", pattern: /^\s*(?:codex(?:-cli)?|Codex(?: CLI)?)\s*:?[ \t]*v?(\d+\.\d+(?:\.\d+)?)/im, minimum: version(0, 141, 0) }],
+  "codex-internal": [{ label: "codex", pattern: /^\s*(?:codex(?:-cli)?|Codex(?: CLI)?)\s*:?[ \t]*v?(\d+\.\d+\.\d+)[ \t]*$/im, minimum: version(0, 141, 0) }],
 };
+
+function migrationCodexHome(homeDir: string, platform: NodeJS.Platform): string {
+  const platformPath = platform === "win32" ? path.win32 : path.posix;
+  return platformPath.join(homeDir, ".codex-internal");
+}
 
 function buildResumeProcessArgs(
   session: SessionSearchResult,
@@ -639,7 +646,7 @@ export function getMigrationResumeProcessSpec(
   const platform = options.platform ?? process.platform;
   const shell = localShellKind(platform, settings);
   const env = target === "codex-internal"
-    ? { CODEX_HOME: path.join(options.homeDir ?? homedir(), ".codex-internal") }
+    ? { CODEX_HOME: migrationCodexHome(options.homeDir ?? homedir(), platform) }
     : undefined;
   const spec = {
     command: migrationBinary(target, settings),
@@ -1032,9 +1039,15 @@ function runProcessIgnoringExit(command: string, args: string[]): Promise<void> 
 
 type CliVersionRunner = (command: string, args: string[], env?: Record<string, string>) => Promise<string>;
 
+// `ResumeProcessSpec.env` and version-runner env values are override maps, not
+// complete process environments. Keep the merge at the child execution edge.
+export function mergeProcessEnvOverrides(overrides?: Record<string, string>): NodeJS.ProcessEnv {
+  return { ...process.env, ...(overrides ?? {}) };
+}
+
 function runCliVersion(command: string, args: string[], env?: Record<string, string>): Promise<string> {
   return new Promise((resolve, reject) => {
-    execFile(command, args, { env: env ? { ...process.env, ...env } : process.env }, (error, stdout, stderr) => {
+    execFile(command, args, { env: mergeProcessEnvOverrides(env) }, (error, stdout, stderr) => {
       if (!error) {
         resolve(stdout);
         return;
@@ -1077,11 +1090,12 @@ export async function inspectMigrationCli(
   target: MigrationTarget,
   settings: AppSettings,
   runner: CliVersionRunner = runCliVersion,
-  options: { homeDir?: string } = {},
+  options: { homeDir?: string; platform?: NodeJS.Platform } = {},
 ): Promise<void> {
   const binary = migrationBinary(target, settings);
+  const platform = options.platform ?? process.platform;
   const env = target === "codex-internal"
-    ? { CODEX_HOME: path.join(options.homeDir ?? homedir(), ".codex-internal") }
+    ? { CODEX_HOME: migrationCodexHome(options.homeDir ?? homedir(), platform) }
     : undefined;
   let versionOutput: string;
   try {

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -690,6 +690,15 @@ export function getSafeMigrationResumeCommand(
     return `$__assHadCodexHome = Test-Path Env:CODEX_HOME; $__assCodexHome = $env:CODEX_HOME; try { $env:CODEX_HOME = ${safePowerShellMigrationToken(codexHome)}; ${located} } finally { if ($__assHadCodexHome) { $env:CODEX_HOME = $__assCodexHome } else { Remove-Item Env:CODEX_HOME -ErrorAction SilentlyContinue } }`;
   }
 
+  if ([command, ...args, projectPath, codexHome].some((value) => value != null && /[%!"\r\n&|<>^]/.test(value))) {
+    const statements = ["$ErrorActionPreference = 'Stop'"];
+    if (codexHome) statements.push(`$env:CODEX_HOME = ${safePowerShellMigrationToken(codexHome)}`);
+    if (projectPath) statements.push(`Set-Location -LiteralPath ${safePowerShellMigrationToken(projectPath)}`);
+    statements.push(`& ${[command, ...args].map(safePowerShellMigrationToken).join(" ")}`);
+    const encoded = Buffer.from(statements.join("; "), "utf16le").toString("base64");
+    return `setlocal DisableDelayedExpansion & powershell.exe -NoLogo -NoProfile -EncodedCommand ${encoded} & endlocal`;
+  }
+
   const invocation = [command, ...args].map(safeCmdMigrationToken).join(" ");
   const located = projectPath ? `cd /d ${safeCmdMigrationToken(projectPath)} && ${invocation}` : invocation;
   return codexHome
@@ -707,7 +716,7 @@ function safePowerShellMigrationToken(value: string): string {
 
 function safeCmdMigrationToken(value: string): string {
   if (/^[A-Za-z0-9_\-./:\\]+$/.test(value)) return value;
-  return `"${value.replace(/%/g, "%%").replace(/!/g, "^!").replace(/"/g, '""')}"`;
+  return `"${value.replace(/"/g, '""')}"`;
 }
 
 // Ghostty has no `--initial-command` option, so the previous flag was silently

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -359,11 +359,15 @@ function buildMigrationResumeShellCommand(
   shell: ShellKind,
   withCwd = true,
 ): string {
+  const codexHome = spec.env?.CODEX_HOME;
+  if (shell === "cmd" && requiresEncodedCmdCommand(spec, projectPath, withCwd)) {
+    return buildEncodedCmdCommand(spec, projectPath, withCwd);
+  }
+
   const invocation = buildShellCommand(spec.command, spec.args, projectPath, {
     shell,
     withCwd: withCwd && !spec.env?.CODEX_HOME,
   });
-  const codexHome = spec.env?.CODEX_HOME;
   if (!codexHome) return invocation;
 
   if (shell === "posix") {
@@ -377,6 +381,37 @@ function buildMigrationResumeShellCommand(
 
   const command = buildShellCommand(spec.command, spec.args, projectPath, { shell, withCwd });
   return `setlocal & set "CODEX_HOME=${codexHome.replace(/"/g, '""')}" & ${command} & endlocal`;
+}
+
+function requiresEncodedCmdCommand(
+  spec: Omit<ResumeProcessSpec, "displayCommand">,
+  projectPath: string,
+  withCwd: boolean,
+): boolean {
+  const values = [spec.command, ...spec.args, spec.env?.CODEX_HOME, withCwd ? projectPath : undefined];
+  // `%NAME%` is expanded by cmd.exe even inside quotes, while `!NAME!` is
+  // expanded when delayed expansion is enabled by the parent shell. Embedded
+  // quotes/newlines can also escape the token boundary. Avoid cmd's parser for
+  // these values instead of relying on batch-only percent escaping.
+  return values.some((value) => value !== undefined && /[%!"\r\n]/.test(value));
+}
+
+function buildEncodedCmdCommand(
+  spec: Omit<ResumeProcessSpec, "displayCommand">,
+  projectPath: string,
+  withCwd: boolean,
+): string {
+  const statements = ["$ErrorActionPreference = 'Stop'"];
+  if (spec.env?.CODEX_HOME) {
+    statements.push(`$env:CODEX_HOME = ${powershellQuote(spec.env.CODEX_HOME)}`);
+  }
+  if (withCwd && projectPath) {
+    statements.push(`Set-Location -LiteralPath ${powershellQuote(projectPath)}`);
+  }
+  statements.push(`& ${[spec.command, ...spec.args].map((token) => shellTokenQuote(token, "powershell")).join(" ")}`);
+  const script = statements.join("; ");
+  const encoded = Buffer.from(script, "utf16le").toString("base64");
+  return `setlocal DisableDelayedExpansion & powershell.exe -NoLogo -NoProfile -EncodedCommand ${encoded} & endlocal`;
 }
 
 function buildMigrationResumeCommands(

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -663,6 +663,53 @@ export function getMigrationResumeProcessSpec(
   };
 }
 
+export function getSafeMigrationResumeCommand(
+  target: MigrationTarget,
+  sessionId: string,
+  projectPath: string,
+  settings: AppSettings = defaultSettings,
+  options: { homeDir?: string; platform?: NodeJS.Platform } = {},
+): string {
+  const platform = options.platform ?? process.platform;
+  const command = migrationBinary(target, settings);
+  const args = migrationResumeArgs(target, sessionId);
+  const codexHome = target === "codex-internal"
+    ? migrationCodexHome(options.homeDir ?? homedir(), platform)
+    : null;
+
+  if (platform !== "win32") {
+    const invocation = [safePosixMigrationToken(command), ...args.map(safePosixMigrationToken)].join(" ");
+    const scoped = codexHome ? `CODEX_HOME=${safePosixMigrationToken(codexHome)} ${invocation}` : invocation;
+    return projectPath ? `cd ${safePosixMigrationToken(projectPath)} && ${scoped}` : scoped;
+  }
+
+  if (settings.defaultTerminal === "PowerShell") {
+    const invocation = `& ${[command, ...args].map(safePowerShellMigrationToken).join(" ")}`;
+    const located = projectPath ? `Set-Location -LiteralPath ${safePowerShellMigrationToken(projectPath)}; ${invocation}` : invocation;
+    if (!codexHome) return located;
+    return `$__assHadCodexHome = Test-Path Env:CODEX_HOME; $__assCodexHome = $env:CODEX_HOME; try { $env:CODEX_HOME = ${safePowerShellMigrationToken(codexHome)}; ${located} } finally { if ($__assHadCodexHome) { $env:CODEX_HOME = $__assCodexHome } else { Remove-Item Env:CODEX_HOME -ErrorAction SilentlyContinue } }`;
+  }
+
+  const invocation = [command, ...args].map(safeCmdMigrationToken).join(" ");
+  const located = projectPath ? `cd /d ${safeCmdMigrationToken(projectPath)} && ${invocation}` : invocation;
+  return codexHome
+    ? `setlocal & set "CODEX_HOME=${codexHome.replace(/[%!"]/g, (value) => value === "%" ? "%%" : value === "!" ? "^!" : '""')}" & ${located} & endlocal`
+    : located;
+}
+
+function safePosixMigrationToken(value: string): string {
+  return /^[A-Za-z0-9_\-./]+$/.test(value) ? value : `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function safePowerShellMigrationToken(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function safeCmdMigrationToken(value: string): string {
+  if (/^[A-Za-z0-9_\-./:\\]+$/.test(value)) return value;
+  return `"${value.replace(/%/g, "%%").replace(/!/g, "^!").replace(/"/g, '""')}"`;
+}
+
 // Ghostty has no `--initial-command` option, so the previous flag was silently
 // ignored and the window opened without resuming. The documented way to run a
 // command is the special `-e <command>` argument; run it through the user's

--- a/src/core/session-environment.test.ts
+++ b/src/core/session-environment.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { isLocalSessionEnvironment } from "./session-environment";
+
+describe("session environment classification", () => {
+  it.each([
+    ["strict local", { environmentKind: "local", environmentId: "local" }, true],
+    ["imported local", { environmentKind: "local", environmentId: "imported-local" }, false],
+    ["ssh", { environmentKind: "ssh", environmentId: "ssh-dev" }, false],
+    ["inconsistent ssh local id", { environmentKind: "ssh", environmentId: "local" }, false],
+  ] as const)("classifies %s", (_label, session, expected) => {
+    expect(isLocalSessionEnvironment(session)).toBe(expected);
+  });
+});

--- a/src/core/session-environment.ts
+++ b/src/core/session-environment.ts
@@ -1,0 +1,10 @@
+import type { EnvironmentKind } from "./types";
+
+export interface SessionEnvironmentIdentity {
+  environmentKind: EnvironmentKind;
+  environmentId: string;
+}
+
+export function isLocalSessionEnvironment(session: SessionEnvironmentIdentity): boolean {
+  return session.environmentKind === "local" && session.environmentId === "local";
+}

--- a/src/core/session-migration-writers.test.ts
+++ b/src/core/session-migration-writers.test.ts
@@ -5,11 +5,11 @@ import * as path from "node:path";
 import {
   loadClaudeCliSessionRows,
   loadCodeBuddyCliSessionFile,
-  loadCodexSessionFile,
+  loadCodexSessionRows,
   parseJsonlText,
 } from "./session-loader";
 import { writeMigratedSession } from "./session-migration-writers";
-import type { MigrationAgent, PortableSession } from "./types";
+import type { LoadedSession, MigrationTarget, PortableSession, SessionSource } from "./types";
 
 const SESSION_ID = "10000000-0000-4000-8000-000000000001";
 const MESSAGE_IDS = [
@@ -18,6 +18,20 @@ const MESSAGE_IDS = [
   "20000000-0000-4000-8000-000000000003",
 ];
 const NOW = new Date("2026-06-23T06:07:08.901Z");
+const TARGETS = [
+  { target: "claude", root: ".claude", source: "claude-cli", family: "claude" },
+  { target: "tclaude", root: ".tclaude", source: "tclaude-cli", family: "claude" },
+  { target: "claude-internal", root: ".claude-internal", source: "claude-internal", family: "claude" },
+  { target: "codex", root: ".codex", source: "codex-cli", family: "codex" },
+  { target: "tcodex", root: ".tcodex", source: "tcodex-cli", family: "codex" },
+  { target: "codex-internal", root: ".codex-internal", source: "codex-internal", family: "codex" },
+  { target: "codebuddy", root: ".codebuddy", source: "codebuddy-cli", family: "codebuddy" },
+] as const satisfies readonly {
+  target: MigrationTarget;
+  root: string;
+  source: SessionSource;
+  family: "claude" | "codex" | "codebuddy";
+}[];
 
 function portable(): PortableSession {
   return {
@@ -51,64 +65,97 @@ function readRows(filePath: string): Array<Record<string, any>> {
 }
 
 function expectRoundTrip(
-  target: MigrationAgent,
+  target: MigrationTarget,
+  source: SessionSource,
   sessionId: string,
   filePath: string,
   rows: Array<Record<string, any>>,
 ): void {
-  const loaded =
-    target === "codex"
-      ? loadCodexSessionFile(filePath)
-      : target === "claude"
-        ? loadClaudeCliSessionRows(filePath, rows)
-        : loadCodeBuddyCliSessionFile(filePath);
+  const loaded = loadWrittenSession(target, source, filePath, rows);
 
   expect(loaded?.session).toMatchObject({
     rawId: sessionId,
     projectPath: portable().projectPath,
     originalTitle: portable().title,
-    source: target === "codex" ? "codex-cli" : target === "claude" ? "claude-cli" : "codebuddy-cli",
+    source,
   });
   expect(loaded?.messages.map(({ role, content, timestamp }) => ({ role, content, timestamp }))).toEqual(
     portable().messages.map(({ role, content, timestamp }) => ({ role, content, timestamp })),
   );
 }
 
+function loadWrittenSession(
+  target: MigrationTarget,
+  source: SessionSource,
+  filePath: string,
+  rows: Array<Record<string, any>>,
+): LoadedSession | null {
+  if (target === "codebuddy") return loadCodeBuddyCliSessionFile(filePath);
+  if (target === "codex" || target === "tcodex" || target === "codex-internal") {
+    return loadCodexSessionRows(filePath, rows, { sourceOverride: source });
+  }
+  return loadClaudeCliSessionRows(filePath, rows, { source });
+}
+
 describe("writeMigratedSession", () => {
-  it.each(["codex", "claude", "codebuddy"] as const)(
-    "creates the temporary and final %s files with mode 0600",
-    async (target) => {
+  it.each(TARGETS)(
+    "creates the temporary and final $target files with mode 0600",
+    async ({ target, root, family }) => {
       const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), `migration-writer-mode-${target}-`));
       let temporaryMode = 0;
-      const targetDirectory = target === "codex"
-        ? path.join(homeDir, ".codex", "sessions", "2026", "06", "23")
-        : target === "claude"
-          ? path.join(homeDir, ".claude", "projects", "-Users----My-Project")
+      const targetDirectory = family === "codex"
+        ? path.join(homeDir, root, "sessions", "2026", "06", "23")
+        : family === "claude"
+          ? path.join(homeDir, root, "projects", "-Users----My-Project")
           : path.join(homeDir, ".codebuddy", "projects", "Users----My-Project");
       fs.mkdirSync(targetDirectory, { recursive: true });
       const previousUmask = process.umask(0o777);
 
-      let result;
       try {
-        result = await writeMigratedSession({
+        let result;
+        try {
+          result = await writeMigratedSession({
+            target,
+            session: portable(),
+            homeDir,
+            now: NOW,
+            idFactory: idFactory(family === "codex" ? [SESSION_ID] : [SESSION_ID, ...MESSAGE_IDS]),
+            beforeValidate: (filePath) => {
+              temporaryMode = fs.statSync(filePath).mode & 0o777;
+              fs.chmodSync(filePath, 0o644);
+            },
+          });
+        } finally {
+          process.umask(previousUmask);
+        }
+
+        expect(temporaryMode).toBe(0o600);
+        expect(fs.statSync(result.filePath).mode & 0o777).toBe(0o600);
+      } finally {
+        fs.rmSync(homeDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each(TARGETS)(
+    "writes $target under $root and round-trips with its concrete source",
+    async ({ target, root, source, family }) => {
+      const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), `migration-writer-roundtrip-${target}-`));
+      try {
+        const result = await writeMigratedSession({
           target,
           session: portable(),
           homeDir,
           now: NOW,
-          idFactory: idFactory(target === "codex" ? [SESSION_ID] : [SESSION_ID, ...MESSAGE_IDS]),
-          beforeValidate: (filePath) => {
-            temporaryMode = fs.statSync(filePath).mode & 0o777;
-            fs.chmodSync(filePath, 0o644);
-          },
+          idFactory: idFactory(family === "codex" ? [SESSION_ID] : [SESSION_ID, ...MESSAGE_IDS]),
         });
+
+        expect(path.relative(homeDir, result.filePath).split(path.sep)[0]).toBe(root);
+        const rows = readRows(result.filePath);
+        expectRoundTrip(target, source, result.sessionId, result.filePath, rows);
       } finally {
-        process.umask(previousUmask);
+        fs.rmSync(homeDir, { recursive: true, force: true });
       }
-
-      expect(temporaryMode).toBe(0o600);
-      expect(fs.statSync(result.filePath).mode & 0o777).toBe(0o600);
-
-      fs.rmSync(homeDir, { recursive: true, force: true });
     },
   );
 
@@ -157,7 +204,7 @@ describe("writeMigratedSession", () => {
       "output_text",
       "input_text",
     ]);
-    expectRoundTrip("codex", result.sessionId, result.filePath, rows);
+    expectRoundTrip("codex", "codex-cli", result.sessionId, result.filePath, rows);
 
     fs.rmSync(homeDir, { recursive: true, force: true });
   });
@@ -197,7 +244,7 @@ describe("writeMigratedSession", () => {
         version: "migration",
       });
     }
-    expectRoundTrip("claude", result.sessionId, result.filePath, rows);
+    expectRoundTrip("claude", "claude-cli", result.sessionId, result.filePath, rows);
 
     fs.rmSync(homeDir, { recursive: true, force: true });
   });
@@ -232,7 +279,7 @@ describe("writeMigratedSession", () => {
       portable().messages.map((message) => new Date(message.timestamp).getTime()),
     );
     expect(messages.map((row) => row.content[0].type)).toEqual(["input_text", "output_text", "input_text"]);
-    expectRoundTrip("codebuddy", result.sessionId, result.filePath, rows);
+    expectRoundTrip("codebuddy", "codebuddy-cli", result.sessionId, result.filePath, rows);
 
     fs.rmSync(homeDir, { recursive: true, force: true });
   });
@@ -249,28 +296,30 @@ describe("writeMigratedSession", () => {
     fs.rmSync(homeDir, { recursive: true, force: true });
   });
 
-  it("deletes the temporary file and leaves no final file when validation fails", async () => {
-    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "migration-writer-validation-"));
+  it.each(TARGETS)("deletes $target output when validation fails", async ({ target, family }) => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), `migration-writer-validation-${target}-`));
     let temporaryFile = "";
+    try {
+      await expect(
+        writeMigratedSession({
+          target,
+          session: portable(),
+          homeDir,
+          now: NOW,
+          idFactory: idFactory(family === "codex" ? [SESSION_ID] : [SESSION_ID, ...MESSAGE_IDS]),
+          validate: (filePath) => {
+            temporaryFile = filePath;
+            return null;
+          },
+        }),
+      ).rejects.toThrow(/validation/i);
 
-    await expect(
-      writeMigratedSession({
-        target: "codex",
-        session: portable(),
-        homeDir,
-        now: NOW,
-        idFactory: idFactory([SESSION_ID]),
-        validate: (filePath) => {
-          temporaryFile = filePath;
-          return null;
-        },
-      }),
-    ).rejects.toThrow(/validation/i);
-
-    expect(temporaryFile).not.toBe("");
-    expect(fs.existsSync(temporaryFile)).toBe(false);
-    expect(filesUnder(homeDir)).toEqual([]);
-    fs.rmSync(homeDir, { recursive: true, force: true });
+      expect(temporaryFile).not.toBe("");
+      expect(fs.existsSync(temporaryFile)).toBe(false);
+      expect(filesUnder(homeDir)).toEqual([]);
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    }
   });
 
   it("deletes the temporary file and leaves no final file when atomic rename fails", async () => {
@@ -300,52 +349,50 @@ describe("writeMigratedSession", () => {
     fs.rmSync(homeDir, { recursive: true, force: true });
   });
 
-  it("rejects a tampered Codex title before rename and cleans the temporary file", async () => {
-    await expectTamperedSessionRejected("codex", (rows) => {
-      rows[0].payload.title = "被篡改的标题";
-    });
-  });
-
-  it("rejects a tampered CodeBuddy message timestamp before rename and cleans the temporary file", async () => {
-    await expectTamperedSessionRejected("codebuddy", (rows) => {
-      rows[1].timestamp += 1;
-    });
-  });
-
-  it("rejects a broken Claude parent UUID chain before rename and cleans the temporary file", async () => {
-    await expectTamperedSessionRejected("claude", (rows) => {
-      rows[2].parentUuid = null;
-    });
-  });
+  it.each(TARGETS)(
+    "rejects tampered $target native content before rename and cleans the temporary file",
+    async ({ target, family }) => {
+      await expectTamperedSessionRejected(target, (rows) => {
+        if (family === "codex") rows[0].payload.title = "被篡改的标题";
+        else if (family === "claude") rows[2].parentUuid = null;
+        else rows[1].timestamp += 1;
+      });
+    },
+  );
 });
 
 async function expectTamperedSessionRejected(
-  target: MigrationAgent,
+  target: MigrationTarget,
   mutate: (rows: Array<Record<string, any>>) => void,
 ): Promise<void> {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), `migration-writer-tamper-${target}-`));
   let temporaryFile = "";
 
-  await expect(
-    writeMigratedSession({
-      target,
-      session: portable(),
-      homeDir,
-      now: NOW,
-      idFactory: idFactory(target === "codex" ? [SESSION_ID] : [SESSION_ID, ...MESSAGE_IDS]),
-      beforeValidate: (filePath) => {
-        temporaryFile = filePath;
-        const rows = parseJsonlText(fs.readFileSync(filePath, "utf8")) as Array<Record<string, any>>;
-        mutate(rows);
-        fs.writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
-      },
-    }),
-  ).rejects.toThrow(/validation/i);
+  try {
+    await expect(
+      writeMigratedSession({
+        target,
+        session: portable(),
+        homeDir,
+        now: NOW,
+        idFactory: idFactory(target === "codex" || target === "tcodex" || target === "codex-internal"
+          ? [SESSION_ID]
+          : [SESSION_ID, ...MESSAGE_IDS]),
+        beforeValidate: (filePath) => {
+          temporaryFile = filePath;
+          const rows = parseJsonlText(fs.readFileSync(filePath, "utf8")) as Array<Record<string, any>>;
+          mutate(rows);
+          fs.writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+        },
+      }),
+    ).rejects.toThrow(/validation/i);
 
-  expect(temporaryFile).not.toBe("");
-  expect(fs.existsSync(temporaryFile)).toBe(false);
-  expect(filesUnder(homeDir)).toEqual([]);
-  fs.rmSync(homeDir, { recursive: true, force: true });
+    expect(temporaryFile).not.toBe("");
+    expect(fs.existsSync(temporaryFile)).toBe(false);
+    expect(filesUnder(homeDir)).toEqual([]);
+  } finally {
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
 }
 
 function filesUnder(root: string): string[] {

--- a/src/core/session-migration-writers.test.ts
+++ b/src/core/session-migration-writers.test.ts
@@ -322,6 +322,28 @@ describe("writeMigratedSession", () => {
     }
   });
 
+  it.each(TARGETS)("deletes $target output when beforeValidate fails", async ({ target, family }) => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), `migration-writer-before-validate-${target}-`));
+    try {
+      await expect(
+        writeMigratedSession({
+          target,
+          session: portable(),
+          homeDir,
+          now: NOW,
+          idFactory: idFactory(family === "codex" ? [SESSION_ID] : [SESSION_ID, ...MESSAGE_IDS]),
+          beforeValidate: () => {
+            throw new Error("beforeValidate exploded");
+          },
+        }),
+      ).rejects.toThrow("beforeValidate exploded");
+
+      expect(filesUnder(homeDir)).toEqual([]);
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
   it("deletes the temporary file and leaves no final file when atomic rename fails", async () => {
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "migration-writer-rename-"));
     let temporaryFile = "";

--- a/src/core/session-migration-writers.ts
+++ b/src/core/session-migration-writers.ts
@@ -5,13 +5,14 @@ import * as path from "node:path";
 import {
   loadClaudeCliSessionRows,
   loadCodeBuddyCliSessionFile,
-  loadCodexSessionFile,
+  loadCodexSessionRows,
   parseJsonlText,
 } from "./session-loader";
-import type { LoadedSession, MigrationAgent, PortableSession } from "./types";
+import { migrationTargetDescriptor } from "./migration-targets";
+import type { LoadedSession, MigrationTarget, PortableSession } from "./types";
 
 export interface WriteMigratedSessionOptions {
-  target: MigrationAgent;
+  target: MigrationTarget;
   session: PortableSession;
   homeDir?: string;
   now?: Date;
@@ -62,13 +63,14 @@ export async function writeMigratedSession(options: WriteMigratedSessionOptions)
 }
 
 function serializeSession(
-  target: MigrationAgent,
+  target: MigrationTarget,
   session: PortableSession,
   sessionId: string,
   createId: () => string,
 ): unknown[] {
-  if (target === "codex") return serializeCodex(session, sessionId);
-  if (target === "claude") return serializeClaude(session, sessionId, createId);
+  const family = migrationTargetDescriptor(target).family;
+  if (family === "codex") return serializeCodex(session, sessionId);
+  if (family === "claude") return serializeClaude(session, sessionId, createId);
   return serializeCodeBuddy(session, sessionId, createId);
 }
 
@@ -183,26 +185,38 @@ function serializeCodeBuddy(
 }
 
 export function targetFilePath(
-  target: MigrationAgent,
+  target: MigrationTarget,
   projectPath: string,
   sessionId: string,
   homeDir: string,
   now: Date,
 ): string {
-  if (target === "codex") {
+  const family = migrationTargetDescriptor(target).family;
+  const root = TARGET_ROOTS[target];
+  if (family === "codex") {
     const year = String(now.getUTCFullYear()).padStart(4, "0");
     const month = String(now.getUTCMonth() + 1).padStart(2, "0");
     const day = String(now.getUTCDate()).padStart(2, "0");
     const safeTimestamp = now.toISOString().replace(/[:.]/g, "-");
-    return path.join(homeDir, ".codex", "sessions", year, month, day, `rollout-${safeTimestamp}-${sessionId}.jsonl`);
+    return path.join(homeDir, root, "sessions", year, month, day, `rollout-${safeTimestamp}-${sessionId}.jsonl`);
   }
 
-  if (target === "claude") {
-    return path.join(homeDir, ".claude", "projects", encodeClaudeProjectDir(projectPath), `${sessionId}.jsonl`);
+  if (family === "claude") {
+    return path.join(homeDir, root, "projects", encodeClaudeProjectDir(projectPath), `${sessionId}.jsonl`);
   }
 
-  return path.join(homeDir, ".codebuddy", "projects", encodeCodeBuddyProjectDir(projectPath), `${sessionId}.jsonl`);
+  return path.join(homeDir, root, "projects", encodeCodeBuddyProjectDir(projectPath), `${sessionId}.jsonl`);
 }
+
+const TARGET_ROOTS: Record<MigrationTarget, string> = {
+  claude: ".claude",
+  tclaude: ".tclaude",
+  "claude-internal": ".claude-internal",
+  codex: ".codex",
+  tcodex: ".tcodex",
+  "codex-internal": ".codex-internal",
+  codebuddy: ".codebuddy",
+};
 
 function encodeClaudeProjectDir(projectPath: string): string {
   return encodeProjectDirectory(projectPath);
@@ -241,7 +255,7 @@ async function writeJsonlAndSync(filePath: string, rows: unknown[]): Promise<voi
   }
 }
 
-function readJsonlStrict(filePath: string, target: MigrationAgent): unknown[] {
+function readJsonlStrict(filePath: string, target: MigrationTarget): unknown[] {
   const rows: unknown[] = [];
   const content = fs.readFileSync(filePath, "utf8");
   for (const line of content.split("\n")) {
@@ -256,14 +270,15 @@ function readJsonlStrict(filePath: string, target: MigrationAgent): unknown[] {
 }
 
 function validateNativeStructure(
-  target: MigrationAgent,
+  target: MigrationTarget,
   rows: unknown[],
   sessionId: string,
   session: PortableSession,
 ): void {
-  if (target === "codex") {
+  const family = migrationTargetDescriptor(target).family;
+  if (family === "codex") {
     validateCodexStructure(rows, sessionId, session);
-  } else if (target === "claude") {
+  } else if (family === "claude") {
     validateClaudeStructure(rows, sessionId, session);
   } else {
     validateCodeBuddyStructure(rows, sessionId, session);
@@ -387,38 +402,41 @@ function record(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-function failValidation(target: MigrationAgent, detail: string): never {
+function failValidation(target: MigrationTarget, detail: string): never {
   throw new Error(`Migrated ${target} session failed validation: ${detail}.`);
 }
 
 function loadWrittenSession(
-  target: MigrationAgent,
+  target: MigrationTarget,
   filePath: string,
   sessionId: string,
   session: PortableSession,
 ): LoadedSession | null {
-  if (target === "codex") return loadCodexSessionFile(filePath);
-  if (target === "codebuddy") return loadCodeBuddyCliSessionFile(filePath);
-
+  const descriptor = migrationTargetDescriptor(target);
   const rows = parseJsonlText(fs.readFileSync(filePath, "utf8"));
+  if (descriptor.family === "codex") {
+    return loadCodexSessionRows(filePath, rows, { sourceOverride: descriptor.source });
+  }
+  if (descriptor.family === "codebuddy") return loadCodeBuddyCliSessionFile(filePath);
   return loadClaudeCliSessionRows(filePath, rows, {
     rawId: sessionId,
     cwd: session.projectPath,
     startedAt: new Date(session.startedAt).getTime(),
+    source: descriptor.source,
   });
 }
 
 function validateRoundTrip(
   loaded: LoadedSession | null,
-  target: MigrationAgent,
+  target: MigrationTarget,
   sessionId: string,
   portable: PortableSession,
 ): void {
-  const expectedSource = target === "codex" ? "codex-cli" : target === "claude" ? "claude-cli" : "codebuddy-cli";
+  const descriptor = migrationTargetDescriptor(target);
   const messagesMatch = loaded?.messages.length === portable.messages.length
     && loaded.messages.every((message, index) => {
       const expected = portable.messages[index];
-      const timestampMatches = target === "codebuddy"
+      const timestampMatches = descriptor.family === "codebuddy"
         ? new Date(message.timestamp).getTime() === new Date(expected.timestamp).getTime()
         : message.timestamp === expected.timestamp;
       return message.role === expected.role
@@ -428,7 +446,7 @@ function validateRoundTrip(
 
   if (
     !loaded
-    || loaded.session.source !== expectedSource
+    || loaded.session.source !== descriptor.source
     || loaded.session.rawId !== sessionId
     || loaded.session.projectPath !== portable.projectPath
     || loaded.session.originalTitle !== portable.title

--- a/src/core/session-migration.test.ts
+++ b/src/core/session-migration.test.ts
@@ -222,6 +222,15 @@ describe("session migration model", () => {
     expect(targets).toEqual(["claude", "codex", "codebuddy"]);
   });
 
+  it("preserves the narrow element type of explicitly enabled targets", () => {
+    const targets: Array<"tclaude" | "tcodex"> = supportedMigrationTargets(
+      "claude-cli",
+      ["tclaude", "tcodex"] as const,
+    );
+
+    expect(targets).toEqual(["tclaude", "tcodex"]);
+  });
+
   it("returns no migration targets for an unsupported source", () => {
     expect(supportedMigrationTargets("hermes")).toEqual([]);
     expect(supportedMigrationTargets("hermes", ["tclaude", "tcodex"] as const)).toEqual([]);

--- a/src/core/session-migration.test.ts
+++ b/src/core/session-migration.test.ts
@@ -294,6 +294,26 @@ describe("session migration model", () => {
 });
 
 describe("migrateSession", () => {
+  it("preserves a concrete migration target while keeping the portable source agent family", async () => {
+    const { deps, inspectCli, write, launch, refreshIndex, seenRecords } = createDependencies();
+
+    const result = await migrateSession({
+      source: session("tclaude-cli"),
+      messages,
+      target: "codex-internal",
+      deps,
+    });
+
+    expect(result.target).toBe("codex-internal");
+    expect(inspectCli).toHaveBeenCalledWith("codex-internal");
+    expect(write).toHaveBeenCalledWith("codex-internal", expect.objectContaining({ sourceAgent: "claude" }));
+    expect(refreshIndex).toHaveBeenCalledWith("codex-internal", "/tmp/target-session-1.jsonl");
+    expect(launch).toHaveBeenCalledWith("codex-internal", "target-session-1", "/repo");
+    expect(seenRecords).toEqual([
+      expect.objectContaining({ sourceAgent: "claude", targetAgent: "codex-internal" }),
+    ]);
+  });
+
   it.each([
     ["claude-cli", "claude"],
     ["claude-cli", "codex"],

--- a/src/core/session-migration.test.ts
+++ b/src/core/session-migration.test.ts
@@ -9,7 +9,13 @@ import {
   type SessionMigrationDependencies,
 } from "./session-migration";
 import type { WrittenMigratedSession } from "./session-migration-writers";
-import type { SessionMessage, SessionSearchResult, SessionSource } from "./types";
+import type {
+  MigrationAgent,
+  MigrationTarget,
+  SessionMessage,
+  SessionSearchResult,
+  SessionSource,
+} from "./types";
 
 function session(
   source: SessionSource,
@@ -171,9 +177,11 @@ describe("session migration model", () => {
     ["claude-cli", "claude"],
     ["claude-app", "claude"],
     ["claude-internal", "claude"],
+    ["tclaude-cli", "claude"],
     ["codex-cli", "codex"],
     ["codex-app", "codex"],
     ["codex-internal", "codex"],
+    ["tcodex-cli", "codex"],
     ["codebuddy-cli", "codebuddy"],
     ["openclaw", null],
     ["hermes", null],
@@ -185,12 +193,38 @@ describe("session migration model", () => {
   });
 
   it.each([
-    ["claude-cli", ["claude", "codex", "codebuddy"]],
-    ["codex-app", ["claude", "codex", "codebuddy"]],
-    ["codebuddy-cli", ["claude", "codex", "codebuddy"]],
-    ["hermes", []],
-  ] as const)("returns ordered migration targets for %s", (source, expected) => {
-    expect(supportedMigrationTargets(source)).toEqual(expected);
+    "claude-cli",
+    "claude-app",
+    "claude-internal",
+    "tclaude-cli",
+    "codex-cli",
+    "codex-app",
+    "codex-internal",
+    "tcodex-cli",
+    "codebuddy-cli",
+  ] as const)("returns all enabled migration targets for %s", (source) => {
+    const enabledTargets = [
+      "claude",
+      "codex",
+      "codebuddy",
+      "tclaude",
+      "tcodex",
+      "claude-internal",
+      "codex-internal",
+    ] as const satisfies readonly MigrationTarget[];
+
+    expect(supportedMigrationTargets(source, enabledTargets)).toEqual(enabledTargets);
+  });
+
+  it("returns the base migration targets when enabled targets are omitted", () => {
+    const targets: MigrationAgent[] = supportedMigrationTargets("claude-cli");
+
+    expect(targets).toEqual(["claude", "codex", "codebuddy"]);
+  });
+
+  it("returns no migration targets for an unsupported source", () => {
+    expect(supportedMigrationTargets("hermes")).toEqual([]);
+    expect(supportedMigrationTargets("hermes", ["tclaude", "tcodex"] as const)).toEqual([]);
   });
 
   it("normalizes a local session and copies only user and assistant messages", () => {

--- a/src/core/session-migration.test.ts
+++ b/src/core/session-migration.test.ts
@@ -374,6 +374,12 @@ describe("migrateSession", () => {
       "Remote session migration is not supported yet.",
     ],
     [
+      "imported local session",
+      session("claude-cli", { environmentKind: "local", environmentId: "imported-local" }),
+      "codex",
+      "Remote session migration is not supported yet.",
+    ],
+    [
       "empty project path",
       session("claude-cli", { projectPath: "   " }),
       "codex",

--- a/src/core/session-migration.ts
+++ b/src/core/session-migration.ts
@@ -1,5 +1,5 @@
 import type { MigrationCompressionListener, PreparedMigrationSession } from "./session-migration-compression";
-import { BASE_MIGRATION_TARGETS } from "./migration-targets";
+import { BASE_MIGRATION_TARGETS, isMigrationTarget } from "./migration-targets";
 import type { WrittenMigratedSession } from "./session-migration-writers";
 import type {
   MigrationAgent,
@@ -17,29 +17,29 @@ import type {
 export const MIGRATION_TOKEN_LIMIT = 60_000;
 
 export interface SessionMigrationDependencies {
-  inspectCli: (target: MigrationAgent) => Promise<void> | void;
+  inspectCli: (target: MigrationTarget) => Promise<void> | void;
   prepare: (
     session: PortableSession,
     onProgress?: MigrationCompressionListener,
   ) => Promise<PreparedMigrationSession>;
   write: (
-    target: MigrationAgent,
+    target: MigrationTarget,
     session: PortableSession,
   ) => Promise<WrittenMigratedSession>;
   record: (record: SessionMigrationRecord) => Promise<void> | void;
-  refreshIndex: (target: MigrationAgent, targetFilePath: string) => Promise<void>;
+  refreshIndex: (target: MigrationTarget, targetFilePath: string) => Promise<void>;
   launch: (
-    target: MigrationAgent,
+    target: MigrationTarget,
     sessionId: string,
     projectPath: string,
   ) => Promise<void>;
   resumeCommand: (
-    target: MigrationAgent,
+    target: MigrationTarget,
     sessionId: string,
     projectPath: string,
   ) => string;
   fallbackResumeCommand: (
-    target: MigrationAgent,
+    target: MigrationTarget,
     sessionId: string,
     projectPath: string,
   ) => string;
@@ -53,7 +53,7 @@ export interface SessionMigrationDependencies {
 export interface MigrateSessionOptions {
   source: SessionSearchResult;
   messages: SessionMessage[];
-  target: MigrationAgent;
+  target: MigrationTarget;
   deps: SessionMigrationDependencies;
 }
 
@@ -255,7 +255,7 @@ export async function migrateSession({
 
 async function validateMigrationRequest(
   source: SessionSearchResult,
-  target: MigrationAgent,
+  target: MigrationTarget,
   deps: SessionMigrationDependencies,
 ): Promise<void> {
   const sourceAgent = migrationAgentForSource(source.source);
@@ -265,7 +265,7 @@ async function validateMigrationRequest(
   if (source.environmentKind !== "local" || source.environmentId !== "local") {
     throw new Error("Remote session migration is not supported yet.");
   }
-  if (!BASE_MIGRATION_TARGETS.includes(target)) {
+  if (!isMigrationTarget(target)) {
     throw new Error(`Migration target ${target} is not supported.`);
   }
 
@@ -316,7 +316,7 @@ function errorMessage(error: unknown): string {
 function safeResumeCommand(
   deps: SessionMigrationDependencies,
   warnings: string[],
-  target: MigrationAgent,
+  target: MigrationTarget,
   sessionId: string,
   projectPath: string,
 ): string {

--- a/src/core/session-migration.ts
+++ b/src/core/session-migration.ts
@@ -1,6 +1,7 @@
 import type { MigrationCompressionListener, PreparedMigrationSession } from "./session-migration-compression";
 import { BASE_MIGRATION_TARGETS, isMigrationTarget } from "./migration-targets";
 import type { WrittenMigratedSession } from "./session-migration-writers";
+import { isLocalSessionEnvironment } from "./session-environment";
 import type {
   MigrationAgent,
   MigrationCompressionEvent,
@@ -96,7 +97,7 @@ export function portableSessionFrom(
   if (!sourceAgent) {
     throw new Error(`Session source ${session.source} cannot be migrated.`);
   }
-  if (session.environmentKind !== "local" || session.environmentId !== "local") {
+  if (!isLocalSessionEnvironment(session)) {
     throw new Error("Remote session migration is not supported yet.");
   }
   if (!session.projectPath.trim()) {
@@ -262,7 +263,7 @@ async function validateMigrationRequest(
   if (!sourceAgent) {
     throw new Error(`Session source ${source.source} cannot be migrated.`);
   }
-  if (source.environmentKind !== "local" || source.environmentId !== "local") {
+  if (!isLocalSessionEnvironment(source)) {
     throw new Error("Remote session migration is not supported yet.");
   }
   if (!isMigrationTarget(target)) {

--- a/src/core/session-migration.ts
+++ b/src/core/session-migration.ts
@@ -1,8 +1,10 @@
 import type { MigrationCompressionListener, PreparedMigrationSession } from "./session-migration-compression";
+import { BASE_MIGRATION_TARGETS } from "./migration-targets";
 import type { WrittenMigratedSession } from "./session-migration-writers";
 import type {
   MigrationAgent,
   MigrationCompressionEvent,
+  MigrationTarget,
   PortableSession,
   SessionMessage,
   SessionMigrationProgress,
@@ -13,8 +15,6 @@ import type {
 } from "./types";
 
 export const MIGRATION_TOKEN_LIMIT = 60_000;
-
-const MIGRATION_AGENTS = ["claude", "codex", "codebuddy"] as const;
 
 export interface SessionMigrationDependencies {
   inspectCli: (target: MigrationAgent) => Promise<void> | void;
@@ -62,10 +62,12 @@ export function migrationAgentForSource(source: SessionSource): MigrationAgent |
     case "claude-cli":
     case "claude-app":
     case "claude-internal":
+    case "tclaude-cli":
       return "claude";
     case "codex-cli":
     case "codex-app":
     case "codex-internal":
+    case "tcodex-cli":
       return "codex";
     case "codebuddy-cli":
       return "codebuddy";
@@ -74,9 +76,16 @@ export function migrationAgentForSource(source: SessionSource): MigrationAgent |
   }
 }
 
-export function supportedMigrationTargets(source: SessionSource): MigrationAgent[] {
-  const sourceAgent = migrationAgentForSource(source);
-  return sourceAgent ? [...MIGRATION_AGENTS] : [];
+export function supportedMigrationTargets(source: SessionSource): MigrationAgent[];
+export function supportedMigrationTargets<T extends MigrationTarget>(
+  source: SessionSource,
+  enabledTargets: readonly T[],
+): T[];
+export function supportedMigrationTargets(
+  source: SessionSource,
+  enabledTargets: readonly MigrationTarget[] = BASE_MIGRATION_TARGETS,
+): MigrationTarget[] {
+  return migrationAgentForSource(source) ? [...enabledTargets] : [];
 }
 
 export function portableSessionFrom(
@@ -256,7 +265,7 @@ async function validateMigrationRequest(
   if (source.environmentKind !== "local" || source.environmentId !== "local") {
     throw new Error("Remote session migration is not supported yet.");
   }
-  if (!MIGRATION_AGENTS.includes(target)) {
+  if (!BASE_MIGRATION_TARGETS.includes(target)) {
     throw new Error(`Migration target ${target} is not supported.`);
   }
 

--- a/src/core/session-store.test.ts
+++ b/src/core/session-store.test.ts
@@ -606,6 +606,38 @@ describe("SessionStore", () => {
     }
   });
 
+  it("round-trips a concrete migration target without changing the SQLite schema", () => {
+    const store = createInMemoryStore();
+    try {
+      const record = migrationRecord({ targetAgent: "tcodex" });
+      store.recordSessionMigration(record);
+
+      expect(store.listSessionMigrations(record.sourceSessionKey)).toEqual([record]);
+      const columns = (store as unknown as { db: InstanceType<typeof DatabaseSync> }).db
+        .prepare("PRAGMA table_info(session_migrations)")
+        .all() as Array<{ name: string; type: string }>;
+      expect(columns.find(({ name }) => name === "target_agent")?.type).toBe("TEXT");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("rejects an unregistered migration target read from SQLite", () => {
+    const store = createInMemoryStore();
+    try {
+      const db = (store as unknown as { db: InstanceType<typeof DatabaseSync> }).db;
+      db.prepare(`
+        INSERT INTO session_migrations (
+          id, source_session_key, source_agent, target_agent, target_session_id, target_file_path, strategy, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `).run("bad-target", "codex:abc", "codex", "hermes", "id", "/tmp/id", "complete", 1);
+
+      expect(() => store.listSessionMigrations("codex:abc")).toThrow("Unsupported migration target: hermes");
+    } finally {
+      store.close();
+    }
+  });
+
   it("persists session migrations across database reopen with unicode paths and all strategy values", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-store-migration-"));
     const dbPath = path.join(tempDir, "store.sqlite");

--- a/src/core/session-store.ts
+++ b/src/core/session-store.ts
@@ -8,6 +8,7 @@ import {
   type SkillUsageSource,
 } from "./skill-usage";
 import { truncateTraceDetail } from "./trace-detail";
+import { migrationTargetDescriptor } from "./migration-targets";
 import type {
   EnvironmentKind,
   EnvironmentSyncState,
@@ -158,7 +159,7 @@ interface SessionMigrationRow {
   id: string;
   source_session_key: string;
   source_agent: SessionMigrationRecord["sourceAgent"];
-  target_agent: SessionMigrationRecord["targetAgent"];
+  target_agent: string;
   target_session_id: string;
   target_file_path: string;
   strategy: SessionMigrationRecord["strategy"];
@@ -1057,7 +1058,7 @@ export class SessionStore {
       id: row.id,
       sourceSessionKey: row.source_session_key,
       sourceAgent: row.source_agent,
-      targetAgent: row.target_agent,
+      targetAgent: migrationTargetDescriptor(row.target_agent).id,
       targetSessionId: row.target_session_id,
       targetFilePath: row.target_file_path,
       strategy: row.strategy,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -58,6 +58,7 @@ export interface SessionMessage {
 }
 
 export type MigrationAgent = "claude" | "codex" | "codebuddy";
+export type MigrationTarget = MigrationAgent | "tclaude" | "tcodex" | "claude-internal" | "codex-internal";
 export type SessionMigrationStrategy = "complete" | "ai-compressed" | "locally-truncated";
 export type SessionMigrationStage = "reading" | "compressing" | "writing" | "indexing" | "launching";
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -90,7 +90,7 @@ export interface PortableSession {
 
 export interface SessionMigrationProgress {
   sessionKey: string;
-  target: MigrationAgent;
+  target: MigrationTarget;
   stage: SessionMigrationStage;
   // 0-100 progress within the current stage. Only meaningful during
   // "compressing" (the only stage with multiple discrete units of work).
@@ -100,7 +100,7 @@ export interface SessionMigrationProgress {
 }
 
 export interface SessionMigrationResult {
-  target: MigrationAgent;
+  target: MigrationTarget;
   targetSessionId: string;
   targetFilePath: string;
   strategy: SessionMigrationStrategy;
@@ -114,7 +114,7 @@ export interface SessionMigrationRecord {
   id: string;
   sourceSessionKey: string;
   sourceAgent: MigrationAgent;
-  targetAgent: MigrationAgent;
+  targetAgent: MigrationTarget;
   targetSessionId: string;
   targetFilePath: string;
   strategy: SessionMigrationStrategy;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -64,6 +64,7 @@ import {
 } from "../core/ai-assistant";
 import { applyMigrationLengthPolicy, createMigrationCompressor } from "../core/session-migration-compression";
 import { migrateSession } from "../core/session-migration";
+import { assertMigrationTargetEnabled, isMigrationTarget } from "../core/migration-targets";
 import { targetFilePath, writeMigratedSession } from "../core/session-migration-writers";
 import { writeDbPointer } from "../core/app-paths";
 import { routeResumeSession } from "../core/resume-router";
@@ -120,6 +121,7 @@ import type { AppSettings, AppSettingsUpdate } from "../core/platform";
 import type {
   EnvironmentUpsertInput,
   MigrationAgent,
+  MigrationTarget,
   PortableSession,
   SearchOptions,
   SessionEnvironment,
@@ -1255,7 +1257,7 @@ async function pathIsDirectory(targetPath: string): Promise<boolean> {
   }
 }
 
-function migrationResumeDisplayCommand(target: MigrationAgent, sessionId: string, projectPath: string): string {
+function migrationResumeDisplayCommand(target: MigrationTarget, sessionId: string, projectPath: string): string {
   return getMigrationResumeProcessSpec(target, sessionId, projectPath, getSettings()).displayCommand;
 }
 
@@ -1263,12 +1265,8 @@ function quotePosixToken(value: string): string {
   return /^[A-Za-z0-9_\-./]+$/.test(value) ? value : `'${value.replace(/'/g, "'\\''")}'`;
 }
 
-function fallbackMigrationResumeDisplayCommand(target: MigrationAgent, sessionId: string, projectPath: string): string {
-  const settings = getSettings();
-  const binary =
-    target === "claude" ? settings.claudeBinary : target === "codex" ? settings.codexBinary : settings.codeBuddyBinary;
-  const args = target === "codex" ? ["resume", sessionId] : ["--resume", sessionId];
-  return `cd ${quotePosixToken(projectPath)} && ${[binary, ...args].map(quotePosixToken).join(" ")}`;
+function fallbackMigrationResumeDisplayCommand(target: MigrationTarget, sessionId: string, projectPath: string): string {
+  return getMigrationResumeProcessSpec(target, sessionId, projectPath, getSettings()).displayCommand;
 }
 
 function remoteMigrationResumeDisplayCommand(
@@ -1277,7 +1275,7 @@ function remoteMigrationResumeDisplayCommand(
   sessionId: string,
   projectPath: string,
 ): string {
-  const remoteCommand = fallbackMigrationResumeDisplayCommand(target, sessionId, projectPath);
+  const remoteCommand = getMigrationResumeProcessSpec(target, sessionId, projectPath, getSettings(), { platform: "linux" }).displayCommand;
   return ["ssh", ...buildRemoteSyncSshArgs(environment, remoteCommand).map(quotePosixToken)].join(" ");
 }
 
@@ -1749,7 +1747,9 @@ function registerIpc(): void {
     await openResumeInSpecificTerminal(session, getSettings(), "iTerm", { sshArgs });
     store.markResumed(sessionKey);
   });
-  ipcMain.handle("session:migrate", async (event, sessionKey: string, target: MigrationAgent) => {
+  ipcMain.handle("session:migrate", async (event, sessionKey: string, target: unknown) => {
+    if (!isMigrationTarget(target)) throw new Error(`Migration target ${String(target)} is not supported.`);
+    assertMigrationTargetEnabled(target, getSettings());
     const session = store.getSession(sessionKey);
     if (!session) throw new Error("Session not found.");
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -36,6 +36,7 @@ import { formatSessionMarkdown, formatSessionPlainText } from "../core/format-se
 import {
   defaultSettings,
   getMigrationResumeProcessSpec,
+  getSafeMigrationResumeCommand,
   getResumeCommand,
   inspectMigrationCli,
   mergeAppSettings,
@@ -64,7 +65,7 @@ import {
 } from "../core/ai-assistant";
 import { applyMigrationLengthPolicy, createMigrationCompressor } from "../core/session-migration-compression";
 import { migrateSession } from "../core/session-migration";
-import { assertMigrationTargetEnabled, isMigrationTarget } from "../core/migration-targets";
+import { runLocalSessionMigration } from "./local-session-migration";
 import { targetFilePath, writeMigratedSession } from "../core/session-migration-writers";
 import { writeDbPointer } from "../core/app-paths";
 import { routeResumeSession } from "../core/resume-router";
@@ -117,6 +118,7 @@ import {
   INITIAL_SKILL_USAGE_REFRESH_DELAY_MS,
 } from "../core/refresh-policy";
 import { globalShortcutLabel, normalizeGlobalShortcut } from "../core/shortcuts";
+import { isLocalSessionEnvironment } from "../core/session-environment";
 import type { AppSettings, AppSettingsUpdate } from "../core/platform";
 import type {
   EnvironmentUpsertInput,
@@ -748,12 +750,8 @@ function markdownExportFileName(title: string): string {
   return `${safeTitle || "session"}.md`;
 }
 
-function isLocalSession(session: SessionSearchResult): boolean {
-  return session.environmentKind === "local" || session.environmentId === "local";
-}
-
 function sshArgsForSession(session: SessionSearchResult): string[] | undefined {
-  if (isLocalSession(session)) return undefined;
+  if (isLocalSessionEnvironment(session)) return undefined;
   const environment = store.getEnvironment(session.environmentId);
   if (!environment || environment.kind !== "ssh") return undefined;
   try {
@@ -766,14 +764,14 @@ function sshArgsForSession(session: SessionSearchResult): string[] | undefined {
 
 function requireSshArgsForRemoteSession(session: SessionSearchResult): string[] | undefined {
   const sshArgs = sshArgsForSession(session);
-  if (!isLocalSession(session) && !sshArgs) {
+  if (!isLocalSessionEnvironment(session) && !sshArgs) {
     throw new Error("SSH environment is not available for this remote session.");
   }
   return sshArgs;
 }
 
 function requireRemoteSshEnvironment(session: SessionSearchResult): SessionEnvironment | null {
-  if (isLocalSession(session)) return null;
+  if (isLocalSessionEnvironment(session)) return null;
   const environment = store.getEnvironment(session.environmentId);
   if (!environment || environment.kind !== "ssh") throw new Error("SSH environment is not available for this remote session.");
   return environment;
@@ -802,7 +800,7 @@ function hasHydratedRemoteDetails(sessionKey: string): boolean {
 
 async function ensureRemoteSessionDetailsLoaded(sessionKey: string): Promise<void> {
   const session = store.getSession(sessionKey);
-  if (!session || isLocalSession(session)) return;
+  if (!session || isLocalSessionEnvironment(session)) return;
   if (hasHydratedRemoteDetails(sessionKey)) return;
 
   const active = remoteDetailLoads.get(sessionKey);
@@ -810,7 +808,7 @@ async function ensureRemoteSessionDetailsLoaded(sessionKey: string): Promise<voi
 
   const load = (async () => {
     const latest = store.getSession(sessionKey);
-    if (!latest || isLocalSession(latest)) return;
+    if (!latest || isLocalSessionEnvironment(latest)) return;
     const environment = store.getEnvironment(latest.environmentId);
     if (!environment || environment.kind !== "ssh") throw new Error("SSH environment is not available for this remote session.");
     const payload = await fetchRemoteSessionFilePayload(environment, latest);
@@ -1266,7 +1264,7 @@ function quotePosixToken(value: string): string {
 }
 
 function fallbackMigrationResumeDisplayCommand(target: MigrationTarget, sessionId: string, projectPath: string): string {
-  return getMigrationResumeProcessSpec(target, sessionId, projectPath, getSettings()).displayCommand;
+  return getSafeMigrationResumeCommand(target, sessionId, projectPath, getSettings());
 }
 
 function remoteMigrationResumeDisplayCommand(
@@ -1277,6 +1275,46 @@ function remoteMigrationResumeDisplayCommand(
 ): string {
   const remoteCommand = getMigrationResumeProcessSpec(target, sessionId, projectPath, getSettings(), { platform: "linux" }).displayCommand;
   return ["ssh", ...buildRemoteSyncSshArgs(environment, remoteCommand).map(quotePosixToken)].join(" ");
+}
+
+function localSessionMigrationRuntime(event: IpcMainInvokeEvent) {
+  return {
+    resolveSummaryEndpoint: (snapshot: AppSettings) => resolveSummaryEndpointFromSettingsShared(snapshot, {
+      onTemporarySession: (temporarySessionKey) => {
+        try {
+          store.deleteSession(temporarySessionKey);
+        } catch {
+          // Best-effort cleanup if an ephemeral summary call is indexed before it exits.
+        }
+      },
+    }) ?? buildCodexExecEndpoint(snapshot),
+    createCompressor: (endpoint: SummaryEndpoint, concurrency: number) =>
+      createMigrationCompressor(endpoint, undefined, concurrency),
+    migrate: migrateSession,
+    inspectCli: (migrationTarget: MigrationTarget, snapshot: AppSettings) => inspectMigrationCli(migrationTarget, snapshot),
+    prepare: (portable: PortableSession, onProgress: Parameters<typeof applyMigrationLengthPolicy>[2], compressor: ReturnType<typeof createMigrationCompressor> | null) =>
+      applyMigrationLengthPolicy(portable, compressor, onProgress),
+    write: (migrationTarget: MigrationTarget, portable: PortableSession) =>
+      writeMigratedSession({ target: migrationTarget, session: portable }),
+    record: (record: Parameters<SessionStore["recordSessionMigration"]>[0]) => store.recordSessionMigration(record),
+    refreshIndex: async (migrationTarget: MigrationTarget, writtenFilePath: string) => {
+      const status = indexMigratedSessionFile(store, migrationTarget, writtenFilePath);
+      indexStatus = status;
+      mainWindow?.webContents.send("index-status", indexStatus);
+    },
+    launch: (migrationTarget: MigrationTarget, targetSessionId: string, projectPath: string, snapshot: AppSettings) =>
+      openMigrationResumeInTerminal(migrationTarget, targetSessionId, projectPath, snapshot),
+    resumeCommand: (migrationTarget: MigrationTarget, targetSessionId: string, projectPath: string, snapshot: AppSettings) =>
+      getMigrationResumeProcessSpec(migrationTarget, targetSessionId, projectPath, snapshot).displayCommand,
+    fallbackResumeCommand: (migrationTarget: MigrationTarget, targetSessionId: string, projectPath: string, snapshot: AppSettings) =>
+      getSafeMigrationResumeCommand(migrationTarget, targetSessionId, projectPath, snapshot),
+    onProgress: (progress: Parameters<NonNullable<import("../core/session-migration").SessionMigrationDependencies["onProgress"]>>[0]) =>
+      event.sender.send("session:migration-progress", progress),
+    idFactory: () => randomUUID(),
+    now: () => Date.now(),
+    projectPathExists: pathExists,
+    projectPathIsDirectory: pathIsDirectory,
+  };
 }
 
 async function writeMigratedSessionToSshEnvironment(
@@ -1436,7 +1474,7 @@ function registerIpc(): void {
     const pageOffset = offset ?? 0;
     const pageLimit = limit ?? 120;
     const session = store.getSession(sessionKey);
-    if (session && !isLocalSession(session) && !hasHydratedRemoteDetails(sessionKey)) {
+    if (session && !isLocalSessionEnvironment(session) && !hasHydratedRemoteDetails(sessionKey)) {
       if (session.messageCount <= 0) return [];
       const environment = requireRemoteSshEnvironment(session);
       if (!environment) return [];
@@ -1447,7 +1485,7 @@ function registerIpc(): void {
   });
   ipcMain.handle("session:trace-events", async (_event, sessionKey: string, options?: TraceEventQueryOptions) => {
     const session = store.getSession(sessionKey);
-    if (session && !isLocalSession(session) && !hasHydratedRemoteDetails(sessionKey)) return [];
+    if (session && !isLocalSessionEnvironment(session) && !hasHydratedRemoteDetails(sessionKey)) return [];
     await ensureRemoteSessionDetailsLoaded(sessionKey);
     return store.getTraceEvents(sessionKey, options);
   });
@@ -1722,7 +1760,7 @@ function registerIpc(): void {
     const session = store.getSession(sessionKey);
     if (!session) return { route: "resume" as const };
     const sshArgs = requireSshArgsForRemoteSession(session);
-    if (!isLocalSession(session)) {
+    if (!isLocalSessionEnvironment(session)) {
       await ensureRemoteResumePreflight(session);
       await openResumeInTerminal(session, getSettings(), { sshArgs });
       store.markResumed(sessionKey);
@@ -1748,53 +1786,29 @@ function registerIpc(): void {
     store.markResumed(sessionKey);
   });
   ipcMain.handle("session:migrate", async (event, sessionKey: string, target: unknown) => {
-    if (!isMigrationTarget(target)) throw new Error(`Migration target ${String(target)} is not supported.`);
-    assertMigrationTargetEnabled(target, getSettings());
     const session = store.getSession(sessionKey);
     if (!session) throw new Error("Session not found.");
+    const messages = store.getAllMessages(sessionKey);
+    const settings = Object.freeze(await getHydratedSettings());
 
-    // 没配自定义摘要 endpoint 时回退本地 Codex CLI(缺失则再退 Claude),让迁移仍走 AI 压缩而非直接本地截断——与 AI 助手一致。
-    const settings = await getHydratedSettings();
-    const endpoint = (await resolveSummaryEndpointFromSettings()) ?? buildCodexExecEndpoint(settings);
-    const compressor = endpoint ? createMigrationCompressor(endpoint, undefined, settings.compressionConcurrency) : null;
-    const result = await migrateSession({
+    return runLocalSessionMigration({
       source: session,
-      messages: store.getAllMessages(sessionKey),
+      messages,
       target,
-      deps: {
-        inspectCli: (migrationTarget) => inspectMigrationCli(migrationTarget, getSettings()),
-        prepare: (portable, onProgress) => applyMigrationLengthPolicy(portable, compressor, onProgress),
-        write: (migrationTarget, portable) => writeMigratedSession({ target: migrationTarget, session: portable }),
-        record: (record) => store.recordSessionMigration(record),
-        refreshIndex: async (migrationTarget, writtenFilePath) => {
-          const status = indexMigratedSessionFile(store, migrationTarget, writtenFilePath);
-          indexStatus = status;
-          mainWindow?.webContents.send("index-status", indexStatus);
-        },
-        launch: (migrationTarget, targetSessionId, projectPath) =>
-          openMigrationResumeInTerminal(migrationTarget, targetSessionId, projectPath, getSettings()),
-        resumeCommand: migrationResumeDisplayCommand,
-        fallbackResumeCommand: fallbackMigrationResumeDisplayCommand,
-        onProgress: (progress) => event.sender.send("session:migration-progress", progress),
-        idFactory: () => randomUUID(),
-        now: () => Date.now(),
-        projectPathExists: pathExists,
-        projectPathIsDirectory: pathIsDirectory,
-      },
-    });
-    return result;
+      settings,
+    }, localSessionMigrationRuntime(event));
   });
   ipcMain.handle("command:open-app", async (_event, sessionKey: string) => {
     const session = store.getSession(sessionKey);
     if (!session) return false;
-    if (!isLocalSession(session)) return false;
+    if (!isLocalSessionEnvironment(session)) return false;
     await openNativeApp(session.source);
     return true;
   });
   ipcMain.handle("command:reveal", async (_event, sessionKey: string) => {
     const session = store.getSession(sessionKey);
     if (!session) return false;
-    if (!isLocalSession(session)) return false;
+    if (!isLocalSessionEnvironment(session)) return false;
     await revealInFileManager(session.projectPath || session.filePath);
     return true;
   });

--- a/src/main/local-session-migration.test.ts
+++ b/src/main/local-session-migration.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+import { defaultSettings, getSafeMigrationResumeCommand } from "../core/platform";
+import { migrateSession, type SessionMigrationDependencies } from "../core/session-migration";
+import type { SessionMessage, SessionSearchResult } from "../core/types";
+import { runLocalSessionMigration, type LocalSessionMigrationRuntime } from "./local-session-migration";
+
+const source = {
+  sessionKey: "claude-cli:1",
+  source: "claude-cli",
+  environmentKind: "local",
+  environmentId: "local",
+  projectPath: "/repo",
+  displayTitle: "Source",
+  timestamp: Date.parse("2026-07-10T00:00:00Z"),
+} as SessionSearchResult;
+const messages: SessionMessage[] = [];
+
+function runtime(): LocalSessionMigrationRuntime<object, object> {
+  return {
+    resolveSummaryEndpoint: vi.fn(() => ({ provider: "snapshot" })),
+    createCompressor: vi.fn(() => ({ compressor: true })),
+    migrate: vi.fn<LocalSessionMigrationRuntime<object, object>["migrate"]>(async () => ({
+      target: "codex",
+      targetSessionId: "id",
+      targetFilePath: "/tmp/id",
+      strategy: "complete",
+      resumeCommand: "resume",
+      indexed: true,
+      launched: true,
+    })),
+    inspectCli: vi.fn(),
+    prepare: vi.fn<LocalSessionMigrationRuntime<object, object>["prepare"]>(async (session) => ({ session, strategy: "complete" })),
+    write: vi.fn(async () => ({ sessionId: "id", filePath: "/tmp/id" })),
+    record: vi.fn(),
+    refreshIndex: vi.fn(),
+    launch: vi.fn(),
+    resumeCommand: vi.fn(() => "primary"),
+    fallbackResumeCommand: vi.fn(() => "fallback"),
+    onProgress: vi.fn(),
+    idFactory: vi.fn(() => "record"),
+    now: vi.fn(() => 1),
+    projectPathExists: vi.fn(() => true),
+    projectPathIsDirectory: vi.fn(() => true),
+  };
+}
+
+describe("runLocalSessionMigration", () => {
+  it.each([
+    ["invalid", "hermes", defaultSettings, "Migration target hermes is not supported."],
+    ["disabled", "tcodex", defaultSettings, "TCodex migration target is disabled in Settings."],
+  ] as const)("rejects %s targets before endpoint, compressor, or migration work", async (_label, target, settings, message) => {
+    const deps = runtime();
+
+    await expect(runLocalSessionMigration({ source, messages, target, settings }, deps)).rejects.toThrow(message);
+
+    expect(deps.resolveSummaryEndpoint).not.toHaveBeenCalled();
+    expect(deps.createCompressor).not.toHaveBeenCalled();
+    expect(deps.migrate).not.toHaveBeenCalled();
+    expect(deps.inspectCli).not.toHaveBeenCalled();
+    expect(deps.prepare).not.toHaveBeenCalled();
+    expect(deps.write).not.toHaveBeenCalled();
+    expect(deps.record).not.toHaveBeenCalled();
+    expect(deps.refreshIndex).not.toHaveBeenCalled();
+    expect(deps.launch).not.toHaveBeenCalled();
+    expect(deps.resumeCommand).not.toHaveBeenCalled();
+    expect(deps.fallbackResumeCommand).not.toHaveBeenCalled();
+  });
+
+  it("captures one immutable settings snapshot in every downstream callback", async () => {
+    const snapshot = Object.freeze({
+      ...defaultSettings,
+      includeTcodex: true,
+      codexBinary: "/snapshot/codex",
+      compressionConcurrency: 3,
+    });
+    const laterSettings = { ...snapshot, codexBinary: "/later/codex", compressionConcurrency: 99 };
+    const deps = runtime();
+    const seenSettings: unknown[] = [];
+    deps.resolveSummaryEndpoint = vi.fn((settings) => {
+      seenSettings.push(settings);
+      return { provider: "snapshot" };
+    });
+    deps.inspectCli = vi.fn((_target, settings) => {
+      seenSettings.push(settings);
+    });
+    deps.launch = vi.fn(async (_target, _id, _path, settings) => {
+      seenSettings.push(settings);
+    });
+    deps.resumeCommand = vi.fn((_target, _id, _path, settings) => {
+      seenSettings.push(settings);
+      return settings.codexBinary;
+    });
+    deps.fallbackResumeCommand = vi.fn((_target, _id, _path, settings) => {
+      seenSettings.push(settings);
+      return settings.codexBinary;
+    });
+    deps.migrate = vi.fn<LocalSessionMigrationRuntime<object, object>["migrate"]>(async (options) => {
+      await options.deps.inspectCli("tcodex");
+      options.deps.resumeCommand("tcodex", "id", "/repo");
+      options.deps.fallbackResumeCommand("tcodex", "id", "/repo");
+      await options.deps.launch("tcodex", "id", "/repo");
+      expect(laterSettings.codexBinary).toBe("/later/codex");
+      return {
+        target: "tcodex", targetSessionId: "id", targetFilePath: "/tmp/id", strategy: "complete",
+        resumeCommand: "resume", indexed: true, launched: true,
+      };
+    });
+
+    await runLocalSessionMigration({ source, messages, target: "tcodex", settings: snapshot }, deps);
+
+    expect(deps.createCompressor).toHaveBeenCalledWith({ provider: "snapshot" }, 3);
+    expect(seenSettings).toHaveLength(5);
+    expect(seenSettings.every((settings) => settings === snapshot)).toBe(true);
+  });
+
+  it("returns the independent safe command when the primary formatter throws", async () => {
+    const settings = { ...defaultSettings, includeTcodex: true, tcodexBinary: "/safe/tcodex cli" };
+    const deps = runtime();
+    deps.migrate = migrateSession;
+    deps.resumeCommand = vi.fn(() => {
+      throw new Error("primary formatter failed");
+    });
+    deps.fallbackResumeCommand = vi.fn((target, sessionId, projectPath, snapshot) =>
+      getSafeMigrationResumeCommand(target, sessionId, projectPath, snapshot, { platform: "linux" }));
+
+    const result = await runLocalSessionMigration({ source, messages, target: "tcodex", settings }, deps);
+
+    expect(result.resumeCommand).toBe("cd /repo && '/safe/tcodex cli' resume id");
+    expect(result.warning).toContain("Failed to build resume command: primary formatter failed");
+  });
+});

--- a/src/main/local-session-migration.ts
+++ b/src/main/local-session-migration.ts
@@ -1,0 +1,77 @@
+import { assertMigrationTargetEnabled, isMigrationTarget } from "../core/migration-targets";
+import type { AppSettings } from "../core/platform";
+import type { MigrationCompressionListener, PreparedMigrationSession } from "../core/session-migration-compression";
+import type { WrittenMigratedSession } from "../core/session-migration-writers";
+import type {
+  MigrateSessionOptions,
+  SessionMigrationDependencies,
+} from "../core/session-migration";
+import type {
+  MigrationTarget,
+  PortableSession,
+  SessionMessage,
+  SessionMigrationProgress,
+  SessionMigrationRecord,
+  SessionMigrationResult,
+  SessionSearchResult,
+} from "../core/types";
+
+export interface LocalSessionMigrationRuntime<TEndpoint, TCompressor> {
+  resolveSummaryEndpoint: (settings: AppSettings) => Promise<TEndpoint | null> | TEndpoint | null;
+  createCompressor: (endpoint: TEndpoint, concurrency: number) => TCompressor;
+  migrate: (options: MigrateSessionOptions) => Promise<SessionMigrationResult>;
+  inspectCli: (target: MigrationTarget, settings: AppSettings) => Promise<void> | void;
+  prepare: (
+    session: PortableSession,
+    onProgress: MigrationCompressionListener | undefined,
+    compressor: TCompressor | null,
+  ) => Promise<PreparedMigrationSession>;
+  write: (target: MigrationTarget, session: PortableSession) => Promise<WrittenMigratedSession>;
+  record: (record: SessionMigrationRecord) => Promise<void> | void;
+  refreshIndex: (target: MigrationTarget, targetFilePath: string) => Promise<void>;
+  launch: (target: MigrationTarget, sessionId: string, projectPath: string, settings: AppSettings) => Promise<void>;
+  resumeCommand: (target: MigrationTarget, sessionId: string, projectPath: string, settings: AppSettings) => string;
+  fallbackResumeCommand: (target: MigrationTarget, sessionId: string, projectPath: string, settings: AppSettings) => string;
+  onProgress?: (progress: SessionMigrationProgress) => void;
+  idFactory: () => string;
+  now: () => number;
+  projectPathExists: SessionMigrationDependencies["projectPathExists"];
+  projectPathIsDirectory: SessionMigrationDependencies["projectPathIsDirectory"];
+}
+
+export async function runLocalSessionMigration<TEndpoint, TCompressor>(
+  input: {
+    source: SessionSearchResult;
+    messages: SessionMessage[];
+    target: unknown;
+    settings: AppSettings;
+  },
+  runtime: LocalSessionMigrationRuntime<TEndpoint, TCompressor>,
+): Promise<SessionMigrationResult> {
+  const { source, messages, target, settings } = input;
+  if (!isMigrationTarget(target)) throw new Error(`Migration target ${String(target)} is not supported.`);
+  assertMigrationTargetEnabled(target, settings);
+
+  const endpoint = await runtime.resolveSummaryEndpoint(settings);
+  const compressor = endpoint ? runtime.createCompressor(endpoint, settings.compressionConcurrency) : null;
+  return runtime.migrate({
+    source,
+    messages,
+    target,
+    deps: {
+      inspectCli: (migrationTarget) => runtime.inspectCli(migrationTarget, settings),
+      prepare: (session, onProgress) => runtime.prepare(session, onProgress, compressor),
+      write: runtime.write,
+      record: runtime.record,
+      refreshIndex: runtime.refreshIndex,
+      launch: (migrationTarget, sessionId, projectPath) => runtime.launch(migrationTarget, sessionId, projectPath, settings),
+      resumeCommand: (migrationTarget, sessionId, projectPath) => runtime.resumeCommand(migrationTarget, sessionId, projectPath, settings),
+      fallbackResumeCommand: (migrationTarget, sessionId, projectPath) => runtime.fallbackResumeCommand(migrationTarget, sessionId, projectPath, settings),
+      onProgress: runtime.onProgress,
+      idFactory: runtime.idFactory,
+      now: runtime.now,
+      projectPathExists: runtime.projectPathExists,
+      projectPathIsDirectory: runtime.projectPathIsDirectory,
+    },
+  });
+}

--- a/src/mcp/migration-entry.ts
+++ b/src/mcp/migration-entry.ts
@@ -12,3 +12,17 @@ export {
   type McpMigrationResult,
   type McpMigrateSessionInput,
 } from "../core/mcp-migration";
+export {
+  MIGRATION_TARGET_IDS,
+  MIGRATION_TARGETS,
+  assertMigrationTargetEnabled,
+  isMigrationTarget,
+  migrationTargetDescriptor,
+} from "../core/migration-targets";
+export {
+  getMigrationResumeProcessSpec,
+  getSafeMigrationResumeCommand,
+  inspectMigrationCli,
+  type AppSettings,
+} from "../core/platform";
+export type { MigrationTarget } from "../core/types";

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -23,6 +23,7 @@ import type {
   EnvironmentUpsertInput,
   LiveSessionSnapshot,
   MigrationAgent,
+  MigrationTarget,
   ProjectSummary,
   SearchOptions,
   SessionEnvironment,
@@ -120,7 +121,7 @@ const api = {
   copyResumeCommand: (sessionKey: string): Promise<void> => ipcRenderer.invoke("command:copy-resume", sessionKey),
   resumeSession: (sessionKey: string): Promise<ResumeRouteResult> => ipcRenderer.invoke("command:resume", sessionKey),
   resumeSessionInIterm: (sessionKey: string): Promise<void> => ipcRenderer.invoke("command:resume-iterm", sessionKey),
-  migrateSession: (sessionKey: string, target: MigrationAgent): Promise<SessionMigrationResult> =>
+  migrateSession: (sessionKey: string, target: MigrationTarget): Promise<SessionMigrationResult> =>
     ipcRenderer.invoke("session:migrate", sessionKey, target),
   openNativeApp: (sessionKey: string): Promise<void> => ipcRenderer.invoke("command:open-app", sessionKey),
   revealSession: (sessionKey: string): Promise<void> => ipcRenderer.invoke("command:reveal", sessionKey),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -47,6 +47,7 @@ import type { IndexStatus } from "../../core/indexer";
 import { formatRelativeTime } from "../../core/format-session";
 import { LIVE_SESSION_REFRESH_INTERVAL_MS, QUOTA_REFRESH_INTERVAL_MS } from "../../core/refresh-policy";
 import type { AppSettings, AppSettingsUpdate } from "../../core/platform";
+import type { MigrationTargetSettings } from "../../core/migration-targets";
 import type { RemoteHealthReport } from "../../core/remote-health";
 import type { RemoteSessionDetailSnapshot } from "../../core/remote-session-sync";
 import type { TraceEventQueryOptions } from "../../core/session-store";
@@ -132,6 +133,7 @@ import {
   supportsResumeSource,
   unsupportedMigrationTitle,
   migrationAgentLabel,
+  migrationTargetsForSource,
 } from "./session-ui";
 
 const STATS_PERIOD_OPTIONS: Array<{ label: string; value: SessionStatsPeriod }> = [
@@ -152,6 +154,13 @@ const LIVE_STATUS_FILTERS: Array<{ label: string; value: LiveStatusFilter }> = [
   { label: "Open", value: "open" },
   { label: "Closed", value: "closed" },
 ];
+
+const DEFAULT_MIGRATION_TARGET_SETTINGS = {
+  includeTclaude: false,
+  includeTcodex: false,
+  includeClaudeInternal: false,
+  includeCodexInternal: false,
+} satisfies MigrationTargetSettings;
 
 type ViewMode = "default" | "favorites" | "pinned" | "hidden";
 type PendingSourceKey = "claude" | "codex" | "tclaude" | "tcodex" | "codebuddy" | "openclaw" | "hermes" | "opencode" | "cursor" | "trae";
@@ -2141,6 +2150,7 @@ export function App(): ReactElement {
       {migrationDialog?.kind === "select" ? (
         <SessionMigrationDialog
           session={migrationDialog.session}
+          targets={migrationTargetsForSource(migrationDialog.session.source, appSettings ?? DEFAULT_MIGRATION_TARGET_SETTINGS)}
           language={language}
           busy={actionStatus?.kind === "running"}
           progress={migrationProgress}
@@ -2969,7 +2979,7 @@ function SettingsDialog({
                 <label className="settings-field settings-toggle">
                   <div className="settings-field-text">
                     <span className="settings-field-title">Include ~/.claude-internal</span>
-                    <span className="settings-field-sub">{l("Adds a separate Claude Extra source filter.", "添加独立的 Claude Extra 来源过滤项。")}</span>
+                    <span className="settings-field-sub">{l("Indexes Claude Code Internal sessions and allows migration to that CLI.", "索引 Claude Code Internal 会话，并允许迁移到该 CLI。")}</span>
                   </div>
                   <input
                     type="checkbox"
@@ -2982,7 +2992,7 @@ function SettingsDialog({
                 <label className="settings-field settings-toggle">
                   <div className="settings-field-text">
                     <span className="settings-field-title">Include ~/.codex-internal</span>
-                    <span className="settings-field-sub">{l("Adds a separate Codex Extra source filter.", "添加独立的 Codex Extra 来源过滤项。")}</span>
+                    <span className="settings-field-sub">{l("Indexes Codex Internal sessions and allows migration to that CLI.", "索引 Codex Internal 会话，并允许迁移到该 CLI。")}</span>
                   </div>
                   <input
                     type="checkbox"
@@ -2995,7 +3005,7 @@ function SettingsDialog({
                 <label className="settings-field settings-toggle">
                   <div className="settings-field-text">
                     <span className="settings-field-title">Include ~/.tclaude</span>
-                    <span className="settings-field-sub">{l("Indexes TClaude CLI sessions (Claude Code fork).", "索引 TClaude CLI 会话（Claude Code 分支）。")}</span>
+                    <span className="settings-field-sub">{l("Indexes TClaude CLI sessions and allows migration to that CLI.", "索引 TClaude CLI 会话，并允许迁移到该 CLI。")}</span>
                   </div>
                   <input
                     type="checkbox"
@@ -3008,7 +3018,7 @@ function SettingsDialog({
                 <label className="settings-field settings-toggle">
                   <div className="settings-field-text">
                     <span className="settings-field-title">Include ~/.tcodex</span>
-                    <span className="settings-field-sub">{l("Indexes TCodex CLI sessions (Codex fork).", "索引 TCodex CLI 会话（Codex 分支）。")}</span>
+                    <span className="settings-field-sub">{l("Indexes TCodex CLI sessions and allows migration to that CLI.", "索引 TCodex CLI 会话，并允许迁移到该 CLI。")}</span>
                   </div>
                   <input
                     type="checkbox"

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -133,7 +133,7 @@ import {
   supportsResumeSource,
   unsupportedMigrationTitle,
   migrationAgentLabel,
-  migrationTargetsForSource,
+  migrationTargetsForSession,
 } from "./session-ui";
 
 const STATS_PERIOD_OPTIONS: Array<{ label: string; value: SessionStatsPeriod }> = [
@@ -2150,7 +2150,7 @@ export function App(): ReactElement {
       {migrationDialog?.kind === "select" ? (
         <SessionMigrationDialog
           session={migrationDialog.session}
-          targets={migrationTargetsForSource(migrationDialog.session.source, appSettings ?? DEFAULT_MIGRATION_TARGET_SETTINGS)}
+          targets={migrationTargetsForSession(migrationDialog.session, appSettings ?? DEFAULT_MIGRATION_TARGET_SETTINGS)}
           language={language}
           busy={actionStatus?.kind === "running"}
           progress={migrationProgress}

--- a/src/renderer/src/components/session-migration-dialog.tsx
+++ b/src/renderer/src/components/session-migration-dialog.tsx
@@ -1,19 +1,20 @@
 import type { ReactElement } from "react";
 import { Copy, X } from "lucide-react";
 import type {
-  MigrationAgent,
+  MigrationTarget,
   SessionMigrationProgress,
   SessionMigrationResult,
   SessionSearchResult,
 } from "../../../core/types";
 import { localize, type LanguageMode } from "../language";
-import { isRemoteSession, migrationAgentLabel, migrationTargetsForSource } from "../session-ui";
+import { isRemoteSession, migrationAgentLabel } from "../session-ui";
 
 export function SessionMigrationDialog({
   session,
   language,
   busy,
   progress,
+  targets,
   onSelect,
   onClose,
 }: {
@@ -21,11 +22,11 @@ export function SessionMigrationDialog({
   language: LanguageMode;
   busy: boolean;
   progress?: SessionMigrationProgress | null;
-  onSelect: (target: MigrationAgent) => void;
+  targets: readonly MigrationTarget[];
+  onSelect: (target: MigrationTarget) => void;
   onClose: () => void;
 }): ReactElement {
   const l = (en: string, zh: string) => localize(language, en, zh);
-  const targets = migrationTargetsForSource(session.source);
   const remote = isRemoteSession(session);
 
   return (
@@ -43,8 +44,8 @@ export function SessionMigrationDialog({
         {remote ? <p className="dialog-copy danger-copy">{l("Remote session migration is not supported yet.", "首版仅支持本地会话迁移。")}</p> : null}
         {busy ? <MigrationProgressPanel progress={progress ?? null} language={language} /> : null}
         <div className="migration-targets">
-          {(["claude", "codex", "codebuddy"] as const).map((target) => {
-            const disabled = busy || remote || !targets.includes(target);
+          {targets.map((target) => {
+            const disabled = busy || remote;
             return (
               <button key={target} type="button" onClick={() => onSelect(target)} disabled={disabled}>
                 {migrationAgentLabel(target)}

--- a/src/renderer/src/components/session-migration-dialog.tsx
+++ b/src/renderer/src/components/session-migration-dialog.tsx
@@ -28,6 +28,7 @@ export function SessionMigrationDialog({
 }): ReactElement {
   const l = (en: string, zh: string) => localize(language, en, zh);
   const remote = isRemoteSession(session);
+  const availableTargets = remote ? [] : targets;
 
   return (
     <div className="dialog-backdrop" onMouseDown={onClose}>
@@ -44,8 +45,10 @@ export function SessionMigrationDialog({
         {remote ? <p className="dialog-copy danger-copy">{l("Remote session migration is not supported yet.", "首版仅支持本地会话迁移。")}</p> : null}
         {busy ? <MigrationProgressPanel progress={progress ?? null} language={language} /> : null}
         <div className="migration-targets">
-          {targets.map((target) => {
-            const disabled = busy || remote;
+          {availableTargets.length === 0 ? (
+            <p className="dialog-copy">{l("No migration targets are available for this session.", "当前会话没有可用的迁移目标。")}</p>
+          ) : availableTargets.map((target) => {
+            const disabled = busy;
             return (
               <button key={target} type="button" onClick={() => onSelect(target)} disabled={disabled}>
                 {migrationAgentLabel(target)}

--- a/src/renderer/src/detail-panel-actions.test.ts
+++ b/src/renderer/src/detail-panel-actions.test.ts
@@ -197,6 +197,27 @@ describe("detail panel actions", () => {
     expect(mainHandlerSource("session:migrate")).toContain("fallbackMigrationResumeDisplayCommand");
   });
 
+  it("validates and settings-gates concrete migration targets before migration side effects", () => {
+    const handler = mainHandlerSource("session:migrate");
+    const validationIndex = handler.indexOf("isMigrationTarget(target)");
+    const gateIndex = handler.indexOf("assertMigrationTargetEnabled(target, getSettings())");
+    const migrateIndex = handler.indexOf("migrateSession({");
+
+    expect(validationIndex).toBeGreaterThanOrEqual(0);
+    expect(gateIndex).toBeGreaterThan(validationIndex);
+    expect(migrateIndex).toBeGreaterThan(gateIndex);
+    expect(preloadSource).toContain("target: MigrationTarget");
+  });
+
+  it("builds remote restore commands with POSIX syntax regardless of the local platform", () => {
+    const remoteCommand = mainSource.slice(
+      mainSource.indexOf("function remoteMigrationResumeDisplayCommand"),
+      mainSource.indexOf("async function writeMigratedSessionToSshEnvironment"),
+    );
+    expect(remoteCommand).toContain('getMigrationResumeProcessSpec(target, sessionId, projectPath, getSettings(), { platform: "linux" })');
+    expect(remoteCommand).not.toContain("fallbackMigrationResumeDisplayCommand(target");
+  });
+
   it("exposes visible session bulk remote upload and remote-environment restore actions", () => {
     expect(appSource).toContain("uploadVisibleRemoteSessions");
     expect(appSource).not.toContain("CloudUpload");

--- a/src/renderer/src/detail-panel-actions.test.ts
+++ b/src/renderer/src/detail-panel-actions.test.ts
@@ -151,8 +151,8 @@ describe("detail panel actions", () => {
     expect(mainSource).toContain("throw new Error(\"SSH environment is not available for this remote session.\")");
     expect(mainSource).toContain("openResumeInTerminal(session, getSettings(), { sshArgs })");
     expect(mainSource).toContain("openResumeInSpecificTerminal(session, getSettings(), \"iTerm\", { sshArgs })");
-    expect(mainSource).toContain("if (!isLocalSession(session)) return false");
-    expect(mainSource).toContain("if (!isLocalSession(session)) {");
+    expect(mainSource).toContain("if (!isLocalSessionEnvironment(session)) return false");
+    expect(mainSource).toContain("if (!isLocalSessionEnvironment(session)) {");
     expect(mainSource).toContain("return { route: \"resume\" as const };");
   });
 
@@ -193,19 +193,17 @@ describe("detail panel actions", () => {
     expect(mainSource).toContain('event.sender.send("session:migration-progress"');
     expect(mainHandlerSource("session:migrate")).not.toContain("ensureRemoteSessionDetailsLoaded");
     expect(mainHandlerSource("session:migrate")).not.toContain("runIndexSync");
-    expect(mainHandlerSource("session:migrate")).toContain("indexMigratedSessionFile");
-    expect(mainHandlerSource("session:migrate")).toContain("fallbackMigrationResumeDisplayCommand");
+    expect(mainSource).toContain("indexMigratedSessionFile");
+    expect(mainSource).toContain("getSafeMigrationResumeCommand");
   });
 
-  it("validates and settings-gates concrete migration targets before migration side effects", () => {
+  it("keeps the migration IPC handler on one immutable settings snapshot and delegates behavior", () => {
     const handler = mainHandlerSource("session:migrate");
-    const validationIndex = handler.indexOf("isMigrationTarget(target)");
-    const gateIndex = handler.indexOf("assertMigrationTargetEnabled(target, getSettings())");
-    const migrateIndex = handler.indexOf("migrateSession({");
-
-    expect(validationIndex).toBeGreaterThanOrEqual(0);
-    expect(gateIndex).toBeGreaterThan(validationIndex);
-    expect(migrateIndex).toBeGreaterThan(gateIndex);
+    expect(handler.match(/getHydratedSettings\(\)/g)).toHaveLength(1);
+    expect(handler).toContain("Object.freeze(await getHydratedSettings())");
+    expect(handler).toContain("runLocalSessionMigration");
+    expect(handler).toContain("localSessionMigrationRuntime(event)");
+    expect(handler).not.toContain("getSettings()");
     expect(preloadSource).toContain("target: MigrationTarget");
   });
 

--- a/src/renderer/src/session-migration-ui.test.ts
+++ b/src/renderer/src/session-migration-ui.test.ts
@@ -1,5 +1,8 @@
 import { readFileSync } from "node:fs";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
+import type { SessionSearchResult } from "../../core/types";
+import { SessionMigrationDialog } from "./components/session-migration-dialog";
 
 const appSource = readFileSync(new URL("./App.tsx", import.meta.url), "utf8");
 const detailPanelSource = readFileSync(new URL("./components/detail-panel.tsx", import.meta.url), "utf8");
@@ -31,9 +34,50 @@ describe("session migration UI wiring", () => {
 
   it("renders caller-provided concrete targets instead of a hardcoded family list", () => {
     expect(dialogSource).toContain("targets: readonly MigrationTarget[]");
-    expect(dialogSource).toContain("targets.map((target)");
+    expect(dialogSource).toContain("availableTargets.map((target)");
     expect(dialogSource).not.toContain('(["claude", "codex", "codebuddy"] as const)');
-    expect(appSource).toContain("targets={migrationTargetsForSource(");
+    expect(appSource).toContain("targets={migrationTargetsForSession(");
+  });
+
+  it("shows an empty state and no target buttons when a remote dialog is opened programmatically", () => {
+    const session = {
+      source: "claude-cli",
+      environmentId: "ssh-dev",
+      environmentKind: "ssh",
+      displayTitle: "Remote session",
+    } as SessionSearchResult;
+    const html = renderToStaticMarkup(SessionMigrationDialog({
+      session,
+      language: "en",
+      busy: false,
+      targets: ["claude", "codex-internal"],
+      onSelect: () => undefined,
+      onClose: () => undefined,
+    }));
+
+    expect(html).toContain("No migration targets are available for this session.");
+    expect(html).not.toContain(">Claude Code</button>");
+    expect(html).not.toContain(">Codex Internal</button>");
+  });
+
+  it("keeps local target buttons and omits the empty state", () => {
+    const session = {
+      source: "claude-cli",
+      environmentId: "local",
+      environmentKind: "local",
+      displayTitle: "Local session",
+    } as SessionSearchResult;
+    const html = renderToStaticMarkup(SessionMigrationDialog({
+      session,
+      language: "zh",
+      busy: false,
+      targets: ["tcodex"],
+      onSelect: () => undefined,
+      onClose: () => undefined,
+    }));
+
+    expect(html).toContain(">TCodex</button>");
+    expect(html).not.toContain("当前会话没有可用的迁移目标。");
   });
 
   it("keeps Node-backed platform helpers out of the renderer bundle", () => {

--- a/src/renderer/src/session-migration-ui.test.ts
+++ b/src/renderer/src/session-migration-ui.test.ts
@@ -28,4 +28,17 @@ describe("session migration UI wiring", () => {
     expect(dialogSource).toContain("migration-progress-fill");
     expect(dialogSource).toContain('role="progressbar"');
   });
+
+  it("renders caller-provided concrete targets instead of a hardcoded family list", () => {
+    expect(dialogSource).toContain("targets: readonly MigrationTarget[]");
+    expect(dialogSource).toContain("targets.map((target)");
+    expect(dialogSource).not.toContain('(["claude", "codex", "codebuddy"] as const)');
+    expect(appSource).toContain("targets={migrationTargetsForSource(");
+  });
+
+  it("keeps Node-backed platform helpers out of the renderer bundle", () => {
+    expect(appSource).toContain('import type { AppSettings, AppSettingsUpdate } from "../../core/platform"');
+    expect(appSource).not.toContain("defaultSettings");
+    expect(appSource).toContain("DEFAULT_MIGRATION_TARGET_SETTINGS");
+  });
 });

--- a/src/renderer/src/session-ui.test.ts
+++ b/src/renderer/src/session-ui.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { defaultSettings } from "../../core/platform";
-import { projectSortTimestamp, sessionSortTimestamp, sourceFilterLabel, sourceFilters } from "./session-ui";
+import {
+  migrationTargetsForSource,
+  projectSortTimestamp,
+  sessionSortTimestamp,
+  sourceFilterLabel,
+  sourceFilters,
+} from "./session-ui";
 
 describe("session source labels", () => {
   it("keeps Claude Code and Codex as the only first-party source filters", () => {
@@ -28,6 +34,33 @@ describe("session source labels", () => {
     }).map((filter) => sourceFilterLabel(filter, "en"));
 
     expect(enabledLabels).toEqual(expect.arrayContaining(["OpenClaw", "Hermes", "OpenCode", "Cursor Agent", "Trae"]));
+  });
+
+  it("uses Internal labels for all four optional migration sources", () => {
+    const labels = sourceFilters({
+      ...defaultSettings,
+      includeTclaude: true,
+      includeTcodex: true,
+      includeClaudeInternal: true,
+      includeCodexInternal: true,
+    }).map((filter) => sourceFilterLabel(filter, "en"));
+
+    expect(labels).toEqual(expect.arrayContaining(["TClaude", "TCodex", "Claude Code Internal", "Codex Internal"]));
+  });
+
+  it("derives migration targets from enabled settings in registry order", () => {
+    expect(migrationTargetsForSource("claude-cli", defaultSettings)).toEqual(["claude", "codex", "codebuddy"]);
+    expect(migrationTargetsForSource("claude-cli", { ...defaultSettings, includeTcodex: true })).toEqual([
+      "claude", "codex", "codebuddy", "tcodex",
+    ]);
+    expect(migrationTargetsForSource("claude-cli", {
+      ...defaultSettings,
+      includeTclaude: true,
+      includeTcodex: true,
+      includeClaudeInternal: true,
+      includeCodexInternal: true,
+    })).toEqual(["claude", "codex", "codebuddy", "tclaude", "tcodex", "claude-internal", "codex-internal"]);
+    expect(migrationTargetsForSource("hermes", defaultSettings)).toEqual([]);
   });
 
   it("uses the latest activity timestamp shown in session rows", () => {

--- a/src/renderer/src/session-ui.test.ts
+++ b/src/renderer/src/session-ui.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { defaultSettings } from "../../core/platform";
 import {
+  migrationTargetsForSession,
   migrationTargetsForSource,
   projectSortTimestamp,
   sessionSortTimestamp,
@@ -61,6 +62,23 @@ describe("session source labels", () => {
       includeCodexInternal: true,
     })).toEqual(["claude", "codex", "codebuddy", "tclaude", "tcodex", "claude-internal", "codex-internal"]);
     expect(migrationTargetsForSource("hermes", defaultSettings)).toEqual([]);
+  });
+
+  it("returns no dialog targets for remote sessions without changing local targets", () => {
+    const settings = {
+      ...defaultSettings,
+      includeTclaude: true,
+      includeTcodex: true,
+      includeClaudeInternal: true,
+      includeCodexInternal: true,
+    };
+    const local = { source: "claude-cli", environmentId: "local", environmentKind: "local" } as const;
+    const remote = { source: "claude-cli", environmentId: "ssh-dev", environmentKind: "ssh" } as const;
+
+    expect(migrationTargetsForSession(remote, settings)).toEqual([]);
+    expect(migrationTargetsForSession(local, settings)).toEqual([
+      "claude", "codex", "codebuddy", "tclaude", "tcodex", "claude-internal", "codex-internal",
+    ]);
   });
 
   it("uses the latest activity timestamp shown in session rows", () => {

--- a/src/renderer/src/session-ui.test.ts
+++ b/src/renderer/src/session-ui.test.ts
@@ -73,9 +73,11 @@ describe("session source labels", () => {
       includeCodexInternal: true,
     };
     const local = { source: "claude-cli", environmentId: "local", environmentKind: "local" } as const;
+    const importedLocal = { source: "claude-cli", environmentId: "imported-local", environmentKind: "local" } as const;
     const remote = { source: "claude-cli", environmentId: "ssh-dev", environmentKind: "ssh" } as const;
 
     expect(migrationTargetsForSession(remote, settings)).toEqual([]);
+    expect(migrationTargetsForSession(importedLocal, settings)).toEqual([]);
     expect(migrationTargetsForSession(local, settings)).toEqual([
       "claude", "codex", "codebuddy", "tclaude", "tcodex", "claude-internal", "codex-internal",
     ]);

--- a/src/renderer/src/session-ui.ts
+++ b/src/renderer/src/session-ui.ts
@@ -5,6 +5,7 @@ import type { AppSettings } from "../../core/platform";
 import type { ResumeRouteResult } from "../../core/resume-router";
 import { localize, type LanguageMode } from "./language";
 import { liveStateLabel, type LiveSessionState, type LiveStatusFilter } from "./live-filter";
+import { isLocalSessionEnvironment } from "../../core/session-environment";
 
 export const SOURCE_LABEL: Record<SessionSource, string> = {
   "claude-cli": "Claude Code",
@@ -72,7 +73,7 @@ export function migrationTargetsForSession(
   session: Pick<SessionSearchResult, "source" | "environmentId" | "environmentKind">,
   settings: MigrationTargetSettings,
 ): MigrationTarget[] {
-  return isRemoteSession(session) ? [] : migrationTargetsForSource(session.source, settings);
+  return isLocalSessionEnvironment(session) ? migrationTargetsForSource(session.source, settings) : [];
 }
 
 export function migrationAgentLabel(target: MigrationTarget): string {
@@ -121,7 +122,7 @@ export function resumeRouteMessage(result: ResumeRouteResult, language: Language
 }
 
 export function isRemoteSession(session: Pick<SessionSearchResult, "environmentId" | "environmentKind">): boolean {
-  return session.environmentKind === "ssh" && session.environmentId !== "local";
+  return !isLocalSessionEnvironment(session);
 }
 
 export function environmentBadgeLabel(

--- a/src/renderer/src/session-ui.ts
+++ b/src/renderer/src/session-ui.ts
@@ -1,5 +1,6 @@
-import type { MigrationAgent, ProjectSummary, SearchOptions, SessionSearchResult, SessionSource, SessionStatsPeriod } from "../../core/types";
+import type { MigrationAgent, MigrationTarget, ProjectSummary, SearchOptions, SessionSearchResult, SessionSource, SessionStatsPeriod } from "../../core/types";
 import { migrationAgentForSource, supportedMigrationTargets } from "../../core/session-migration";
+import { enabledMigrationTargets, migrationTargetDescriptor, type MigrationTargetSettings } from "../../core/migration-targets";
 import type { AppSettings } from "../../core/platform";
 import type { ResumeRouteResult } from "../../core/resume-router";
 import { localize, type LanguageMode } from "./language";
@@ -8,10 +9,10 @@ import { liveStateLabel, type LiveSessionState, type LiveStatusFilter } from "./
 export const SOURCE_LABEL: Record<SessionSource, string> = {
   "claude-cli": "Claude Code",
   "claude-app": "Claude Code",
-  "claude-internal": "Claude Extra",
+  "claude-internal": "Claude Code Internal",
   "codex-cli": "Codex",
   "codex-app": "Codex",
-  "codex-internal": "Codex Extra",
+  "codex-internal": "Codex Internal",
   "tclaude-cli": "TClaude",
   "tcodex-cli": "TCodex",
   "codebuddy-cli": "CodeBuddy CLI",
@@ -31,8 +32,8 @@ const BASE_SOURCE_FILTERS: Array<{ label: string; value: SearchOptions["source"]
 export function sourceFilters(settings: AppSettings | null): Array<{ label: string; value: SearchOptions["source"] }> {
   return [
     ...BASE_SOURCE_FILTERS,
-    ...(settings?.includeClaudeInternal ? [{ label: "Claude Extra", value: "claude-internal" as const }] : []),
-    ...(settings?.includeCodexInternal ? [{ label: "Codex Extra", value: "codex-internal" as const }] : []),
+    ...(settings?.includeClaudeInternal ? [{ label: migrationTargetDescriptor("claude-internal").label, value: "claude-internal" as const }] : []),
+    ...(settings?.includeCodexInternal ? [{ label: migrationTargetDescriptor("codex-internal").label, value: "codex-internal" as const }] : []),
     ...(settings?.includeTclaude ? [{ label: "TClaude", value: "tclaude-cli" as const }] : []),
     ...(settings?.includeTcodex ? [{ label: "TCodex", value: "tcodex-cli" as const }] : []),
     ...(settings?.includeCodeBuddyCli ? [{ label: "CodeBuddy CLI", value: "codebuddy-cli" as const }] : []),
@@ -63,14 +64,12 @@ export function supportsMigrationSource(source: SessionSource): boolean {
   return supportedMigrationTargets(source).length > 0;
 }
 
-export function migrationTargetsForSource(source: SessionSource): MigrationAgent[] {
-  return supportedMigrationTargets(source);
+export function migrationTargetsForSource(source: SessionSource, settings: MigrationTargetSettings): MigrationTarget[] {
+  return supportedMigrationTargets(source, enabledMigrationTargets(settings));
 }
 
-export function migrationAgentLabel(agent: MigrationAgent): string {
-  if (agent === "claude") return "Claude Code";
-  if (agent === "codex") return "Codex";
-  return "CodeBuddy";
+export function migrationAgentLabel(target: MigrationTarget): string {
+  return migrationTargetDescriptor(target).label;
 }
 
 export function sourceMigrationAgent(source: SessionSource): MigrationAgent | null {

--- a/src/renderer/src/session-ui.ts
+++ b/src/renderer/src/session-ui.ts
@@ -68,6 +68,13 @@ export function migrationTargetsForSource(source: SessionSource, settings: Migra
   return supportedMigrationTargets(source, enabledMigrationTargets(settings));
 }
 
+export function migrationTargetsForSession(
+  session: Pick<SessionSearchResult, "source" | "environmentId" | "environmentKind">,
+  settings: MigrationTargetSettings,
+): MigrationTarget[] {
+  return isRemoteSession(session) ? [] : migrationTargetsForSource(session.source, settings);
+}
+
 export function migrationAgentLabel(target: MigrationTarget): string {
   return migrationTargetDescriptor(target).label;
 }


### PR DESCRIPTION
## Summary
- 支持 TClaude、TCodex、Claude Code Internal、Codex Internal 作为本地迁移来源与目标。
- Optional sources 开关统一控制索引、桌面按钮和 MCP 后端授权；Internal 会话普通 Resume 也使用正确 CLI/`CODEX_HOME`。
- 补齐跨平台 CLI 预检、命令安全、MCP 配置路径与中英文文档；远程恢复仍仅 Claude Code、Codex、CodeBuddy。

## Validation
- [x] `npm test -- --run`（69 files, 767 tests）
- [x] `npm run typecheck`
- [x] `npm run build:mcp`
- [x] `npm run build`
- [x] 四个新增 CLI 只读版本预检；真实会话目录未变化