### PR TITLE
fix: add qoder to SkillUsageAgent type

### DIFF
--- a/.release-notes/fix-qoder-skill-usage-agent.md
+++ b/.release-notes/fix-qoder-skill-usage-agent.md
@@ -1,0 +1,5 @@
+# 修复 Qoder Skills 类型遗漏
+
+## Bug 修复
+
+- 修复 SkillUsageAgent 类型未包含 qoder 导致 CI typecheck 失败的问题

--- a/src/core/skill-usage.ts
+++ b/src/core/skill-usage.ts
@@ -13,7 +13,7 @@ export interface SkillUsageStat {
   lastUsedAt: number;
 }
 
-export type SkillUsageAgent = "codex" | "claude";
+export type SkillUsageAgent = "codex" | "claude" | "qoder";
 export type SkillUsageSourceKind = "claude-hook" | "codex-session";
 
 export interface SkillUsageEvent {


### PR DESCRIPTION
修复 PR #115 遗漏的 SkillUsageAgent 类型扩展，CI typecheck 失败的根因。