### PR TITLE
fix: 修正 Codex 7d 额度周期显示

### DIFF
--- a/docs/superpowers/plans/2026-07-13-codex-quota-window-label.md
+++ b/docs/superpowers/plans/2026-07-13-codex-quota-window-label.md
@@ -1,0 +1,123 @@
+# Codex Quota Window Label Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Correctly display the current Codex seven-day primary quota while retaining compatibility with legacy five-hour and seven-day responses.
+
+**Architecture:** Keep the request and renderer unchanged. Add a small duration-aware mapping in the Codex response parser so each rate-limit window selects its existing stable key and label from `limit_window_seconds`, with the previous primary/secondary position mapping as a fallback when duration is absent.
+
+**Tech Stack:** TypeScript, Vitest, Electron/Vite
+
+## Global Constraints
+
+- `18000` seconds maps to `five_hour` / `5h`.
+- `604800` seconds maps to `seven_day` / `7d`.
+- Missing or unknown durations preserve the legacy primary 5h and secondary 7d mapping.
+- Codex request/authentication, Claude quota parsing, code-review quota, and renderer behavior remain unchanged.
+
+---
+
+### Task 1: Detect Codex quota windows from duration
+
+**Files:**
+- Modify: `src/core/quota.ts`
+- Test: `src/core/quota.test.ts`
+
+**Interfaces:**
+- Consumes: `CodexUsageWindow.limit_window_seconds?: number` and the existing `quotaFromUsedPercent(...)` normalizer.
+- Produces: duration-aware `UsageQuota` entries from `codexQuotasFromResponse(response, now)`; no public API changes.
+
+- [ ] **Step 1: Write the failing regression test**
+
+Add a test after the existing Codex normalization test:
+
+```ts
+it("labels a seven-day Codex primary window from its duration", async () => {
+  const homeDir = makeHome();
+  try {
+    writeJson(path.join(homeDir, ".codex", "auth.json"), {
+      tokens: { access_token: "codex-access", account_id: "account-1" },
+    });
+
+    const card = await loadCodexQuotaCard({
+      now: NOW,
+      homeDir,
+      env: {},
+      codexFetcher: async () => ({
+        rate_limit: {
+          primary_window: {
+            used_percent: 20,
+            limit_window_seconds: 604800,
+            reset_at: 1_807_000_000,
+          },
+          secondary_window: null,
+        },
+      }),
+    });
+
+    expect(card.quotas).toEqual([
+      expect.objectContaining({ key: "seven_day", label: "7d", usedPercent: 20, remainingPercent: 80 }),
+    ]);
+  } finally {
+    rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+```
+
+- [ ] **Step 2: Run the regression test and verify RED**
+
+Run: `npm test -- --run src/core/quota.test.ts -t "labels a seven-day Codex primary window from its duration"`
+
+Expected: FAIL because the actual quota still has `key: "five_hour"` and `label: "5h"`.
+
+- [ ] **Step 3: Implement the minimal duration-aware mapping**
+
+Add duration constants and a helper near the existing Codex quota constants/functions:
+
+```ts
+const FIVE_HOURS_SECONDS = 5 * 60 * 60;
+const SEVEN_DAYS_SECONDS = 7 * 24 * 60 * 60;
+
+function codexWindowIdentity(
+  window: CodexUsageWindow,
+  fallback: { key: string; label: string },
+): { key: string; label: string } {
+  if (window.limit_window_seconds === FIVE_HOURS_SECONDS) return { key: QUOTA_FIVE_HOUR, label: "5h" };
+  if (window.limit_window_seconds === SEVEN_DAYS_SECONDS) return { key: QUOTA_SEVEN_DAY, label: "7d" };
+  return fallback;
+}
+```
+
+Update `codexQuotasFromResponse(...)` so primary and secondary each call the helper before `quotaFromUsedPercent(...)`:
+
+```ts
+if (primary) {
+  const identity = codexWindowIdentity(primary, { key: QUOTA_FIVE_HOUR, label: "5h" });
+  quotas.push(quotaFromUsedPercent(identity.key, identity.label, codexWindowUsedPercent(primary), codexWindowResetAt(primary, now), now));
+}
+if (secondary) {
+  const identity = codexWindowIdentity(secondary, { key: QUOTA_SEVEN_DAY, label: "7d" });
+  quotas.push(quotaFromUsedPercent(identity.key, identity.label, codexWindowUsedPercent(secondary), codexWindowResetAt(secondary, now), now));
+}
+```
+
+- [ ] **Step 4: Verify GREEN and compatibility**
+
+Run: `npm test -- --run src/core/quota.test.ts`
+
+Expected: all quota tests pass, including the new seven-day primary regression and the legacy two-window tests.
+
+Run: `npm run typecheck`
+
+Expected: exit code 0 with no TypeScript errors.
+
+Run: `npm test -- --run`
+
+Expected: all repository tests pass. If the sandbox reports `listen EPERM 127.0.0.1`, rerun the same command with host permissions before classifying it as a regression.
+
+- [ ] **Step 5: Commit the fix**
+
+```bash
+git add src/core/quota.ts src/core/quota.test.ts docs/superpowers/plans/2026-07-13-codex-quota-window-label.md
+git commit -m "fix: detect Codex quota window duration"
+```

--- a/docs/superpowers/plans/2026-07-13-codex-quota-window-label.md
+++ b/docs/superpowers/plans/2026-07-13-codex-quota-window-label.md
@@ -27,7 +27,7 @@
 - Consumes: `CodexUsageWindow.limit_window_seconds?: number` and the existing `quotaFromUsedPercent(...)` normalizer.
 - Produces: duration-aware `UsageQuota` entries from `codexQuotasFromResponse(response, now)`; no public API changes.
 
-- [ ] **Step 1: Write the failing regression test**
+- [x] **Step 1: Write the failing regression test**
 
 Add a test after the existing Codex normalization test:
 
@@ -64,13 +64,13 @@ it("labels a seven-day Codex primary window from its duration", async () => {
 });
 ```
 
-- [ ] **Step 2: Run the regression test and verify RED**
+- [x] **Step 2: Run the regression test and verify RED**
 
 Run: `npm test -- --run src/core/quota.test.ts -t "labels a seven-day Codex primary window from its duration"`
 
 Expected: FAIL because the actual quota still has `key: "five_hour"` and `label: "5h"`.
 
-- [ ] **Step 3: Implement the minimal duration-aware mapping**
+- [x] **Step 3: Implement the minimal duration-aware mapping**
 
 Add duration constants and a helper near the existing Codex quota constants/functions:
 
@@ -101,7 +101,7 @@ if (secondary) {
 }
 ```
 
-- [ ] **Step 4: Verify GREEN and compatibility**
+- [x] **Step 4: Verify GREEN and compatibility**
 
 Run: `npm test -- --run src/core/quota.test.ts`
 

--- a/docs/superpowers/specs/2026-07-13-codex-quota-window-label-design.md
+++ b/docs/superpowers/specs/2026-07-13-codex-quota-window-label-design.md
@@ -1,0 +1,33 @@
+# Codex 额度周期识别修复设计
+
+## 背景
+
+Codex 当前额度接口只返回 `rate_limit.primary_window`，其中 `limit_window_seconds` 为 `604800`（7 天），`secondary_window` 为 `null`。现有解析逻辑把 `primary_window` 固定标记为 `5h`，导致界面把实际 7 天额度错误显示成 5 小时额度。
+
+## 目标
+
+- 根据接口返回的 `limit_window_seconds` 识别额度周期。
+- `18000` 秒显示为 `5h`，`604800` 秒显示为 `7d`。
+- 兼容旧版同时返回 primary 5h、secondary 7d 的响应。
+- 不改动额度请求、认证、缓存和 UI 渲染链路。
+
+## 设计
+
+在 `src/core/quota.ts` 的 Codex 响应解析层增加窗口周期识别：
+
+1. 优先根据 `limit_window_seconds` 选择稳定的额度 key 和 label。
+2. 时长为 5 小时或 7 天时分别映射到现有 `five_hour` / `seven_day` 数据模型。
+3. 接口未提供窗口时长时，保留现有位置兜底：primary 为 5h，secondary 为 7d，以兼容历史响应。
+4. 不影响 `code_review_rate_limit`，其标签仍为 `Review`。
+
+## 测试
+
+- 新增回归测试：只有 primary 窗口且 `limit_window_seconds = 604800` 时，只输出 `7d`。
+- 保留并运行旧双窗口测试，验证 primary 5h、secondary 7d 的兼容行为。
+- 运行额度模块测试、类型检查和完整测试套件。
+
+## 非目标
+
+- 不改变 Codex 官方接口地址或请求方式。
+- 不修改 Claude Code 的 5h / 7d 额度解析。
+- 不增加新的设置项或 UI 控件。

--- a/src/core/quota.test.ts
+++ b/src/core/quota.test.ts
@@ -59,6 +59,37 @@ describe("usage quota loader", () => {
     }
   });
 
+  it("labels a seven-day Codex primary window from its duration", async () => {
+    const homeDir = makeHome();
+    try {
+      writeJson(path.join(homeDir, ".codex", "auth.json"), {
+        tokens: { access_token: "codex-access", account_id: "account-1" },
+      });
+
+      const card = await loadCodexQuotaCard({
+        now: NOW,
+        homeDir,
+        env: {},
+        codexFetcher: async () => ({
+          rate_limit: {
+            primary_window: {
+              used_percent: 20,
+              limit_window_seconds: 604800,
+              reset_at: 1_807_000_000,
+            },
+            secondary_window: null,
+          },
+        }),
+      });
+
+      expect(card.quotas).toEqual([
+        expect.objectContaining({ key: "seven_day", label: "7d", usedPercent: 20, remainingPercent: 80 }),
+      ]);
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
   it("parses Codex quota from percent_left when used_percent is absent", async () => {
     const homeDir = makeHome();
     try {

--- a/src/core/quota.ts
+++ b/src/core/quota.ts
@@ -16,6 +16,8 @@ const HTTP_BODY_LIMIT = 64 * 1024;
 const QUOTA_FIVE_HOUR = "five_hour";
 const QUOTA_SEVEN_DAY = "seven_day";
 const QUOTA_CODE_REVIEW = "code_review";
+const FIVE_HOURS_SECONDS = 5 * 60 * 60;
+const SEVEN_DAYS_SECONDS = 7 * 24 * 60 * 60;
 const CLAUDE_STATUSLINE_SCRIPT_BASENAME = "claude-statusline-snapshot.cjs";
 const CLAUDE_STATUSLINE_BIN_NAME = "agent-session-search-claude-statusline";
 
@@ -378,13 +380,28 @@ function codexWindowResetAt(window: CodexUsageWindow, now: Date): number | undef
   return undefined;
 }
 
+function codexWindowIdentity(
+  window: CodexUsageWindow,
+  fallback: { key: string; label: string },
+): { key: string; label: string } {
+  if (window.limit_window_seconds === FIVE_HOURS_SECONDS) return { key: QUOTA_FIVE_HOUR, label: "5h" };
+  if (window.limit_window_seconds === SEVEN_DAYS_SECONDS) return { key: QUOTA_SEVEN_DAY, label: "7d" };
+  return fallback;
+}
+
 function codexQuotasFromResponse(response: CodexUsageResponse, now: Date): UsageQuota[] {
   const quotas: UsageQuota[] = [];
   const primary = response.rate_limit?.primary_window ?? null;
   const secondary = response.rate_limit?.secondary_window ?? null;
   const codeReview = response.code_review_rate_limit?.primary_window ?? null;
-  if (primary) quotas.push(quotaFromUsedPercent(QUOTA_FIVE_HOUR, "5h", codexWindowUsedPercent(primary), codexWindowResetAt(primary, now), now));
-  if (secondary) quotas.push(quotaFromUsedPercent(QUOTA_SEVEN_DAY, "7d", codexWindowUsedPercent(secondary), codexWindowResetAt(secondary, now), now));
+  if (primary) {
+    const identity = codexWindowIdentity(primary, { key: QUOTA_FIVE_HOUR, label: "5h" });
+    quotas.push(quotaFromUsedPercent(identity.key, identity.label, codexWindowUsedPercent(primary), codexWindowResetAt(primary, now), now));
+  }
+  if (secondary) {
+    const identity = codexWindowIdentity(secondary, { key: QUOTA_SEVEN_DAY, label: "7d" });
+    quotas.push(quotaFromUsedPercent(identity.key, identity.label, codexWindowUsedPercent(secondary), codexWindowResetAt(secondary, now), now));
+  }
   if (codeReview) quotas.push(quotaFromUsedPercent(QUOTA_CODE_REVIEW, "Review", codexWindowUsedPercent(codeReview), codexWindowResetAt(codeReview, now), now));
   return quotas.filter(Boolean);
 }


### PR DESCRIPTION
## 变更内容

- 根据 Codex 额度窗口的 `limit_window_seconds` 识别 5h 和 7d 周期
- 保留缺少或未知窗口时长时的旧 primary / secondary 位置兜底
- 新增当前“仅返回 7d primary window”响应格式的回归测试

## 修复原因

Codex 当前额度接口只返回 `primary_window`，窗口时长为 `604800` 秒（7 天），`secondary_window` 为 `null`。原解析逻辑将 primary 固定标记为 5h，导致界面把真实 7d 额度错误显示为 5h。

## 影响

- 当前 Codex 7 天额度会正确显示为 `7d`
- 旧版 5h + 7d 双窗口响应继续兼容
- 不改变请求、认证、Claude Code 额度、Review 额度或 UI 渲染逻辑

## 验证

- 回归测试在修复前稳定复现 `five_hour / 5h` 错标
- 修复后真实接口脱敏验证输出 `seven_day / 7d`
- `npm test -- --run`：72 个测试文件、795 个测试通过
- `npm run typecheck`：通过
