### PR TITLE
fix: 压缩远端 collector 脚本以适配 Windows 命令行长度上限

### DIFF
--- a/.release-notes/fix-windows-remote-sync.md
+++ b/.release-notes/fix-windows-remote-sync.md
@@ -1,0 +1,5 @@
+# 修复 Windows 上 SSH 会话拉取为空
+
+## Bug 修复
+
+- 修复 Windows 上启用 TClaude / TCodex / CodeBuddy CLI 会话来源后，SSH 环境刷新看似完成、但一条远端会话都拉不到的问题。

--- a/src/core/remote-health.ts
+++ b/src/core/remote-health.ts
@@ -207,8 +207,10 @@ print(json.dumps({
 }
 
 function buildPythonBase64Command(script: string): string {
-  const encoded = Buffer.from(script, "utf-8").toString("base64");
-  const pythonCommand = `python3 -c 'import base64; exec(base64.b64decode("${encoded}").decode("utf-8"))'`;
+  const zlib = require("node:zlib") as typeof import("node:zlib");
+  const compressed = zlib.deflateRawSync(Buffer.from(script, "utf-8"));
+  const encoded = compressed.toString("base64");
+  const pythonCommand = `python3 -c 'import base64,zlib; exec(zlib.decompress(base64.b64decode("${encoded}"), -15).decode("utf-8"))'`;
   return `bash -lc ${posixShellQuote(pythonCommand)}`;
 }
 

--- a/src/core/remote-sync.ts
+++ b/src/core/remote-sync.ts
@@ -1321,6 +1321,8 @@ function buildRemoteCollectorCommand(enabledOptionalSources: SessionSource[]): s
 }
 
 function buildPythonBase64Command(script: string): string {
-  const encoded = Buffer.from(script, "utf-8").toString("base64");
-  return `python3 -c 'import base64; exec(base64.b64decode("${encoded}").decode("utf-8"))'`;
+  const zlib = require("node:zlib") as typeof import("node:zlib");
+  const compressed = zlib.deflateRawSync(Buffer.from(script, "utf-8"));
+  const encoded = compressed.toString("base64");
+  return `python3 -c 'import base64,zlib; exec(zlib.decompress(base64.b64decode("${encoded}"), -15).decode("utf-8"))'`;
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1562,8 +1562,10 @@ function runSshWithInput(environment: SessionEnvironment, remoteCommand: string,
 }
 
 function buildPythonBase64Command(script: string): string {
-  const encoded = Buffer.from(script, "utf-8").toString("base64");
-  return `python3 -c 'import base64; exec(base64.b64decode("${encoded}").decode("utf-8"))'`;
+  const zlib = require("node:zlib") as typeof import("node:zlib");
+  const compressed = zlib.deflateRawSync(Buffer.from(script, "utf-8"));
+  const encoded = compressed.toString("base64");
+  return `python3 -c 'import base64,zlib; exec(zlib.decompress(base64.b64decode("${encoded}"), -15).decode("utf-8"))'`;
 }
 
 const REMOTE_WRITE_FILE_SCRIPT = [


### PR DESCRIPTION
## 变更概述

修复 Windows 上启用 `Include ~/.tclaude` / `Include ~/.tcodex` / `CodeBuddy CLI` 后，SSH 环境拉不到任何远端会话的问题。

**根因**：`buildPythonBase64Command` 把 base64 编码后的 collector Python 脚本作为**单个命令行参数**送给 `ssh`。启用可选源时会向脚本注入更多 descriptor 与 index loader，编码后突破 Windows CreateProcess 的 32,768 字符命令行硬上限，`execFile("ssh", ...)` 直接以 `spawn ENAMETOOLONG` 秒退。错误在 `runSync` 里被 catch 后写入 `sync_state=error`，但随后 watcher 触发的下一次同步会覆盖状态回 `watching`、清空 `last_error`,UI 因此看不到任何错误痕迹——表现为「刷新完成、无报错、SSH 环境一条可选源会话都没拉到」。macOS / Linux 的 `ARG_MAX` 在 MB 级别所以未暴露此问题。

**修复**:三处 `buildPythonBase64Command`(`src/core/remote-sync.ts`、`src/core/remote-health.ts`、`src/main/index.ts`) 都改成先 `zlib.deflateRawSync` 压缩再 base64;远端 Python 用 `zlib.decompress(..., -15)`(`wbits=-15` 匹配 raw deflate) 解回再 `exec`。脚本压缩率 ~30%,稳稳压过 32K 限制。`zlib` 是 Python 标准库,远端不需要额外装依赖。

## 更新说明检查

- [x] 本分支已新增且仅新增一个 `.release-notes/fix-windows-remote-sync.md`
- [x] 更新说明包含面向用户的"新增功能"或"Bug 修复"列表
- [x] 更新说明已移除 MR、分支、CI、发布流程、内部服务、路径及其他不应暴露的实现或敏感信息
- [x] 已运行 `npm run release-note:check`(输出 `0 feature(s), 1 fix(es)`)

## 验证

在 Windows 11 + 远端 Linux 上人肉验证:

**修复前**(三个 `include*` 全开、点刷新):

```
sessions by (source, environment_id):
  claude-cli / SSH env : 1
  tclaude-cli / local  : 66      (本机自己的 .tclaude 数据)
  claude-internal/local: 4
```

给 `syncEnvironment` 临时加日志确认到:

```
env=52 tclaude=true tcodex=true codebuddy=true sources=["tclaude-cli","tcodex-cli","codebuddy-cli"]
env=52 ERR spawn ENAMETOOLONG
```

**修复后**(同样开关、同样操作、同样远端):

```
sessions by (source, environment_id):
  tclaude-cli   / SSH env : 96     ← 新增
  codebuddy-cli / SSH env : 16     ← 新增
  claude-cli    / SSH env : 1
  tclaude-cli   / local   : 66
  claude-internal/local   : 4
```

与远端 `find ~/.tclaude/projects ~/.codebuddy/projects ~/.claude/projects -name '*.jsonl' | wc -l` 输出完全一致(96 + 16 + 1 = 113)。同步耗时约 3 秒。

**其他检查**:

- [x] `npm run build`(prepare 阶段包括 typecheck) 通过
- [x] `npm run release-note:check` 通过
- [ ] macOS 上跑一次同步确认无回归(手上无 macOS 环境,请审阅者代跑)
