### PR TITLE
fix: 修复 Codex 迁移会话恢复失败

### DIFF
--- a/.release-notes/fix-codex-migration-model-provider.md
+++ b/.release-notes/fix-codex-migration-model-provider.md
@@ -1,0 +1,5 @@
+# Codex 迁移会话可正常恢复
+
+## Bug 修复
+
+- 修复会话迁移到 Codex、TCodex 或 Codex Internal 后，恢复时可能因缺少模型服务配置而失败的问题。

--- a/src/core/session-migration-writers.test.ts
+++ b/src/core/session-migration-writers.test.ts
@@ -233,6 +233,7 @@ describe("writeMigratedSession", () => {
         title: portable().title,
         originator: "agent-session-search",
         cli_version: "migration",
+        model_provider: "openai",
       },
     });
     expect(rows.slice(1).map((row) => row.payload.content[0].type)).toEqual([
@@ -243,6 +244,28 @@ describe("writeMigratedSession", () => {
     expectRoundTrip("codex", "codex-cli", result.sessionId, result.filePath, rows);
 
     fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it.each([
+    ["codex", "openai"],
+    ["tcodex", "tencent"],
+    ["codex-internal", "codebuddy"],
+  ] as const)("writes the resumable $target model provider", async (target, modelProvider) => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), `migration-writer-provider-${target}-`));
+    try {
+      const result = await writeMigratedSession({
+        target,
+        session: portable(),
+        homeDir,
+        now: NOW,
+        idFactory: idFactory([SESSION_ID]),
+      });
+
+      const rows = readRows(result.filePath);
+      expect(rows[0]?.payload?.model_provider).toBe(modelProvider);
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    }
   });
 
   it("writes native Claude rows with a unique UUID parent chain and embedded title", async () => {

--- a/src/core/session-migration-writers.ts
+++ b/src/core/session-migration-writers.ts
@@ -74,12 +74,12 @@ function serializeSession(
 ): unknown[] {
   if (target === "cursor") return serializeCursor(session);
   const family = migrationTargetDescriptor(target).family;
-  if (family === "codex") return serializeCodex(session, sessionId);
+  if (family === "codex") return serializeCodex(session, sessionId, codexModelProvider(target));
   if (family === "claude") return serializeClaude(session, sessionId, createId);
   return serializeCodeBuddy(session, sessionId, createId);
 }
 
-function serializeCodex(session: PortableSession, sessionId: string): unknown[] {
+function serializeCodex(session: PortableSession, sessionId: string, modelProvider: string): unknown[] {
   return [
     {
       type: "session_meta",
@@ -91,6 +91,7 @@ function serializeCodex(session: PortableSession, sessionId: string): unknown[] 
         title: session.title,
         originator: "agent-session-search",
         cli_version: "migration",
+        model_provider: modelProvider,
       },
     },
     ...session.messages.map((message) => ({
@@ -106,6 +107,12 @@ function serializeCodex(session: PortableSession, sessionId: string): unknown[] 
       },
     })),
   ];
+}
+
+function codexModelProvider(target: MigrationTarget): string {
+  if (target === "tcodex") return "tencent";
+  if (target === "codex-internal") return "codebuddy";
+  return "openai";
 }
 
 function serializeClaude(


### PR DESCRIPTION
## 修改内容

- 为迁移到 Codex、TCodex 和 Codex Internal 的会话写入目标原生的 `model_provider`
- 分别使用 `openai`、`tencent` 和 `codebuddy`
- 增加三类目标的回归测试和用户可见 Bug 修复说明

## 根因

迁移生成的 `session_meta.payload` 缺少 `model_provider`。新版 Codex 在 `thread/resume` 时恢复会话持久化的 provider，缺失值被解析为空 provider，导致恢复阶段报错。

## 影响

新生成的 Codex-family 迁移会话可按目标 CLI 的原生 provider 正常恢复。已有缺字段的迁移文件需要重新迁移。

## 验证

- `npm test`：832 个 Vitest、35 个脚本测试通过
- `npm run typecheck`
- `npm run build`
- `npm run release-note:check`
- `git diff --check`
- 使用修复分支生成真实 Codex JSONL，并在隔离 `CODEX_HOME` 下执行 `codex resume`；会话成功通过 `thread/resume` 配置加载并进入登录界面，不再出现空 `model_provider` 错误
