### PR TITLE
fix: MCP 迁移 bundle 过期时软降级

### DIFF
--- a/bin/agent-session-search-mcp.mjs
+++ b/bin/agent-session-search-mcp.mjs
@@ -261,6 +261,22 @@ export function setVisibility(db, { sessionKey, visibility } = {}) {
 // scripts/build-mcp-bundle.mjs) so this standalone bin can call it without
 // --experimental-strip-types. The bundle is resolved relative to this file.
 let migrationBundle = null;
+
+function validateMigrationBundle(bundle) {
+  if (
+    !Array.isArray(bundle?.MIGRATION_TARGET_IDS) ||
+    bundle.MIGRATION_TARGET_IDS.length === 0 ||
+    !bundle.MIGRATION_TARGET_IDS.every((value) => typeof value === "string")
+  ) {
+    throw new Error("migration bundle is missing MIGRATION_TARGET_IDS");
+  }
+  for (const name of ["isMigrationTarget", "SessionStore", "migrateSessionForMcp"]) {
+    if (typeof bundle[name] !== "function") {
+      throw new Error(`migration bundle is missing ${name}`);
+    }
+  }
+}
+
 async function loadMigrationBundle() {
   if (migrationBundle) return migrationBundle;
   const candidates = [
@@ -271,7 +287,9 @@ async function loadMigrationBundle() {
   for (const candidate of candidates) {
     if (!existsSync(candidate)) continue;
     try {
-      migrationBundle = await import(pathToFileURL(candidate).href);
+      const candidateBundle = await import(pathToFileURL(candidate).href);
+      validateMigrationBundle(candidateBundle);
+      migrationBundle = candidateBundle;
       return migrationBundle;
     } catch (error) {
       lastError = error;
@@ -342,7 +360,15 @@ async function runServer() {
   db.exec("PRAGMA busy_timeout = 5000");
   db.exec("PRAGMA foreign_keys = ON");
   const server = new McpServer({ name: "agent-session-search", version: "0.1.0" });
-  const migrateTargetSchema = await migrationTargetSchema(z);
+  let migrateTargetSchema = null;
+  try {
+    migrateTargetSchema = await migrationTargetSchema(z);
+  } catch (error) {
+    process.stderr.write(
+      `agent-session-search MCP migration tools disabled: ${error instanceof Error ? error.message : String(error)}. ` +
+        "Run `npm run build:mcp` in the Agent-Session-Search install directory, then restart the MCP client.\n",
+    );
+  }
 
   server.registerTool(
     "search_sessions",
@@ -454,8 +480,9 @@ async function runServer() {
     },
   );
 
-  server.registerTool(
-    "migrate_session",
+  if (migrateTargetSchema) {
+    server.registerTool(
+      "migrate_session",
     {
       description:
         "跨 Agent 迁移会话（Migrate session across agents）。把一个本地会话（Claude Code / Codex / CodeBuddy）迁移到另一个目标 Agent，生成目标 Agent 能直接 resume 的会话文件。" +
@@ -473,7 +500,8 @@ async function runServer() {
       const result = await migrateSession(db, args);
       return result.ok ? jsonContent(result) : errorContent(result.error);
     },
-  );
+    );
+  }
 
   await server.connect(new StdioServerTransport());
 }

--- a/docs/superpowers/plans/2026-07-11-mcp-stale-bundle-degradation.md
+++ b/docs/superpowers/plans/2026-07-11-mcp-stale-bundle-degradation.md
@@ -1,0 +1,203 @@
+# MCP Stale Bundle Degradation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the Agent-Session-Search MCP server available when its optional migration bundle is stale, while omitting only `migrate_session` and reporting an actionable rebuild warning.
+
+**Architecture:** The standalone MCP entry keeps its eight bundle-independent tools on the unconditional startup path. Migration bundle loading validates the runtime contract before caching it; startup catches only migration capability failures, logs one warning, and connects the stdio transport without registering `migrate_session`.
+
+**Tech Stack:** Node.js 22 `node:sqlite`, MCP TypeScript SDK over stdio, Zod 4, Vitest, Electron/Vite build.
+
+## Global Constraints
+
+- Normal bundles must keep all existing nine tools and behavior unchanged.
+- Missing, unloadable, or contract-incomplete migration bundles must not prevent MCP `initialize`.
+- Degraded startup must keep eight non-migration tools and omit `migrate_session`.
+- The warning must include the underlying reason and the exact recovery command `npm run build:mcp`.
+- MCP startup must not build files or require development dependencies at runtime.
+- Database absence remains fatal because no MCP tool can operate without it.
+- Do not change migration targets, migration behavior, database schema, or MCP client configuration.
+
+---
+
+### Task 1: Stale Migration Bundle Soft Degradation
+
+**Files:**
+- Modify: `bin/agent-session-search-mcp.mjs`
+- Modify: `src/core/mcp-server.test.ts`
+
+**Interfaces:**
+- Consumes: `runServer()`'s existing database, `McpServer`, `StdioServerTransport`, and Zod initialization; the migration bundle exports `MIGRATION_TARGET_IDS`, `isMigrationTarget`, `SessionStore`, and `migrateSessionForMcp`.
+- Produces: `validateMigrationBundle(bundle): void`, which throws an actionable contract error; startup behavior in which `migrate_session` is conditionally registered and all other tools remain unconditional.
+
+- [ ] **Step 1: Write the failing child-process regression test**
+
+Add Node child-process and URL imports to `src/core/mcp-server.test.ts`. Add a helper that creates a temporary package layout containing:
+
+```text
+<temp>/bin/agent-session-search-mcp.mjs
+<temp>/out/mcp/migration-entry.js
+<temp>/node_modules -> <repo>/node_modules
+<temp>/package.json  { "type": "module" }
+<temp>/sessions.db
+```
+
+Copy the real MCP entry, write an old-style migration module that exports only `SessionStore`, create a file-backed `SessionStore`, then spawn Node with `AGENT_SESSION_SEARCH_DB=<temp>/sessions.db`. Send newline-delimited JSON-RPC messages in this order:
+
+```ts
+{ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "test", version: "1" } } }
+{ jsonrpc: "2.0", method: "notifications/initialized" }
+{ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }
+```
+
+Parse stdout by response `id`, terminate the child after `id: 2`, and assert:
+
+```ts
+expect(initialize.result.serverInfo.name).toBe("agent-session-search");
+expect(toolNames).toEqual([
+  "search_sessions",
+  "get_session",
+  "list_projects",
+  "list_tags",
+  "get_latest_sessions",
+  "tag_session",
+  "toggle_favorite",
+  "set_visibility",
+]);
+expect(stderr).toContain("migration tools disabled");
+expect(stderr).toContain("MIGRATION_TARGET_IDS");
+expect(stderr).toContain("npm run build:mcp");
+```
+
+The helper must enforce a five-second timeout, report early child exit with captured stderr, close the seeded store before spawn, and remove the temporary directory in `finally`.
+
+- [ ] **Step 2: Run the regression test and verify RED**
+
+Run:
+
+```bash
+npm test -- --run src/core/mcp-server.test.ts
+```
+
+Expected: the new child-process test fails because the child exits before returning response `id: 1`, with stderr containing the current `Cannot convert undefined or null to object` startup failure.
+
+- [ ] **Step 3: Add explicit migration bundle contract validation**
+
+In `bin/agent-session-search-mcp.mjs`, validate an imported candidate before assigning it to the module cache:
+
+```js
+function validateMigrationBundle(bundle) {
+  if (!Array.isArray(bundle?.MIGRATION_TARGET_IDS) || bundle.MIGRATION_TARGET_IDS.length === 0) {
+    throw new Error("migration bundle is missing MIGRATION_TARGET_IDS");
+  }
+  for (const name of ["isMigrationTarget", "SessionStore", "migrateSessionForMcp"]) {
+    if (typeof bundle[name] !== "function") {
+      throw new Error(`migration bundle is missing ${name}`);
+    }
+  }
+}
+```
+
+Change `loadMigrationBundle()` so it imports into a local variable, validates it, and caches only a valid module. Preserve the existing candidate order and include the validation/import error in the final thrown message.
+
+- [ ] **Step 4: Move migration registration behind a startup capability boundary**
+
+Keep the existing eight non-migration `server.registerTool` calls unconditional. Replace eager schema initialization with a nullable capability:
+
+```js
+let migrateTargetSchema = null;
+try {
+  migrateTargetSchema = await migrationTargetSchema(z);
+} catch (error) {
+  process.stderr.write(
+    `agent-session-search MCP migration tools disabled: ${error instanceof Error ? error.message : String(error)}. ` +
+      "Run `npm run build:mcp` in the Agent-Session-Search install directory, then restart the MCP client.\n",
+  );
+}
+```
+
+Wrap only the existing `migrate_session` registration in `if (migrateTargetSchema)`. Do not catch database setup, SDK loading, transport connection, or base-tool registration errors.
+
+- [ ] **Step 5: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+npm test -- --run src/core/mcp-server.test.ts
+```
+
+Expected: all tests in `src/core/mcp-server.test.ts` pass, including the child-process stale-bundle handshake test.
+
+- [ ] **Step 6: Add a normal-bundle startup assertion**
+
+Reuse the child-process JSON-RPC helper with the worktree's real `out/mcp/migration-entry.js`. Assert the returned tool names contain `migrate_session` and stderr does not contain `migration tools disabled`. This proves the soft-degradation branch does not change the normal nine-tool contract.
+
+- [ ] **Step 7: Run focused tests again**
+
+Run:
+
+```bash
+npm test -- --run src/core/mcp-server.test.ts
+```
+
+Expected: all focused tests pass with both degraded and normal startup paths covered.
+
+- [ ] **Step 8: Commit the behavior and regression tests**
+
+```bash
+git add bin/agent-session-search-mcp.mjs src/core/mcp-server.test.ts
+git commit -m "fix: degrade MCP when migration bundle is stale"
+```
+
+### Task 2: Full Verification and Documentation Closeout
+
+**Files:**
+- Modify only if verification exposes a defect: `bin/agent-session-search-mcp.mjs`, `src/core/mcp-server.test.ts`
+- Existing design: `docs/superpowers/specs/2026-07-11-mcp-stale-bundle-degradation-design.md`
+
+**Interfaces:**
+- Consumes: Task 1's conditional `migrate_session` registration and regression harness.
+- Produces: verified build artifacts and evidence that the full repository remains healthy.
+
+- [ ] **Step 1: Run static and complete automated verification**
+
+Run each command separately:
+
+```bash
+npm run typecheck
+npm test -- --run
+npm run build
+git diff --check
+```
+
+Expected: TypeScript exits 0; all Vitest files and tests pass; `build:mcp` plus Electron/Vite build exits 0; `git diff --check` prints nothing.
+
+- [ ] **Step 2: Run a fresh real stdio handshake probe**
+
+Spawn `node bin/agent-session-search-mcp.mjs` with the live database pointer, send `initialize`, `notifications/initialized`, and `tools/list`, and verify response `id: 1` names `agent-session-search` and response `id: 2` contains all nine tools including `migrate_session`.
+
+- [ ] **Step 3: Inspect final repository state**
+
+Run:
+
+```bash
+git status --short --branch
+git log -3 --oneline
+```
+
+Expected: only intentional plan or implementation changes are present; ignored `out/` build products do not appear; the branch contains the design commit and implementation commit.
+
+- [ ] **Step 4: Record durable project memory**
+
+Update `/Users/xjx/Documents/Obsidian Vault/Codex/projects/agent-session-search.md` with a dated concise note covering the root cause, soft-degradation behavior, tests, branch, and commit. Do not store credentials or raw logs. Update `TODO.md` only if verification leaves an unresolved action.
+
+- [ ] **Step 5: Commit any verification-driven source correction**
+
+Only when Step 1 or Step 2 required a source correction:
+
+```bash
+git add bin/agent-session-search-mcp.mjs src/core/mcp-server.test.ts
+git commit -m "fix: complete MCP degradation verification"
+```
+
+If no correction was needed, do not create an empty commit.

--- a/docs/superpowers/specs/2026-07-11-mcp-stale-bundle-degradation-design.md
+++ b/docs/superpowers/specs/2026-07-11-mcp-stale-bundle-degradation-design.md
@@ -1,0 +1,46 @@
+# MCP 迁移 Bundle 过期时软降级设计
+
+## 背景
+
+独立 MCP 入口 `bin/agent-session-search-mcp.mjs` 会加载 `out/mcp/migration-entry.js`，以注册 `migrate_session`。当入口源码更新、但被 `.gitignore` 忽略的 `out/mcp` 仍是旧构建时，bundle 可能缺少入口需要的导出。当前实现会在连接 stdio transport 前抛错，导致整个 MCP 进程退出，Codex 只报告 `initialize response` 前连接关闭。一个可选迁移工具的构建不一致因此会连带禁用搜索、读取和会话管理工具。
+
+## 目标
+
+- 正常 bundle 下保持现有 9 个工具及其行为不变。
+- bundle 缺失、导入失败或缺少迁移契约导出时，MCP 仍完成 `initialize`。
+- 降级状态下保留 8 个与迁移无关的工具，不注册 `migrate_session`。
+- stderr 给出可操作的诊断信息，明确建议运行 `npm run build:mcp`。
+- 用真实子进程和 stdio JSON-RPC 覆盖回归场景。
+
+## 非目标
+
+- MCP 启动时不自动调用构建工具。
+- 不在运行时修复或覆盖 `out/mcp`。
+- 不改变迁移目标、迁移逻辑、数据库结构或客户端配置格式。
+- 不为降级状态设计新的 MCP 管理工具或协议扩展。
+
+## 方案
+
+将迁移能力初始化从 MCP 基础能力初始化中隔离出来。服务先创建数据库与 `McpServer`，并注册与 bundle 无关的 8 个工具。随后在局部 `try/catch` 中加载并校验迁移 bundle；只有拿到有效的迁移目标 schema 时才注册 `migrate_session`。
+
+bundle 校验至少覆盖 `MIGRATION_TARGET_IDS` 为非空字符串数组，以及迁移执行所需导出存在。校验失败时向 stderr 输出单行警告，包含失败原因和 `npm run build:mcp`，然后继续连接 `StdioServerTransport`。数据库不存在等基础前置条件仍保持启动失败，因为此时所有工具都不可用。
+
+不采用启动时自动构建：安装环境不保证存在开发依赖，且 MCP 握手不应承担构建延迟与写文件副作用。不采用仅改善致命报错：这仍会扩大可选功能故障的影响面。
+
+## 测试
+
+新增子进程级 MCP 启动测试：在临时目录放置入口脚本、可用数据库和一个模拟旧版本的迁移 bundle，通过环境变量或可注入的 bundle 路径让入口加载该 bundle。测试发送 `initialize`、`notifications/initialized` 和 `tools/list`，断言：
+
+- `initialize` 返回成功；
+- `tools/list` 包含现有 8 个基础工具；
+- `tools/list` 不包含 `migrate_session`；
+- stderr 包含重建提示。
+
+正常 bundle 的启动测试断言 `migrate_session` 仍存在。现有 SDK-free 单元测试继续覆盖迁移 schema 和迁移执行。最终运行 MCP 定向测试、完整测试、typecheck、build，并进行一次手工 stdio 握手探测。
+
+## 验收标准
+
+- 旧 bundle 不再造成 MCP 握手失败。
+- 正常构建不丢失或改变任何工具契约。
+- 降级原因对用户可诊断、可恢复。
+- 所有自动化验证通过，源码工作区不依赖手工保留生成产物。

--- a/src/core/mcp-server.test.ts
+++ b/src/core/mcp-server.test.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { createRequire } from "node:module";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -47,6 +48,96 @@ async function withMcpConfig(
 
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require("node:sqlite") as { DatabaseSync: new (path: string) => import("node:sqlite").DatabaseSync };
+
+type JsonRpcResponse = {
+  id?: number;
+  result?: {
+    serverInfo?: { name?: string };
+    tools?: Array<{ name: string }>;
+  };
+};
+
+async function runMcpWithMigrationBundle(bundleSource: string): Promise<{
+  initialize: JsonRpcResponse;
+  toolsList: JsonRpcResponse;
+  stderr: string;
+}> {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "mcp-stale-bundle-")));
+  const binDir = path.join(root, "bin");
+  const bundleDir = path.join(root, "out", "mcp");
+  const dbPath = path.join(root, "sessions.db");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.mkdirSync(bundleDir, { recursive: true });
+  fs.copyFileSync(path.resolve("bin", "agent-session-search-mcp.mjs"), path.join(binDir, "agent-session-search-mcp.mjs"));
+  fs.writeFileSync(path.join(bundleDir, "migration-entry.js"), bundleSource, "utf8");
+  fs.writeFileSync(path.join(root, "package.json"), '{"type":"module"}\n', "utf8");
+  fs.symlinkSync(path.resolve("node_modules"), path.join(root, "node_modules"), "dir");
+
+  const db = new DatabaseSync(dbPath);
+  const store = new SessionStore(db);
+  store.close();
+
+  try {
+    return await new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [path.join(binDir, "agent-session-search-mcp.mjs")], {
+        env: { ...process.env, AGENT_SESSION_SEARCH_DB: dbPath },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      const responses = new Map<number, JsonRpcResponse>();
+      let stdout = "";
+      let stderr = "";
+      let toolsRequested = false;
+      let settled = false;
+      const finish = (error?: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        child.kill();
+        if (error) reject(error);
+        else resolve({ initialize: responses.get(1)!, toolsList: responses.get(2)!, stderr });
+      };
+      const timeout = setTimeout(() => finish(new Error(`MCP probe timed out. stderr: ${stderr}`)), 5_000);
+
+      child.stderr.on("data", (chunk) => {
+        stderr += chunk.toString();
+      });
+      child.stdout.on("data", (chunk) => {
+        stdout += chunk.toString();
+        const lines = stdout.split("\n");
+        stdout = lines.pop() ?? "";
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          const response = JSON.parse(line) as JsonRpcResponse;
+          if (typeof response.id === "number") responses.set(response.id, response);
+          if (response.id === 1 && !toolsRequested) {
+            toolsRequested = true;
+            child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" })}\n`);
+            child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} })}\n`);
+          }
+          if (response.id === 2) finish();
+        }
+      });
+      child.once("error", (error) => finish(error));
+      child.once("exit", (code, signal) => {
+        if (!settled) finish(new Error(`MCP exited before tools/list (code=${code}, signal=${signal}). stderr: ${stderr}`));
+      });
+      child.stdin.write(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-03-26",
+            capabilities: {},
+            clientInfo: { name: "test", version: "1" },
+          },
+        })}\n`,
+      );
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
 
 function seedStore(): { db: import("node:sqlite").DatabaseSync; store: SessionStore } {
   const db = new DatabaseSync(":memory:");
@@ -286,6 +377,34 @@ describe("MCP migrate_session tool", () => {
       "claude-internal",
       "codex-internal",
     ]);
+  });
+
+  it("keeps base tools available when the migration bundle is stale", async () => {
+    const result = await runMcpWithMigrationBundle("export class SessionStore {}\n");
+
+    expect(result.initialize.result?.serverInfo?.name).toBe("agent-session-search");
+    expect(result.toolsList.result?.tools?.map((tool) => tool.name)).toEqual([
+      "search_sessions",
+      "get_session",
+      "list_projects",
+      "list_tags",
+      "get_latest_sessions",
+      "tag_session",
+      "toggle_favorite",
+      "set_visibility",
+    ]);
+    expect(result.stderr).toContain("migration tools disabled");
+    expect(result.stderr).toContain("MIGRATION_TARGET_IDS");
+    expect(result.stderr).toContain("npm run build:mcp");
+  });
+
+  it("registers migrate_session when the migration bundle is current", async () => {
+    const bundleSource = fs.readFileSync(path.resolve("out", "mcp", "migration-entry.js"), "utf8");
+    const result = await runMcpWithMigrationBundle(bundleSource);
+
+    expect(result.initialize.result?.serverInfo?.name).toBe("agent-session-search");
+    expect(result.toolsList.result?.tools?.map((tool) => tool.name)).toContain("migrate_session");
+    expect(result.stderr).not.toContain("migration tools disabled");
   });
 
   it("reads an isolated enabled TClaude setting and reaches CLI inspection", async () => {


### PR DESCRIPTION
## 修改内容

- 校验 MCP 迁移 bundle 的运行时契约，避免缓存缺少必要导出的旧构建产物
- 迁移 bundle 缺失、过期或不完整时软降级：保留 8 个基础工具，仅不注册 `migrate_session`
- stderr 输出明确的 `npm run build:mcp` 恢复提示
- 增加真实子进程 stdio 回归测试，覆盖旧 bundle 降级和正常 bundle 九工具路径

## 根因

`bin/agent-session-search-mcp.mjs` 已开始读取 `MIGRATION_TARGET_IDS`，但增量更新后的 `out/mcp/migration-entry.js` 可能仍是旧构建。入口在连接 stdio transport 前执行 `z.enum(undefined)`，进程直接退出，导致 Codex 报 MCP `initialize response` 前连接关闭。一个可选迁移能力的构建不一致因此连带禁用了所有搜索和管理工具。

## 影响

正常 bundle 行为保持不变，仍暴露全部 9 个工具。旧 bundle 下 MCP 现在仍可完成握手并提供搜索、读取、标签、收藏和可见性等 8 个工具，用户可以根据 stderr 提示重建后恢复迁移能力。

## 验证

- `npm run typecheck`
- `npm test -- --run`：71 个测试文件，787 个测试通过
- `npm run build`
- 真实本机数据库 stdio `initialize` + `tools/list`：返回全部 9 个工具，stderr 为空
