### PR TITLE
fix: extract browser-safe asset-identity module to fix renderer build

### DIFF
--- a/.release-notes/fix-digital-assets-browser-bundle.md
+++ b/.release-notes/fix-digital-assets-browser-bundle.md
@@ -1,0 +1,5 @@
+# 修复数字资产面板渲染进程构建失败
+
+## Bug 修复
+
+- 修复 digital-assets-dialog 从 rules-sync/memories-sync 导入值函数导致渲染进程 bundle 拉入 Node 内置模块、Rollup 构建失败的问题，抽取浏览器安全的 asset-identity 共享模块

--- a/src/core/asset-identity.ts
+++ b/src/core/asset-identity.ts
@@ -1,0 +1,22 @@
+/**
+ * Browser-safe asset identity helpers.
+ * This module must NOT import any Node.js built-ins (fs, os, path, crypto, sqlite)
+ * because it is imported by renderer components bundled for the browser environment.
+ */
+
+export interface AssetIdentityInput {
+  agent: string;
+  scope: string;
+  name: string;
+  projectPath: string;
+}
+
+/**
+ * Computes a stable identity string for a digital asset (rule or memory).
+ * Project-scoped assets include the project path; global assets do not.
+ */
+export function assetIdentity(asset: AssetIdentityInput): string {
+  return asset.scope === "project"
+    ? `${asset.agent}:${asset.scope}:${asset.projectPath}:${asset.name}`
+    : `${asset.agent}:${asset.scope}:${asset.name}`;
+}

--- a/src/core/memories-sync.ts
+++ b/src/core/memories-sync.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { DatabaseSync as DatabaseSyncType } from "node:sqlite";
+import { assetIdentity } from "./asset-identity";
 
 const require = createRequire(import.meta.url);
 
@@ -216,9 +217,7 @@ function readMemoryFile(filePath: string, agent: MemoriesAgent, scope: MemoriesS
 // ---------------------------------------------------------------------------
 
 export function memoryIdentity(memory: Pick<AgentMemory, "agent" | "scope" | "name" | "projectPath">): string {
-  return memory.scope === "project"
-    ? `${memory.agent}:${memory.scope}:${memory.projectPath}:${memory.name}`
-    : `${memory.agent}:${memory.scope}:${memory.name}`;
+  return assetIdentity(memory);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/rules-sync.ts
+++ b/src/core/rules-sync.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { assetIdentity } from "./asset-identity";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -127,9 +128,7 @@ function readRuleFile(filePath: string, agent: RulesAgent, scope: RulesScope, na
 // ---------------------------------------------------------------------------
 
 export function ruleIdentity(rule: Pick<AgentRule, "agent" | "scope" | "name" | "projectPath">): string {
-  return rule.scope === "project"
-    ? `${rule.agent}:${rule.scope}:${rule.projectPath}:${rule.name}`
-    : `${rule.agent}:${rule.scope}:${rule.name}`;
+  return assetIdentity(rule);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/renderer/src/digital-assets-panel.test.ts
+++ b/src/renderer/src/digital-assets-panel.test.ts
@@ -69,8 +69,9 @@ describe("digital assets panel", () => {
     expect(stylesheet).toContain(".asset-sync-icon");
   });
 
-  it("uses ruleIdentity and memoryIdentity for stable asset matching", () => {
-    expect(dialogSource).toContain("ruleIdentity");
-    expect(dialogSource).toContain("memoryIdentity");
+  it("uses browser-safe assetIdentity for stable asset matching", () => {
+    expect(dialogSource).toContain("assetIdentity");
+    expect(dialogSource).not.toContain("import { ruleIdentity }");
+    expect(dialogSource).not.toContain("import { memoryIdentity }");
   });
 });

--- a/src/renderer/src/features/digital-assets/digital-assets-dialog.tsx
+++ b/src/renderer/src/features/digital-assets/digital-assets-dialog.tsx
@@ -3,8 +3,7 @@ import type { ReactElement } from "react";
 import { PackageSearch, X } from "lucide-react";
 import type { RulesSyncSnapshot, AgentRule, RemoteRule } from "../../../../core/rules-sync";
 import type { MemoriesSyncSnapshot, AgentMemory, RemoteMemory } from "../../../../core/memories-sync";
-import { ruleIdentity } from "../../../../core/rules-sync";
-import { memoryIdentity } from "../../../../core/memories-sync";
+import { assetIdentity } from "../../../../core/asset-identity";
 import { localize, type LanguageMode } from "../../language";
 import { AssetSyncTab, type LocalAssetItem, type RemoteAssetItem } from "./asset-sync-tab";
 import type { SyncStatusKind } from "./sync-status-badge";
@@ -133,7 +132,7 @@ export function DigitalAssetsDialog({
   const rulesLocalItems: LocalAssetItem[] = useMemo(() => {
     if (!rulesSnapshot) return [];
     return rulesSnapshot.localRules.map((rule: AgentRule) => ({
-      identity: ruleIdentity(rule),
+      identity: assetIdentity(rule),
       name: rule.name,
       scope: rule.scope,
       agent: rule.agent,
@@ -158,7 +157,7 @@ export function DigitalAssetsDialog({
   const memoriesLocalItems: LocalAssetItem[] = useMemo(() => {
     if (!memoriesSnapshot) return [];
     return memoriesSnapshot.localMemories.map((memory: AgentMemory) => ({
-      identity: memoryIdentity(memory),
+      identity: assetIdentity(memory),
       name: memory.name,
       scope: memory.scope,
       agent: memory.agent,


### PR DESCRIPTION
修复 PR #128 引入的渲染进程构建失败：digital-assets-dialog 从 rules-sync/memories-sync 导入值函数 ruleIdentity/memoryIdentity，导致 Node 内置模块被拉入浏览器 bundle。抽取零 Node 依赖的 asset-identity.ts 共享模块解决。本地 electron-vite build 已验证通过。