### PR TITLE
fix: 修复搜索历史点击不触发搜索 & 新增详情面板 Ctrl+F 会话内搜索

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -368,6 +368,8 @@ const SearchBox = forwardRef<
 
   function selectRecentSearch(query: string): void {
     setValue(query);
+    onSearch(query);
+    setHistory((current) => recordSearch(window.localStorage, current, query));
     setFocused(false);
   }
 

--- a/src/renderer/src/app-loading.test.ts
+++ b/src/renderer/src/app-loading.test.ts
@@ -28,12 +28,12 @@ describe("app loading performance", () => {
     expect(handleChange).toContain("setFocused(next.length > 0)");
   });
 
-  it("fills recent searches without running them until Enter", () => {
+  it("runs recent searches immediately on click", () => {
     const searchBox = sourceBlock("const SearchBox = forwardRef", ["export function App"]);
     const selectRecent = searchBox.slice(searchBox.indexOf("function selectRecentSearch"), searchBox.indexOf("function runSearch"));
     expect(selectRecent).toContain("setValue(query)");
-    expect(selectRecent).not.toContain("onSearch");
-    expect(selectRecent).not.toContain("recordSearch");
+    expect(selectRecent).toContain("onSearch(query)");
+    expect(selectRecent).toContain("recordSearch(window.localStorage, current, query)");
   });
 
   it("does not focus the main search input on startup", () => {

--- a/src/renderer/src/components/detail-panel.tsx
+++ b/src/renderer/src/components/detail-panel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { ReactElement } from "react";
-import { ArrowRightLeft, ChevronDown, ChevronUp, CloudUpload, Copy, Download, Edit3, FolderOpen, Laptop, Play, Server, Sparkles, Star, Tag, Terminal as TerminalIcon, Trash2, X } from "lucide-react";
+import { ArrowRightLeft, ChevronDown, ChevronUp, CloudUpload, Copy, Download, Edit3, FolderOpen, Laptop, Play, Search, Server, Sparkles, Star, Tag, Terminal as TerminalIcon, Trash2, X } from "lucide-react";
 import { formatMessageTime } from "../../../core/format-session";
 import type { SessionMessage, SessionSearchResult, SessionTraceEvent } from "../../../core/types";
 import { formatTokenCount } from "../format-count";
@@ -202,6 +202,78 @@ export function DetailPanel({
     });
   };
 
+  const [panelSearchOpen, setPanelSearchOpen] = useState(false);
+  const [panelSearchQuery, setPanelSearchQuery] = useState("");
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
+  const panelSearchInputRef = useRef<HTMLInputElement>(null);
+
+  const panelSearchTerms = useMemo(
+    () => (panelSearchQuery ? searchHighlightTerms(panelSearchQuery) : []),
+    [panelSearchQuery],
+  );
+
+  const panelSearchMatchIndices = useMemo(() => {
+    if (panelSearchTerms.length === 0) return [] as number[];
+    const indices: number[] = [];
+    for (const item of timelineItems) {
+      if (item.kind === "message") {
+        const lower = item.message.content.toLocaleLowerCase();
+        if (panelSearchTerms.some((term) => lower.includes(term))) {
+          indices.push(item.message.index);
+        }
+      }
+    }
+    return indices;
+  }, [timelineItems, panelSearchTerms]);
+
+  useEffect(() => {
+    if (panelSearchOpen && panelSearchInputRef.current) {
+      panelSearchInputRef.current.focus();
+      panelSearchInputRef.current.select();
+    }
+  }, [panelSearchOpen]);
+
+  useEffect(() => {
+    if (panelSearchMatchIndices.length === 0) {
+      setCurrentMatchIndex(0);
+      return;
+    }
+    if (currentMatchIndex >= panelSearchMatchIndices.length) {
+      setCurrentMatchIndex(0);
+    }
+  }, [panelSearchMatchIndices, currentMatchIndex]);
+
+  const scrollToPanelMatch = (index: number) => {
+    const el = bodyRef.current;
+    if (!el) return;
+    const messageIndex = panelSearchMatchIndices[index];
+    if (messageIndex === undefined) return;
+    const target = el.querySelector(`[data-message-index="${messageIndex}"]`) as HTMLElement | null;
+    if (target) {
+      target.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  };
+
+  const nextPanelMatch = () => {
+    if (panelSearchMatchIndices.length === 0) return;
+    const next = (currentMatchIndex + 1) % panelSearchMatchIndices.length;
+    setCurrentMatchIndex(next);
+    scrollToPanelMatch(next);
+  };
+
+  const prevPanelMatch = () => {
+    if (panelSearchMatchIndices.length === 0) return;
+    const prev = (currentMatchIndex - 1 + panelSearchMatchIndices.length) % panelSearchMatchIndices.length;
+    setCurrentMatchIndex(prev);
+    scrollToPanelMatch(prev);
+  };
+
+  const closePanelSearch = () => {
+    setPanelSearchOpen(false);
+    setPanelSearchQuery("");
+    setCurrentMatchIndex(0);
+  };
+
   useEffect(() => {
     pendingInitialScrollRef.current = session.sessionKey;
     setRoleFilter("all");
@@ -222,9 +294,23 @@ export function DetailPanel({
       if (!el) return;
       const target = event.target as HTMLElement | null;
       const tag = target?.tagName;
+
+      // Ctrl+F / Cmd+F: open panel search
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "f") {
+        event.preventDefault();
+        setPanelSearchOpen(true);
+        return;
+      }
+
       if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
       const page = el.clientHeight * 0.9;
       switch (event.key) {
+        case "Escape":
+          if (panelSearchOpen) {
+            closePanelSearch();
+            event.preventDefault();
+          }
+          return;
         case "ArrowDown":
           el.scrollBy({ top: 64 });
           break;
@@ -251,7 +337,7 @@ export function DetailPanel({
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, []);
+  }, [panelSearchOpen, panelSearchMatchIndices]);
 
   return (
     <div className="detail-backdrop" onClick={onClose}>
@@ -405,6 +491,62 @@ export function DetailPanel({
                 </button>
               </div>
             </div>
+            {panelSearchOpen ? (
+              <div className="panel-search-bar">
+                <Search size={14} />
+                <input
+                  ref={panelSearchInputRef}
+                  className="panel-search-input"
+                  type="text"
+                  value={panelSearchQuery}
+                  onChange={(event) => {
+                    setPanelSearchQuery(event.target.value);
+                    setCurrentMatchIndex(0);
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Escape") {
+                      closePanelSearch();
+                      event.stopPropagation();
+                    } else if (event.key === "Enter") {
+                      event.preventDefault();
+                      if (event.shiftKey) prevPanelMatch();
+                      else nextPanelMatch();
+                    }
+                  }}
+                  placeholder={l("Find in conversation…", "在会话中查找…")}
+                />
+                {panelSearchQuery ? (
+                  <span className="panel-search-count">
+                    {panelSearchMatchIndices.length > 0
+                      ? `${currentMatchIndex + 1}/${panelSearchMatchIndices.length}`
+                      : l("No matches", "无匹配")}
+                  </span>
+                ) : null}
+                <button
+                  className="panel-search-nav"
+                  onClick={prevPanelMatch}
+                  disabled={panelSearchMatchIndices.length === 0}
+                  title={l("Previous match (Shift+Enter)", "上一个匹配 (Shift+Enter)")}
+                >
+                  <ChevronUp size={14} />
+                </button>
+                <button
+                  className="panel-search-nav"
+                  onClick={nextPanelMatch}
+                  disabled={panelSearchMatchIndices.length === 0}
+                  title={l("Next match (Enter)", "下一个匹配 (Enter)")}
+                >
+                  <ChevronDown size={14} />
+                </button>
+                <button
+                  className="panel-search-close"
+                  onClick={closePanelSearch}
+                  title={l("Close (Esc)", "关闭 (Esc)")}
+                >
+                  <X size={14} />
+                </button>
+              </div>
+            ) : null}
             {loading ? <div className="loading-state">{l("Loading conversation...", "正在加载会话...")}</div> : null}
             {!loading && messages.length === 0 ? <div className="loading-state">{l("No visible messages indexed for this session.", "这个会话没有可见消息被索引。")}</div> : null}
             {!loading && olderMessageCount > 0 ? (
@@ -417,7 +559,13 @@ export function DetailPanel({
             ) : null}
             {visibleTimelineItems.map((item) => (
               item.kind === "message" ? (
-                <MessageBlock key={item.key} message={item.message} query={query} language={language} />
+                <MessageBlock
+                  key={item.key}
+                  message={item.message}
+                  query={panelSearchQuery || query}
+                  language={language}
+                  highlight={panelSearchQuery ? panelSearchMatchIndices.includes(item.message.index) : false}
+                />
               ) : (
                 <TraceEventBlock key={item.key} event={item.event} language={language} />
               )

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -4904,3 +4904,76 @@ body.overlay-open .sidebar {
     flex-wrap: wrap;
   }
 }
+
+/* ── Panel search bar (Ctrl+F in-conversation search) ── */
+
+.panel-search-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  margin: 0 0 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--panel-subtle);
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.panel-search-input {
+  flex: 1;
+  min-width: 0;
+  height: 26px;
+  padding: 0 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--panel-bg);
+  color: var(--text);
+  font-size: 12px;
+  outline: none;
+  transition: border-color 0.12s ease;
+}
+
+.panel-search-input:focus {
+  border-color: var(--accent-line);
+}
+
+.panel-search-input::placeholder {
+  color: var(--text-muted);
+  opacity: 0.6;
+}
+
+.panel-search-count {
+  white-space: nowrap;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  min-width: 40px;
+  text-align: center;
+}
+
+.panel-search-nav,
+.panel-search-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.panel-search-nav:hover:not(:disabled),
+.panel-search-close:hover {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.panel-search-nav:disabled {
+  opacity: 0.35;
+  cursor: default;
+}


### PR DESCRIPTION
## 问题描述

**问题 1：搜索历史点击不触发搜索**
日常使用中会频繁点击搜索历史记录来快速切换查询，但发现点击历史记录项后，搜索框虽然填入了对应关键词，结果列表并没有更新，还需要手动按回车才能看到结果。

**问题 2：详情面板无法在会话内容中定位关键词**
打开一个长会话后，没有任何方式在对话内容中定位关键词。我个人工作时习惯了 Cmd+F 快速检索关键词，于是加一个快速检索的功能，增强体验。

## 改动内容

### 1. 修复搜索历史点击不触发搜索
- `src/renderer/src/App.tsx`：`selectRecentSearch` 增加 `onSearch(query)` 立即执行搜索，增加 `recordSearch` 更新历史排序
- `src/renderer/src/app-loading.test.ts`：更新测试断言以匹配新行为

### 2. 详情面板 Ctrl+F 会话内搜索
- `src/renderer/src/components/detail-panel.tsx`：
  - 新增 `Ctrl+F` / `Cmd+F` 快捷键拦截，打开面板内搜索栏
  - 搜索栏 UI：搜索输入框、匹配计数（如 3/15）、上/下导航按钮、关闭按钮
  - 复用已有 `searchHighlightTerms` 和 `HighlightedSearchText` 组件高亮匹配消息
  - 匹配导航通过 `querySelector` + `scrollIntoView` 实现
  - `Enter` 跳转下一个匹配，`Shift+Enter` 跳转上一个，`Esc` 关闭搜索
- `src/renderer/src/styles.css`：新增 `.panel-search-bar` 等样式，与现有 UI 风格一致
