### PR TITLE
docs: add contributors list to README with contributors-readme-action

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,0 +1,24 @@
+name: Contributors README
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  contrib-readme-job:
+    runs-on: ubuntu-latest
+    name: A job to automate contrib in readme
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Contribute List
+        uses: akhilmhdh/contributors-readme-action@v2.3.11
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          image_size: 80
+          columns_per_row: 6
+          use_username: true
+          commit_message: "docs(contributor): update contributors list in README"

--- a/.release-notes/contributors-readme.md
+++ b/.release-notes/contributors-readme.md
@@ -1,0 +1,5 @@
+# README 展示贡献者列表
+
+## 新增功能
+
+- README 新增贡献者展示区域，通过 contributors-readme-action 自动维护，区分 Collaborators 和 Contributors 两个列表

--- a/README.md
+++ b/README.md
@@ -249,6 +249,18 @@ npm run package:smoke
 
 本项目基于 [MIT License](./LICENSE) 开源。你可以自由使用、修改和分发本项目，但需要保留原始版权声明和许可声明。
 
+## 贡献者
+
+### Collaborators
+
+<!-- readme: collaborators -start -->
+<!-- readme: collaborators -end -->
+
+### Contributors
+
+<!-- readme: contributors -start -->
+<!-- readme: contributors -end -->
+
 ## Star History
 
 <a href="https://www.star-history.com/?repos=zszz3%2FAgentRecall&type=date&legend=top-left">


### PR DESCRIPTION
## 变更概述

README 加了贡献者展示，用 contributors-readme-action 自动维护，以后有人提 PR 合并后列表会自动更新。

1. 新增 `.github/workflows/contributors.yml`：push 到 main 时自动更新 README 贡献者表格
2. README 新增「贡献者」区域，分 Collaborators 和 Contributors 两个列表
3. 配置：头像 80px、每行 6 列、显示用户名

合并后首次 push 到 main 时 action 会自动填充列表。

## 验证

- `node scripts/release-notes.mjs check-range upstream/main HEAD`：通过（1 feature）