### PR TITLE
feat: add rules sync core module with scanner and Supabase client

### DIFF
--- a/.release-notes/rules-sync-core.md
+++ b/.release-notes/rules-sync-core.md
@@ -1,0 +1,6 @@
+# Rules 跨设备同步核心模块
+
+## 新增功能
+
+- 新增 Rules 同步核心模块（rules-sync.ts），支持扫描本地 Claude CLAUDE.md 和 Qoder .qoder/rules/*.md 规则文件，通过 Supabase 上传/下载实现跨设备同步
+- 新增 rulesSyncEnabled 设置项（默认关闭），为后续 Settings UI 和 IPC 集成做准备

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -86,6 +86,7 @@ export interface AppSettings {
   includeCursorAgent: boolean;
   includeTrae: boolean;
   includeQoder: boolean;
+  rulesSyncEnabled: boolean;
   hideCodexQuota: boolean;
   hideClaudeQuota: boolean;
   hideSubagentSessions: boolean;
@@ -143,6 +144,7 @@ export const defaultSettings: AppSettings = {
   includeCursorAgent: false,
   includeTrae: false,
   includeQoder: false,
+  rulesSyncEnabled: false,
   hideCodexQuota: false,
   hideClaudeQuota: false,
   hideSubagentSessions: true,

--- a/src/core/rules-sync.test.ts
+++ b/src/core/rules-sync.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  buildRulesSyncSetupSql,
+  ruleIdentity,
+  scanLocalRules,
+  SupabaseRulesSyncClient,
+  type AgentRule,
+} from "./rules-sync";
+
+describe("rules sync", () => {
+  it("scans Claude global CLAUDE.md and Qoder project rules", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "rules-sync-scan-"));
+    const projectDir = path.join(homeDir, "my-project");
+
+    // Claude global CLAUDE.md
+    fs.mkdirSync(path.join(homeDir, ".claude"), { recursive: true });
+    fs.writeFileSync(path.join(homeDir, ".claude", "CLAUDE.md"), "# Global Rules\nUse Chinese.", "utf8");
+
+    // Project-level CLAUDE.md
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(path.join(projectDir, "CLAUDE.md"), "# Project Rules", "utf8");
+
+    // Qoder project rules
+    const qoderRulesDir = path.join(projectDir, ".qoder", "rules");
+    fs.mkdirSync(qoderRulesDir, { recursive: true });
+    fs.writeFileSync(path.join(qoderRulesDir, "lunzi.md"), "---\ntrigger: always_on\n---\nNo reinventing wheels.", "utf8");
+
+    const rules = scanLocalRules({ homeDir, projectDirs: [projectDir] });
+
+    expect(rules).toHaveLength(3);
+
+    const claudeGlobal = rules.find((r) => r.agent === "claude" && r.scope === "global");
+    expect(claudeGlobal).toMatchObject({ name: "CLAUDE.md", projectPath: "", content: "# Global Rules\nUse Chinese." });
+    expect(claudeGlobal!.contentHash).toHaveLength(64);
+
+    const claudeProject = rules.find((r) => r.agent === "claude" && r.scope === "project");
+    expect(claudeProject).toMatchObject({ name: "CLAUDE.md", projectPath: "my-project" });
+
+    const qoderRule = rules.find((r) => r.agent === "qoder");
+    expect(qoderRule).toMatchObject({ name: "lunzi.md", scope: "project", projectPath: "my-project" });
+    expect(qoderRule!.content).toContain("trigger: always_on");
+
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("skips missing or empty rule files", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "rules-sync-empty-"));
+    const projectDir = path.join(homeDir, "empty-project");
+    fs.mkdirSync(path.join(projectDir, ".qoder", "rules"), { recursive: true });
+    fs.writeFileSync(path.join(projectDir, ".qoder", "rules", "empty.md"), "", "utf8");
+
+    const rules = scanLocalRules({ homeDir, projectDirs: [projectDir] });
+    expect(rules).toHaveLength(0);
+
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("builds rule identity from agent, scope, name, and project path", () => {
+    expect(ruleIdentity({ agent: "claude", scope: "global", name: "CLAUDE.md", projectPath: "" })).toBe("claude:global:CLAUDE.md");
+    expect(ruleIdentity({ agent: "qoder", scope: "project", name: "lunzi.md", projectPath: "my-app" })).toBe("qoder:project:my-app:lunzi.md");
+  });
+
+  it("builds setup SQL with table, unique index, and RLS", () => {
+    const sql = buildRulesSyncSetupSql();
+    expect(sql).toContain("create table if not exists public.agent_recall_rules");
+    expect(sql).toContain("agent in ('claude', 'qoder')");
+    expect(sql).toContain("scope in ('global', 'project')");
+    expect(sql).toContain("agent_recall_rules_identity_idx");
+    expect(sql).toContain("(agent, scope, name, project_path)");
+    expect(sql).toContain("enable row level security");
+    expect(sql).toContain("grant select, insert, update, delete");
+  });
+
+  it("uploads a rule via Supabase REST with upsert", async () => {
+    const calls: Array<{ url: string; method: string; body?: unknown }> = [];
+    const client = new SupabaseRulesSyncClient({
+      url: "https://example.supabase.co",
+      anonKey: "anon",
+      fetchImpl: async (url, init) => {
+        calls.push({ url: String(url), method: init?.method ?? "GET", body: init?.body ? JSON.parse(String(init.body)) : undefined });
+        if (init?.method === "POST") {
+          return new Response(JSON.stringify([{ ...JSON.parse(String(init.body)), id: "remote-1", version: 1, created_at: "x", updated_at: "y" }]), { status: 201 });
+        }
+        return new Response("[]", { status: 200 });
+      },
+    });
+
+    const rule: AgentRule = {
+      agent: "qoder", scope: "project", name: "lunzi.md", content: "rules", contentHash: "abc",
+      projectPath: "my-app", filePath: "/tmp/lunzi.md",
+    };
+    const result = await client.uploadRule(rule);
+
+    expect(result.id).toBe("remote-1");
+    expect(calls[0].url).toContain("on_conflict=agent,scope,name,project_path");
+    expect(calls[0].method).toBe("POST");
+  });
+
+  it("lists remote rules and filters invalid rows", async () => {
+    const client = new SupabaseRulesSyncClient({
+      url: "https://example.supabase.co",
+      anonKey: "anon",
+      fetchImpl: async () =>
+        new Response(
+          JSON.stringify([
+            { id: "r1", agent: "claude", scope: "global", name: "CLAUDE.md", content: "rules", content_hash: "h", project_path: "", version: 1, created_at: "x", updated_at: "y" },
+            { id: "r2", agent: "qoder" }, // invalid — missing fields
+          ]),
+          { status: 200 },
+        ),
+    });
+
+    const rules = await client.listRemoteRules();
+    expect(rules).toHaveLength(1);
+    expect(rules[0].id).toBe("r1");
+  });
+
+  it("checks status and reports missing table", async () => {
+    const client = new SupabaseRulesSyncClient({
+      url: "https://example.supabase.co",
+      anonKey: "anon",
+      fetchImpl: async () => new Response(JSON.stringify({ message: 'relation "public.agent_recall_rules" does not exist' }), { status: 404 }),
+    });
+
+    const status = await client.checkStatus();
+    expect(status.kind).toBe("missing-table");
+    expect(status.remediation).toBe("sql");
+  });
+});

--- a/src/core/rules-sync.ts
+++ b/src/core/rules-sync.ts
@@ -1,0 +1,344 @@
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type RulesAgent = "claude" | "qoder";
+export type RulesScope = "global" | "project";
+
+export interface AgentRule {
+  agent: RulesAgent;
+  scope: RulesScope;
+  name: string;
+  content: string;
+  contentHash: string;
+  projectPath: string;
+  filePath: string;
+}
+
+export interface RemoteRule {
+  id: string;
+  agent: string;
+  scope: string;
+  name: string;
+  content: string;
+  content_hash: string;
+  project_path: string;
+  version: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export type RulesSyncStatusKind = "ready" | "missing-table" | "error" | "unconfigured";
+
+export interface RulesSyncStatus {
+  kind: RulesSyncStatusKind;
+  setupSql: string;
+  remediation?: "sql" | "settings";
+  message?: string;
+}
+
+export interface RulesSyncSnapshot {
+  status: RulesSyncStatus;
+  localRules: AgentRule[];
+  remoteRules: RemoteRule[];
+  scannedAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const AGENT_RECALL_RULES_TABLE = "agent_recall_rules";
+const DEFAULT_RULES_SYNC_TIMEOUT_MS = 15_000;
+
+// ---------------------------------------------------------------------------
+// Local scanner
+// ---------------------------------------------------------------------------
+
+export interface ScanLocalRulesOptions {
+  homeDir?: string;
+  projectDirs?: string[];
+}
+
+export function scanLocalRules(options: ScanLocalRulesOptions = {}): AgentRule[] {
+  const homeDir = options.homeDir ?? os.homedir();
+  const projectDirs = options.projectDirs ?? [];
+  const rules: AgentRule[] = [];
+
+  // Claude global CLAUDE.md
+  const claudeGlobalPath = path.join(homeDir, ".claude", "CLAUDE.md");
+  const claudeGlobal = readRuleFile(claudeGlobalPath, "claude", "global", "CLAUDE.md", "");
+  if (claudeGlobal) rules.push(claudeGlobal);
+
+  // Per-project rules
+  for (const projectDir of projectDirs) {
+    const projectBasename = path.basename(projectDir);
+
+    // Project-level CLAUDE.md
+    const claudeProjectPath = path.join(projectDir, "CLAUDE.md");
+    const claudeProject = readRuleFile(claudeProjectPath, "claude", "project", "CLAUDE.md", projectBasename);
+    if (claudeProject) rules.push(claudeProject);
+
+    // Qoder project rules: .qoder/rules/*.md
+    const qoderRulesDir = path.join(projectDir, ".qoder", "rules");
+    if (fs.existsSync(qoderRulesDir)) {
+      try {
+        for (const entry of fs.readdirSync(qoderRulesDir, { withFileTypes: true })) {
+          if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+          const filePath = path.join(qoderRulesDir, entry.name);
+          const rule = readRuleFile(filePath, "qoder", "project", entry.name, projectBasename);
+          if (rule) rules.push(rule);
+        }
+      } catch {
+        // Ignore unreadable rules directories.
+      }
+    }
+  }
+
+  return rules;
+}
+
+function readRuleFile(filePath: string, agent: RulesAgent, scope: RulesScope, name: string, projectPath: string): AgentRule | null {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    const content = fs.readFileSync(filePath, "utf8");
+    if (!content.trim()) return null;
+    return {
+      agent,
+      scope,
+      name,
+      content,
+      contentHash: sha256(content),
+      projectPath,
+      filePath,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rule identity (for matching local ↔ remote)
+// ---------------------------------------------------------------------------
+
+export function ruleIdentity(rule: Pick<AgentRule, "agent" | "scope" | "name" | "projectPath">): string {
+  return rule.scope === "project"
+    ? `${rule.agent}:${rule.scope}:${rule.projectPath}:${rule.name}`
+    : `${rule.agent}:${rule.scope}:${rule.name}`;
+}
+
+// ---------------------------------------------------------------------------
+// Setup SQL
+// ---------------------------------------------------------------------------
+
+export function buildRulesSyncSetupSql(tableName = AGENT_RECALL_RULES_TABLE): string {
+  return [
+    `create table if not exists public.${tableName} (`,
+    "  id uuid primary key default gen_random_uuid(),",
+    "  agent text not null check (agent in ('claude', 'qoder')),",
+    "  scope text not null check (scope in ('global', 'project')),",
+    "  name text not null,",
+    "  content text not null,",
+    "  content_hash text not null default '',",
+    "  project_path text not null default '',",
+    "  version integer not null default 1,",
+    "  created_at timestamptz not null default now(),",
+    "  updated_at timestamptz not null default now()",
+    ");",
+    "",
+    `create unique index if not exists ${tableName}_identity_idx`,
+    `  on public.${tableName} (agent, scope, name, project_path);`,
+    "",
+    `alter table public.${tableName} enable row level security;`,
+    "",
+    `create policy "${tableName}_anon_all" on public.${tableName}`,
+    "  for all to anon using (true) with check (true);",
+    "",
+    `grant select, insert, update, delete on table public.${tableName} to anon;`,
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Supabase client
+// ---------------------------------------------------------------------------
+
+export interface SupabaseRulesSyncClientOptions {
+  url: string;
+  anonKey: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+const RULES_SYNC_COLUMNS = "id,agent,scope,name,content,content_hash,project_path,version,created_at,updated_at";
+
+export class SupabaseRulesSyncClient {
+  private readonly baseUrl: string;
+  private readonly anonKey: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+
+  constructor(options: SupabaseRulesSyncClientOptions) {
+    this.baseUrl = normalizeSupabaseUrl(options.url);
+    this.anonKey = options.anonKey.trim();
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.timeoutMs = options.timeoutMs && options.timeoutMs > 0 ? options.timeoutMs : DEFAULT_RULES_SYNC_TIMEOUT_MS;
+    if (!this.baseUrl) throw new Error("Supabase URL is required.");
+    if (!this.anonKey) throw new Error("Supabase anon key is required.");
+  }
+
+  async checkStatus(): Promise<RulesSyncStatus> {
+    const setupSql = buildRulesSyncSetupSql();
+    try {
+      const response = await this.restRequest(`/${AGENT_RECALL_RULES_TABLE}?select=id&limit=1`, { method: "GET" });
+      if (response.ok) return { kind: "ready", setupSql };
+      const body = await readResponseBody(response);
+      if (isMissingTableError(response.status, body)) {
+        return { kind: "missing-table", setupSql, remediation: "sql", message: `Supabase table ${AGENT_RECALL_RULES_TABLE} was not found.` };
+      }
+      return { kind: "error", setupSql, remediation: "sql", message: supabaseErrorMessage(response.status, body) };
+    } catch (error) {
+      return { kind: "error", setupSql, remediation: "settings", message: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  async listRemoteRules(): Promise<RemoteRule[]> {
+    const { body } = await this.selectRows(`order=updated_at.desc`);
+    return parseRuleRows(body);
+  }
+
+  async uploadRule(rule: AgentRule): Promise<RemoteRule> {
+    const payload = {
+      agent: rule.agent,
+      scope: rule.scope,
+      name: rule.name,
+      content: rule.content,
+      content_hash: rule.contentHash,
+      project_path: rule.projectPath,
+    };
+    const response = await this.restRequest(`/${AGENT_RECALL_RULES_TABLE}?on_conflict=agent,scope,name,project_path`, {
+      method: "POST",
+      headers: { Prefer: "resolution=merge-duplicates,return=representation" },
+      body: JSON.stringify(payload),
+    });
+    const body = await readResponseBody(response);
+    if (!response.ok) throw new Error(supabaseErrorMessage(response.status, body));
+    const rows = parseRuleRows(body);
+    if (rows.length === 0) throw new Error("Supabase did not return the uploaded rule.");
+    return rows[0];
+  }
+
+  async deleteRule(remoteId: string): Promise<boolean> {
+    const response = await this.restRequest(`/${AGENT_RECALL_RULES_TABLE}?id=eq.${encodeURIComponent(remoteId)}`, {
+      method: "DELETE",
+    });
+    if (!response.ok) {
+      const body = await readResponseBody(response);
+      throw new Error(supabaseErrorMessage(response.status, body));
+    }
+    return true;
+  }
+
+  private async selectRows(query: string): Promise<{ body: unknown }> {
+    const response = await this.restRequest(`/${AGENT_RECALL_RULES_TABLE}?select=${RULES_SYNC_COLUMNS}&${query}`, { method: "GET" });
+    const body = await readResponseBody(response);
+    if (!response.ok) throw new Error(supabaseErrorMessage(response.status, body));
+    return { body };
+  }
+
+  private async restRequest(path: string, init: RequestInit): Promise<Response> {
+    return this.authenticatedRequest(`${this.baseUrl}/rest/v1${path}`, {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        ...(init.headers ?? {}),
+      },
+    });
+  }
+
+  private async authenticatedRequest(url: string, init: RequestInit): Promise<Response> {
+    return this.request(url, {
+      ...init,
+      headers: {
+        apikey: this.anonKey,
+        Authorization: `Bearer ${this.anonKey}`,
+        ...(init.headers ?? {}),
+      },
+    });
+  }
+
+  private async request(url: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      return await this.fetchImpl(url, { ...init, signal: controller.signal });
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw new Error(`Supabase request timed out after ${Math.round(this.timeoutMs / 1000)}s.`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeSupabaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+async function readResponseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function supabaseErrorMessage(status: number, body: unknown): string {
+  if (body && typeof body === "object") {
+    const message = (body as { message?: unknown }).message;
+    if (typeof message === "string" && message.trim()) return message;
+  }
+  if (typeof body === "string" && body.trim()) return body;
+  return `Supabase request failed with status ${status}.`;
+}
+
+function isMissingTableError(status: number, body: unknown): boolean {
+  if (status !== 404 && status !== 400) return false;
+  const message = typeof body === "string" ? body : (body as { message?: string })?.message ?? "";
+  return /does not exist|could not find the table|relation/i.test(message);
+}
+
+function parseRuleRows(body: unknown): RemoteRule[] {
+  if (!Array.isArray(body)) return [];
+  return body.flatMap((row) => (isRuleRow(row) ? [row] : []));
+}
+
+function isRuleRow(value: unknown): value is RemoteRule {
+  if (!value || typeof value !== "object") return false;
+  const row = value as Partial<RemoteRule>;
+  return (
+    typeof row.id === "string" &&
+    typeof row.agent === "string" &&
+    typeof row.scope === "string" &&
+    typeof row.name === "string" &&
+    typeof row.content === "string" &&
+    typeof row.created_at === "string" &&
+    typeof row.updated_at === "string"
+  );
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}


### PR DESCRIPTION
## 变更概述

像我上一个提交说到的：**我们AgentRecall的设计初衷就是，尽可能屏蔽多平台多设备之间的差异，让用户可以通过管理会话来尽可能无痛切换设备、切换agent平台。
所以我想定义一个新的概念——数字资产：除了会话记录，skill，api provider之外，rules、hooks、memories、甚至一些插件，应该都可以被我们的AgentRecall管理，之后我会陆续理清它们的可行性，并依此给AgentRecall做升级**

本次提交为Rules跨设备同步的核心模块。

1. 新增 `rules-sync.ts`：扫描本地 Claude `CLAUDE.md`（全局）和 Qoder `.qoder/rules/*.md`（项目级），
   计算 content hash，通过 Supabase REST API 上传/下载，支持 upsert 和 RLS
2. 新增 `rulesSyncEnabled` 设置项（默认关闭），复用 skillSync 的 Supabase 配置
3. 7 个测试覆盖：扫描器、空文件跳过、identity 生成、setup SQL、Supabase 上传/列表/状态检查

主要改动已回归验证
