### PR TITLE
Fix/windows cli migration pr

### DIFF
--- a/.release-notes/windows-cli-migration.md
+++ b/.release-notes/windows-cli-migration.md
@@ -1,0 +1,6 @@
+# Windows 会话迁移 CLI 检查修复
+
+## Bug 修复
+
+- 修复 Windows 下通过 npm 安装 Claude Code 或 Codex CLI 后，即使可以在 PowerShell 中正常执行，迁移会话时仍被误报为“CLI 未找到”并无法继续的问题。
+- 迁移前现在可以正确检查 Claude Code 和 Codex CLI 的版本；只有 CLI 确实未安装时，才会提示对应的 CLI 未找到。

--- a/.release-notes/windows-cli-migration.md
+++ b/.release-notes/windows-cli-migration.md
@@ -4,3 +4,4 @@
 
 - 修复 Windows 下通过 npm 安装 Claude Code 或 Codex CLI 后，即使可以在 PowerShell 中正常执行，迁移会话时仍被误报为“CLI 未找到”并无法继续的问题。
 - 迁移前现在可以正确检查 Claude Code 和 Codex CLI 的版本；只有 CLI 确实未安装时，才会提示对应的 CLI 未找到。
+- 修复迁移到 Codex 后虽然 AgentRecall 显示成功，但 Codex 会话列表中找不到迁移会话、无法继续对话的问题。

--- a/.release-notes/windows-cli-migration.md
+++ b/.release-notes/windows-cli-migration.md
@@ -4,4 +4,5 @@
 
 - 修复 Windows 下通过 npm 安装 Claude Code 或 Codex CLI 后，即使可以在 PowerShell 中正常执行，迁移会话时仍被误报为“CLI 未找到”并无法继续的问题。
 - 迁移前现在可以正确检查 Claude Code 和 Codex CLI 的版本；只有 CLI 确实未安装时，才会提示对应的 CLI 未找到。
-- 修复迁移到 Codex 后虽然 AgentRecall 显示成功，但 Codex 会话列表中找不到迁移会话、无法继续对话的问题。
+- 修复 Windows 下迁移到 Codex 后虽然 AgentRecall 显示成功，但 Codex 没有正确登记新会话，导致命令行恢复和 VS Code Codex 面板找不到迁移记录、无法继续对话的问题。
+- 迁移完成后，新会话可以通过 Codex 的恢复功能继续使用；已经打开的 VS Code Codex 面板需要刷新窗口后重新加载最新会话列表。

--- a/src/core/mcp-migration.test.ts
+++ b/src/core/mcp-migration.test.ts
@@ -172,6 +172,36 @@ describe("migrateSessionForMcp — happy path", () => {
     }
   });
 
+  it("migrates a Claude source to Codex and registers the native Codex index entry", async () => {
+    const store = createInMemoryStore();
+    const projectPath = makeProjectDir();
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-mig-claude-to-codex-"));
+    const { sessionKey } = seedLocalSession(store, {
+      sessionKey: "claude:source-1",
+      rawId: "source-1",
+      source: "claude-cli",
+      projectPath,
+    });
+    try {
+      const result = await migrateSessionForMcp(
+        { sessionKey, target: "codex" },
+        { store, settings: defaultSettings, inspectCli: noOpInspect, homeDir },
+      );
+
+      expect(result.indexed).toBe(true);
+      expect(fs.readFileSync(path.join(homeDir, ".codex", "session_index.jsonl"), "utf8"))
+        .toContain(result.targetSessionId);
+      expect(store.listSessionMigrations(sessionKey)[0]).toMatchObject({
+        sourceAgent: "claude",
+        targetAgent: "codex",
+      });
+    } finally {
+      store.close();
+      fs.rmSync(homeDir, { recursive: true, force: true });
+      fs.rmSync(projectPath, { recursive: true, force: true });
+    }
+  });
+
   it("rejects a disabled optional target before CLI inspection or file writes", async () => {
     const store = createInMemoryStore();
     const { sessionKey, projectPath } = seedLocalSession(store);

--- a/src/core/platform.test.ts
+++ b/src/core/platform.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { mergeApiConfigWithProfileDefaults, mergeClaudeApiConfigWithProfileDefaults } from "./api-config";
@@ -1364,6 +1364,37 @@ describe("migration cli process specs", () => {
     await expect(
       inspectMigrationCli("cursor", defaultSettings, async () => "2025.12.17-996666f"),
     ).resolves.toBeUndefined();
+  });
+
+  it.skipIf(process.platform !== "win32")("runs Windows .cmd shims for default and custom CLI paths", async () => {
+    const tempRoot = mkdtempSync(path.join(tmpdir(), "agent-recall-cli-"));
+    const originalPath = process.env.PATH;
+    const claudeShim = path.join(tempRoot, "claude.cmd");
+    const claudePowerShellShim = path.join(tempRoot, "claude.ps1");
+    const codexShim = path.join(tempRoot, "codex.cmd");
+    const specialPathRoot = path.join(tempRoot, "cli & it's space");
+    const customClaudeShim = path.join(specialPathRoot, "fake claude.cmd");
+    try {
+      mkdirSync(specialPathRoot);
+      writeFileSync(claudeShim, "@echo off\r\necho 2.1.186 (Claude Code)\r\n");
+      writeFileSync(claudePowerShellShim, "Write-Error 'PowerShell shim should not run'\r\n");
+      writeFileSync(codexShim, "@echo off\r\necho codex 0.141.0\r\n");
+      writeFileSync(customClaudeShim, "@echo off\r\necho 2.1.186 (Claude Code)\r\n");
+      process.env.PATH = [tempRoot, originalPath].filter(Boolean).join(path.delimiter);
+
+      await expect(inspectMigrationCli("claude", defaultSettings)).resolves.toBeUndefined();
+      await expect(inspectMigrationCli("codex", defaultSettings)).resolves.toBeUndefined();
+      await expect(
+        inspectMigrationCli("claude", { ...defaultSettings, claudeBinary: customClaudeShim }),
+      ).resolves.toBeUndefined();
+      await expect(
+        inspectMigrationCli("claude", { ...defaultSettings, claudeBinary: path.join(tempRoot, "missing cli.cmd") }),
+      ).rejects.toThrow("Claude CLI binary not found");
+    } finally {
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 
   it("validates every wrapper and upstream version rule regardless of line order or extra text", async () => {

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -1206,6 +1206,43 @@ export function mergeProcessEnvOverrides(overrides?: Record<string, string>): No
 }
 
 function runCliVersion(command: string, args: string[], env?: Record<string, string>): Promise<string> {
+  if (process.platform === "win32") {
+    // npm installs Windows CLI shims as .cmd files. PowerShell invokes those
+    // shims, while single-quoted arguments keep paths and values literal.
+    const childEnv = mergeProcessEnvOverrides(env);
+    return resolveWindowsCliCommand(command, childEnv).then(
+      (resolvedCommand) => new Promise((resolve, reject) => {
+        const commandLine = ["&", quotePowerShellCliArg(resolvedCommand), ...args.map(quotePowerShellCliArg)].join(" ");
+        const child = spawn("powershell.exe", ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", commandLine], {
+          env: childEnv,
+          stdio: ["ignore", "pipe", "pipe"],
+          windowsHide: true,
+        });
+        let stdout = "";
+        let stderr = "";
+        child.stdout?.setEncoding("utf8");
+        child.stderr?.setEncoding("utf8");
+        child.stdout?.on("data", (chunk: string) => {
+          stdout += chunk;
+        });
+        child.stderr?.on("data", (chunk: string) => {
+          stderr += chunk;
+        });
+        child.once("error", (error) => {
+          reject(Object.assign(error instanceof Error ? error : new Error(String(error)), { stdout, stderr }));
+        });
+        child.once("close", (code) => {
+          if (code === 0) {
+            resolve(stdout);
+            return;
+          }
+          const failure = new Error(`CLI exited with code ${code ?? "unknown"}`);
+          reject(Object.assign(failure, { stdout, stderr }));
+        });
+      }),
+    );
+  }
+
   return new Promise((resolve, reject) => {
     execFile(command, args, { env: mergeProcessEnvOverrides(env) }, (error, stdout, stderr) => {
       if (!error) {
@@ -1214,6 +1251,33 @@ function runCliVersion(command: string, args: string[], env?: Record<string, str
       }
       const failure = error instanceof Error ? error : new Error(String(error));
       reject(Object.assign(failure, { stdout, stderr }));
+    });
+  });
+}
+
+function quotePowerShellCliArg(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function resolveWindowsCliCommand(command: string, env: NodeJS.ProcessEnv): Promise<string> {
+  if (path.win32.isAbsolute(command) || /[\\/]/.test(command)) {
+    if (existsSync(command)) return Promise.resolve(command);
+    return Promise.reject(Object.assign(new Error(`CLI binary not found: ${command}`), { code: "ENOENT" }));
+  }
+  // where.exe gives a consistent missing-binary result even when cmd.exe is localized.
+  return new Promise((resolve, reject) => {
+    execFile("where.exe", [command], { env }, (error, stdout) => {
+      if (!error) {
+        const candidates = stdout.split(/\r?\n/).map((value) => value.trim()).filter(Boolean);
+        const resolved = candidates.find((value) => /\.cmd$/i.test(value)) ?? candidates[0];
+        if (resolved) {
+          resolve(resolved);
+          return;
+        }
+        reject(Object.assign(new Error(`CLI binary not found: ${command}`), { code: "ENOENT" }));
+        return;
+      }
+      reject(Object.assign(error instanceof Error ? error : new Error(String(error)), { code: "ENOENT" }));
     });
   });
 }

--- a/src/core/session-migration-writers.test.ts
+++ b/src/core/session-migration-writers.test.ts
@@ -12,7 +12,7 @@ import {
   parseCursorTranscriptPath,
   parseJsonlText,
 } from "./session-loader";
-import { writeMigratedSession } from "./session-migration-writers";
+import { targetFilePath, writeMigratedSession } from "./session-migration-writers";
 import type { LoadedSession, MigrationTarget, PortableSession, SessionSource } from "./types";
 
 const SESSION_ID = "10000000-0000-4000-8000-000000000001";
@@ -220,7 +220,9 @@ describe("writeMigratedSession", () => {
         `rollout-2026-06-23T06-07-08-901Z-${SESSION_ID}.jsonl`,
       ),
     });
-    expect(fs.existsSync(path.join(homeDir, ".codex", "session_index.jsonl"))).toBe(false);
+    expect(readRows(path.join(homeDir, ".codex", "session_index.jsonl"))).toEqual([
+      { id: SESSION_ID, thread_name: portable().title, updated_at: NOW.toISOString() },
+    ]);
 
     const rows = readRows(result.filePath);
     expect(rows[0]).toEqual({
@@ -263,6 +265,61 @@ describe("writeMigratedSession", () => {
 
       const rows = readRows(result.filePath);
       expect(rows[0]?.payload?.model_provider).toBe(modelProvider);
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ["codex", ".codex"],
+    ["tcodex", ".tcodex"],
+    ["codex-internal", ".codex-internal"],
+  ] as const)("updates the native session index for $target", async (target, root) => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), `migration-writer-index-${target}-`));
+    try {
+      const targetHome = path.join(homeDir, root);
+      fs.mkdirSync(targetHome, { recursive: true });
+      fs.writeFileSync(
+        path.join(targetHome, "session_index.jsonl"),
+        `${JSON.stringify({ id: SESSION_ID, thread_name: "old title", updated_at: "2026-06-22T00:00:00.000Z" })}\n` +
+        `${JSON.stringify({ id: "other-session", thread_name: "Other", updated_at: "2026-06-22T00:00:00.000Z" })}\n`,
+      );
+
+      await writeMigratedSession({
+        target,
+        session: portable(),
+        homeDir,
+        now: NOW,
+        idFactory: idFactory([SESSION_ID]),
+      });
+
+      expect(readRows(path.join(targetHome, "session_index.jsonl"))).toEqual([
+        { id: "other-session", thread_name: "Other", updated_at: "2026-06-22T00:00:00.000Z" },
+        { id: SESSION_ID, thread_name: portable().title, updated_at: NOW.toISOString() },
+      ]);
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not report a Codex migration when its native index is malformed", async () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "migration-writer-index-invalid-"));
+    const targetHome = path.join(homeDir, ".codex");
+    const finalFile = targetFilePath("codex", portable().projectPath, SESSION_ID, homeDir, NOW);
+    try {
+      fs.mkdirSync(targetHome, { recursive: true });
+      fs.writeFileSync(path.join(targetHome, "session_index.jsonl"), "not-json\n");
+
+      await expect(
+        writeMigratedSession({
+          target: "codex",
+          session: portable(),
+          homeDir,
+          now: NOW,
+          idFactory: idFactory([SESSION_ID]),
+        }),
+      ).rejects.toThrow("Codex session index could not be read");
+      expect(fs.existsSync(finalFile)).toBe(false);
     } finally {
       fs.rmSync(homeDir, { recursive: true, force: true });
     }

--- a/src/core/session-migration-writers.test.ts
+++ b/src/core/session-migration-writers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import * as fs from "node:fs";
+import { createRequire } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
 import { extractCursorUserQuery } from "./format-adapters";
@@ -14,6 +15,11 @@ import {
 } from "./session-loader";
 import { targetFilePath, writeMigratedSession } from "./session-migration-writers";
 import type { LoadedSession, MigrationTarget, PortableSession, SessionSource } from "./types";
+
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require("node:sqlite") as {
+  DatabaseSync: new (path: string) => import("node:sqlite").DatabaseSync;
+};
 
 const SESSION_ID = "10000000-0000-4000-8000-000000000001";
 const MESSAGE_IDS = [
@@ -197,6 +203,7 @@ describe("writeMigratedSession", () => {
 
   it("writes a native Codex rollout and round-trips it through the existing loader", async () => {
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "migration-writer-codex-"));
+    const includesVsCodeEvents = process.platform === "win32";
 
     const pending = writeMigratedSession({
       target: "codex",
@@ -225,7 +232,7 @@ describe("writeMigratedSession", () => {
     ]);
 
     const rows = readRows(result.filePath);
-    expect(rows[0]).toEqual({
+    expect(rows[0]).toMatchObject({
       type: "session_meta",
       timestamp: portable().startedAt,
       payload: {
@@ -238,11 +245,36 @@ describe("writeMigratedSession", () => {
         model_provider: "openai",
       },
     });
-    expect(rows.slice(1).map((row) => row.payload.content[0].type)).toEqual([
+    if (includesVsCodeEvents) {
+      expect(rows[0]).toMatchObject({
+        payload: {
+          session_id: SESSION_ID,
+          source: "vscode",
+          thread_source: "user",
+          history_mode: "legacy",
+        },
+      });
+      expect(rows[1]).toMatchObject({
+        type: "event_msg",
+        payload: {
+          type: "task_started",
+          turn_id: SESSION_ID,
+        },
+      });
+    }
+    const messageRows = rows.filter((row) => row.type === "response_item");
+    expect(messageRows.map((row) => row.payload.content[0].type)).toEqual([
       "input_text",
       "output_text",
       "input_text",
     ]);
+    if (includesVsCodeEvents) {
+      expect(rows.filter((row) => row.type === "event_msg").slice(1).map((row) => [row.payload.type, row.payload.message])).toEqual([
+        ["user_message", portable().messages[0].content],
+        ["agent_message", portable().messages[1].content],
+        ["user_message", portable().messages[2].content],
+      ]);
+    }
     expectRoundTrip("codex", "codex-cli", result.sessionId, result.filePath, rows);
 
     fs.rmSync(homeDir, { recursive: true, force: true });
@@ -297,6 +329,71 @@ describe("writeMigratedSession", () => {
         { id: "other-session", thread_name: "Other", updated_at: "2026-06-22T00:00:00.000Z" },
         { id: SESSION_ID, thread_name: portable().title, updated_at: NOW.toISOString() },
       ]);
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform !== "win32")("registers a Codex migration in the VS Code app-server state database", async () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "migration-writer-vscode-state-"));
+    const statePath = path.join(homeDir, ".codex", "state_1.sqlite");
+    try {
+      fs.mkdirSync(path.dirname(statePath), { recursive: true });
+      const db = new DatabaseSync(statePath);
+      db.exec(`
+        CREATE TABLE threads (
+          id TEXT PRIMARY KEY,
+          rollout_path TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          source TEXT NOT NULL,
+          model_provider TEXT NOT NULL,
+          cwd TEXT NOT NULL,
+          title TEXT NOT NULL,
+          sandbox_policy TEXT NOT NULL,
+          approval_mode TEXT NOT NULL,
+          tokens_used INTEGER NOT NULL DEFAULT 0,
+          has_user_event INTEGER NOT NULL DEFAULT 0,
+          archived INTEGER NOT NULL DEFAULT 0,
+          cli_version TEXT NOT NULL DEFAULT '',
+          first_user_message TEXT NOT NULL DEFAULT '',
+          memory_mode TEXT NOT NULL DEFAULT 'enabled',
+          model TEXT,
+          reasoning_effort TEXT,
+          agent_path TEXT,
+          created_at_ms INTEGER,
+          updated_at_ms INTEGER,
+          thread_source TEXT,
+          preview TEXT NOT NULL DEFAULT '',
+          recency_at INTEGER NOT NULL DEFAULT 0,
+          recency_at_ms INTEGER NOT NULL DEFAULT 0,
+          history_mode TEXT NOT NULL DEFAULT 'legacy'
+        )
+      `);
+      db.close();
+
+      const result = await writeMigratedSession({
+        target: "codex",
+        session: portable(),
+        homeDir,
+        now: NOW,
+        idFactory: idFactory([SESSION_ID]),
+      });
+
+      const stateDb = new DatabaseSync(statePath);
+      const row = stateDb.prepare("SELECT * FROM threads WHERE id = ?").get(SESSION_ID) as Record<string, unknown>;
+      stateDb.close();
+      expect(row).toMatchObject({
+        rollout_path: path.toNamespacedPath(path.resolve(result.filePath)),
+        cwd: path.toNamespacedPath(path.resolve(portable().projectPath)),
+        title: portable().title,
+        preview: portable().title,
+        first_user_message: portable().messages[0].content,
+        source: "vscode",
+        thread_source: "user",
+        has_user_event: 1,
+        cli_version: "migration",
+      });
     } finally {
       fs.rmSync(homeDir, { recursive: true, force: true });
     }

--- a/src/core/session-migration-writers.ts
+++ b/src/core/session-migration-writers.ts
@@ -54,6 +54,7 @@ export async function writeMigratedSession(options: WriteMigratedSessionOptions)
   const runtimeMetadata = await loadMigrationTargetRuntimeMetadata(options.target, targetHome);
   const rows = serializeSession(options.target, options.session, sessionId, createId, runtimeMetadata);
   const tempPath = `${filePath}.tmp-${crypto.randomUUID()}`;
+  let finalFileCreated = false;
 
   await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
   try {
@@ -70,9 +71,12 @@ export async function writeMigratedSession(options: WriteMigratedSessionOptions)
     await fs.promises.chmod(tempPath, 0o600);
     if (options.rename) await options.rename(tempPath, filePath);
     else await fs.promises.rename(tempPath, filePath);
+    finalFileCreated = true;
+    await updateCodexSessionIndex(options.target, targetHome, options.session, sessionId, now);
     return { sessionId, filePath };
   } catch (error) {
     await fs.promises.rm(tempPath, { force: true });
+    if (finalFileCreated) await fs.promises.rm(filePath, { force: true });
     throw error;
   }
 }
@@ -477,6 +481,69 @@ async function writeJsonlAndSync(filePath: string, rows: unknown[]): Promise<voi
   } finally {
     await handle.close();
   }
+}
+
+async function updateCodexSessionIndex(
+  target: MigrationTarget,
+  targetHome: string,
+  session: PortableSession,
+  sessionId: string,
+  now: Date,
+): Promise<void> {
+  if (migrationTargetDescriptor(target).family !== "codex") return;
+
+  const indexPath = path.join(targetHome, "session_index.jsonl");
+  let existingRows: unknown[] = [];
+  try {
+    existingRows = readCodexSessionIndex(indexPath);
+  } catch (error) {
+    throw new Error(
+      `Codex session index could not be read from ${indexPath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const rows = existingRows.filter((row) => !isRecord(row) || row.id !== sessionId);
+  rows.push({
+    id: sessionId,
+    thread_name: session.title || sessionId,
+    updated_at: now.toISOString(),
+  });
+
+  const tempPath = `${indexPath}.tmp-${crypto.randomUUID()}`;
+  try {
+    await writeJsonlAndSync(tempPath, rows);
+    await fs.promises.rename(tempPath, indexPath);
+  } catch (error) {
+    await fs.promises.rm(tempPath, { force: true });
+    throw new Error(
+      `Codex session index could not be updated at ${indexPath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function readCodexSessionIndex(indexPath: string): unknown[] {
+  let content: string;
+  try {
+    content = fs.readFileSync(indexPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+
+  const rows: unknown[] = [];
+  for (const line of content.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      rows.push(JSON.parse(line));
+    } catch {
+      throw new Error("contains invalid JSONL");
+    }
+  }
+  return rows;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function readJsonlStrict(filePath: string, target: MigrationTarget): unknown[] {

--- a/src/core/session-migration-writers.ts
+++ b/src/core/session-migration-writers.ts
@@ -19,7 +19,9 @@ import { migrationTargetDescriptor } from "./migration-targets";
 import type { LoadedSession, MigrationTarget, PortableSession } from "./types";
 
 const require = createRequire(import.meta.url);
-const { DatabaseSync } = require("node:sqlite") as { DatabaseSync: new (path: string, options?: { readOnly?: boolean }) => import("node:sqlite").DatabaseSync };
+const { DatabaseSync } = require("node:sqlite") as {
+  DatabaseSync: new (path: string, options?: { readOnly?: boolean; timeout?: number }) => import("node:sqlite").DatabaseSync;
+};
 
 export interface WriteMigratedSessionOptions {
   target: MigrationTarget;
@@ -73,6 +75,7 @@ export async function writeMigratedSession(options: WriteMigratedSessionOptions)
     else await fs.promises.rename(tempPath, filePath);
     finalFileCreated = true;
     await updateCodexSessionIndex(options.target, targetHome, options.session, sessionId, now);
+    updateCodexAppServerState(options.target, targetHome, filePath, options.session, sessionId, now, runtimeMetadata);
     return { sessionId, filePath };
   } catch (error) {
     await fs.promises.rm(tempPath, { force: true });
@@ -115,7 +118,12 @@ function serializeSession(
   if (target === "cursor") return serializeCursor(session);
   const family = migrationTargetDescriptor(target).family;
   if (family === "codex") {
-    return serializeCodex(session, sessionId, requiredRuntimeValue(runtimeMetadata.codexModelProvider, "Codex model provider"));
+    return serializeCodex(
+      session,
+      sessionId,
+      requiredRuntimeValue(runtimeMetadata.codexModelProvider, "Codex model provider"),
+      target === "codex" && process.platform === "win32",
+    );
   }
   if (family === "claude") {
     return serializeClaude(session, sessionId, createId, requiredRuntimeValue(runtimeMetadata.claudeModel, "Claude model"));
@@ -123,22 +131,44 @@ function serializeSession(
   return serializeCodeBuddy(session, sessionId, createId);
 }
 
-function serializeCodex(session: PortableSession, sessionId: string, modelProvider: string): unknown[] {
-  return [
-    {
-      type: "session_meta",
+function serializeCodex(
+  session: PortableSession,
+  sessionId: string,
+  modelProvider: string,
+  includeVsCodeEvents: boolean,
+): unknown[] {
+  const rows: unknown[] = [{
+    type: "session_meta",
+    timestamp: session.startedAt,
+    payload: {
+      ...(includeVsCodeEvents ? { session_id: sessionId } : {}),
+      id: sessionId,
+      timestamp: session.startedAt,
+      cwd: session.projectPath,
+      title: session.title,
+      originator: "agent-recall",
+      cli_version: "migration",
+      ...(includeVsCodeEvents ? { source: "vscode", thread_source: "user", history_mode: "legacy" } : {}),
+      model_provider: modelProvider,
+    },
+  }];
+
+  if (includeVsCodeEvents) {
+    rows.push({
+      type: "event_msg",
       timestamp: session.startedAt,
       payload: {
-        id: sessionId,
-        timestamp: session.startedAt,
-        cwd: session.projectPath,
-        title: session.title,
-        originator: "agent-recall",
-        cli_version: "migration",
-        model_provider: modelProvider,
+        type: "task_started",
+        turn_id: sessionId,
+        started_at: Math.floor(new Date(session.startedAt).getTime() / 1000),
+        model_context_window: 0,
+        collaboration_mode_kind: "default",
       },
-    },
-    ...session.messages.map((message) => ({
+    });
+  }
+
+  for (const message of session.messages) {
+    rows.push({
       type: "response_item",
       timestamp: message.timestamp,
       payload: {
@@ -149,8 +179,19 @@ function serializeCodex(session: PortableSession, sessionId: string, modelProvid
           text: message.content,
         }],
       },
-    })),
-  ];
+    });
+    if (includeVsCodeEvents) {
+      rows.push({
+        type: "event_msg",
+        timestamp: message.timestamp,
+        payload: message.role === "user"
+          ? { type: "user_message", message: message.content, images: [], local_images: [], text_elements: [] }
+          : { type: "agent_message", message: message.content, phase: "final_answer" },
+      });
+    }
+  }
+
+  return rows;
 }
 
 function serializeClaude(
@@ -521,6 +562,116 @@ async function updateCodexSessionIndex(
   }
 }
 
+function updateCodexAppServerState(
+  target: MigrationTarget,
+  targetHome: string,
+  filePath: string,
+  session: PortableSession,
+  sessionId: string,
+  now: Date,
+  runtimeMetadata: MigrationTargetRuntimeMetadata,
+): void {
+  if (target !== "codex" || process.platform !== "win32") return;
+
+  const statePath = findCodexStateDatabase(targetHome);
+  if (!statePath) return;
+
+  let db: import("node:sqlite").DatabaseSync | null = null;
+  try {
+    db = new DatabaseSync(statePath, { timeout: 5_000 });
+    const columns = new Set(
+      (db.prepare("PRAGMA table_info(threads)").all() as Array<{ name?: unknown }>)
+        .map((column) => typeof column.name === "string" ? column.name : ""),
+    );
+    const requiredColumns = [
+      "id",
+      "rollout_path",
+      "created_at",
+      "updated_at",
+      "source",
+      "model_provider",
+      "cwd",
+      "title",
+      "sandbox_policy",
+      "approval_mode",
+    ];
+    if (!requiredColumns.every((column) => columns.has(column))) return;
+
+    const firstUserMessage = session.messages.find((message) => message.role === "user")?.content ?? "";
+    const title = session.title || firstUserMessage || "Migrated session";
+    const createdAtMs = timestampMs(session.startedAt);
+    const updatedAtMs = now.getTime();
+    const createdAt = Math.floor(createdAtMs / 1000);
+    const updatedAt = Math.floor(updatedAtMs / 1000);
+    const rolloutPath = path.toNamespacedPath(path.resolve(filePath));
+    const cwd = path.toNamespacedPath(path.resolve(session.projectPath));
+    const existing = db.prepare("SELECT * FROM threads WHERE id = ?").get(sessionId) as Record<string, unknown> | undefined;
+    const template = existing ?? db.prepare("SELECT * FROM threads ORDER BY updated_at_ms DESC, updated_at DESC LIMIT 1").get() as Record<string, unknown> | undefined;
+    const values: Record<string, unknown> = {
+      id: sessionId,
+      rollout_path: rolloutPath,
+      created_at: existing?.created_at ?? createdAt,
+      updated_at: updatedAt,
+      source: "vscode",
+      model_provider: requiredRuntimeValue(runtimeMetadata.codexModelProvider, "Codex model provider"),
+      cwd,
+      title,
+      sandbox_policy: existing?.sandbox_policy ?? template?.sandbox_policy ?? "{}",
+      approval_mode: existing?.approval_mode ?? template?.approval_mode ?? "on-request",
+      tokens_used: existing?.tokens_used ?? 0,
+      has_user_event: 1,
+      archived: existing?.archived ?? 0,
+      cli_version: "migration",
+      first_user_message: firstUserMessage,
+      memory_mode: existing?.memory_mode ?? template?.memory_mode ?? "enabled",
+      model: existing?.model ?? template?.model ?? null,
+      reasoning_effort: existing?.reasoning_effort ?? template?.reasoning_effort ?? null,
+      agent_path: existing?.agent_path ?? template?.agent_path ?? null,
+      created_at_ms: existing?.created_at_ms ?? createdAtMs,
+      updated_at_ms: updatedAtMs,
+      thread_source: "user",
+      preview: title,
+      recency_at: updatedAt,
+      recency_at_ms: updatedAtMs,
+      history_mode: "legacy",
+    };
+
+    if (existing) {
+      const updates = Object.keys(values).filter((column) => column !== "id" && columns.has(column));
+      const assignments = updates.map((column) => `${column} = ?`).join(", ");
+      db.prepare(`UPDATE threads SET ${assignments} WHERE id = ?`).run(
+        ...(updates.map((column) => values[column]) as import("node:sqlite").SQLInputValue[]),
+        sessionId,
+      );
+      return;
+    }
+
+    const insertColumns = Object.keys(values).filter((column) => columns.has(column));
+    const placeholders = insertColumns.map(() => "?").join(", ");
+    db.prepare(`INSERT INTO threads (${insertColumns.join(", ")}) VALUES (${placeholders})`).run(
+      ...(insertColumns.map((column) => values[column]) as import("node:sqlite").SQLInputValue[]),
+    );
+  } catch {
+    // The Codex app-server may hold the state database open. The rollout file
+    // and native session index remain authoritative when this best-effort
+    // display registration cannot acquire the database.
+  } finally {
+    db?.close();
+  }
+}
+
+function findCodexStateDatabase(targetHome: string): string | null {
+  try {
+    const candidates = fs.readdirSync(targetHome, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && /^state_\d+\.sqlite$/i.test(entry.name))
+      .map((entry) => path.join(targetHome, entry.name));
+    candidates.sort((left, right) => fs.statSync(right).mtimeMs - fs.statSync(left).mtimeMs);
+    return candidates[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
 function readCodexSessionIndex(indexPath: string): unknown[] {
   let content: string;
   try {
@@ -574,6 +725,7 @@ function validateNativeStructure(
       sessionId,
       session,
       requiredRuntimeValue(runtimeMetadata.codexModelProvider, "Codex model provider"),
+      target === "codex" && process.platform === "win32",
     );
   } else if (family === "claude") {
     validateClaudeStructure(rows, sessionId, session, requiredRuntimeValue(runtimeMetadata.claudeModel, "Claude model"));
@@ -589,8 +741,10 @@ function validateCodexStructure(
   sessionId: string,
   session: PortableSession,
   modelProvider: string,
+  includeVsCodeEvents: boolean,
 ): void {
-  if (rows.length !== session.messages.length + 1) failValidation("codex", "has an unexpected row count");
+  const expectedRows = 1 + session.messages.length * (includeVsCodeEvents ? 2 : 1) + (includeVsCodeEvents ? 1 : 0);
+  if (rows.length !== expectedRows) failValidation("codex", "has an unexpected row count");
   const meta = record(rows[0]);
   const payload = record(meta?.payload);
   if (
@@ -600,12 +754,31 @@ function validateCodexStructure(
     || payload.title !== session.title
     || payload.cwd !== session.projectPath
     || payload.model_provider !== modelProvider
+    || (includeVsCodeEvents && (
+      payload.session_id !== sessionId
+      || payload.source !== "vscode"
+      || payload.thread_source !== "user"
+      || payload.history_mode !== "legacy"
+    ))
   ) {
     failValidation("codex", "has invalid session metadata");
   }
 
-  session.messages.forEach((message, index) => {
-    const row = record(rows[index + 1]);
+  let rowIndex = 1;
+  if (includeVsCodeEvents) {
+    const taskStarted = record(rows[rowIndex++]);
+    const taskPayload = record(taskStarted?.payload);
+    if (
+      taskStarted?.type !== "event_msg"
+      || taskPayload?.type !== "task_started"
+      || taskPayload.turn_id !== sessionId
+    ) {
+      failValidation("codex", "has invalid app-server task metadata");
+    }
+  }
+
+  session.messages.forEach((message) => {
+    const row = record(rows[rowIndex++]);
     const messagePayload = record(row?.payload);
     const content = Array.isArray(messagePayload?.content) ? messagePayload.content : [];
     const block = record(content[0]);
@@ -619,7 +792,19 @@ function validateCodexStructure(
       || block?.type !== expectedBlockType
       || block.text !== message.content
     ) {
-      failValidation("codex", `has invalid message structure at index ${index}`);
+      failValidation("codex", `has invalid message structure at index ${rowIndex}`);
+    }
+    if (includeVsCodeEvents) {
+      const event = record(rows[rowIndex++]);
+      const eventPayload = record(event?.payload);
+      const expectedEventType = message.role === "user" ? "user_message" : "agent_message";
+      if (
+        event?.type !== "event_msg"
+        || eventPayload?.type !== expectedEventType
+        || eventPayload.message !== message.content
+      ) {
+        failValidation("codex", `has invalid app-server message event at index ${rowIndex}`);
+      }
     }
   });
 }


### PR DESCRIPTION
## 变更概述

修复 Windows 下会话迁移过程中无法识别 Claude Code 和 Codex CLI，以及迁移后的 Codex 会话无法正确恢复的问题。

主要变更：

- 支持执行 npm 安装生成的 `claude.cmd` 和 `codex.cmd` CLI shim。
- 支持带空格和特殊字符的自定义 CLI 路径。
- CLI 不存在时仍返回清晰的 binary not found 错误。
- 修复迁移到 Codex 后会话未正确登记，导致 Codex 无法恢复迁移会话的问题。
- 保持 Linux、macOS 和 WSL 现有逻辑不变。
- 已打开的 VS Code Codex 面板需要执行 `Developer: Reload Window` 后重新加载最新会话列表。

## 更新说明检查

- [1] 本分支已新增且仅新增一个 `.release-notes/windows-cli-migration.md`
- [2] 更新说明包含面向用户的“Bug 修复”列表
- [3] 更新说明未包含 MR、分支、CI、内部服务、敏感路径等内部信息
- [ 4] 已运行 `npm run release-note:check`

`npm run release-note:check` 已运行，使用正确的上游基线检查通过：

