### PR TITLE
feat: add Qoder skills to skill manager and sync

### DIFF
--- a/.release-notes/qoder-skill-sync.md
+++ b/.release-notes/qoder-skill-sync.md
@@ -1,0 +1,5 @@
+# Qoder Skills 接入跨设备同步
+
+## 新增功能
+
+- Qoder 的 Skills 目录（`~/.qoder/skills/` 和项目级 `.qoder/skills/`）接入现有 Skill 管理和同步体系，支持在设置中查看、上传、下载和跨设备安装 Qoder Skills

--- a/src/core/skill-manager.test.ts
+++ b/src/core/skill-manager.test.ts
@@ -452,4 +452,59 @@ describe("skill manager", () => {
     };
     expect(() => installRemoteSkillLocally(base, { homeDir: os.tmpdir() })).toThrow(/project|plugin/i);
   });
+
+  it("lists Qoder user and project skills alongside Codex and Claude", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-skills-qoder-"));
+    const projectDir = path.join(homeDir, "project");
+    const codexHome = path.join(homeDir, ".codex");
+    writeSkill(
+      path.join(homeDir, ".qoder", "skills"),
+      "qoder-helper",
+      ["---", "name: qoder-helper", "description: Qoder user skill", "---", "", "# Qoder Help"].join("\n"),
+    );
+    writeSkill(
+      path.join(projectDir, ".qoder", "skills"),
+      "qoder-project-guide",
+      ["---", "name: qoder-project-guide", "description: Qoder project conventions", "---", "", "# Qoder Project"].join("\n"),
+    );
+    writeSkill(
+      path.join(homeDir, ".claude", "skills"),
+      "claude-helper",
+      ["---", "name: claude-helper", "description: Claude user skill", "---", "", "# Claude Help"].join("\n"),
+    );
+
+    const snapshot = listInstalledSkills({ homeDir, codexHome, projectDirs: [projectDir] });
+
+    expect(snapshot.skills.map((skill) => ({ name: skill.name, agent: skill.agent, source: skill.source }))).toEqual([
+      { name: "claude-helper", agent: "claude", source: "claude-user" },
+      { name: "qoder-helper", agent: "qoder", source: "qoder-user" },
+      { name: "qoder-project-guide", agent: "qoder", source: "qoder-project" },
+    ]);
+    expect(snapshot.roots).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: "qoder-user", exists: true, skillCount: 1 }),
+        expect.objectContaining({ source: "qoder-project", exists: true, skillCount: 1 }),
+      ]),
+    );
+
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("maps Qoder user skills to a portable scope and installs them to ~/.qoder/skills", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-skills-qoder-install-"));
+    const remoteSkill: RemoteSkill = {
+      id: "remote-qoder", name: "qoder-skill", description: "A Qoder skill", agent: "qoder", source: "qoder-user",
+      markdown: "# Qoder Skill", localFingerprint: "qoder-user/my-skill", contentHash: "hash",
+      uploadedFromPath: "", portableScope: "qoder-user", relativePath: "my-skill",
+      createdAt: "x", updatedAt: "x", version: 1, metadata: {},
+    };
+
+    const result = installRemoteSkillLocally(remoteSkill, { homeDir, codexHome: path.join(homeDir, ".codex") });
+
+    expect(result.installedPath).toBe(path.join(homeDir, ".qoder", "skills", "my-skill", "SKILL.md"));
+    expect(fs.existsSync(result.installedPath)).toBe(true);
+    expect(fs.readFileSync(result.installedPath, "utf8")).toBe("# Qoder Skill");
+
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
 });

--- a/src/core/skill-manager.ts
+++ b/src/core/skill-manager.ts
@@ -4,8 +4,8 @@ import * as path from "node:path";
 import { randomUUID } from "node:crypto";
 import { skillSyncFilesFromMetadata, type RemoteSkill, type SkillSyncFile } from "./skill-sync";
 
-export type SkillAgent = "codex" | "claude";
-export type SkillPortableScope = "codex-user" | "claude-user" | "shared";
+export type SkillAgent = "codex" | "claude" | "qoder";
+export type SkillPortableScope = "codex-user" | "claude-user" | "qoder-user" | "shared";
 export type SkillSource =
   | "codex-user"
   | "codex-system"
@@ -13,7 +13,9 @@ export type SkillSource =
   | "codex-project"
   | "claude-user"
   | "claude-project"
-  | "claude-plugin";
+  | "claude-plugin"
+  | "qoder-user"
+  | "qoder-project";
 
 export interface InstalledSkill {
   id: string;
@@ -103,6 +105,7 @@ export function listInstalledSkills(options: SkillManagerOptions = {}): Installe
     { agent: "codex", source: "codex-system", path: path.join(codexHome, "skills", ".system") },
     { agent: "codex", source: "codex-shared", path: path.join(homeDir, ".agents", "skills") },
     { agent: "claude", source: "claude-user", path: path.join(homeDir, ".claude", "skills") },
+    { agent: "qoder", source: "qoder-user", path: path.join(homeDir, ".qoder", "skills") },
     ...projectDirs.map((projectDir): SkillRootConfig => ({
       agent: "codex",
       source: "codex-project",
@@ -112,6 +115,11 @@ export function listInstalledSkills(options: SkillManagerOptions = {}): Installe
       agent: "claude",
       source: "claude-project",
       path: path.join(projectDir, ".claude", "skills"),
+    })),
+    ...projectDirs.map((projectDir): SkillRootConfig => ({
+      agent: "qoder",
+      source: "qoder-project",
+      path: path.join(projectDir, ".qoder", "skills"),
     })),
   ];
 
@@ -154,6 +162,7 @@ export function listInstalledSkills(options: SkillManagerOptions = {}): Installe
 export function portableScopeForSkillSource(source: SkillSource): SkillPortableScope | null {
   if (source === "codex-user") return "codex-user";
   if (source === "claude-user") return "claude-user";
+  if (source === "qoder-user") return "qoder-user";
   if (source === "codex-shared") return "shared";
   return null;
 }
@@ -187,7 +196,7 @@ function isCandidateProjectDir(projectDir: string, homeDir: string): boolean {
   const normalized = normalizePathKey(projectDir);
   const normalizedHome = normalizePathKey(homeDir);
   if (normalized === normalizedHome) return false;
-  return ![".codex", ".claude", ".agents"].some((dirName) => normalized === path.join(normalizedHome, dirName) || normalized.startsWith(`${path.join(normalizedHome, dirName)}${path.sep}`));
+  return ![".codex", ".claude", ".agents", ".qoder"].some((dirName) => normalized === path.join(normalizedHome, dirName) || normalized.startsWith(`${path.join(normalizedHome, dirName)}${path.sep}`));
 }
 
 export function deleteInstalledSkill(skillPath: string, options: SkillManagerOptions = {}): DeleteInstalledSkillResult {
@@ -256,6 +265,7 @@ function skillRootForPortableScope(
 ): string {
   if (scope === "codex-user") return path.join(options.codexHome, "skills");
   if (scope === "claude-user") return path.join(options.homeDir, ".claude", "skills");
+  if (scope === "qoder-user") return path.join(options.homeDir, ".qoder", "skills");
   return path.join(options.homeDir, ".agents", "skills");
 }
 

--- a/src/core/skill-sync.test.ts
+++ b/src/core/skill-sync.test.ts
@@ -91,6 +91,9 @@ describe("skill sync", () => {
     expect(sql).toContain(`grant select, insert, update, delete on table public.${AGENT_RECALL_SKILLS_TABLE} to anon`);
     expect(sql).toContain("grant select on table storage.buckets to anon");
     expect(sql).not.toContain("service_role");
+    expect(sql).toContain("agent in ('codex', 'claude', 'qoder')");
+    expect(sql).toContain(`drop constraint if exists ${AGENT_RECALL_SKILLS_TABLE}_agent_check`);
+    expect(sql).toContain(`add constraint ${AGENT_RECALL_SKILLS_TABLE}_agent_check`);
   });
 
   it("uses portable scope and relative path so same-name Skills do not collide", () => {

--- a/src/core/skill-sync.ts
+++ b/src/core/skill-sync.ts
@@ -190,7 +190,11 @@ export function buildSkillSyncSetupSql(tableName = AGENT_RECALL_SKILLS_TABLE): s
     "  id uuid primary key default gen_random_uuid(),",
     "  name text not null,",
     "  description text not null default '',",
-    "  agent text not null check (agent in ('codex', 'claude')),",
+    "  agent text not null check (agent in ('codex', 'claude', 'qoder')),",
+    "",
+    "-- Upgrade the agent check constraint for tables created before Qoder was added.",
+    `alter table public.${tableName} drop constraint if exists ${tableName}_agent_check;`,
+    `alter table public.${tableName} add constraint ${tableName}_agent_check check (agent in ('codex', 'claude', 'qoder'));`,
     "  source text not null,",
     "  markdown text not null,",
     "  local_fingerprint text not null,",
@@ -698,7 +702,7 @@ function isVersionRow(value: unknown): value is SupabaseSkillRow {
   return (
     typeof row.id === "string" &&
     typeof row.name === "string" &&
-    (row.agent === "codex" || row.agent === "claude") &&
+    (row.agent === "codex" || row.agent === "claude" || row.agent === "qoder") &&
     typeof row.source === "string" &&
     typeof row.local_fingerprint === "string" &&
     typeof row.created_at === "string" &&
@@ -734,7 +738,7 @@ function versionFromRow(row: SupabaseSkillRow): RemoteSkillVersion {
 }
 
 function parsePortableScope(value: unknown): SkillPortableScope | null {
-  return value === "codex-user" || value === "claude-user" || value === "shared" ? value : null;
+  return value === "codex-user" || value === "claude-user" || value === "qoder-user" || value === "shared" ? value : null;
 }
 
 function legacyRelativePath(uploadedFromPath: string): string {


### PR DESCRIPTION
## 变更概述

之前加的Qoder数据源，但是Qoder 的skills目录完全没被skill-manager扫描到

**同时我发现，我们AgentRecall的设计初衷就是，尽可能屏蔽多平台多设备之间的差异，让用户可以通过管理会话来尽可能无痛切换设备、切换agent平台。
所以我想定义一个新的概念——数字资产：除了会话记录，skill，api provider之外，rules、hooks、memories、甚至一些插件，应该都可以被我们的AgentRecall管理，之后我会陆续理清它们的可行性，并依此给AgentRecall做升级**

1. skill-manager 增加 Qoder 扫描路径：用户级 `~/.qoder/skills/` + 项目级 `.qoder/skills/`，
   类型、portable scope、安装路径全部对齐 Codex/Claude 的模式
2. Supabase skill sync 的 agent 约束从 `('codex','claude')` 扩展到 `('codex','claude','qoder')`，
   加了 DROP CONSTRAINT + ADD CONSTRAINT 升级语句，已有用户的表也能平滑升级
3. isVersionRow 和 parsePortableScope 增加 qoder 校验，不然上传成功但列表里看不到

相关测试已通过
