### PR TITLE
Feat/session json export

### DIFF
--- a/.release-notes/feat-session-json-export.md
+++ b/.release-notes/feat-session-json-export.md
@@ -1,0 +1,5 @@
+# 会话请求体 JSON 导出
+
+## 新增功能
+
+- 会话详情现在可导出为 OpenAI Chat Completions、OpenAI Responses 或 Anthropic Messages 格式的 JSON 请求体，便于修改模型名称后直接用于 API 调试。

--- a/.release-notes/feat-session-json-export.md
+++ b/.release-notes/feat-session-json-export.md
@@ -2,4 +2,4 @@
 
 ## 新增功能
 
-- 会话详情现在可导出为 OpenAI Chat Completions、OpenAI Responses 或 Anthropic Messages 格式的 JSON 请求体，便于修改模型名称后直接用于 API 调试。
+- 会话详情现在可导出为 OpenAI Chat Completions、OpenAI Responses 或 Anthropic Messages 格式的 JSON 请求体；Codex 会话会尽可能保留模型、指令、工具调用、推理与流式参数，并在本地启用请求 trace 时支持导出原始 OpenAI Responses 请求体。导出完成后会明确提示本次使用的是原始 trace、历史重建还是标准化格式。

--- a/.release-notes/feat-session-json-export.md
+++ b/.release-notes/feat-session-json-export.md
@@ -2,4 +2,4 @@
 
 ## 新增功能
 
-- 会话详情现在可导出为 OpenAI Chat Completions、OpenAI Responses 或 Anthropic Messages 格式的 JSON 请求体；Codex 会话会尽可能保留模型、指令、工具调用、推理与流式参数，并在本地启用请求 trace 时支持导出原始 OpenAI Responses 请求体。导出完成后会明确提示本次使用的是原始 trace、历史重建还是标准化格式。
+- 会话详情现在可导出为 OpenAI Chat Completions、OpenAI Responses 或 Anthropic Messages 格式的 JSON 请求体；Codex 会话会尽可能保留模型、指令、并行工具调用、结构化工具结果、推理与流式参数，并在本地启用请求 trace 时支持导出原始 OpenAI Responses 请求体。导出完成后会明确提示本次使用的是原始 trace、历史重建还是标准化格式。

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ npm install -g https://github.com/zszz3/AgentRecall/releases/download/v0.2.0/age
 - **统一搜索和管理多种 AI Coding Agent 会话**：
   搜索、过滤、查看、整理和快速启动 Claude Code、Codex，以及可选的 TClaude、TCodex、CodeBuddy、CodeWiz、OpenClaw、Hermes、OpenCode、ZCode、Cursor Agent、Trae、Qoder 等会话；支持自定义标题、标签、收藏、置顶、隐藏和一键快速启动；也支持本地环境和 SSH 远程环境，远程机器无需安装本应用。侧边栏项目按环境分组展示，每组可折叠，组内按最近活跃时间排序。会话可按全部时间或最近 7 天、30 天或 90 天过滤；搜索结果默认按智能排序（相关性与时间衰减混合），也可切换为按最新或最早活跃时间排序。
 - **完整查看会话上下文**：
-  详情页展示完整消息、tool call 与 Markdown / code block，并支持查看 AI 摘要、导出 Markdown，以及导出 OpenAI Chat、OpenAI Responses 或 Anthropic 请求体 JSON。
+  详情页展示完整消息、tool call 与 Markdown / code block，并支持查看 AI 摘要、导出 Markdown，以及导出 OpenAI Chat、OpenAI Responses 或 Anthropic 请求体 JSON。Codex 会话会从 rollout 重建模型、指令、工具调用、推理参数、流式开关和请求 metadata；如果启动 Codex 与 AgentRecall 时均设置了 `CODEX_ROLLOUT_TRACE_ROOT`，OpenAI Responses 导出还会优先使用 Codex trace 中捕获的原始请求体。trace 可能包含完整提示词、工具参数与响应，请只保存到受信任的本地目录并妥善清理。
 - **AI / Agent 辅助检索历史会话**：
   可以使用 AI 摘要增强历史会话检索，也支持自然语言找会话；同时开放 MCP 能力,让 Claude Code / Codex / CodeBuddy 可以在对话里直接搜索、读取历史会话,并对会话打标签、收藏、设置可见性。
 - **跨 Agent 迁移会话**：

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ npm install -g https://github.com/zszz3/AgentRecall/releases/download/v0.2.0/age
 - **统一搜索和管理多种 AI Coding Agent 会话**：
   搜索、过滤、查看、整理和快速启动 Claude Code、Codex，以及可选的 TClaude、TCodex、CodeBuddy、CodeWiz、OpenClaw、Hermes、OpenCode、ZCode、Cursor Agent、Trae、Qoder 等会话；支持自定义标题、标签、收藏、置顶、隐藏和一键快速启动；也支持本地环境和 SSH 远程环境，远程机器无需安装本应用。侧边栏项目按环境分组展示，每组可折叠，组内按最近活跃时间排序。会话可按全部时间或最近 7 天、30 天或 90 天过滤；搜索结果默认按智能排序（相关性与时间衰减混合），也可切换为按最新或最早活跃时间排序。
 - **完整查看会话上下文**：
-  详情页展示完整消息、tool call 与 Markdown / code block，并支持查看 AI 摘要和导出 Markdown。
+  详情页展示完整消息、tool call 与 Markdown / code block，并支持查看 AI 摘要、导出 Markdown，以及导出 OpenAI Chat、OpenAI Responses 或 Anthropic 请求体 JSON。
 - **AI / Agent 辅助检索历史会话**：
   可以使用 AI 摘要增强历史会话检索，也支持自然语言找会话；同时开放 MCP 能力,让 Claude Code / Codex / CodeBuddy 可以在对话里直接搜索、读取历史会话,并对会话打标签、收藏、设置可见性。
 - **跨 Agent 迁移会话**：

--- a/src/core/codex-request-export.test.ts
+++ b/src/core/codex-request-export.test.ts
@@ -1,0 +1,108 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  findLatestCodexTraceRequest,
+  reconstructCodexResponsesRequest,
+  resolveCodexResponsesRequest,
+} from "./codex-request-export";
+
+const temporaryDirectories: string[] = [];
+
+function temporaryDirectory(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-codex-export-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function writeJsonLines(filePath: string, rows: unknown[]): void {
+  fs.writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`, "utf8");
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) fs.rmSync(directory, { recursive: true, force: true });
+});
+
+describe("Codex request export", () => {
+  it("returns the newest exact request captured for the matching thread", () => {
+    const root = temporaryDirectory();
+    const bundle = path.join(root, "trace-bundle-thread-1");
+    fs.mkdirSync(path.join(bundle, "payloads"), { recursive: true });
+    fs.writeFileSync(path.join(bundle, "payloads", "old.json"), JSON.stringify({ model: "old" }));
+    fs.writeFileSync(path.join(bundle, "payloads", "new.json"), JSON.stringify({ model: "gpt-5", stream: true }));
+    writeJsonLines(path.join(bundle, "trace.jsonl"), [
+      { wall_time_unix_ms: 1, payload: { type: "inference_started", thread_id: "thread-1", request_payload: { path: "payloads/old.json" } } },
+      { wall_time_unix_ms: 3, payload: { type: "inference_started", thread_id: "other", request_payload: { path: "payloads/ignored.json" } } },
+      { wall_time_unix_ms: 2, payload: { type: "inference_started", thread_id: "thread-1", request_payload: { path: "payloads/new.json" } } },
+    ]);
+
+    expect(findLatestCodexTraceRequest(root, "thread-1")).toEqual({ model: "gpt-5", stream: true });
+  });
+
+  it("does not read a trace payload outside its bundle", () => {
+    const root = temporaryDirectory();
+    const bundle = path.join(root, "trace-bundle-thread-1");
+    fs.mkdirSync(bundle, { recursive: true });
+    fs.writeFileSync(path.join(root, "outside.json"), JSON.stringify({ secret: true }));
+    writeJsonLines(path.join(bundle, "trace.jsonl"), [
+      { payload: { type: "inference_started", thread_id: "thread-1", request_payload: { path: "../outside.json" } } },
+    ]);
+
+    expect(findLatestCodexTraceRequest(root, "thread-1")).toBeNull();
+  });
+
+  it("reconstructs persisted Responses fields and tools", () => {
+    const root = temporaryDirectory();
+    const rollout = path.join(root, "rollout.jsonl");
+    writeJsonLines(rollout, [
+      { type: "session_meta", payload: {
+        id: "thread-1",
+        session_id: "session-1",
+        base_instructions: { text: "Follow the repository instructions." },
+        dynamic_tools: [{ Function: {
+          name: "lookup",
+          description: "Look up a record",
+          inputSchema: { type: "object", properties: { id: { type: "string" } }, required: ["id"] },
+        } }],
+      } },
+      { type: "turn_context", payload: { turn_id: "turn-1", model: "gpt-5.4", effort: "high", summary: "concise" } },
+      { type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "Find it" }] } },
+      { type: "response_item", payload: { type: "function_call", name: "lookup", call_id: "call-1", arguments: "{\"id\":\"42\"}" } },
+      { type: "response_item", payload: { type: "function_call_output", call_id: "call-1", output: "found" } },
+    ]);
+
+    expect(reconstructCodexResponsesRequest(rollout)).toEqual({
+      model: "gpt-5.4",
+      instructions: "Follow the repository instructions.",
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "Find it" }] },
+        { type: "function_call", name: "lookup", call_id: "call-1", arguments: "{\"id\":\"42\"}" },
+        { type: "function_call_output", call_id: "call-1", output: "found" },
+      ],
+      tools: [{ type: "function", name: "lookup", description: "Look up a record", strict: false, parameters: { type: "object", properties: { id: { type: "string" } }, required: ["id"] } }],
+      tool_choice: "auto",
+      parallel_tool_calls: false,
+      reasoning: { effort: "high", summary: "concise" },
+      store: false,
+      stream: true,
+      include: ["reasoning.encrypted_content"],
+      prompt_cache_key: "session-1",
+      client_metadata: { session_id: "session-1", thread_id: "thread-1", turn_id: "turn-1" },
+    });
+  });
+
+  it("falls back to reconstruction when no matching trace is available", () => {
+    const root = temporaryDirectory();
+    const rollout = path.join(root, "rollout.jsonl");
+    writeJsonLines(rollout, [
+      { type: "session_meta", payload: { id: "thread-1" } },
+      { type: "turn_context", payload: { model: "gpt-5" } },
+    ]);
+
+    expect(resolveCodexResponsesRequest({ filePath: rollout, rawId: "thread-1", traceRoot: root })).toMatchObject({
+      fidelity: "reconstructed",
+      body: { model: "gpt-5", stream: true },
+    });
+  });
+});

--- a/src/core/codex-request-export.test.ts
+++ b/src/core/codex-request-export.test.ts
@@ -25,22 +25,22 @@ afterEach(() => {
 });
 
 describe("Codex request export", () => {
-  it("returns the newest exact request captured for the matching thread", () => {
+  it("returns the newest exact request captured for the matching thread", async () => {
     const root = temporaryDirectory();
     const bundle = path.join(root, "trace-bundle-thread-1");
     fs.mkdirSync(path.join(bundle, "payloads"), { recursive: true });
     fs.writeFileSync(path.join(bundle, "payloads", "old.json"), JSON.stringify({ model: "old" }));
-    fs.writeFileSync(path.join(bundle, "payloads", "new.json"), JSON.stringify({ model: "gpt-5", stream: true }));
+    fs.writeFileSync(path.join(bundle, "payloads", "new.json"), JSON.stringify({ model: "gpt-5", stream: true, parallel_tool_calls: true }));
     writeJsonLines(path.join(bundle, "trace.jsonl"), [
       { wall_time_unix_ms: 1, payload: { type: "inference_started", thread_id: "thread-1", request_payload: { path: "payloads/old.json" } } },
       { wall_time_unix_ms: 3, payload: { type: "inference_started", thread_id: "other", request_payload: { path: "payloads/ignored.json" } } },
       { wall_time_unix_ms: 2, payload: { type: "inference_started", thread_id: "thread-1", request_payload: { path: "payloads/new.json" } } },
     ]);
 
-    expect(findLatestCodexTraceRequest(root, "thread-1")).toEqual({ model: "gpt-5", stream: true });
+    expect(await findLatestCodexTraceRequest(root, "thread-1")).toEqual({ model: "gpt-5", stream: true, parallel_tool_calls: true });
   });
 
-  it("does not read a trace payload outside its bundle", () => {
+  it("does not read a trace payload outside its bundle", async () => {
     const root = temporaryDirectory();
     const bundle = path.join(root, "trace-bundle-thread-1");
     fs.mkdirSync(bundle, { recursive: true });
@@ -49,10 +49,10 @@ describe("Codex request export", () => {
       { payload: { type: "inference_started", thread_id: "thread-1", request_payload: { path: "../outside.json" } } },
     ]);
 
-    expect(findLatestCodexTraceRequest(root, "thread-1")).toBeNull();
+    expect(await findLatestCodexTraceRequest(root, "thread-1")).toBeNull();
   });
 
-  it("reconstructs persisted Responses fields and tools", () => {
+  it("reconstructs persisted Responses fields and tools", async () => {
     const root = temporaryDirectory();
     const rollout = path.join(root, "rollout.jsonl");
     writeJsonLines(rollout, [
@@ -72,7 +72,7 @@ describe("Codex request export", () => {
       { type: "response_item", payload: { type: "function_call_output", call_id: "call-1", output: "found" } },
     ]);
 
-    expect(reconstructCodexResponsesRequest(rollout)).toEqual({
+    expect(await reconstructCodexResponsesRequest(rollout)).toEqual({
       model: "gpt-5.4",
       instructions: "Follow the repository instructions.",
       input: [
@@ -82,7 +82,6 @@ describe("Codex request export", () => {
       ],
       tools: [{ type: "function", name: "lookup", description: "Look up a record", strict: false, parameters: { type: "object", properties: { id: { type: "string" } }, required: ["id"] } }],
       tool_choice: "auto",
-      parallel_tool_calls: false,
       reasoning: { effort: "high", summary: "concise" },
       store: false,
       stream: true,
@@ -92,7 +91,108 @@ describe("Codex request export", () => {
     });
   });
 
-  it("falls back to reconstruction when no matching trace is available", () => {
+  it("rebuilds legacy compaction from retained user messages and a user-role summary", async () => {
+    const root = temporaryDirectory();
+    const rollout = path.join(root, "rollout.jsonl");
+    const message = (role: "user" | "assistant", text: string) => ({
+      type: "response_item",
+      payload: { type: "message", role, content: [{ type: role === "user" ? "input_text" : "output_text", text }] },
+    });
+    writeJsonLines(rollout, [
+      { type: "session_meta", payload: { id: "thread-1" } },
+      message("user", "first user"),
+      message("assistant", "first assistant"),
+      { type: "compacted", payload: { message: "summary one" } },
+      message("user", "second user"),
+      message("assistant", "second assistant"),
+      { type: "compacted", payload: { message: "summary two" } },
+      message("user", "third user"),
+    ]);
+
+    const request = await reconstructCodexResponsesRequest(rollout);
+    expect(request?.input).toEqual([
+      { type: "message", role: "user", content: [{ type: "input_text", text: "first user" }] },
+      { type: "message", role: "user", content: [{ type: "input_text", text: "second user" }] },
+      { type: "message", role: "user", content: [{ type: "input_text", text: "summary two" }] },
+      { type: "message", role: "user", content: [{ type: "input_text", text: "third user" }] },
+    ]);
+  });
+
+  it("rejects a trace payload symlink that resolves outside the bundle", async () => {
+    const root = temporaryDirectory();
+    const bundle = path.join(root, "trace-bundle-thread-1");
+    fs.mkdirSync(path.join(bundle, "payloads"), { recursive: true });
+    const outside = path.join(root, "outside.json");
+    const linkedPayload = path.join(bundle, "payloads", "request.json");
+    fs.writeFileSync(outside, JSON.stringify({ secret: true }));
+    try {
+      fs.symlinkSync(outside, linkedPayload, "file");
+    } catch (error) {
+      if (process.platform === "win32" && (error as NodeJS.ErrnoException).code === "EPERM") return;
+      throw error;
+    }
+    writeJsonLines(path.join(bundle, "trace.jsonl"), [
+      { payload: { type: "inference_started", thread_id: "thread-1", request_payload: { path: "payloads/request.json" } } },
+    ]);
+
+    expect(await findLatestCodexTraceRequest(root, "thread-1")).toBeNull();
+  });
+
+  it("keeps namespaced dynamic tools and infers custom tools without duplicates", async () => {
+    const root = temporaryDirectory();
+    const rollout = path.join(root, "rollout.jsonl");
+    writeJsonLines(rollout, [
+      { type: "session_meta", payload: {
+        id: "thread-1",
+        dynamic_tools: [{ Namespace: {
+          name: "files",
+          tools: [{ Function: { name: "read", inputSchema: { type: "object" } } }],
+        } }],
+      } },
+      { type: "response_item", payload: { type: "function_call", namespace: "files", name: "read", call_id: "call-1", arguments: "{}" } },
+      { type: "response_item", payload: { type: "custom_tool_call", name: "python", call_id: "call-2", input: "print(1)" } },
+    ]);
+
+    const request = await reconstructCodexResponsesRequest(rollout);
+    expect(request?.tools).toEqual([
+      {
+        type: "namespace",
+        name: "files",
+        description: "",
+        tools: [{
+          type: "function",
+          name: "read",
+          description: "",
+          strict: false,
+          parameters: { type: "object" },
+        }],
+      },
+      {
+        type: "custom",
+        name: "python",
+        description: "Reconstructed from recorded custom tool calls; the original format was not persisted.",
+      },
+    ]);
+  });
+
+  it("streams large rollout files without changing item order", async () => {
+    const root = temporaryDirectory();
+    const rollout = path.join(root, "rollout.jsonl");
+    const rows = Array.from({ length: 1_500 }, (_, index) => ({
+      type: "response_item",
+      payload: { type: "message", role: "user", content: [{ type: "input_text", text: `message-${index}` }] },
+    }));
+    writeJsonLines(rollout, [
+      { type: "session_meta", payload: { id: "thread-1" } },
+      ...rows,
+    ]);
+
+    const request = await reconstructCodexResponsesRequest(rollout);
+    expect((request?.input as unknown[] | undefined)?.length).toBe(1_500);
+    expect((request?.input as Array<{ content: Array<{ text: string }> }>)[1_499].content[0].text).toBe("message-1499");
+  });
+
+  it("falls back to reconstruction when no matching trace is available", async () => {
     const root = temporaryDirectory();
     const rollout = path.join(root, "rollout.jsonl");
     writeJsonLines(rollout, [
@@ -100,7 +200,7 @@ describe("Codex request export", () => {
       { type: "turn_context", payload: { model: "gpt-5" } },
     ]);
 
-    expect(resolveCodexResponsesRequest({ filePath: rollout, rawId: "thread-1", traceRoot: root })).toMatchObject({
+    expect(await resolveCodexResponsesRequest({ filePath: rollout, rawId: "thread-1", traceRoot: root })).toMatchObject({
       fidelity: "reconstructed",
       body: { model: "gpt-5", stream: true },
     });

--- a/src/core/codex-request-export.ts
+++ b/src/core/codex-request-export.ts
@@ -1,0 +1,246 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export type CodexRequestFidelity = "exact-trace" | "reconstructed" | "normalized";
+
+export interface CodexRequestExport {
+  body: Record<string, unknown>;
+  fidelity: CodexRequestFidelity;
+}
+
+interface TraceCandidate {
+  body: Record<string, unknown>;
+  timestamp: number;
+}
+
+export function resolveCodexResponsesRequest(options: {
+  filePath: string;
+  rawId: string;
+  traceRoot?: string;
+}): CodexRequestExport | null {
+  const exact = options.traceRoot ? findLatestCodexTraceRequest(options.traceRoot, options.rawId) : null;
+  if (exact) return { body: exact, fidelity: "exact-trace" };
+  const reconstructed = reconstructCodexResponsesRequest(options.filePath);
+  return reconstructed ? { body: reconstructed, fidelity: "reconstructed" } : null;
+}
+
+export function findLatestCodexTraceRequest(traceRoot: string, threadId: string): Record<string, unknown> | null {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(traceRoot, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  let latest: TraceCandidate | null = null;
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !entry.name.startsWith("trace-")) continue;
+    const bundlePath = path.join(traceRoot, entry.name);
+    const eventLogPath = path.join(bundlePath, "trace.jsonl");
+    let lines: string[];
+    try {
+      lines = fs.readFileSync(eventLogPath, "utf8").split(/\r?\n/);
+    } catch {
+      continue;
+    }
+
+    for (const line of lines) {
+      const event = parseObject(line);
+      if (!event) continue;
+      const payload = objectField(event, "payload");
+      if (!payload || payload.type !== "inference_started" || payload.thread_id !== threadId) continue;
+      const requestPayload = objectField(payload, "request_payload");
+      const relativePath = requestPayload && typeof requestPayload.path === "string" ? requestPayload.path : "";
+      const payloadPath = resolveBundlePath(bundlePath, relativePath);
+      if (!payloadPath) continue;
+      const body = readJsonObject(payloadPath);
+      if (!body) continue;
+      const timestamp = typeof event.wall_time_unix_ms === "number" ? event.wall_time_unix_ms : 0;
+      if (!latest || timestamp >= latest.timestamp) latest = { body, timestamp };
+    }
+  }
+  return latest?.body ?? null;
+}
+
+export function reconstructCodexResponsesRequest(filePath: string): Record<string, unknown> | null {
+  let lines: string[];
+  try {
+    lines = fs.readFileSync(filePath, "utf8").split(/\r?\n/);
+  } catch {
+    return null;
+  }
+
+  let sessionMeta: Record<string, unknown> | null = null;
+  let turnContext: Record<string, unknown> | null = null;
+  let input: unknown[] = [];
+  for (const line of lines) {
+    const row = parseObject(line);
+    if (!row) continue;
+    const payload = objectField(row, "payload");
+    if (row.type === "session_meta" && payload) {
+      sessionMeta = payload;
+    } else if (row.type === "turn_context" && payload) {
+      turnContext = payload;
+    } else if (row.type === "response_item" && payload && isRequestInputItem(payload)) {
+      input.push(payload);
+    } else if (row.type === "compacted" && payload) {
+      const replacement = Array.isArray(payload.replacement_history) ? payload.replacement_history : null;
+      if (replacement) {
+        input = replacement.filter(isRequestInputItem);
+      } else if (typeof payload.message === "string" && payload.message.trim()) {
+        input = [{ type: "message", role: "assistant", content: [{ type: "output_text", text: payload.message }] }];
+      }
+    }
+  }
+  if (!sessionMeta && !turnContext && input.length === 0) return null;
+
+  const model = stringField(turnContext, "model") || "YOUR_MODEL";
+  const sessionId = stringField(sessionMeta, "session_id") || stringField(sessionMeta, "id");
+  const threadId = stringField(sessionMeta, "id") || sessionId;
+  const instructions = baseInstructionsText(sessionMeta?.base_instructions);
+  const tools = reconstructedTools(sessionMeta?.dynamic_tools, input);
+  const reasoning = reconstructedReasoning(turnContext);
+  const clientMetadata: Record<string, string> = {};
+  if (sessionId) clientMetadata.session_id = sessionId;
+  if (threadId) clientMetadata.thread_id = threadId;
+  const turnId = stringField(turnContext, "turn_id");
+  if (turnId) clientMetadata.turn_id = turnId;
+
+  return {
+    model,
+    ...(instructions ? { instructions } : {}),
+    input,
+    tools,
+    tool_choice: "auto",
+    parallel_tool_calls: false,
+    ...(reasoning ? { reasoning } : {}),
+    store: false,
+    stream: true,
+    include: ["reasoning.encrypted_content"],
+    ...(sessionId ? { prompt_cache_key: sessionId } : {}),
+    ...(Object.keys(clientMetadata).length > 0 ? { client_metadata: clientMetadata } : {}),
+  };
+}
+
+function reconstructedReasoning(turnContext: Record<string, unknown> | null): Record<string, unknown> | null {
+  if (!turnContext) return null;
+  const effort = stringField(turnContext, "effort");
+  const summary = stringField(turnContext, "summary");
+  if (!effort && !summary) return null;
+  return { ...(effort ? { effort } : {}), ...(summary && summary !== "none" ? { summary } : {}) };
+}
+
+function reconstructedTools(dynamicTools: unknown, input: unknown[]): unknown[] {
+  const tools: Record<string, unknown>[] = [];
+  const knownNames = new Set<string>();
+  for (const raw of Array.isArray(dynamicTools) ? dynamicTools : []) {
+    for (const tool of responseToolsFromDynamic(raw)) {
+      tools.push(tool);
+      if (typeof tool.name === "string") knownNames.add(tool.name);
+    }
+  }
+  for (const item of input) {
+    if (!isObject(item) || item.type !== "function_call" || typeof item.name !== "string" || knownNames.has(item.name)) continue;
+    knownNames.add(item.name);
+    tools.push({
+      type: "function",
+      name: item.name,
+      description: "Reconstructed from recorded tool calls; the original description was not persisted.",
+      strict: false,
+      parameters: { type: "object", additionalProperties: true },
+    });
+  }
+  return tools;
+}
+
+function responseToolsFromDynamic(raw: unknown): Record<string, unknown>[] {
+  if (!isObject(raw)) return [];
+  const functionSpec = objectField(raw, "Function") ?? objectField(raw, "function");
+  if (functionSpec) return [responseFunctionTool(functionSpec)];
+  const namespace = objectField(raw, "Namespace") ?? objectField(raw, "namespace");
+  if (!namespace) return isDynamicFunction(raw) ? [responseFunctionTool(raw)] : [];
+  const namespaceTools = Array.isArray(namespace.tools) ? namespace.tools : [];
+  const functions = namespaceTools.flatMap(responseToolsFromDynamic);
+  return functions.length > 0
+    ? [{ type: "namespace", name: stringField(namespace, "name"), description: stringField(namespace, "description"), tools: functions }]
+    : [];
+}
+
+function responseFunctionTool(spec: Record<string, unknown>): Record<string, unknown> {
+  return {
+    type: "function",
+    name: stringField(spec, "name"),
+    description: stringField(spec, "description"),
+    strict: false,
+    parameters: spec.inputSchema ?? spec.input_schema ?? { type: "object", additionalProperties: true },
+  };
+}
+
+function isDynamicFunction(value: Record<string, unknown>): boolean {
+  return typeof value.name === "string" && ("inputSchema" in value || "input_schema" in value);
+}
+
+function isRequestInputItem(value: unknown): boolean {
+  if (!isObject(value) || typeof value.type !== "string") return false;
+  return [
+    "message",
+    "agent_message",
+    "reasoning",
+    "local_shell_call",
+    "function_call",
+    "function_call_output",
+    "custom_tool_call",
+    "custom_tool_call_output",
+    "tool_search_call",
+    "tool_search_output",
+    "web_search_call",
+    "image_generation_call",
+    "context_compaction",
+  ].includes(value.type);
+}
+
+function baseInstructionsText(value: unknown): string {
+  if (typeof value === "string") return value;
+  return stringField(isObject(value) ? value : null, "text");
+}
+
+function resolveBundlePath(bundlePath: string, relativePath: string): string | null {
+  if (!relativePath || path.isAbsolute(relativePath)) return null;
+  const resolvedBundle = path.resolve(bundlePath);
+  const resolvedPath = path.resolve(resolvedBundle, relativePath);
+  const relative = path.relative(resolvedBundle, resolvedPath);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) return null;
+  return resolvedPath;
+}
+
+function readJsonObject(filePath: string): Record<string, unknown> | null {
+  try {
+    const value = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    return isObject(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseObject(line: string): Record<string, unknown> | null {
+  if (!line.trim()) return null;
+  try {
+    const value = JSON.parse(line);
+    return isObject(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function objectField(value: unknown, key: string): Record<string, unknown> | null {
+  return isObject(value) && isObject(value[key]) ? value[key] : null;
+}
+
+function stringField(value: Record<string, unknown> | null, key: string): string {
+  const field = value?.[key];
+  return typeof field === "string" ? field : "";
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/core/codex-request-export.ts
+++ b/src/core/codex-request-export.ts
@@ -1,5 +1,7 @@
-import * as fs from "node:fs";
+import { createReadStream, type Dirent } from "node:fs";
+import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { createInterface } from "node:readline";
 
 export type CodexRequestFidelity = "exact-trace" | "reconstructed" | "normalized";
 
@@ -13,21 +15,21 @@ interface TraceCandidate {
   timestamp: number;
 }
 
-export function resolveCodexResponsesRequest(options: {
+export async function resolveCodexResponsesRequest(options: {
   filePath: string;
   rawId: string;
   traceRoot?: string;
-}): CodexRequestExport | null {
-  const exact = options.traceRoot ? findLatestCodexTraceRequest(options.traceRoot, options.rawId) : null;
+}): Promise<CodexRequestExport | null> {
+  const exact = options.traceRoot ? await findLatestCodexTraceRequest(options.traceRoot, options.rawId) : null;
   if (exact) return { body: exact, fidelity: "exact-trace" };
-  const reconstructed = reconstructCodexResponsesRequest(options.filePath);
+  const reconstructed = await reconstructCodexResponsesRequest(options.filePath);
   return reconstructed ? { body: reconstructed, fidelity: "reconstructed" } : null;
 }
 
-export function findLatestCodexTraceRequest(traceRoot: string, threadId: string): Record<string, unknown> | null {
-  let entries: fs.Dirent[];
+export async function findLatestCodexTraceRequest(traceRoot: string, threadId: string): Promise<Record<string, unknown> | null> {
+  let entries: Dirent[];
   try {
-    entries = fs.readdirSync(traceRoot, { withFileTypes: true });
+    entries = await fs.readdir(traceRoot, { withFileTypes: true });
   } catch {
     return null;
   }
@@ -37,60 +39,54 @@ export function findLatestCodexTraceRequest(traceRoot: string, threadId: string)
     if (!entry.isDirectory() || !entry.name.startsWith("trace-")) continue;
     const bundlePath = path.join(traceRoot, entry.name);
     const eventLogPath = path.join(bundlePath, "trace.jsonl");
-    let lines: string[];
     try {
-      lines = fs.readFileSync(eventLogPath, "utf8").split(/\r?\n/);
+      for await (const event of readJsonObjects(eventLogPath)) {
+        const payload = objectField(event, "payload");
+        if (!payload || payload.type !== "inference_started" || payload.thread_id !== threadId) continue;
+        const requestPayload = objectField(payload, "request_payload");
+        const relativePath = requestPayload && typeof requestPayload.path === "string" ? requestPayload.path : "";
+        const payloadPath = await resolveBundlePath(bundlePath, relativePath);
+        if (!payloadPath) continue;
+        const body = await readJsonObject(payloadPath);
+        if (!body) continue;
+        const timestamp = typeof event.wall_time_unix_ms === "number" ? event.wall_time_unix_ms : 0;
+        if (!latest || timestamp >= latest.timestamp) latest = { body, timestamp };
+      }
     } catch {
       continue;
-    }
-
-    for (const line of lines) {
-      const event = parseObject(line);
-      if (!event) continue;
-      const payload = objectField(event, "payload");
-      if (!payload || payload.type !== "inference_started" || payload.thread_id !== threadId) continue;
-      const requestPayload = objectField(payload, "request_payload");
-      const relativePath = requestPayload && typeof requestPayload.path === "string" ? requestPayload.path : "";
-      const payloadPath = resolveBundlePath(bundlePath, relativePath);
-      if (!payloadPath) continue;
-      const body = readJsonObject(payloadPath);
-      if (!body) continue;
-      const timestamp = typeof event.wall_time_unix_ms === "number" ? event.wall_time_unix_ms : 0;
-      if (!latest || timestamp >= latest.timestamp) latest = { body, timestamp };
     }
   }
   return latest?.body ?? null;
 }
 
-export function reconstructCodexResponsesRequest(filePath: string): Record<string, unknown> | null {
-  let lines: string[];
-  try {
-    lines = fs.readFileSync(filePath, "utf8").split(/\r?\n/);
-  } catch {
-    return null;
-  }
-
+export async function reconstructCodexResponsesRequest(filePath: string): Promise<Record<string, unknown> | null> {
   let sessionMeta: Record<string, unknown> | null = null;
   let turnContext: Record<string, unknown> | null = null;
   let input: unknown[] = [];
-  for (const line of lines) {
-    const row = parseObject(line);
-    if (!row) continue;
-    const payload = objectField(row, "payload");
-    if (row.type === "session_meta" && payload) {
-      sessionMeta = payload;
-    } else if (row.type === "turn_context" && payload) {
-      turnContext = payload;
-    } else if (row.type === "response_item" && payload && isRequestInputItem(payload)) {
-      input.push(payload);
-    } else if (row.type === "compacted" && payload) {
-      const replacement = Array.isArray(payload.replacement_history) ? payload.replacement_history : null;
-      if (replacement) {
-        input = replacement.filter(isRequestInputItem);
-      } else if (typeof payload.message === "string" && payload.message.trim()) {
-        input = [{ type: "message", role: "assistant", content: [{ type: "output_text", text: payload.message }] }];
+  const compactionSummaries = new Set<string>();
+  try {
+    for await (const row of readJsonObjects(filePath)) {
+      const payload = objectField(row, "payload");
+      if (row.type === "session_meta" && payload) {
+        sessionMeta = payload;
+      } else if (row.type === "turn_context" && payload) {
+        turnContext = payload;
+      } else if (row.type === "response_item" && payload && isRequestInputItem(payload)) {
+        input.push(payload);
+      } else if (row.type === "compacted" && payload) {
+        const replacement = Array.isArray(payload.replacement_history) ? payload.replacement_history : null;
+        const summary = typeof payload.message === "string" ? payload.message.trim() : "";
+        if (replacement) {
+          input = replacement.filter(isRequestInputItem);
+        } else if (summary) {
+          input = input.filter((item) => isRetainedCompactionUserMessage(item, compactionSummaries));
+          input.push({ type: "message", role: "user", content: [{ type: "input_text", text: summary }] });
+        }
+        if (summary) compactionSummaries.add(summary);
       }
     }
+  } catch {
+    return null;
   }
   if (!sessionMeta && !turnContext && input.length === 0) return null;
 
@@ -112,7 +108,6 @@ export function reconstructCodexResponsesRequest(filePath: string): Record<strin
     input,
     tools,
     tool_choice: "auto",
-    parallel_tool_calls: false,
     ...(reasoning ? { reasoning } : {}),
     store: false,
     stream: true,
@@ -136,21 +131,53 @@ function reconstructedTools(dynamicTools: unknown, input: unknown[]): unknown[] 
   for (const raw of Array.isArray(dynamicTools) ? dynamicTools : []) {
     for (const tool of responseToolsFromDynamic(raw)) {
       tools.push(tool);
-      if (typeof tool.name === "string") knownNames.add(tool.name);
+      collectResponseToolKeys(tool, knownNames);
     }
   }
   for (const item of input) {
-    if (!isObject(item) || item.type !== "function_call" || typeof item.name !== "string" || knownNames.has(item.name)) continue;
-    knownNames.add(item.name);
-    tools.push({
-      type: "function",
-      name: item.name,
-      description: "Reconstructed from recorded tool calls; the original description was not persisted.",
-      strict: false,
-      parameters: { type: "object", additionalProperties: true },
-    });
+    if (!isObject(item) || typeof item.name !== "string") continue;
+    if (item.type !== "function_call" && item.type !== "custom_tool_call") continue;
+    const namespace = typeof item.namespace === "string" ? item.namespace : "";
+    const key = responseToolKey(namespace, item.name);
+    if (knownNames.has(key)) continue;
+    knownNames.add(key);
+    if (item.type === "custom_tool_call") {
+      tools.push({
+        type: "custom",
+        name: item.name,
+        ...(namespace ? { namespace } : {}),
+        description: "Reconstructed from recorded custom tool calls; the original format was not persisted.",
+      });
+    } else {
+      tools.push({
+        type: "function",
+        name: item.name,
+        ...(namespace ? { namespace } : {}),
+        description: "Reconstructed from recorded tool calls; the original description was not persisted.",
+        strict: false,
+        parameters: { type: "object", additionalProperties: true },
+      });
+    }
   }
   return tools;
+}
+
+function collectResponseToolKeys(tool: Record<string, unknown>, keys: Set<string>, namespace = ""): void {
+  if (tool.type === "namespace" && typeof tool.name === "string") {
+    const childNamespace = namespace ? `${namespace}/${tool.name}` : tool.name;
+    for (const child of Array.isArray(tool.tools) ? tool.tools : []) {
+      if (isObject(child)) collectResponseToolKeys(child, keys, childNamespace);
+    }
+    return;
+  }
+  if (typeof tool.name === "string") {
+    const explicitNamespace = typeof tool.namespace === "string" ? tool.namespace : namespace;
+    keys.add(responseToolKey(explicitNamespace, tool.name));
+  }
+}
+
+function responseToolKey(namespace: string, name: string): string {
+  return namespace ? `${namespace}::${name}` : name;
 }
 
 function responseToolsFromDynamic(raw: unknown): Record<string, unknown>[] {
@@ -204,22 +231,43 @@ function baseInstructionsText(value: unknown): string {
   return stringField(isObject(value) ? value : null, "text");
 }
 
-function resolveBundlePath(bundlePath: string, relativePath: string): string | null {
+async function resolveBundlePath(bundlePath: string, relativePath: string): Promise<string | null> {
   if (!relativePath || path.isAbsolute(relativePath)) return null;
-  const resolvedBundle = path.resolve(bundlePath);
-  const resolvedPath = path.resolve(resolvedBundle, relativePath);
-  const relative = path.relative(resolvedBundle, resolvedPath);
-  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) return null;
-  return resolvedPath;
+  try {
+    const resolvedBundle = await fs.realpath(bundlePath);
+    const resolvedPath = await fs.realpath(path.resolve(bundlePath, relativePath));
+    const relative = path.relative(resolvedBundle, resolvedPath);
+    if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) return null;
+    const stat = await fs.stat(resolvedPath);
+    return stat.isFile() ? resolvedPath : null;
+  } catch {
+    return null;
+  }
 }
 
-function readJsonObject(filePath: string): Record<string, unknown> | null {
+async function readJsonObject(filePath: string): Promise<Record<string, unknown> | null> {
   try {
-    const value = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    const value = JSON.parse(await fs.readFile(filePath, "utf8"));
     return isObject(value) ? value : null;
   } catch {
     return null;
   }
+}
+
+async function* readJsonObjects(filePath: string): AsyncGenerator<Record<string, unknown>> {
+  const input = createReadStream(filePath, { encoding: "utf8" });
+  const lines = createInterface({ input, crlfDelay: Infinity });
+  for await (const line of lines) {
+    const parsed = parseObject(line);
+    if (parsed) yield parsed;
+  }
+}
+
+function isRetainedCompactionUserMessage(value: unknown, priorSummaries: Set<string>): boolean {
+  if (!isObject(value) || value.type !== "message" || value.role !== "user") return false;
+  const content = Array.isArray(value.content) ? value.content : [];
+  const text = content.flatMap((part) => isObject(part) && typeof part.text === "string" ? [part.text] : []).join("\n").trim();
+  return !priorSummaries.has(text);
 }
 
 function parseObject(line: string): Record<string, unknown> | null {

--- a/src/core/format-session.test.ts
+++ b/src/core/format-session.test.ts
@@ -108,4 +108,70 @@ describe("formatSessionJson", () => {
       stream: false,
     });
   });
+
+  it("preserves a captured Codex Responses request without normalizing it", () => {
+    const request = {
+      model: "gpt-5.4",
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "Hello" }] }],
+      tools: [{ type: "function", name: "lookup", parameters: { type: "object" } }],
+      stream: true,
+      metadata: { trace: "kept" },
+    };
+
+    expect(JSON.parse(formatSessionJson(messages, "openai_responses", request))).toEqual(request);
+  });
+
+  it("converts Responses tools and tool calls to Chat Completions", () => {
+    const request = {
+      model: "gpt-5.4",
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "Find it" }] },
+        { type: "function_call", call_id: "call-1", name: "lookup", arguments: "{\"id\":\"42\"}" },
+        { type: "function_call_output", call_id: "call-1", output: "found" },
+      ],
+      tools: [{ type: "function", name: "lookup", description: "Look it up", parameters: { type: "object" } }],
+      tool_choice: "auto",
+      parallel_tool_calls: false,
+      stream: true,
+    };
+
+    expect(JSON.parse(formatSessionJson(messages, "openai_chat", request))).toEqual({
+      model: "gpt-5.4",
+      messages: [
+        { role: "user", content: "Find it" },
+        { role: "assistant", content: null, tool_calls: [{ id: "call-1", type: "function", function: { name: "lookup", arguments: "{\"id\":\"42\"}" } }] },
+        { role: "tool", tool_call_id: "call-1", content: "found" },
+      ],
+      stream: true,
+      tools: [{ type: "function", function: { name: "lookup", description: "Look it up", parameters: { type: "object" } } }],
+      tool_choice: "auto",
+      parallel_tool_calls: false,
+    });
+  });
+
+  it("converts Responses instructions and tool calls to Anthropic Messages", () => {
+    const request = {
+      model: "claude-sonnet-4-5",
+      instructions: "Be concise.",
+      input: [
+        { type: "message", role: "developer", content: [{ type: "input_text", text: "Use tools." }] },
+        { type: "function_call", call_id: "call-1", name: "lookup", arguments: "{\"id\":\"42\"}" },
+        { type: "function_call_output", call_id: "call-1", output: "found" },
+      ],
+      tools: [{ type: "function", name: "lookup", parameters: { type: "object" } }],
+      stream: true,
+    };
+
+    expect(JSON.parse(formatSessionJson(messages, "anthropic", request))).toEqual({
+      model: "claude-sonnet-4-5",
+      max_tokens: 4096,
+      messages: [
+        { role: "assistant", content: [{ type: "tool_use", id: "call-1", name: "lookup", input: { id: "42" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "call-1", content: "found" }] },
+      ],
+      stream: true,
+      system: "Be concise.\n\nUse tools.",
+      tools: [{ name: "lookup", input_schema: { type: "object" } }],
+    });
+  });
 });

--- a/src/core/format-session.test.ts
+++ b/src/core/format-session.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatSessionMarkdown, formatSessionPlainText } from "./format-session";
+import { formatSessionJson, formatSessionMarkdown, formatSessionPlainText } from "./format-session";
 import type { IndexedSession, SessionMessage, SessionTraceEvent } from "./types";
 
 const session: IndexedSession = {
@@ -71,5 +71,41 @@ describe("formatSessionPlainText", () => {
     expect(text).toContain("Tool Trace");
     expect(text).toContain("shell_command · npm test");
     expect(text).toContain("stdout:");
+  });
+});
+
+describe("formatSessionJson", () => {
+  it("exports an OpenAI Chat Completions request body", () => {
+    expect(JSON.parse(formatSessionJson(messages, "openai_chat"))).toEqual({
+      model: "YOUR_MODEL",
+      messages: [
+        { role: "user", content: "run tests" },
+        { role: "assistant", content: "I will run them." },
+      ],
+      stream: false,
+    });
+  });
+
+  it("exports an OpenAI Responses request body", () => {
+    expect(JSON.parse(formatSessionJson(messages, "openai_responses"))).toEqual({
+      model: "YOUR_MODEL",
+      input: [
+        { role: "user", content: "run tests" },
+        { role: "assistant", content: "I will run them." },
+      ],
+      stream: false,
+    });
+  });
+
+  it("exports an Anthropic Messages request body with max_tokens", () => {
+    expect(JSON.parse(formatSessionJson(messages, "anthropic"))).toEqual({
+      model: "YOUR_MODEL",
+      max_tokens: 4096,
+      messages: [
+        { role: "user", content: "run tests" },
+        { role: "assistant", content: "I will run them." },
+      ],
+      stream: false,
+    });
   });
 });

--- a/src/core/format-session.test.ts
+++ b/src/core/format-session.test.ts
@@ -174,4 +174,105 @@ describe("formatSessionJson", () => {
       tools: [{ name: "lookup", input_schema: { type: "object" } }],
     });
   });
+
+  it("preserves instructions and groups parallel namespaced tools in Chat Completions", () => {
+    const request = {
+      model: "gpt-5.4",
+      instructions: "Follow repository rules.",
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "Inspect both" }] },
+        { type: "function_call", namespace: "files/tools", call_id: "call-1", name: "read", arguments: "{\"path\":\"a.ts\"}" },
+        { type: "custom_tool_call", call_id: "call-2", name: "python", input: "print(1)" },
+        { type: "function_call_output", call_id: "call-1", output: { text: "source" } },
+        { type: "custom_tool_call_output", call_id: "call-2", output: ["line 1", "line 2"] },
+      ],
+      tools: [
+        { type: "namespace", name: "files/tools", tools: [{ type: "function", name: "read", parameters: { type: "object" } }] },
+        { type: "custom", name: "python", description: "Run Python" },
+      ],
+      stream: true,
+    };
+
+    expect(JSON.parse(formatSessionJson(messages, "openai_chat", request))).toEqual({
+      model: "gpt-5.4",
+      messages: [
+        { role: "developer", content: "Follow repository rules." },
+        { role: "user", content: "Inspect both" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            { id: "call-1", type: "function", function: { name: "files__tools__read", arguments: "{\"path\":\"a.ts\"}" } },
+            { id: "call-2", type: "function", function: { name: "python", arguments: "{\"input\":\"print(1)\"}" } },
+          ],
+        },
+        { role: "tool", tool_call_id: "call-1", content: "{\"text\":\"source\"}" },
+        { role: "tool", tool_call_id: "call-2", content: "[\"line 1\",\"line 2\"]" },
+      ],
+      stream: true,
+      tools: [
+        { type: "function", function: { name: "files__tools__read", parameters: { type: "object" } } },
+        {
+          type: "function",
+          function: {
+            name: "python",
+            description: "Run Python",
+            parameters: {
+              type: "object",
+              properties: { input: { type: "string" } },
+              required: ["input"],
+              additionalProperties: false,
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  it("groups parallel Anthropic tool blocks and preserves structured result content", () => {
+    const request = {
+      model: "claude-sonnet-4-5",
+      input: [
+        { type: "function_call", call_id: "call-1", name: "lookup", arguments: "{\"id\":1}" },
+        { type: "custom_tool_call", call_id: "call-2", name: "python", input: "print(1)" },
+        { type: "function_call_output", call_id: "call-1", output: { found: true } },
+        { type: "custom_tool_call_output", call_id: "call-2", output: { content: [{ type: "output_text", text: "1" }] } },
+      ],
+      tools: [
+        { type: "function", name: "lookup", parameters: { type: "object" } },
+        { type: "custom", name: "python" },
+      ],
+    };
+
+    expect(JSON.parse(formatSessionJson(messages, "anthropic", request))).toMatchObject({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "call-1", name: "lookup", input: { id: 1 } },
+            { type: "tool_use", id: "call-2", name: "python", input: { input: "print(1)" } },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "call-1", content: "{\"found\":true}" },
+            { type: "tool_result", tool_use_id: "call-2", content: [{ type: "text", text: "1" }] },
+          ],
+        },
+      ],
+      tools: [
+        { name: "lookup", input_schema: { type: "object" } },
+        {
+          name: "python",
+          input_schema: {
+            type: "object",
+            properties: { input: { type: "string" } },
+            required: ["input"],
+            additionalProperties: false,
+          },
+        },
+      ],
+    });
+  });
 });

--- a/src/core/format-session.ts
+++ b/src/core/format-session.ts
@@ -86,7 +86,20 @@ export function formatSessionPlainText(
   return formatSessionMarkdown(session, messages, traceEvents).replace(/^#+\s/gm, "");
 }
 
-export function formatSessionJson(messages: SessionMessage[], format: SessionJsonExportFormat): string {
+export function formatSessionJson(
+  messages: SessionMessage[],
+  format: SessionJsonExportFormat,
+  codexResponsesRequest?: Record<string, unknown> | null,
+): string {
+  if (codexResponsesRequest) {
+    const body = format === "openai_responses"
+      ? codexResponsesRequest
+      : format === "anthropic"
+        ? responsesToAnthropic(codexResponsesRequest)
+        : responsesToChatCompletions(codexResponsesRequest);
+    return `${JSON.stringify(body, null, 2)}\n`;
+  }
+
   const conversation = messages.map(({ role, content }) => ({ role, content }));
   const body = format === "openai_responses"
     ? {
@@ -108,4 +121,141 @@ export function formatSessionJson(messages: SessionMessage[], format: SessionJso
         };
 
   return `${JSON.stringify(body, null, 2)}\n`;
+}
+
+function responsesToChatCompletions(request: Record<string, unknown>): Record<string, unknown> {
+  const messages: Record<string, unknown>[] = [];
+  for (const item of Array.isArray(request.input) ? request.input : []) {
+    if (!isObject(item)) continue;
+    if (item.type === "message") {
+      messages.push({ role: item.role, content: responseContentText(item.content) });
+    } else if (item.type === "function_call") {
+      messages.push({
+        role: "assistant",
+        content: null,
+        tool_calls: [{
+          id: item.call_id,
+          type: "function",
+          function: { name: item.name, arguments: item.arguments },
+        }],
+      });
+    } else if (item.type === "function_call_output") {
+      messages.push({ role: "tool", tool_call_id: item.call_id, content: item.output });
+    } else if (item.type === "custom_tool_call") {
+      messages.push({
+        role: "assistant",
+        content: null,
+        tool_calls: [{
+          id: item.call_id,
+          type: "function",
+          function: { name: item.name, arguments: item.input },
+        }],
+      });
+    } else if (item.type === "custom_tool_call_output") {
+      messages.push({ role: "tool", tool_call_id: item.call_id, content: item.output });
+    }
+  }
+
+  const body: Record<string, unknown> = {
+    model: request.model ?? EXPORTED_MODEL_PLACEHOLDER,
+    messages,
+    stream: request.stream ?? false,
+  };
+  const tools = responseToolsToChat(request.tools);
+  if (tools.length > 0) body.tools = tools;
+  if (request.tool_choice !== undefined) body.tool_choice = request.tool_choice;
+  if (request.parallel_tool_calls !== undefined) body.parallel_tool_calls = request.parallel_tool_calls;
+  if (request.metadata !== undefined) body.metadata = request.metadata;
+  return body;
+}
+
+function responsesToAnthropic(request: Record<string, unknown>): Record<string, unknown> {
+  const systemParts: string[] = typeof request.instructions === "string" && request.instructions
+    ? [request.instructions]
+    : [];
+  const messages: Record<string, unknown>[] = [];
+  for (const item of Array.isArray(request.input) ? request.input : []) {
+    if (!isObject(item)) continue;
+    if (item.type === "message") {
+      const text = responseContentText(item.content);
+      if (item.role === "system" || item.role === "developer") {
+        if (text) systemParts.push(text);
+      } else {
+        messages.push({ role: item.role === "assistant" ? "assistant" : "user", content: text });
+      }
+    } else if (item.type === "function_call" || item.type === "custom_tool_call") {
+      const rawInput = item.type === "function_call" ? item.arguments : item.input;
+      messages.push({
+        role: "assistant",
+        content: [{ type: "tool_use", id: item.call_id, name: item.name, input: parseToolInput(rawInput) }],
+      });
+    } else if (item.type === "function_call_output" || item.type === "custom_tool_call_output") {
+      messages.push({
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: item.call_id, content: String(item.output ?? "") }],
+      });
+    }
+  }
+
+  const body: Record<string, unknown> = {
+    model: request.model ?? EXPORTED_MODEL_PLACEHOLDER,
+    max_tokens: 4096,
+    messages,
+    stream: request.stream ?? false,
+  };
+  if (systemParts.length > 0) body.system = systemParts.join("\n\n");
+  const tools = responseToolsToAnthropic(request.tools);
+  if (tools.length > 0) body.tools = tools;
+  if (request.metadata !== undefined) body.metadata = request.metadata;
+  return body;
+}
+
+function responseToolsToChat(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((tool) => {
+    if (!isObject(tool) || tool.type !== "function" || typeof tool.name !== "string") return [];
+    return [{
+      type: "function",
+      function: {
+        name: tool.name,
+        ...(typeof tool.description === "string" ? { description: tool.description } : {}),
+        parameters: tool.parameters ?? { type: "object", properties: {} },
+      },
+    }];
+  });
+}
+
+function responseToolsToAnthropic(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((tool) => {
+    if (!isObject(tool) || tool.type !== "function" || typeof tool.name !== "string") return [];
+    return [{
+      name: tool.name,
+      ...(typeof tool.description === "string" ? { description: tool.description } : {}),
+      input_schema: tool.parameters ?? { type: "object", properties: {} },
+    }];
+  });
+}
+
+function responseContentText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (!Array.isArray(value)) return "";
+  return value.flatMap((part) => {
+    if (typeof part === "string") return [part];
+    if (!isObject(part)) return [];
+    return typeof part.text === "string" ? [part.text] : [];
+  }).join("\n");
+}
+
+function parseToolInput(value: unknown): unknown {
+  if (typeof value !== "string") return value ?? {};
+  try {
+    return JSON.parse(value);
+  } catch {
+    return { input: value };
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/src/core/format-session.ts
+++ b/src/core/format-session.ts
@@ -1,6 +1,10 @@
 import type { IndexedSession, SessionMessage, SessionSearchResult, SessionTraceEvent } from "./types";
 import { sessionSourceLabel } from "./session-sources";
 
+export type SessionJsonExportFormat = "openai_chat" | "openai_responses" | "anthropic";
+
+const EXPORTED_MODEL_PLACEHOLDER = "YOUR_MODEL";
+
 export function formatRelativeTime(ts: number): string {
   const diff = Date.now() - ts;
   const minutes = Math.floor(diff / 60_000);
@@ -80,4 +84,28 @@ export function formatSessionPlainText(
   traceEvents: SessionTraceEvent[] = [],
 ): string {
   return formatSessionMarkdown(session, messages, traceEvents).replace(/^#+\s/gm, "");
+}
+
+export function formatSessionJson(messages: SessionMessage[], format: SessionJsonExportFormat): string {
+  const conversation = messages.map(({ role, content }) => ({ role, content }));
+  const body = format === "openai_responses"
+    ? {
+        model: EXPORTED_MODEL_PLACEHOLDER,
+        input: conversation,
+        stream: false,
+      }
+    : format === "anthropic"
+      ? {
+          model: EXPORTED_MODEL_PLACEHOLDER,
+          max_tokens: 4096,
+          messages: conversation,
+          stream: false,
+        }
+      : {
+          model: EXPORTED_MODEL_PLACEHOLDER,
+          messages: conversation,
+          stream: false,
+        };
+
+  return `${JSON.stringify(body, null, 2)}\n`;
 }

--- a/src/core/format-session.ts
+++ b/src/core/format-session.ts
@@ -125,36 +125,41 @@ export function formatSessionJson(
 
 function responsesToChatCompletions(request: Record<string, unknown>): Record<string, unknown> {
   const messages: Record<string, unknown>[] = [];
+  if (typeof request.instructions === "string" && request.instructions) {
+    messages.push({ role: "developer", content: request.instructions });
+  }
+  let pendingToolCalls: Record<string, unknown>[] = [];
+  const flushToolCalls = (): void => {
+    if (pendingToolCalls.length === 0) return;
+    messages.push({ role: "assistant", content: null, tool_calls: pendingToolCalls });
+    pendingToolCalls = [];
+  };
   for (const item of Array.isArray(request.input) ? request.input : []) {
     if (!isObject(item)) continue;
     if (item.type === "message") {
+      flushToolCalls();
       messages.push({ role: item.role, content: responseContentText(item.content) });
-    } else if (item.type === "function_call") {
-      messages.push({
-        role: "assistant",
-        content: null,
-        tool_calls: [{
-          id: item.call_id,
-          type: "function",
-          function: { name: item.name, arguments: item.arguments },
-        }],
+    } else if (item.type === "function_call" || item.type === "custom_tool_call") {
+      const custom = item.type === "custom_tool_call";
+      pendingToolCalls.push({
+        id: item.call_id,
+        type: "function",
+        function: {
+          name: qualifiedToolName(item.namespace, item.name),
+          arguments: custom
+            ? safeJsonStringify({ input: item.input ?? "" })
+            : typeof item.arguments === "string" ? item.arguments : safeJsonStringify(item.arguments ?? {}),
+        },
       });
     } else if (item.type === "function_call_output") {
-      messages.push({ role: "tool", tool_call_id: item.call_id, content: item.output });
-    } else if (item.type === "custom_tool_call") {
-      messages.push({
-        role: "assistant",
-        content: null,
-        tool_calls: [{
-          id: item.call_id,
-          type: "function",
-          function: { name: item.name, arguments: item.input },
-        }],
-      });
+      flushToolCalls();
+      messages.push({ role: "tool", tool_call_id: item.call_id, content: serializeToolOutput(item.output) });
     } else if (item.type === "custom_tool_call_output") {
-      messages.push({ role: "tool", tool_call_id: item.call_id, content: item.output });
+      flushToolCalls();
+      messages.push({ role: "tool", tool_call_id: item.call_id, content: serializeToolOutput(item.output) });
     }
   }
+  flushToolCalls();
 
   const body: Record<string, unknown> = {
     model: request.model ?? EXPORTED_MODEL_PLACEHOLDER,
@@ -180,20 +185,24 @@ function responsesToAnthropic(request: Record<string, unknown>): Record<string, 
       const text = responseContentText(item.content);
       if (item.role === "system" || item.role === "developer") {
         if (text) systemParts.push(text);
-      } else {
-        messages.push({ role: item.role === "assistant" ? "assistant" : "user", content: text });
+      } else if (text) {
+        appendAnthropicContent(messages, item.role === "assistant" ? "assistant" : "user", [{ type: "text", text }]);
       }
     } else if (item.type === "function_call" || item.type === "custom_tool_call") {
-      const rawInput = item.type === "function_call" ? item.arguments : item.input;
-      messages.push({
-        role: "assistant",
-        content: [{ type: "tool_use", id: item.call_id, name: item.name, input: parseToolInput(rawInput) }],
-      });
+      const custom = item.type === "custom_tool_call";
+      const rawInput = custom ? { input: item.input ?? "" } : parseToolInput(item.arguments);
+      appendAnthropicContent(messages, "assistant", [{
+        type: "tool_use",
+        id: item.call_id,
+        name: qualifiedToolName(item.namespace, item.name),
+        input: rawInput,
+      }]);
     } else if (item.type === "function_call_output" || item.type === "custom_tool_call_output") {
-      messages.push({
-        role: "user",
-        content: [{ type: "tool_result", tool_use_id: item.call_id, content: String(item.output ?? "") }],
-      });
+      appendAnthropicContent(messages, "user", [{
+        type: "tool_result",
+        tool_use_id: item.call_id,
+        content: anthropicToolResultContent(item.output),
+      }]);
     }
   }
 
@@ -211,30 +220,104 @@ function responsesToAnthropic(request: Record<string, unknown>): Record<string, 
 }
 
 function responseToolsToChat(value: unknown): Record<string, unknown>[] {
-  if (!Array.isArray(value)) return [];
-  return value.flatMap((tool) => {
-    if (!isObject(tool) || tool.type !== "function" || typeof tool.name !== "string") return [];
-    return [{
-      type: "function",
-      function: {
-        name: tool.name,
-        ...(typeof tool.description === "string" ? { description: tool.description } : {}),
-        parameters: tool.parameters ?? { type: "object", properties: {} },
-      },
-    }];
-  });
+  return flattenResponseTools(value).map((tool) => ({
+    type: "function",
+    function: {
+      name: tool.name,
+      ...(tool.description ? { description: tool.description } : {}),
+      parameters: tool.parameters,
+    },
+  }));
 }
 
 function responseToolsToAnthropic(value: unknown): Record<string, unknown>[] {
+  return flattenResponseTools(value).map((tool) => ({
+    name: tool.name,
+    ...(tool.description ? { description: tool.description } : {}),
+    input_schema: tool.parameters,
+  }));
+}
+
+function flattenResponseTools(value: unknown, namespace?: string): Array<{
+  name: string;
+  description: string;
+  parameters: unknown;
+}> {
   if (!Array.isArray(value)) return [];
   return value.flatMap((tool) => {
-    if (!isObject(tool) || tool.type !== "function" || typeof tool.name !== "string") return [];
-    return [{
-      name: tool.name,
-      ...(typeof tool.description === "string" ? { description: tool.description } : {}),
-      input_schema: tool.parameters ?? { type: "object", properties: {} },
-    }];
+    if (!isObject(tool) || typeof tool.name !== "string") return [];
+    if (tool.type === "namespace") {
+      return flattenResponseTools(tool.tools, namespace ? `${namespace}/${tool.name}` : tool.name);
+    }
+    if (tool.type === "function") {
+      return [{
+        name: qualifiedToolName(namespace ?? tool.namespace, tool.name),
+        description: typeof tool.description === "string" ? tool.description : "",
+        parameters: tool.parameters ?? { type: "object", properties: {} },
+      }];
+    }
+    if (tool.type === "custom") {
+      return [{
+        name: qualifiedToolName(namespace ?? tool.namespace, tool.name),
+        description: typeof tool.description === "string" ? tool.description : "",
+        parameters: {
+          type: "object",
+          properties: { input: { type: "string" } },
+          required: ["input"],
+          additionalProperties: false,
+        },
+      }];
+    }
+    return [];
   });
+}
+
+function appendAnthropicContent(
+  messages: Record<string, unknown>[],
+  role: "user" | "assistant",
+  blocks: Record<string, unknown>[],
+): void {
+  const previous = messages.at(-1);
+  if (previous?.role === role && Array.isArray(previous.content)) {
+    previous.content.push(...blocks);
+    return;
+  }
+  messages.push({ role, content: blocks });
+}
+
+function qualifiedToolName(namespace: unknown, name: unknown): string {
+  const toolName = typeof name === "string" && name ? name : "tool";
+  if (typeof namespace !== "string" || !namespace) return sanitizeToolName(toolName);
+  const namespaceParts = namespace.split(/[/.]+/).filter(Boolean).map(sanitizeToolName);
+  return [...namespaceParts, sanitizeToolName(toolName)].join("__");
+}
+
+function sanitizeToolName(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+function serializeToolOutput(value: unknown): string {
+  return typeof value === "string" ? value : safeJsonStringify(value ?? "");
+}
+
+function anthropicToolResultContent(value: unknown): unknown {
+  if (typeof value === "string") return value;
+  const blocks = isObject(value) && Array.isArray(value.content) ? value.content : value;
+  if (Array.isArray(blocks) && blocks.every((item) => isObject(item) && typeof item.type === "string")) {
+    return blocks.map((item) => {
+      if (!isObject(item)) return item;
+      return item.type === "input_text" || item.type === "output_text" ? { ...item, type: "text" } : item;
+    });
+  }
+  return safeJsonStringify(value ?? "");
+}
+
+function safeJsonStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return String(value);
+  }
 }
 
 function responseContentText(value: unknown): string {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,7 +23,12 @@ import { randomUUID } from "node:crypto";
 import { execFile } from "node:child_process";
 import { loadActiveCodexSummaryEndpointDefaults } from "../core/codex-profile";
 import { indexMigratedSessionFile, syncDefaultSessionsInBatches, type IndexStatus } from "../core/indexer";
-import { formatSessionMarkdown, formatSessionPlainText } from "../core/format-session";
+import {
+  formatSessionJson,
+  formatSessionMarkdown,
+  formatSessionPlainText,
+  type SessionJsonExportFormat,
+} from "../core/format-session";
 import { normalizeExternalLink } from "../core/external-link";
 import {
   defaultSettings,
@@ -419,12 +424,12 @@ function enabledRemoteOptionalSources(settings: AppSettings): SessionSource[] {
     .map((descriptor) => descriptor.id);
 }
 
-function markdownExportFileName(title: string): string {
+function exportFileName(title: string, extension: "md" | "json"): string {
   const safeTitle = title
     .replace(/[\\/:*?"<>|\x00-\x1f]/g, " ")
     .replace(/\s+/g, " ")
     .trim();
-  return `${safeTitle || "session"}.md`;
+  return `${safeTitle || "session"}.${extension}`;
 }
 
 function sshArgsForSession(session: SessionSearchResult): string[] | undefined {
@@ -509,6 +514,32 @@ async function chooseMarkdownExportPath(defaultFileName: string): Promise<string
   const result = mainWindow ? await dialog.showSaveDialog(mainWindow, options) : await dialog.showSaveDialog(options);
   if (result.canceled || !result.filePath) return null;
   return path.extname(result.filePath) ? result.filePath : `${result.filePath}.md`;
+}
+
+async function chooseJsonExportFormat(): Promise<SessionJsonExportFormat | null> {
+  const options: Electron.MessageBoxOptions = {
+    type: "question",
+    title: "Export JSON",
+    message: "Choose an API request format",
+    detail: "The exported model is a placeholder. Replace YOUR_MODEL before sending the request.",
+    buttons: ["OpenAI Chat Completions", "OpenAI Responses", "Anthropic Messages", "Cancel"],
+    defaultId: 0,
+    cancelId: 3,
+    noLink: true,
+  };
+  const result = mainWindow ? await dialog.showMessageBox(mainWindow, options) : await dialog.showMessageBox(options);
+  return (["openai_chat", "openai_responses", "anthropic"] as const)[result.response] ?? null;
+}
+
+async function chooseJsonExportPath(defaultFileName: string): Promise<string | null> {
+  const options = {
+    title: "Export JSON",
+    defaultPath: path.join(app.getPath("documents"), defaultFileName),
+    filters: [{ name: "JSON", extensions: ["json"] }],
+  };
+  const result = mainWindow ? await dialog.showSaveDialog(mainWindow, options) : await dialog.showSaveDialog(options);
+  if (result.canceled || !result.filePath) return null;
+  return path.extname(result.filePath) ? result.filePath : `${result.filePath}.json`;
 }
 
 async function chooseLocalProjectDirectory(): Promise<string | null> {
@@ -1551,9 +1582,20 @@ function registerIpc(): void {
     await ensureRemoteSessionDetailsLoaded(sessionKey);
     const session = store.getSession(sessionKey);
     if (!session) return false;
-    const exportPath = await chooseMarkdownExportPath(markdownExportFileName(session.displayTitle || session.originalTitle || session.rawId));
+    const exportPath = await chooseMarkdownExportPath(exportFileName(session.displayTitle || session.originalTitle || session.rawId, "md"));
     if (!exportPath) return false;
     await fs.writeFile(exportPath, formatSessionMarkdown(session, store.getAllMessages(sessionKey), store.getTraceEvents(sessionKey)), "utf-8");
+    return true;
+  });
+  ipcMain.handle("command:export-json", async (_event, sessionKey: string) => {
+    await ensureRemoteSessionDetailsLoaded(sessionKey);
+    const session = store.getSession(sessionKey);
+    if (!session) return false;
+    const format = await chooseJsonExportFormat();
+    if (!format) return false;
+    const exportPath = await chooseJsonExportPath(exportFileName(session.displayTitle || session.originalTitle || session.rawId, "json"));
+    if (!exportPath) return false;
+    await fs.writeFile(exportPath, formatSessionJson(store.getAllMessages(sessionKey), format), "utf-8");
     return true;
   });
   ipcMain.handle("command:copy-plain", async (_event, sessionKey: string) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -22,6 +22,12 @@ import { createRequire } from "node:module";
 import { randomUUID } from "node:crypto";
 import { execFile } from "node:child_process";
 import { loadActiveCodexSummaryEndpointDefaults } from "../core/codex-profile";
+import {
+  reconstructCodexResponsesRequest,
+  resolveCodexResponsesRequest,
+  type CodexRequestExport,
+  type CodexRequestFidelity,
+} from "../core/codex-request-export";
 import { indexMigratedSessionFile, syncDefaultSessionsInBatches, type IndexStatus } from "../core/indexer";
 import {
   formatSessionJson,
@@ -521,7 +527,7 @@ async function chooseJsonExportFormat(): Promise<SessionJsonExportFormat | null>
     type: "question",
     title: "Export JSON",
     message: "Choose an API request format",
-    detail: "The exported model is a placeholder. Replace YOUR_MODEL before sending the request.",
+    detail: "Codex exports use an exact captured request when available, otherwise a reconstructed request. Other sessions use normalized messages.",
     buttons: ["OpenAI Chat Completions", "OpenAI Responses", "Anthropic Messages", "Cancel"],
     defaultId: 0,
     cancelId: 3,
@@ -1590,13 +1596,53 @@ function registerIpc(): void {
   ipcMain.handle("command:export-json", async (_event, sessionKey: string) => {
     await ensureRemoteSessionDetailsLoaded(sessionKey);
     const session = store.getSession(sessionKey);
-    if (!session) return false;
+    if (!session) return { exported: false };
     const format = await chooseJsonExportFormat();
-    if (!format) return false;
+    if (!format) return { exported: false };
     const exportPath = await chooseJsonExportPath(exportFileName(session.displayTitle || session.originalTitle || session.rawId, "json"));
-    if (!exportPath) return false;
-    await fs.writeFile(exportPath, formatSessionJson(store.getAllMessages(sessionKey), format), "utf-8");
-    return true;
+    if (!exportPath) return { exported: false };
+
+    let codexRequest: CodexRequestExport | null = null;
+    const isCodexSession = ["codex-cli", "codex-app", "codex-internal", "tcodex-cli"].includes(session.source);
+    if (isCodexSession && isLocalSessionEnvironment(session)) {
+      if (format === "openai_responses") {
+        codexRequest = resolveCodexResponsesRequest({
+          filePath: session.filePath,
+          rawId: session.rawId,
+          traceRoot: process.env.CODEX_ROLLOUT_TRACE_ROOT?.trim() || undefined,
+        });
+      } else {
+        const reconstructed = reconstructCodexResponsesRequest(session.filePath);
+        if (reconstructed) codexRequest = { body: reconstructed, fidelity: "reconstructed" };
+      }
+    }
+    const fidelity: CodexRequestFidelity = codexRequest?.fidelity ?? "normalized";
+    await fs.writeFile(
+      exportPath,
+      formatSessionJson(store.getAllMessages(sessionKey), format, codexRequest?.body),
+      "utf-8",
+    );
+    const fidelityMessage = fidelity === "exact-trace"
+      ? "Exact Codex request body captured from CODEX_ROLLOUT_TRACE_ROOT."
+      : fidelity === "reconstructed"
+        ? "Request body reconstructed from the Codex rollout history."
+        : "Request body exported in normalized message format.";
+    const fidelityMessageZh = fidelity === "exact-trace"
+      ? "已从 CODEX_ROLLOUT_TRACE_ROOT 导出 Codex 原始请求体。"
+      : fidelity === "reconstructed"
+        ? "已根据 Codex rollout 历史重建请求体。"
+        : "已按标准消息格式导出请求体。";
+    const notice: Electron.MessageBoxOptions = {
+      type: "info",
+      title: "JSON Export Complete",
+      message: fidelityMessage,
+      detail: `${fidelityMessageZh}\n\n${exportPath}`,
+      buttons: ["OK"],
+      noLink: true,
+    };
+    if (mainWindow) await dialog.showMessageBox(mainWindow, notice);
+    else await dialog.showMessageBox(notice);
+    return { exported: true, fidelity };
   });
   ipcMain.handle("command:copy-plain", async (_event, sessionKey: string) => {
     await ensureRemoteSessionDetailsLoaded(sessionKey);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1606,13 +1606,13 @@ function registerIpc(): void {
     const isCodexSession = ["codex-cli", "codex-app", "codex-internal", "tcodex-cli"].includes(session.source);
     if (isCodexSession && isLocalSessionEnvironment(session)) {
       if (format === "openai_responses") {
-        codexRequest = resolveCodexResponsesRequest({
+        codexRequest = await resolveCodexResponsesRequest({
           filePath: session.filePath,
           rawId: session.rawId,
           traceRoot: process.env.CODEX_ROLLOUT_TRACE_ROOT?.trim() || undefined,
         });
       } else {
-        const reconstructed = reconstructCodexResponsesRequest(session.filePath);
+        const reconstructed = await reconstructCodexResponsesRequest(session.filePath);
         if (reconstructed) codexRequest = { body: reconstructed, fidelity: "reconstructed" };
       }
     }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -105,7 +105,10 @@ const api = {
   revealSession: (sessionKey: string): Promise<void> => ipcRenderer.invoke("command:reveal", sessionKey),
   copyMarkdown: (sessionKey: string): Promise<void> => ipcRenderer.invoke("command:copy-markdown", sessionKey),
   exportMarkdown: (sessionKey: string): Promise<boolean> => ipcRenderer.invoke("command:export-markdown", sessionKey),
-  exportJson: (sessionKey: string): Promise<boolean> => ipcRenderer.invoke("command:export-json", sessionKey),
+  exportJson: (sessionKey: string): Promise<{
+    exported: boolean;
+    fidelity?: "exact-trace" | "reconstructed" | "normalized";
+  }> => ipcRenderer.invoke("command:export-json", sessionKey),
   copyPlainText: (sessionKey: string): Promise<void> => ipcRenderer.invoke("command:copy-plain", sessionKey),
   openExternalLink: (url: string): Promise<void> => ipcRenderer.invoke("markdown:open-external", url),
   onIndexStatus: (callback: (status: IndexStatus) => void): (() => void) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -105,6 +105,7 @@ const api = {
   revealSession: (sessionKey: string): Promise<void> => ipcRenderer.invoke("command:reveal", sessionKey),
   copyMarkdown: (sessionKey: string): Promise<void> => ipcRenderer.invoke("command:copy-markdown", sessionKey),
   exportMarkdown: (sessionKey: string): Promise<boolean> => ipcRenderer.invoke("command:export-markdown", sessionKey),
+  exportJson: (sessionKey: string): Promise<boolean> => ipcRenderer.invoke("command:export-json", sessionKey),
   copyPlainText: (sessionKey: string): Promise<void> => ipcRenderer.invoke("command:copy-plain", sessionKey),
   openExternalLink: (url: string): Promise<void> => ipcRenderer.invoke("markdown:open-external", url),
   onIndexStatus: (callback: (status: IndexStatus) => void): (() => void) => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1508,12 +1508,16 @@ export function App(): ReactElement {
     setContextMenu(null);
     setActionStatus({ kind: "running", message: t("Exporting JSON...", "正在导出 JSON...") });
     try {
-      const exported = await window.sessionSearch.exportJson(sessionKey);
-      if (!exported) {
+      const result = await window.sessionSearch.exportJson(sessionKey);
+      if (!result.exported) {
         setActionStatus(null);
         return;
       }
-      const successMessage = t("JSON exported.", "JSON 已导出。");
+      const successMessage = result.fidelity === "exact-trace"
+        ? t("Exact Codex request JSON exported.", "已导出 Codex 真实请求体 JSON。")
+        : result.fidelity === "reconstructed"
+          ? t("Reconstructed request JSON exported.", "已导出重建的请求体 JSON。")
+          : t("Normalized request JSON exported.", "已导出标准化请求体 JSON。");
       setActionStatus({ kind: "success", message: successMessage });
       window.setTimeout(() => {
         setActionStatus((current) => (current?.kind === "success" && current.message === successMessage ? null : current));

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1504,6 +1504,25 @@ export function App(): ReactElement {
     }
   }
 
+  async function exportJson(sessionKey: string): Promise<void> {
+    setContextMenu(null);
+    setActionStatus({ kind: "running", message: t("Exporting JSON...", "正在导出 JSON...") });
+    try {
+      const exported = await window.sessionSearch.exportJson(sessionKey);
+      if (!exported) {
+        setActionStatus(null);
+        return;
+      }
+      const successMessage = t("JSON exported.", "JSON 已导出。");
+      setActionStatus({ kind: "success", message: successMessage });
+      window.setTimeout(() => {
+        setActionStatus((current) => (current?.kind === "success" && current.message === successMessage ? null : current));
+      }, 1800);
+    } catch (error) {
+      setActionStatus({ kind: "error", message: error instanceof Error ? error.message : String(error) });
+    }
+  }
+
   function beginMigrate(session: SessionSearchResult): void {
     setContextMenu(null);
     setMigrationDialog({ kind: "select", session });
@@ -2324,6 +2343,7 @@ export function App(): ReactElement {
             void runAction(t("Copying markdown", "正在复制 Markdown"), () => window.sessionSearch.copyMarkdown(detail.sessionKey), t("Markdown copied.", "Markdown 已复制。"))
           }
           onExportMarkdown={() => void exportMarkdown(detail.sessionKey)}
+          onExportJson={() => void exportJson(detail.sessionKey)}
           onCopyPlain={() =>
             void runAction(t("Copying plain text", "正在复制纯文本"), () => window.sessionSearch.copyPlainText(detail.sessionKey), t("Plain text copied.", "纯文本已复制。"))
           }
@@ -2372,6 +2392,7 @@ export function App(): ReactElement {
           onCopyResume={() => undefined}
           onCopyMarkdown={() => undefined}
           onExportMarkdown={() => undefined}
+          onExportJson={() => undefined}
           onCopyPlain={() => undefined}
           onDelete={() => undefined}
           onReveal={() => undefined}
@@ -2427,6 +2448,7 @@ export function App(): ReactElement {
             void runAction(t("Copying markdown", "正在复制 Markdown"), () => window.sessionSearch.copyMarkdown(contextMenu.session.sessionKey), t("Markdown copied.", "Markdown 已复制。"))
           }
           onExportMarkdown={() => void exportMarkdown(contextMenu.session.sessionKey)}
+          onExportJson={() => void exportJson(contextMenu.session.sessionKey)}
           onDelete={() => requestDeleteSession(contextMenu.session)}
           onReveal={() =>
             void runAction(
@@ -2894,6 +2916,7 @@ function ContextMenu({
   onCopyResume,
   onCopyMarkdown,
   onExportMarkdown,
+  onExportJson,
   onDelete,
   onReveal,
 }: {
@@ -2915,6 +2938,7 @@ function ContextMenu({
   onCopyResume: () => void;
   onCopyMarkdown: () => void;
   onExportMarkdown: () => void;
+  onExportJson: () => void;
   onDelete: () => void;
   onReveal: () => void;
 }): ReactElement {
@@ -2971,6 +2995,9 @@ function ContextMenu({
       <button onClick={onCopyMarkdown}>{l("Copy Markdown", "复制 Markdown")}</button>
       <button onClick={onExportMarkdown}>
         <Download size={14} /> {l("Export Markdown", "导出 Markdown")}
+      </button>
+      <button onClick={onExportJson}>
+        <Download size={14} /> {l("Export JSON", "导出 JSON")}
       </button>
       <button onClick={onReveal} disabled={localOnlyDisabled} title={revealTitle}>
         <FolderOpen size={14} /> Show in {revealLabel}

--- a/src/renderer/src/detail-panel-actions.test.ts
+++ b/src/renderer/src/detail-panel-actions.test.ts
@@ -85,6 +85,10 @@ describe("detail panel actions", () => {
     expect(handler).toContain("chooseJsonExportFormat");
     expect(handler).toContain("chooseJsonExportPath");
     expect(handler).toContain("formatSessionJson");
+    expect(handler).toContain("resolveCodexResponsesRequest");
+    expect(handler).toContain("CODEX_ROLLOUT_TRACE_ROOT");
+    expect(handler).toContain("JSON Export Complete");
+    expect(handler).toContain("Exact Codex request body");
     expect(mainSource).toContain("OpenAI Chat Completions");
     expect(mainSource).toContain("OpenAI Responses");
     expect(mainSource).toContain("Anthropic Messages");

--- a/src/renderer/src/detail-panel-actions.test.ts
+++ b/src/renderer/src/detail-panel-actions.test.ts
@@ -37,6 +37,7 @@ describe("detail panel actions", () => {
 
     expect(detailPanel).toContain("onResume");
     expect(detailPanel).toContain("onExportMarkdown");
+    expect(detailPanel).toContain("onExportJson");
     expect(detailPanel).not.toContain("onFocusTerminal");
     expect(detailPanel).not.toMatch(/Bring to Front/);
     expect(detailPanel).toMatch(/Export MD/);
@@ -55,6 +56,7 @@ describe("detail panel actions", () => {
     expect(contextMenu).not.toMatch(/Bring to Front/);
     expect(contextMenu).not.toContain("onFocusTerminal");
     expect(contextMenu).toMatch(/Export Markdown/);
+    expect(contextMenu).toMatch(/Export JSON/);
     expect(contextMenu).not.toMatch(/Copy Plain Text/);
   });
 
@@ -74,6 +76,18 @@ describe("detail panel actions", () => {
     expect(mainSource).toContain("command:export-markdown");
     expect(mainSource).toContain("showSaveDialog");
     expect(mainSource).toContain("formatSessionMarkdown");
+  });
+
+  it("wires API request JSON export through format selection and a save dialog", () => {
+    expect(preloadSource).toContain("exportJson");
+    expect(preloadSource).toContain("command:export-json");
+    const handler = mainHandlerSource("command:export-json");
+    expect(handler).toContain("chooseJsonExportFormat");
+    expect(handler).toContain("chooseJsonExportPath");
+    expect(handler).toContain("formatSessionJson");
+    expect(mainSource).toContain("OpenAI Chat Completions");
+    expect(mainSource).toContain("OpenAI Responses");
+    expect(mainSource).toContain("Anthropic Messages");
   });
 
   it("opens detail on the newest message window and pages older messages backward", () => {

--- a/src/renderer/src/features/session-detail/detail-panel.tsx
+++ b/src/renderer/src/features/session-detail/detail-panel.tsx
@@ -139,6 +139,7 @@ export function DetailPanel({
   onCopyResume,
   onCopyMarkdown,
   onExportMarkdown,
+  onExportJson,
   onCopyPlain,
   onDelete,
   onReveal,
@@ -180,6 +181,7 @@ export function DetailPanel({
   onCopyResume: () => void;
   onCopyMarkdown: () => void;
   onExportMarkdown: () => void;
+  onExportJson: () => void;
   onCopyPlain: () => void;
   onDelete: () => void;
   onReveal: () => void;
@@ -469,6 +471,9 @@ export function DetailPanel({
             <button onClick={onCopyMarkdown} disabled={actionRunning}>Markdown</button>
             <button onClick={onExportMarkdown} disabled={actionRunning}>
               <Download size={15} /> {l("Export MD", "导出 MD")}
+            </button>
+            <button onClick={onExportJson} disabled={actionRunning}>
+              <Download size={15} /> {l("Export JSON", "导出 JSON")}
             </button>
             <button onClick={onCopyPlain} disabled={actionRunning}>{l("Plain Text", "纯文本")}</button>
           </div>


### PR DESCRIPTION
## 概述

  为会话详情增加 API 请求体 JSON 导出能力，支持以下格式：

  - OpenAI Chat Completions
  - OpenAI Responses
  - Anthropic Messages

 注意，现有实现导出精度不同：

 - Codex 会话：支持 trace 原始请求体，或从 rollout 重建模型、工具、stream、reasoning、metadata 等字段。
  - Claude、CodeBuddy 等其他会话：目前只把已索引的 user/assistant 消息转换成标准化请求体，模型使用 YOUR_MODEL，不会恢复原始 tools、system prompt、metadata 等参数。

  ## 主要改动

  - 支持从会话详情和右键菜单导出 JSON 请求体。
  - Codex 会话优先读取 `CODEX_ROLLOUT_TRACE_ROOT` 中捕获的原始 Responses 请求。
  - 没有 trace 时，从 rollout 重建模型、指令、消息、工具调用、推理参数、流式配置、缓存键和客户端 metadata。
  - 支持将 Responses 工具定义及工具调用转换为 Chat Completions 和 Anthropic Messages 格式。
  - 正确处理 Codex `compacted.replacement_history`；压缩后的请求上下文可能连续保留多条 user 消息，这是 Codex 实际的
  compaction 结构。
  - 导出完成后通过原生提示框说明本次使用的是原始 trace、rollout 重建还是标准化格式，并显示保存路径。
  - 增加 trace payload 路径边界检查，避免读取 trace bundle 之外的文件。
  - 更新 README 和用户可见 release note。

  ## 验证

  - `npm run typecheck`
  - 47 个相关 Vitest 测试通过
  - `npm run release-note:check`
  - `npm run build`
  - `git diff --check`

  ## 注意事项

  - 原始请求捕获只对启用 `CODEX_ROLLOUT_TRACE_ROOT` 后产生的 Codex 请求有效。
  - Trace 可能包含完整提示词、工具参数和响应，应仅保存到受信任的本地目录。
  - 未开启 trace 的历史会话只能根据 rollout 中已持久化的信息重建，无法恢复未记录的服务端字段。
