### PR TITLE
docs: clarify English setup guidance

### DIFF
--- a/.release-notes/docs-windows-readme-setup.md
+++ b/.release-notes/docs-windows-readme-setup.md
@@ -1,0 +1,5 @@
+# Clearer English setup guidance
+
+## Bug 修复
+
+- English installation instructions now describe the correct macOS and Windows launch shortcuts and background app indicators more clearly.

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -146,9 +146,9 @@ agent-recall
 
 The first installation downloads the Electron runtime for the current operating system. See the Development Setup section and [Install.md](../Install.md) for source-based installation.
 
-Once installed, run `agent-recall` from any terminal to launch it. The app stays in the background (with a menu bar icon); press **⌥ Option + Space** by default to open the search window. If it conflicts with Raycast or another launcher, change or disable the global shortcut in Settings. The app uses a single-instance lock, so launching it again focuses the existing window instead of opening another instance.
+Once installed, run `agent-recall` from any terminal to launch it. The app stays in the background with a menu bar icon on macOS or a system tray icon on Windows. Press **⌥ Option + Space** on macOS or **Ctrl + Alt + Space** on Windows to open the search window. If the shortcut conflicts with another launcher, change or disable the global shortcut in Settings. The app uses a single-instance lock, so launching it again focuses the existing window instead of opening another instance.
 
-Settings can also be opened with `Cmd+,`. Use Appearance to switch the color theme and English / Chinese UI.
+On macOS, Settings can also be opened with `Cmd+,`. Use Appearance to switch the color theme and English / Chinese UI.
 
 For daily use, you do not need to reinstall dependencies or rebuild. Just run:
 
@@ -173,8 +173,6 @@ If you do not use nvm and have Node.js 22.13+ installed system-wide, daily start
 
 The terminal checks the latest GitHub Release automatically. When an update is available, it shows the release's new features and bug fixes and asks whether to install it. The same version, release notes, and **Update now** action are available under **Settings → About**. Use `agent-recall --check-update` to check without launching the App or `agent-recall --update` to install immediately. If an automatic update fails, the external updater attempts to reopen the installed version and uses an operating-system dialog to offer actions for copying the manual installation command or opening the latest Release page.
 
-On macOS, press **⌥ Option + Space** by default to open the search window. On Windows, use **Ctrl + Alt + Space**. Both shortcuts can be changed in Settings.
-
 See [Install.md](../Install.md) for updating, uninstalling, installing from a fresh clone, and network mirror tips.
 
 ## Development Setup
@@ -182,6 +180,7 @@ See [Install.md](../Install.md) for updating, uninstalling, installing from a fr
 Requirements:
 
 - macOS or Windows
+- Git
 - Node.js 22.13 or newer
 - npm
 


### PR DESCRIPTION
## Summary

This PR improves the English setup documentation for macOS and Windows users.

Changes include:
- Clarifying that AgentRecall runs in the macOS menu bar or Windows system tray after launch.
- Documenting the default search-window shortcuts for both platforms.
- Marking `Cmd+,` as a macOS-specific Settings shortcut.
- Adding Git to the development setup requirements.

## 中文说明

这个 PR 主要优化英文 README 中的安装和开发环境说明，让 macOS 和 Windows 用户更容易理解启动后的行为和默认快捷键。

具体包括：
- 说明应用启动后会常驻 macOS 菜单栏或 Windows 系统托盘。
- 明确 macOS 默认使用 `⌥ Option + Space` 唤起搜索窗口，Windows 默认使用 `Ctrl + Alt + Space`。
- 标明 `Cmd+,` 只适用于 macOS，避免 Windows 用户误解。
- 在开发环境要求中补充 `Git`。

## Verification

- `npm run release-note:check`