### PR TITLE
feat: add rules sync with IPC, service layer, and Settings UI

### DIFF
--- a/.release-notes/rules-sync-core.md
+++ b/.release-notes/rules-sync-core.md
@@ -1,6 +1,7 @@
-# Rules 跨设备同步核心模块
+# Rules 跨设备同步
 
 ## 新增功能
 
-- 新增 Rules 同步核心模块（rules-sync.ts），支持扫描本地 Claude CLAUDE.md 和 Qoder .qoder/rules/*.md 规则文件，通过 Supabase 上传/下载实现跨设备同步
-- 新增 rulesSyncEnabled 设置项（默认关闭），为后续 Settings UI 和 IPC 集成做准备
+- 新增 Rules 同步功能：扫描本地 Claude CLAUDE.md 和 Qoder .qoder/rules/*.md 规则文件，通过 Supabase 上传/下载实现跨设备同步
+- Settings 页新增「Rules 同步」开关（复用 Skill 同步的 Supabase 配置），支持一键上传所有规则、按条上传、删除远端规则
+- 新增 rulesSyncEnabled 设置项（默认关闭）

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -80,6 +80,7 @@ import { APP_UPDATE_EVENTS } from "../shared/ipc/app-update";
 import { registerAppUpdateIpc } from "./ipc/app-update";
 import { registerProvidersIpc } from "./ipc/providers";
 import { registerRemoteSessionsIpc } from "./ipc/remote-sessions";
+import { registerRulesIpc, type RulesIpcService } from "./ipc/rules";
 import { registerSkillsIpc } from "./ipc/skills";
 import {
   AppUpdateService,
@@ -91,6 +92,7 @@ import {
   RemoteSessionService,
   type SessionSyncHookSetup,
 } from "./services/remote-session-service";
+import { buildRulesSyncSetupSql, ruleIdentity, scanLocalRules, SupabaseRulesSyncClient } from "../core/rules-sync";
 import { SkillService, type SkillUsageHookSetup } from "./services/skill-service";
 import type {
   EnvironmentUpsertInput,
@@ -275,6 +277,56 @@ const remoteSessionService = new RemoteSessionService({
 
 function visibleSearchOptions(options: SearchOptions = {}): SearchOptions {
   return { ...options, excludeSubagents: getSettings().hideSubagentSessions };
+}
+
+function createRulesSyncService(): RulesIpcService {
+  const projectDirs = () => store.listProjects(visibleProjectOptions()).map((p) => p.path);
+  const createClient = () => {
+    const settings = getSettings();
+    return new SupabaseRulesSyncClient({ url: settings.skillSyncSupabaseUrl, anonKey: settings.skillSyncSupabaseAnonKey });
+  };
+  return {
+    async getSyncSnapshot() {
+      const settings = getSettings();
+      const localRules = scanLocalRules({ projectDirs: projectDirs() });
+      if (!settings.rulesSyncEnabled || !settings.skillSyncSupabaseUrl || !settings.skillSyncSupabaseAnonKey) {
+        return { status: { kind: "unconfigured" as const, setupSql: buildRulesSyncSetupSql() }, localRules, remoteRules: [], scannedAt: Date.now() };
+      }
+      const client = createClient();
+      const status = await client.checkStatus();
+      const remoteRules = status.kind === "ready" ? await client.listRemoteRules() : [];
+      return { status, localRules, remoteRules, scannedAt: Date.now() };
+    },
+    async upload(identity) {
+      const localRules = scanLocalRules({ projectDirs: projectDirs() });
+      const rule = localRules.find((r) => ruleIdentity(r) === identity);
+      if (!rule) throw new Error("Rule not found locally.");
+      return createClient().uploadRule(rule);
+    },
+    async uploadAll() {
+      const localRules = scanLocalRules({ projectDirs: projectDirs() });
+      const client = createClient();
+      const remoteRules = await client.listRemoteRules();
+      let uploaded = 0;
+      let skipped = 0;
+      for (const rule of localRules) {
+        const remote = remoteRules.find((r) => r.agent === rule.agent && r.scope === rule.scope && r.name === rule.name && r.project_path === rule.projectPath);
+        if (remote && remote.content_hash === rule.contentHash) {
+          skipped++;
+          continue;
+        }
+        await client.uploadRule(rule);
+        uploaded++;
+      }
+      return { uploaded, skipped };
+    },
+    async deleteRemote(remoteId) {
+      return createClient().deleteRule(remoteId);
+    },
+    copySetupSql() {
+      clipboard.writeText(buildRulesSyncSetupSql());
+    },
+  };
 }
 
 function visibleStatsOptions(options: SessionStatsOptions = {}): SessionStatsOptions {
@@ -1338,6 +1390,7 @@ function registerIpc(): void {
     return providerService.addStoredKeys(next);
   });
   registerSkillsIpc(ipcMain, skillService);
+  registerRulesIpc(ipcMain, createRulesSyncService());
   ipcMain.handle("supabase:copy-combined-setup-sql", () => {
     clipboard.writeText(buildCombinedSupabaseSetupSql());
   });

--- a/src/main/ipc/rules.ts
+++ b/src/main/ipc/rules.ts
@@ -1,0 +1,21 @@
+import type { AgentRule, RemoteRule, RulesSyncSnapshot } from "../../core/rules-sync";
+import { RULES_IPC } from "../../shared/ipc/rules";
+import { combineIpcDisposers, registerIpcHandler, type IpcMainRegistrar } from "./register-ipc-handler";
+
+export interface RulesIpcService {
+  getSyncSnapshot(): Promise<RulesSyncSnapshot>;
+  upload(identity: string): Promise<RemoteRule>;
+  uploadAll(): Promise<{ uploaded: number; skipped: number }>;
+  deleteRemote(remoteId: string): Promise<boolean>;
+  copySetupSql(): void;
+}
+
+export function registerRulesIpc(ipc: IpcMainRegistrar, service: RulesIpcService): () => void {
+  return combineIpcDisposers([
+    registerIpcHandler(ipc, RULES_IPC.getSyncSnapshot, () => service.getSyncSnapshot()),
+    registerIpcHandler(ipc, RULES_IPC.upload, (_event, identity) => service.upload(identity)),
+    registerIpcHandler(ipc, RULES_IPC.uploadAll, () => service.uploadAll()),
+    registerIpcHandler(ipc, RULES_IPC.deleteRemote, (_event, id) => service.deleteRemote(id)),
+    registerIpcHandler(ipc, RULES_IPC.copySetupSql, () => service.copySetupSql()),
+  ]);
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -29,6 +29,7 @@ import type {
 import { createAppUpdateApi } from "./app-update";
 import { createProvidersApi } from "./providers";
 import { createRemoteSessionsApi } from "./remote-sessions";
+import { createRulesApi } from "./rules";
 import { createSkillsApi } from "./skills";
 
 export interface AiAssistantReply {
@@ -85,6 +86,7 @@ const api = {
   setSettings: (settings: AppSettingsUpdate): Promise<AppSettings> => ipcRenderer.invoke("settings:set", settings),
   ...createProvidersApi(ipcRenderer),
   ...createSkillsApi(ipcRenderer),
+  ...createRulesApi(ipcRenderer),
   ...createRemoteSessionsApi(ipcRenderer),
   copyCombinedSyncSetupSql: (): Promise<void> => ipcRenderer.invoke("supabase:copy-combined-setup-sql"),
   openSupabaseSqlEditor: (target: "sessions" | "skills"): Promise<void> => ipcRenderer.invoke("supabase:open-sql-editor", target),

--- a/src/preload/rules.ts
+++ b/src/preload/rules.ts
@@ -1,0 +1,17 @@
+import type { IpcRenderer } from "electron";
+import type { RemoteRule, RulesSyncSnapshot } from "../core/rules-sync";
+import { RULES_IPC } from "../shared/ipc/rules";
+
+export type RulesIpcRenderer = Pick<IpcRenderer, "invoke">;
+
+export function createRulesApi(ipc: RulesIpcRenderer) {
+  return {
+    getRulesSyncSnapshot: (): Promise<RulesSyncSnapshot> => ipc.invoke(RULES_IPC.getSyncSnapshot.channel),
+    uploadRuleToSync: (identity: string): Promise<RemoteRule> => ipc.invoke(RULES_IPC.upload.channel, identity),
+    uploadAllRulesToSync: (): Promise<{ uploaded: number; skipped: number }> => ipc.invoke(RULES_IPC.uploadAll.channel),
+    deleteRemoteRule: (remoteId: string): Promise<boolean> => ipc.invoke(RULES_IPC.deleteRemote.channel, remoteId),
+    copyRulesSyncSetupSql: (): Promise<void> => ipc.invoke(RULES_IPC.copySetupSql.channel),
+  };
+}
+
+export type RulesApi = ReturnType<typeof createRulesApi>;

--- a/src/renderer/src/features/settings/settings-dialog.tsx
+++ b/src/renderer/src/features/settings/settings-dialog.tsx
@@ -981,6 +981,30 @@ export function SettingsDialog({
                     onChange={(event) => onSettingsChange({ skillSyncEnabled: event.currentTarget.checked })}
                   />
                 </label>
+                <header className="settings-pane-head" style={{ marginTop: 18 }}>
+                  <h3>{l("Rules sync", "Rules 同步")}</h3>
+                  <p>
+                    {l(
+                      "Sync CLAUDE.md and .qoder/rules across devices using the same Supabase project as Skill sync.",
+                      "使用与 Skill 同步相同的 Supabase 项目，跨设备同步 CLAUDE.md 和 .qoder/rules 规则文件。",
+                    )}
+                  </p>
+                </header>
+                <label className="settings-field settings-toggle">
+                  <div className="settings-field-text">
+                    <span className="settings-field-title">{l("Enable rules sync", "启用 Rules 同步")}</span>
+                    <span className="settings-field-sub">
+                      {l("Uses the Supabase URL and anon key configured above for Skill sync.", "使用上方 Skill 同步配置的 Supabase URL 和 anon key。")}
+                    </span>
+                  </div>
+                  <input
+                    type="checkbox"
+                    className="switch"
+                    checked={Boolean(settings?.rulesSyncEnabled)}
+                    disabled={!settings || saving}
+                    onChange={(event) => onSettingsChange({ rulesSyncEnabled: event.currentTarget.checked })}
+                  />
+                </label>
               </section>
             ) : null}
             {activeSection === "appearance" ? (

--- a/src/shared/ipc/rules.ts
+++ b/src/shared/ipc/rules.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import { defineIpcRequest } from "./contract";
+
+const noInput = z.tuple([]);
+const ruleIdentityInput = z.string().trim().min(1).max(1024);
+
+export const RULES_IPC = {
+  getSyncSnapshot: defineIpcRequest("rules:sync-snapshot", noInput),
+  upload: defineIpcRequest("rules:sync-upload", z.tuple([ruleIdentityInput])),
+  uploadAll: defineIpcRequest("rules:sync-upload-all", noInput),
+  deleteRemote: defineIpcRequest("rules:sync-delete", z.tuple([ruleIdentityInput])),
+  copySetupSql: defineIpcRequest("rules:sync-copy-setup-sql", noInput),
+} as const;


### PR DESCRIPTION
## 变更概述

数字资产同步第二步：Rules 跨设备同步，从核心模块到 UI 全栈接通。

1. `rules-sync.ts`：扫描 Claude `CLAUDE.md`（全局）+ Qoder `.qoder/rules/*.md`（项目级），
   Supabase REST 上传/下载，upsert + RLS
2. `shared/ipc/rules.ts` + `main/ipc/rules.ts` + `preload/rules.ts`：IPC 全栈
   （snapshot / upload / uploadAll / delete / copySetupSql）
3. `main/index.ts`：`createRulesSyncService()` 服务层，复用 skillSync 的 Supabase 配置
4. Settings 页新增「Rules 同步」开关，注明复用上方 Skill 同步的 Supabase 配置

7 个核心测试通过
主要改动已验证回归
