### PR TITLE
feat: add memories sync for Qoder and Codex across devices

### DIFF
--- a/.release-notes/memories-sync.md
+++ b/.release-notes/memories-sync.md
@@ -1,0 +1,6 @@
+# Memories 跨设备同步
+
+## 新增功能
+
+- 新增 Memories 同步功能：扫描本地 Qoder 长期记忆（`~/.qoder/memories/`）和 Codex 记忆（`~/.codex/memories_1.sqlite`），通过 Supabase 上传/下载实现跨设备同步
+- Settings 页新增「Memories 同步」开关（复用 Skill 同步的 Supabase 配置），支持一键上传所有记忆、按条上传、删除远端记忆

--- a/src/core/memories-sync.test.ts
+++ b/src/core/memories-sync.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import { createRequire } from "node:module";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { DatabaseSync as DatabaseSyncType } from "node:sqlite";
+import {
+  buildMemoriesSyncSetupSql,
+  memoryIdentity,
+  scanLocalMemories,
+  SupabaseMemoriesSyncClient,
+  type AgentMemory,
+} from "./memories-sync";
+
+const require = createRequire(import.meta.url);
+
+describe("memories sync", () => {
+  it("scans Qoder global and project memories across user-id directories", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "memories-sync-scan-"));
+
+    // Global memory
+    const globalDir = path.join(homeDir, ".qoder", "memories", "user-abc", "global", "user_info");
+    fs.mkdirSync(globalDir, { recursive: true });
+    fs.writeFileSync(path.join(globalDir, "my-account.md"), "---\ntitle: Account\n---\nMy GitHub account.", "utf8");
+
+    // Project memory
+    const projectDir = path.join(homeDir, ".qoder", "memories", "user-abc", "projects", "d-my-app", "tool_experience");
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(path.join(projectDir, "git-push-tip.md"), "---\ntitle: Git Push\n---\nAlways clear token.", "utf8");
+
+    const memories = scanLocalMemories({ homeDir });
+
+    expect(memories).toHaveLength(2);
+
+    const global = memories.find((m) => m.scope === "global");
+    expect(global).toMatchObject({
+      agent: "qoder",
+      scope: "global",
+      name: "user_info/my-account.md",
+      category: "user_info",
+      projectPath: "",
+    });
+    expect(global!.content).toContain("My GitHub account.");
+
+    const project = memories.find((m) => m.scope === "project");
+    expect(project).toMatchObject({
+      agent: "qoder",
+      scope: "project",
+      name: "tool_experience/git-push-tip.md",
+      category: "tool_experience",
+      projectPath: "d-my-app",
+    });
+
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("skips empty memory files", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "memories-sync-empty-"));
+    const dir = path.join(homeDir, ".qoder", "memories", "uid", "global", "user_info");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "empty.md"), "   \n  ", "utf8");
+
+    const memories = scanLocalMemories({ homeDir });
+    expect(memories).toHaveLength(0);
+
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("returns empty array when .qoder/memories does not exist", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "memories-sync-none-"));
+    const memories = scanLocalMemories({ homeDir });
+    expect(memories).toHaveLength(0);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("generates stable identity ignoring user-id layer", () => {
+    const global: AgentMemory = {
+      agent: "qoder", scope: "global", name: "user_info/account.md", category: "user_info",
+      content: "x", contentHash: "h", projectPath: "", filePath: "/a/b/c.md",
+    };
+    const project: AgentMemory = {
+      agent: "qoder", scope: "project", name: "tool_experience/git.md", category: "tool_experience",
+      content: "x", contentHash: "h", projectPath: "d-my-app", filePath: "/a/b/d.md",
+    };
+    expect(memoryIdentity(global)).toBe("qoder:global:user_info/account.md");
+    expect(memoryIdentity(project)).toBe("qoder:project:d-my-app:tool_experience/git.md");
+  });
+
+  it("builds setup SQL with table, unique index, RLS, and grants", () => {
+    const sql = buildMemoriesSyncSetupSql();
+    expect(sql).toContain("create table if not exists public.agent_recall_memories");
+    expect(sql).toContain("agent in ('qoder', 'codex')");
+    expect(sql).toContain("create unique index if not exists agent_recall_memories_identity_idx");
+    expect(sql).toContain("enable row level security");
+    expect(sql).toContain("grant select, insert, update, delete on table public.agent_recall_memories to anon");
+  });
+
+  it("uploads a memory via Supabase REST with upsert", async () => {
+    let capturedUrl = "";
+    let capturedInit: RequestInit | undefined;
+    const mockFetch: typeof fetch = async (url, init) => {
+      capturedUrl = String(url);
+      capturedInit = init;
+      return new Response(JSON.stringify([{
+        id: "mem-1", agent: "qoder", scope: "global", name: "user_info/account.md",
+        category: "user_info", content: "test", content_hash: "abc", project_path: "",
+        version: 1, created_at: "2026-01-01", updated_at: "2026-01-01",
+      }]), { status: 201 });
+    };
+
+    const client = new SupabaseMemoriesSyncClient({ url: "https://test.supabase.co", anonKey: "key", fetchImpl: mockFetch });
+    const result = await client.uploadMemory({
+      agent: "qoder", scope: "global", name: "user_info/account.md", category: "user_info",
+      content: "test", contentHash: "abc", projectPath: "", filePath: "/x.md",
+    });
+
+    expect(result.id).toBe("mem-1");
+    expect(capturedUrl).toContain("/rest/v1/agent_recall_memories?on_conflict=agent,scope,name,project_path");
+    expect(capturedInit?.method).toBe("POST");
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers["Prefer"]).toContain("resolution=merge-duplicates");
+  });
+
+  it("lists remote memories ordered by updated_at", async () => {
+    const mockFetch: typeof fetch = async () => new Response(JSON.stringify([
+      { id: "m1", agent: "qoder", scope: "global", name: "a/b.md", category: "a", content: "x", content_hash: "h", project_path: "", version: 1, created_at: "t", updated_at: "t2" },
+      { id: "m2", agent: "qoder", scope: "project", name: "c/d.md", category: "c", content: "y", content_hash: "h2", project_path: "proj", version: 2, created_at: "t", updated_at: "t1" },
+    ]), { status: 200 });
+
+    const client = new SupabaseMemoriesSyncClient({ url: "https://test.supabase.co", anonKey: "key", fetchImpl: mockFetch });
+    const list = await client.listRemoteMemories();
+    expect(list).toHaveLength(2);
+    expect(list[0].id).toBe("m1");
+    expect(list[1].scope).toBe("project");
+  });
+
+  it("reports missing-table status when Supabase returns 404", async () => {
+    const mockFetch: typeof fetch = async () => new Response(JSON.stringify({ message: "relation does not exist" }), { status: 404 });
+    const client = new SupabaseMemoriesSyncClient({ url: "https://test.supabase.co", anonKey: "key", fetchImpl: mockFetch });
+    const status = await client.checkStatus();
+    expect(status.kind).toBe("missing-table");
+    expect(status.remediation).toBe("sql");
+  });
+
+  it("scans Codex memories from stage1_outputs SQLite table", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "memories-sync-codex-"));
+    const codexDir = path.join(homeDir, ".codex");
+    fs.mkdirSync(codexDir, { recursive: true });
+    const dbPath = path.join(codexDir, "memories_1.sqlite");
+
+    const { DatabaseSync } = require("node:sqlite") as { DatabaseSync: typeof DatabaseSyncType };
+    const db = new DatabaseSync(dbPath);
+    db.exec(`CREATE TABLE stage1_outputs (
+      thread_id TEXT PRIMARY KEY,
+      source_updated_at INTEGER NOT NULL,
+      raw_memory TEXT NOT NULL,
+      rollout_summary TEXT NOT NULL,
+      rollout_slug TEXT,
+      generated_at INTEGER NOT NULL,
+      usage_count INTEGER,
+      last_usage INTEGER,
+      selected_for_phase2 INTEGER NOT NULL DEFAULT 0,
+      selected_for_phase2_source_updated_at INTEGER
+    )`);
+    db.prepare("INSERT INTO stage1_outputs (thread_id, source_updated_at, raw_memory, rollout_summary, rollout_slug, generated_at) VALUES (?, ?, ?, ?, ?, ?)")
+      .run("thread-001", 1000, "User prefers TypeScript over JavaScript.", "Discussion about language preference.", "ts-preference", 1720000000);
+    db.prepare("INSERT INTO stage1_outputs (thread_id, source_updated_at, raw_memory, rollout_summary, rollout_slug, generated_at) VALUES (?, ?, ?, ?, ?, ?)")
+      .run("thread-002", 2000, "   ", "Empty memory should be skipped.", null, 1720000100);
+    db.close();
+
+    const memories = scanLocalMemories({ homeDir });
+
+    expect(memories).toHaveLength(1);
+    expect(memories[0]).toMatchObject({
+      agent: "codex",
+      scope: "global",
+      name: "ts-preference",
+      category: "stage1",
+      projectPath: "",
+    });
+    expect(memories[0].content).toBe("User prefers TypeScript over JavaScript.");
+
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("gracefully skips when Codex database does not exist", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "memories-sync-nocodex-"));
+    const memories = scanLocalMemories({ homeDir });
+    expect(memories).toHaveLength(0);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+});

--- a/src/core/memories-sync.ts
+++ b/src/core/memories-sync.ts
@@ -1,0 +1,435 @@
+import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { DatabaseSync as DatabaseSyncType } from "node:sqlite";
+
+const require = createRequire(import.meta.url);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type MemoriesAgent = "qoder" | "codex";
+export type MemoriesScope = "global" | "project";
+
+export interface AgentMemory {
+  agent: MemoriesAgent;
+  scope: MemoriesScope;
+  /** category/filename.md — e.g. "user_info/用户GitHub账号.md" */
+  name: string;
+  category: string;
+  content: string;
+  contentHash: string;
+  /** project slug for project-scope memories, empty for global */
+  projectPath: string;
+  filePath: string;
+}
+
+export interface RemoteMemory {
+  id: string;
+  agent: string;
+  scope: string;
+  name: string;
+  category: string;
+  content: string;
+  content_hash: string;
+  project_path: string;
+  version: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export type MemoriesSyncStatusKind = "ready" | "missing-table" | "error" | "unconfigured";
+
+export interface MemoriesSyncStatus {
+  kind: MemoriesSyncStatusKind;
+  setupSql: string;
+  remediation?: "sql" | "settings";
+  message?: string;
+}
+
+export interface MemoriesSyncSnapshot {
+  status: MemoriesSyncStatus;
+  localMemories: AgentMemory[];
+  remoteMemories: RemoteMemory[];
+  scannedAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const AGENT_RECALL_MEMORIES_TABLE = "agent_recall_memories";
+const DEFAULT_MEMORIES_SYNC_TIMEOUT_MS = 15_000;
+
+// ---------------------------------------------------------------------------
+// Local scanner
+// ---------------------------------------------------------------------------
+
+export interface ScanLocalMemoriesOptions {
+  homeDir?: string;
+}
+
+/**
+ * Scans `~/.qoder/memories/<user-id>/` for all memory markdown files,
+ * and `~/.codex/memories_1.sqlite` for Codex stage1_outputs.
+ * The user-id directory layer is device-specific and ignored for identity purposes.
+ */
+export function scanLocalMemories(options: ScanLocalMemoriesOptions = {}): AgentMemory[] {
+  const homeDir = options.homeDir ?? os.homedir();
+  const memories: AgentMemory[] = [];
+
+  // Qoder markdown memories
+  scanQoderMemories(homeDir, memories);
+
+  // Codex SQLite memories
+  scanCodexMemories(homeDir, memories);
+
+  return memories;
+}
+
+function scanQoderMemories(homeDir: string, memories: AgentMemory[]): void {
+  const memoriesRoot = path.join(homeDir, ".qoder", "memories");
+  if (!fs.existsSync(memoriesRoot)) return;
+
+  let userDirs: fs.Dirent[];
+  try {
+    userDirs = fs.readdirSync(memoriesRoot, { withFileTypes: true }).filter((d) => d.isDirectory());
+  } catch {
+    return;
+  }
+
+  for (const userDir of userDirs) {
+    const userDirPath = path.join(memoriesRoot, userDir.name);
+
+    // Global memories: <user-id>/global/<category>/<file>.md
+    const globalDir = path.join(userDirPath, "global");
+    if (fs.existsSync(globalDir)) {
+      scanCategoryDir(globalDir, "qoder", "global", "", memories);
+    }
+
+    // Project memories: <user-id>/projects/<slug>/<category>/<file>.md
+    const projectsDir = path.join(userDirPath, "projects");
+    if (fs.existsSync(projectsDir)) {
+      let projectDirs: fs.Dirent[];
+      try {
+        projectDirs = fs.readdirSync(projectsDir, { withFileTypes: true }).filter((d) => d.isDirectory());
+      } catch {
+        continue;
+      }
+      for (const projectDir of projectDirs) {
+        const projectPath = path.join(projectsDir, projectDir.name);
+        scanCategoryDir(projectPath, "qoder", "project", projectDir.name, memories);
+      }
+    }
+  }
+}
+
+/**
+ * Reads Codex memories from `~/.codex/memories_1.sqlite` (stage1_outputs table).
+ * Each row maps a thread_id to a raw_memory text extracted from conversations.
+ */
+function scanCodexMemories(homeDir: string, memories: AgentMemory[]): void {
+  const dbPath = path.join(homeDir, ".codex", "memories_1.sqlite");
+  if (!fs.existsSync(dbPath)) return;
+
+  try {
+    const { DatabaseSync } = require("node:sqlite") as { DatabaseSync: typeof DatabaseSyncType };
+    const db = new DatabaseSync(dbPath, { readOnly: true });
+    try {
+      const rows = db.prepare("SELECT thread_id, raw_memory, rollout_summary, rollout_slug, generated_at FROM stage1_outputs").all() as Array<{
+        thread_id: string;
+        raw_memory: string;
+        rollout_summary: string;
+        rollout_slug: string | null;
+        generated_at: number;
+      }>;
+      for (const row of rows) {
+        const content = row.raw_memory?.trim();
+        if (!content) continue;
+        const name = row.rollout_slug || row.thread_id;
+        memories.push({
+          agent: "codex",
+          scope: "global",
+          name,
+          category: "stage1",
+          content,
+          contentHash: sha256(content),
+          projectPath: "",
+          filePath: dbPath,
+        });
+      }
+    } finally {
+      db.close();
+    }
+  } catch {
+    // Ignore unreadable or missing Codex memories database.
+  }
+}
+
+function scanCategoryDir(baseDir: string, agent: MemoriesAgent, scope: MemoriesScope, projectPath: string, out: AgentMemory[]): void {
+  let categories: fs.Dirent[];
+  try {
+    categories = fs.readdirSync(baseDir, { withFileTypes: true }).filter((d) => d.isDirectory());
+  } catch {
+    return;
+  }
+  for (const categoryDir of categories) {
+    const categoryPath = path.join(baseDir, categoryDir.name);
+    let files: fs.Dirent[];
+    try {
+      files = fs.readdirSync(categoryPath, { withFileTypes: true }).filter((d) => d.isFile() && d.name.endsWith(".md"));
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      const filePath = path.join(categoryPath, file.name);
+      const memory = readMemoryFile(filePath, agent, scope, categoryDir.name, file.name, projectPath);
+      if (memory) out.push(memory);
+    }
+  }
+}
+
+function readMemoryFile(filePath: string, agent: MemoriesAgent, scope: MemoriesScope, category: string, fileName: string, projectPath: string): AgentMemory | null {
+  try {
+    const content = fs.readFileSync(filePath, "utf8");
+    if (!content.trim()) return null;
+    return {
+      agent,
+      scope,
+      name: `${category}/${fileName}`,
+      category,
+      content,
+      contentHash: sha256(content),
+      projectPath,
+      filePath,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Memory identity (for matching local ↔ remote)
+// ---------------------------------------------------------------------------
+
+export function memoryIdentity(memory: Pick<AgentMemory, "agent" | "scope" | "name" | "projectPath">): string {
+  return memory.scope === "project"
+    ? `${memory.agent}:${memory.scope}:${memory.projectPath}:${memory.name}`
+    : `${memory.agent}:${memory.scope}:${memory.name}`;
+}
+
+// ---------------------------------------------------------------------------
+// Setup SQL
+// ---------------------------------------------------------------------------
+
+export function buildMemoriesSyncSetupSql(tableName = AGENT_RECALL_MEMORIES_TABLE): string {
+  return [
+    `create table if not exists public.${tableName} (`,
+    "  id uuid primary key default gen_random_uuid(),",
+    "  agent text not null check (agent in ('qoder', 'codex')),",
+    "  scope text not null check (scope in ('global', 'project')),",
+    "  name text not null,",
+    "  category text not null default '',",
+    "  content text not null,",
+    "  content_hash text not null default '',",
+    "  project_path text not null default '',",
+    "  version integer not null default 1,",
+    "  created_at timestamptz not null default now(),",
+    "  updated_at timestamptz not null default now()",
+    ");",
+    "",
+    `create unique index if not exists ${tableName}_identity_idx`,
+    `  on public.${tableName} (agent, scope, name, project_path);`,
+    "",
+    `alter table public.${tableName} enable row level security;`,
+    "",
+    `create policy "${tableName}_anon_all" on public.${tableName}`,
+    "  for all to anon using (true) with check (true);",
+    "",
+    `grant select, insert, update, delete on table public.${tableName} to anon;`,
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Supabase client
+// ---------------------------------------------------------------------------
+
+export interface SupabaseMemoriesSyncClientOptions {
+  url: string;
+  anonKey: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+const MEMORIES_SYNC_COLUMNS = "id,agent,scope,name,category,content,content_hash,project_path,version,created_at,updated_at";
+
+export class SupabaseMemoriesSyncClient {
+  private readonly baseUrl: string;
+  private readonly anonKey: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+
+  constructor(options: SupabaseMemoriesSyncClientOptions) {
+    this.baseUrl = normalizeSupabaseUrl(options.url);
+    this.anonKey = options.anonKey.trim();
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.timeoutMs = options.timeoutMs && options.timeoutMs > 0 ? options.timeoutMs : DEFAULT_MEMORIES_SYNC_TIMEOUT_MS;
+    if (!this.baseUrl) throw new Error("Supabase URL is required.");
+    if (!this.anonKey) throw new Error("Supabase anon key is required.");
+  }
+
+  async checkStatus(): Promise<MemoriesSyncStatus> {
+    const setupSql = buildMemoriesSyncSetupSql();
+    try {
+      const response = await this.restRequest(`/${AGENT_RECALL_MEMORIES_TABLE}?select=id&limit=1`, { method: "GET" });
+      if (response.ok) return { kind: "ready", setupSql };
+      const body = await readResponseBody(response);
+      if (isMissingTableError(response.status, body)) {
+        return { kind: "missing-table", setupSql, remediation: "sql", message: `Supabase table ${AGENT_RECALL_MEMORIES_TABLE} was not found.` };
+      }
+      return { kind: "error", setupSql, remediation: "sql", message: supabaseErrorMessage(response.status, body) };
+    } catch (error) {
+      return { kind: "error", setupSql, remediation: "settings", message: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  async listRemoteMemories(): Promise<RemoteMemory[]> {
+    const { body } = await this.selectRows(`order=updated_at.desc`);
+    return parseMemoryRows(body);
+  }
+
+  async uploadMemory(memory: AgentMemory): Promise<RemoteMemory> {
+    const payload = {
+      agent: memory.agent,
+      scope: memory.scope,
+      name: memory.name,
+      category: memory.category,
+      content: memory.content,
+      content_hash: memory.contentHash,
+      project_path: memory.projectPath,
+    };
+    const response = await this.restRequest(`/${AGENT_RECALL_MEMORIES_TABLE}?on_conflict=agent,scope,name,project_path`, {
+      method: "POST",
+      headers: { Prefer: "resolution=merge-duplicates,return=representation" },
+      body: JSON.stringify(payload),
+    });
+    const body = await readResponseBody(response);
+    if (!response.ok) throw new Error(supabaseErrorMessage(response.status, body));
+    const rows = parseMemoryRows(body);
+    if (rows.length === 0) throw new Error("Supabase did not return the uploaded memory.");
+    return rows[0];
+  }
+
+  async deleteMemory(remoteId: string): Promise<boolean> {
+    const response = await this.restRequest(`/${AGENT_RECALL_MEMORIES_TABLE}?id=eq.${encodeURIComponent(remoteId)}`, {
+      method: "DELETE",
+    });
+    if (!response.ok) {
+      const body = await readResponseBody(response);
+      throw new Error(supabaseErrorMessage(response.status, body));
+    }
+    return true;
+  }
+
+  private async selectRows(query: string): Promise<{ body: unknown }> {
+    const response = await this.restRequest(`/${AGENT_RECALL_MEMORIES_TABLE}?select=${MEMORIES_SYNC_COLUMNS}&${query}`, { method: "GET" });
+    const body = await readResponseBody(response);
+    if (!response.ok) throw new Error(supabaseErrorMessage(response.status, body));
+    return { body };
+  }
+
+  private async restRequest(path: string, init: RequestInit): Promise<Response> {
+    return this.authenticatedRequest(`${this.baseUrl}/rest/v1${path}`, {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        ...(init.headers ?? {}),
+      },
+    });
+  }
+
+  private async authenticatedRequest(url: string, init: RequestInit): Promise<Response> {
+    return this.request(url, {
+      ...init,
+      headers: {
+        apikey: this.anonKey,
+        Authorization: `Bearer ${this.anonKey}`,
+        ...(init.headers ?? {}),
+      },
+    });
+  }
+
+  private async request(url: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      return await this.fetchImpl(url, { ...init, signal: controller.signal });
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw new Error(`Supabase request timed out after ${Math.round(this.timeoutMs / 1000)}s.`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeSupabaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+async function readResponseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function supabaseErrorMessage(status: number, body: unknown): string {
+  if (body && typeof body === "object") {
+    const message = (body as { message?: unknown }).message;
+    if (typeof message === "string" && message.trim()) return message;
+  }
+  if (typeof body === "string" && body.trim()) return body;
+  return `Supabase request failed with status ${status}.`;
+}
+
+function isMissingTableError(status: number, body: unknown): boolean {
+  if (status !== 404 && status !== 400) return false;
+  const message = typeof body === "string" ? body : (body as { message?: string })?.message ?? "";
+  return /does not exist|could not find the table|relation/i.test(message);
+}
+
+function parseMemoryRows(body: unknown): RemoteMemory[] {
+  if (!Array.isArray(body)) return [];
+  return body.flatMap((row) => (isMemoryRow(row) ? [row] : []));
+}
+
+function isMemoryRow(value: unknown): value is RemoteMemory {
+  if (!value || typeof value !== "object") return false;
+  const row = value as Partial<RemoteMemory>;
+  return (
+    typeof row.id === "string" &&
+    typeof row.agent === "string" &&
+    typeof row.scope === "string" &&
+    typeof row.name === "string" &&
+    typeof row.content === "string" &&
+    typeof row.created_at === "string" &&
+    typeof row.updated_at === "string"
+  );
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -87,6 +87,7 @@ export interface AppSettings {
   includeTrae: boolean;
   includeQoder: boolean;
   rulesSyncEnabled: boolean;
+  memoriesSyncEnabled: boolean;
   hideCodexQuota: boolean;
   hideClaudeQuota: boolean;
   hideSubagentSessions: boolean;
@@ -145,6 +146,7 @@ export const defaultSettings: AppSettings = {
   includeTrae: false,
   includeQoder: false,
   rulesSyncEnabled: false,
+  memoriesSyncEnabled: false,
   hideCodexQuota: false,
   hideClaudeQuota: false,
   hideSubagentSessions: true,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -80,6 +80,7 @@ import { APP_UPDATE_EVENTS } from "../shared/ipc/app-update";
 import { registerAppUpdateIpc } from "./ipc/app-update";
 import { registerProvidersIpc } from "./ipc/providers";
 import { registerRemoteSessionsIpc } from "./ipc/remote-sessions";
+import { registerMemoriesIpc, type MemoriesIpcService } from "./ipc/memories";
 import { registerRulesIpc, type RulesIpcService } from "./ipc/rules";
 import { registerSkillsIpc } from "./ipc/skills";
 import {
@@ -92,6 +93,7 @@ import {
   RemoteSessionService,
   type SessionSyncHookSetup,
 } from "./services/remote-session-service";
+import { buildMemoriesSyncSetupSql, memoryIdentity, scanLocalMemories, SupabaseMemoriesSyncClient } from "../core/memories-sync";
 import { buildRulesSyncSetupSql, ruleIdentity, scanLocalRules, SupabaseRulesSyncClient } from "../core/rules-sync";
 import { SkillService, type SkillUsageHookSetup } from "./services/skill-service";
 import type {
@@ -325,6 +327,55 @@ function createRulesSyncService(): RulesIpcService {
     },
     copySetupSql() {
       clipboard.writeText(buildRulesSyncSetupSql());
+    },
+  };
+}
+
+function createMemoriesSyncService(): MemoriesIpcService {
+  const createClient = () => {
+    const settings = getSettings();
+    return new SupabaseMemoriesSyncClient({ url: settings.skillSyncSupabaseUrl, anonKey: settings.skillSyncSupabaseAnonKey });
+  };
+  return {
+    async getSyncSnapshot() {
+      const settings = getSettings();
+      const localMemories = scanLocalMemories();
+      if (!settings.memoriesSyncEnabled || !settings.skillSyncSupabaseUrl || !settings.skillSyncSupabaseAnonKey) {
+        return { status: { kind: "unconfigured" as const, setupSql: buildMemoriesSyncSetupSql() }, localMemories, remoteMemories: [], scannedAt: Date.now() };
+      }
+      const client = createClient();
+      const status = await client.checkStatus();
+      const remoteMemories = status.kind === "ready" ? await client.listRemoteMemories() : [];
+      return { status, localMemories, remoteMemories, scannedAt: Date.now() };
+    },
+    async upload(identity) {
+      const localMemories = scanLocalMemories();
+      const memory = localMemories.find((m) => memoryIdentity(m) === identity);
+      if (!memory) throw new Error("Memory not found locally.");
+      return createClient().uploadMemory(memory);
+    },
+    async uploadAll() {
+      const localMemories = scanLocalMemories();
+      const client = createClient();
+      const remoteMemories = await client.listRemoteMemories();
+      let uploaded = 0;
+      let skipped = 0;
+      for (const memory of localMemories) {
+        const remote = remoteMemories.find((r) => r.agent === memory.agent && r.scope === memory.scope && r.name === memory.name && r.project_path === memory.projectPath);
+        if (remote && remote.content_hash === memory.contentHash) {
+          skipped++;
+          continue;
+        }
+        await client.uploadMemory(memory);
+        uploaded++;
+      }
+      return { uploaded, skipped };
+    },
+    async deleteRemote(remoteId) {
+      return createClient().deleteMemory(remoteId);
+    },
+    copySetupSql() {
+      clipboard.writeText(buildMemoriesSyncSetupSql());
     },
   };
 }
@@ -1391,6 +1442,7 @@ function registerIpc(): void {
   });
   registerSkillsIpc(ipcMain, skillService);
   registerRulesIpc(ipcMain, createRulesSyncService());
+  registerMemoriesIpc(ipcMain, createMemoriesSyncService());
   ipcMain.handle("supabase:copy-combined-setup-sql", () => {
     clipboard.writeText(buildCombinedSupabaseSetupSql());
   });

--- a/src/main/ipc/memories.ts
+++ b/src/main/ipc/memories.ts
@@ -1,0 +1,21 @@
+import type { AgentMemory, RemoteMemory, MemoriesSyncSnapshot } from "../../core/memories-sync";
+import { MEMORIES_IPC } from "../../shared/ipc/memories";
+import { combineIpcDisposers, registerIpcHandler, type IpcMainRegistrar } from "./register-ipc-handler";
+
+export interface MemoriesIpcService {
+  getSyncSnapshot(): Promise<MemoriesSyncSnapshot>;
+  upload(identity: string): Promise<RemoteMemory>;
+  uploadAll(): Promise<{ uploaded: number; skipped: number }>;
+  deleteRemote(remoteId: string): Promise<boolean>;
+  copySetupSql(): void;
+}
+
+export function registerMemoriesIpc(ipc: IpcMainRegistrar, service: MemoriesIpcService): () => void {
+  return combineIpcDisposers([
+    registerIpcHandler(ipc, MEMORIES_IPC.getSyncSnapshot, () => service.getSyncSnapshot()),
+    registerIpcHandler(ipc, MEMORIES_IPC.upload, (_event, identity) => service.upload(identity)),
+    registerIpcHandler(ipc, MEMORIES_IPC.uploadAll, () => service.uploadAll()),
+    registerIpcHandler(ipc, MEMORIES_IPC.deleteRemote, (_event, id) => service.deleteRemote(id)),
+    registerIpcHandler(ipc, MEMORIES_IPC.copySetupSql, () => service.copySetupSql()),
+  ]);
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -29,6 +29,7 @@ import type {
 import { createAppUpdateApi } from "./app-update";
 import { createProvidersApi } from "./providers";
 import { createRemoteSessionsApi } from "./remote-sessions";
+import { createMemoriesApi } from "./memories";
 import { createRulesApi } from "./rules";
 import { createSkillsApi } from "./skills";
 
@@ -87,6 +88,7 @@ const api = {
   ...createProvidersApi(ipcRenderer),
   ...createSkillsApi(ipcRenderer),
   ...createRulesApi(ipcRenderer),
+  ...createMemoriesApi(ipcRenderer),
   ...createRemoteSessionsApi(ipcRenderer),
   copyCombinedSyncSetupSql: (): Promise<void> => ipcRenderer.invoke("supabase:copy-combined-setup-sql"),
   openSupabaseSqlEditor: (target: "sessions" | "skills"): Promise<void> => ipcRenderer.invoke("supabase:open-sql-editor", target),

--- a/src/preload/memories.ts
+++ b/src/preload/memories.ts
@@ -1,0 +1,17 @@
+import type { IpcRenderer } from "electron";
+import type { RemoteMemory, MemoriesSyncSnapshot } from "../core/memories-sync";
+import { MEMORIES_IPC } from "../shared/ipc/memories";
+
+export type MemoriesIpcRenderer = Pick<IpcRenderer, "invoke">;
+
+export function createMemoriesApi(ipc: MemoriesIpcRenderer) {
+  return {
+    getMemoriesSyncSnapshot: (): Promise<MemoriesSyncSnapshot> => ipc.invoke(MEMORIES_IPC.getSyncSnapshot.channel),
+    uploadMemoryToSync: (identity: string): Promise<RemoteMemory> => ipc.invoke(MEMORIES_IPC.upload.channel, identity),
+    uploadAllMemoriesToSync: (): Promise<{ uploaded: number; skipped: number }> => ipc.invoke(MEMORIES_IPC.uploadAll.channel),
+    deleteRemoteMemory: (remoteId: string): Promise<boolean> => ipc.invoke(MEMORIES_IPC.deleteRemote.channel, remoteId),
+    copyMemoriesSyncSetupSql: (): Promise<void> => ipc.invoke(MEMORIES_IPC.copySetupSql.channel),
+  };
+}
+
+export type MemoriesApi = ReturnType<typeof createMemoriesApi>;

--- a/src/renderer/src/features/settings/settings-dialog.tsx
+++ b/src/renderer/src/features/settings/settings-dialog.tsx
@@ -1005,6 +1005,30 @@ export function SettingsDialog({
                     onChange={(event) => onSettingsChange({ rulesSyncEnabled: event.currentTarget.checked })}
                   />
                 </label>
+                <header className="settings-pane-head" style={{ marginTop: 18 }}>
+                  <h3>{l("Memories sync", "Memories 同步")}</h3>
+                  <p>
+                    {l(
+                      "Sync Qoder long-term memories across devices using the same Supabase project as Skill sync.",
+                      "使用与 Skill 同步相同的 Supabase 项目，跨设备同步 Qoder 长期记忆。",
+                    )}
+                  </p>
+                </header>
+                <label className="settings-field settings-toggle">
+                  <div className="settings-field-text">
+                    <span className="settings-field-title">{l("Enable memories sync", "启用 Memories 同步")}</span>
+                    <span className="settings-field-sub">
+                      {l("Uses the Supabase URL and anon key configured above for Skill sync.", "使用上方 Skill 同步配置的 Supabase URL 和 anon key。")}
+                    </span>
+                  </div>
+                  <input
+                    type="checkbox"
+                    className="switch"
+                    checked={Boolean(settings?.memoriesSyncEnabled)}
+                    disabled={!settings || saving}
+                    onChange={(event) => onSettingsChange({ memoriesSyncEnabled: event.currentTarget.checked })}
+                  />
+                </label>
               </section>
             ) : null}
             {activeSection === "appearance" ? (

--- a/src/shared/ipc/memories.ts
+++ b/src/shared/ipc/memories.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import { defineIpcRequest } from "./contract";
+
+const noInput = z.tuple([]);
+const memoryIdentityInput = z.string().trim().min(1).max(1024);
+
+export const MEMORIES_IPC = {
+  getSyncSnapshot: defineIpcRequest("memories:sync-snapshot", noInput),
+  upload: defineIpcRequest("memories:sync-upload", z.tuple([memoryIdentityInput])),
+  uploadAll: defineIpcRequest("memories:sync-upload-all", noInput),
+  deleteRemote: defineIpcRequest("memories:sync-delete", z.tuple([memoryIdentityInput])),
+  copySetupSql: defineIpcRequest("memories:sync-copy-setup-sql", noInput),
+} as const;


### PR DESCRIPTION
## 变更概述

数字资产同步：Memories 跨设备同步，全栈接通。

除了会话和 skill，各平台的长期记忆也是用户的核心资产。
本次改动把 Qoder 和 Codex 的 memories 都接入了同步体系。

1. `memories-sync.ts`：
   - Qoder：扫描 `~/.qoder/memories/<user-id>/global|projects/<category>/*.md`（跳过 user-id 层）
   - Codex：读取 `~/.codex/memories_1.sqlite` 的 `stage1_outputs` 表（raw_memory 字段）
   - Supabase REST 上传/下载，upsert + RLS
2. `shared/ipc/memories.ts` + `main/ipc/memories.ts` + `preload/memories.ts`：IPC 全栈
3. `main/index.ts`：`createMemoriesSyncService()` 服务层，复用 skillSync 的 Supabase 配置
4. Settings 页新增「Memories 同步」开关
5. `memoriesSyncEnabled` 设置项（默认关闭）

Claude Code 无独立 memories 系统（其"记忆"即 CLAUDE.md，已由 Rules 同步覆盖）。

改动相关部分已本地验证回归
