### PR TITLE
docs: add missing release note for rules sync IPC PR

### DIFF
--- a/.release-notes/rules-sync-ipc-ui.md
+++ b/.release-notes/rules-sync-ipc-ui.md
@@ -1,0 +1,5 @@
+# Rules 同步全栈接通
+
+## 新增功能
+
+- Rules 同步新增 IPC 全栈接通和服务层，Settings 页新增「Rules 同步」开关，复用 Skill 同步的 Supabase 配置


### PR DESCRIPTION
补上 PR #118 遗漏的 release note 文件，修复 CI 失败。