### PR TITLE
完善 Workflow Run Center 的真实用量追踪

### DIFF
--- a/.release-notes/feat-workflow-run-center-v1.md
+++ b/.release-notes/feat-workflow-run-center-v1.md
@@ -11,6 +11,9 @@
 - 新增目录级 Agent Memory 管理：用户可主动选择工作目录，查看从 Git 根目录逐级继承的 `AGENTS.md`、`CLAUDE.md` 与 Cursor Rules，并在当前目录新建或编辑记忆文件；还可按 Codex、Claude Code、Cursor 预览最终生效内容，将一份记忆同步为其他 Agent 的格式，确认差异后写入并支持立即撤销。检查范围仅限所选目录的继承链，不会遍历整个项目。
 - 新增 Runtime、MCP 与 Workflow 工作区：可通过紧凑下拉切换并测试 Codex、Claude Code、API、Hermes、OpenCode 和 OpenClaw 配置，管理本地或远程 MCP 服务及工具，把自定义 MCP 按 Agent 绑定到新会话，并在应用内完成 Workflow 的创建、审核、确认、运行、暂停、人工介入和输出查看；工作台会同步展示真实 Workflow 状态并直达详情。
 - Workflow 右侧新增独立的运行历史入口，可展开历史抽屉并进入任意一次运行，查看状态、耗时、图版本、冻结配置、节点执行时间线、重试次数和错误详情。
+- Workflow 运行历史的每个节点现在可展开查看实际使用的 Runtime、Channel、模型、尝试次数和执行耗时；Token 用量会按输入、输出、推理和缓存拆分，并区分 OpenAI 缓存输入与 Anthropic 的缓存读取、5 分钟/1 小时缓存写入，运行时提供数据时同时显示成本。
+- Workflow 运行历史会采集 OpenAI、Anthropic 和直连 API 返回的真实 Token usage；Provider 未返回的字段保持未提供，不会用估算值覆盖实际数据。
+- Workflow 节点在失败、重试、暂停恢复和交互式对话后仍会保留并汇总真实用量；成本没有 Provider 上报时会明确显示“未提供”。
 - Workflow 节点的历史消息会随运行记录持久保存；重新打开应用后，仍可在运行历史的对应节点中查看用户、Agent 与工具消息。
 - Workflow Agent 现在可通过专用完成工具提交结构化节点结果，普通对话内容与下游节点数据分开处理，减少格式误判。
 - 新增 Agent 评测工作区：可维护测试数据集，组合确定性规则或 LLM Judge，针对 Runtime 中的 Agent 重复运行实验，并查看每个 Case 的输出、评分理由、通过率、耗时和历史结果；历史记录较多时仍可按需继续加载。

--- a/.release-notes/feat-workflow-run-center-v1.md
+++ b/.release-notes/feat-workflow-run-center-v1.md
@@ -14,6 +14,7 @@
 - Workflow 运行历史的每个节点现在可展开查看实际使用的 Runtime、Channel、模型、尝试次数和执行耗时；Token 用量会按输入、输出、推理和缓存拆分，并区分 OpenAI 缓存输入与 Anthropic 的缓存读取、5 分钟/1 小时缓存写入，运行时提供数据时同时显示成本。
 - Workflow 运行历史会采集 OpenAI、Anthropic 和直连 API 返回的真实 Token usage；Provider 未返回的字段保持未提供，不会用估算值覆盖实际数据。
 - Workflow 节点在失败、重试、暂停恢复和交互式对话后仍会保留并汇总真实用量；成本没有 Provider 上报时会明确显示“未提供”。
+- 修复 Codex Workflow 未显示真实 Token 用量的问题；现在会读取 Codex app-server 的独立 Token usage 通知，并保留缓存输入与推理输出拆分。
 - Workflow 节点的历史消息会随运行记录持久保存；重新打开应用后，仍可在运行历史的对应节点中查看用户、Agent 与工具消息。
 - Workflow Agent 现在可通过专用完成工具提交结构化节点结果，普通对话内容与下游节点数据分开处理，减少格式误判。
 - 新增 Agent 评测工作区：可维护测试数据集，组合确定性规则或 LLM Judge，针对 Runtime 中的 Agent 重复运行实验，并查看每个 Case 的输出、评分理由、通过率、耗时和历史结果；历史记录较多时仍可按需继续加载。

--- a/docs/workflow-improvement-roadmap.md
+++ b/docs/workflow-improvement-roadmap.md
@@ -1,4 +1,4 @@
-# Workflow 后续改进路线
+    # Workflow 后续改进路线
 
 ## 文档目的
 

--- a/src/automation/engine/main/agents/claude/claude-stream.test.ts
+++ b/src/automation/engine/main/agents/claude/claude-stream.test.ts
@@ -45,6 +45,7 @@ describe("normalizeClaudeStreamEvent", () => {
         cache_creation_input_tokens: 60,
         cache_creation: { ephemeral_5m_input_tokens: 40, ephemeral_1h_input_tokens: 20 },
       },
+      modelUsage: { "claude-sonnet": { costUSD: 0.123 } },
     });
 
     expect(events[0]).toEqual({
@@ -57,6 +58,7 @@ describe("normalizeClaudeStreamEvent", () => {
         cacheWriteInputTokens: 60,
         cacheWrite5mInputTokens: 40,
         cacheWrite1hInputTokens: 20,
+        estimatedCost: 0.123,
       },
     });
   });

--- a/src/automation/engine/main/agents/claude/claude-stream.test.ts
+++ b/src/automation/engine/main/agents/claude/claude-stream.test.ts
@@ -34,6 +34,33 @@ describe("normalizeClaudeStreamEvent", () => {
     ]);
   });
 
+  test("normalizes Anthropic result usage including cache tiers", () => {
+    const events = normalizeClaudeStreamEvent({
+      type: "result",
+      result: "Final answer",
+      usage: {
+        input_tokens: 100,
+        output_tokens: 20,
+        cache_read_input_tokens: 30,
+        cache_creation_input_tokens: 60,
+        cache_creation: { ephemeral_5m_input_tokens: 40, ephemeral_1h_input_tokens: 20 },
+      },
+    });
+
+    expect(events[0]).toEqual({
+      type: "usage",
+      usage: {
+        provider: "anthropic",
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadInputTokens: 30,
+        cacheWriteInputTokens: 60,
+        cacheWrite5mInputTokens: 40,
+        cacheWrite1hInputTokens: 20,
+      },
+    });
+  });
+
   test("emits only new text when Claude partial messages are snapshots", () => {
     const state = createClaudeStreamState();
 

--- a/src/automation/engine/main/agents/claude/claude-stream.ts
+++ b/src/automation/engine/main/agents/claude/claude-stream.ts
@@ -1,4 +1,5 @@
 import type { AgentEvent } from "../../../shared/types";
+import { normalizeAnthropicUsage } from "../../../../../shared/runtime/usage";
 
 export interface ClaudeStreamState {
   lastText: string;
@@ -160,6 +161,8 @@ export function normalizeClaudeStreamEvent(raw: unknown, state?: ClaudeStreamSta
 
   if (type === "result") {
     const events: AgentEvent[] = [];
+    const usage = normalizeAnthropicUsage(record.usage);
+    if (usage) events.push({ type: "usage", usage });
     const sessionId = asString(record.session_id);
     if (sessionId) {
       events.push({

--- a/src/automation/engine/main/agents/claude/claude-stream.ts
+++ b/src/automation/engine/main/agents/claude/claude-stream.ts
@@ -130,6 +130,23 @@ function consumeTextDelta(text: string, state: ClaudeStreamState): string {
   return text;
 }
 
+function normalizeClaudeUsage(record: Record<string, unknown>): ReturnType<typeof normalizeAnthropicUsage> {
+  const usage = normalizeAnthropicUsage(record.usage);
+  const modelUsage = record.modelUsage && typeof record.modelUsage === "object" ? record.modelUsage as Record<string, unknown> : undefined;
+  const estimatedCost: number | undefined = modelUsage
+    ? Object.values(modelUsage).reduce<number>((total, value) => {
+        if (!value || typeof value !== "object") return total;
+        const cost = (value as Record<string, unknown>).costUSD;
+        return total + (typeof cost === "number" && Number.isFinite(cost) && cost >= 0 ? cost : 0);
+      }, 0)
+    : undefined;
+  if (!usage && estimatedCost === undefined) return undefined;
+  return {
+    ...(usage ?? { provider: "anthropic" }),
+    ...(estimatedCost !== undefined ? { estimatedCost } : {}),
+  };
+}
+
 export function normalizeClaudeStreamEvent(raw: unknown, state?: ClaudeStreamState): AgentEvent[] {
   if (!raw || typeof raw !== "object") return [];
   const record = raw as Record<string, unknown>;
@@ -161,7 +178,7 @@ export function normalizeClaudeStreamEvent(raw: unknown, state?: ClaudeStreamSta
 
   if (type === "result") {
     const events: AgentEvent[] = [];
-    const usage = normalizeAnthropicUsage(record.usage);
+    const usage = normalizeClaudeUsage(record);
     if (usage) events.push({ type: "usage", usage });
     const sessionId = asString(record.session_id);
     if (sessionId) {

--- a/src/automation/engine/main/agents/codex/codex-events.test.ts
+++ b/src/automation/engine/main/agents/codex/codex-events.test.ts
@@ -103,6 +103,28 @@ describe("normalizeCodexNotification", () => {
     ]);
   });
 
+  test("emits usage from Codex tokenUsage update notifications", () => {
+    const state = createCodexStreamState();
+
+    expect(normalizeCodexNotification("thread/tokenUsage/updated", {
+      tokenUsage: {
+        total: { inputTokens: 900, cachedInputTokens: 400, outputTokens: 120, reasoningOutputTokens: 30 },
+        last: { inputTokens: 120, cachedInputTokens: 40, outputTokens: 20, reasoningOutputTokens: 6 },
+      },
+    }, state)).toEqual([
+      {
+        type: "usage",
+        usage: {
+          provider: "openai",
+          inputTokens: 120,
+          outputTokens: 20,
+          reasoningTokens: 6,
+          cacheReadInputTokens: 40,
+        },
+      },
+    ]);
+  });
+
   test("does not duplicate final snapshots after streaming deltas", () => {
     const state = createCodexStreamState();
 

--- a/src/automation/engine/main/agents/codex/codex-events.test.ts
+++ b/src/automation/engine/main/agents/codex/codex-events.test.ts
@@ -73,6 +73,36 @@ describe("normalizeCodexNotification", () => {
     ]);
   });
 
+  test("emits OpenAI usage from turn completion", () => {
+    const state = createCodexStreamState();
+
+    expect(normalizeCodexNotification("turn/completed", {
+      turn: {
+        status: "completed",
+        usage: {
+          prompt_tokens: 100,
+          completion_tokens: 20,
+          total_tokens: 120,
+          prompt_tokens_details: { cached_tokens: 30 },
+          completion_tokens_details: { reasoning_tokens: 8 },
+        },
+      },
+    }, state)).toEqual([
+      {
+        type: "usage",
+        usage: {
+          provider: "openai",
+          inputTokens: 100,
+          outputTokens: 20,
+          reasoningTokens: 8,
+          cacheReadInputTokens: 30,
+          totalTokens: 120,
+        },
+      },
+      { type: "completed" },
+    ]);
+  });
+
   test("does not duplicate final snapshots after streaming deltas", () => {
     const state = createCodexStreamState();
 

--- a/src/automation/engine/main/agents/codex/codex-events.ts
+++ b/src/automation/engine/main/agents/codex/codex-events.ts
@@ -1,4 +1,5 @@
 import type { AgentEvent } from "../../../shared/types";
+import { normalizeOpenAIUsage } from "../../../../../shared/runtime/usage";
 
 export interface CodexStreamState {
   lastText: string;
@@ -152,18 +153,20 @@ export function normalizeCodexNotification(
 
   if (method === "turn/completed") {
     const turn = params.turn as Record<string, unknown> | undefined;
+    const usage = normalizeOpenAIUsage(turn?.usage ?? params.usage);
+    const usageEvents: AgentEvent[] = usage ? [{ type: "usage", usage }] : [];
     const status = asString(turn?.status) || "completed";
     if (status === "failed") {
       const error = asString(turn?.error) || "Codex turn failed";
       state.lastError = error;
-      return [{ type: "error", error }];
+      return [...usageEvents, { type: "error", error }];
     }
     const text = extractItemText(turn);
     if (!state.lastText && text) {
       state.lastText = text;
-      return [{ type: "completed", content: text }];
+      return [...usageEvents, { type: "completed", content: text }];
     }
-    return [{ type: "completed" }];
+    return [...usageEvents, { type: "completed" }];
   }
 
   if (method === "error") {

--- a/src/automation/engine/main/agents/codex/codex-events.ts
+++ b/src/automation/engine/main/agents/codex/codex-events.ts
@@ -115,6 +115,19 @@ function extractItemText(item: Record<string, unknown> | undefined): string {
   return "";
 }
 
+function normalizeCodexUsage(value: unknown): ReturnType<typeof normalizeOpenAIUsage> {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  const source = (record.last && typeof record.last === "object" ? record.last : record.usage && typeof record.usage === "object" ? record.usage : record) as Record<string, unknown>;
+  return normalizeOpenAIUsage({
+    input_tokens: source.input_tokens ?? source.prompt_tokens ?? source.inputTokens,
+    output_tokens: source.output_tokens ?? source.completion_tokens ?? source.outputTokens,
+    total_tokens: source.total_tokens ?? source.totalTokens,
+    prompt_tokens_details: source.prompt_tokens_details ?? { cached_tokens: source.cached_tokens ?? source.cachedInputTokens },
+    completion_tokens_details: source.completion_tokens_details ?? { reasoning_tokens: source.reasoning_tokens ?? source.reasoningOutputTokens },
+  });
+}
+
 export function normalizeCodexNotification(
   method: string,
   params: Record<string, unknown>,
@@ -153,7 +166,7 @@ export function normalizeCodexNotification(
 
   if (method === "turn/completed") {
     const turn = params.turn as Record<string, unknown> | undefined;
-    const usage = normalizeOpenAIUsage(turn?.usage ?? params.usage);
+    const usage = normalizeCodexUsage(turn?.usage ?? turn?.tokenUsage ?? params.usage ?? params.tokenUsage);
     const usageEvents: AgentEvent[] = usage ? [{ type: "usage", usage }] : [];
     const status = asString(turn?.status) || "completed";
     if (status === "failed") {
@@ -167,6 +180,11 @@ export function normalizeCodexNotification(
       return [...usageEvents, { type: "completed", content: text }];
     }
     return [...usageEvents, { type: "completed" }];
+  }
+
+  if (method === "thread/tokenUsage/updated" || method === "turn/tokenUsage/updated" || method === "tokenUsage/updated") {
+    const usage = normalizeCodexUsage(params.tokenUsage ?? params.usage);
+    return usage ? [{ type: "usage", usage }] : [];
   }
 
   if (method === "error") {

--- a/src/automation/engine/main/hub/agent-hub.ts
+++ b/src/automation/engine/main/hub/agent-hub.ts
@@ -479,7 +479,19 @@ export class AgentHub {
       stopTask: (taskId) => this.stopTask(taskId),
       deleteTask: (taskId, options) => this.deleteTask(taskId, options),
       executeWorkflowV2Script: (input) => executeWorkflowV2Script(input),
-      startWorkflowNodeConversation: (input) => this.workflowNodeConversations.start(input),
+      startWorkflowNodeConversation: (input) => {
+        const resolved = this.resolveConfiguredAgent(input.configuredAgentId, input.modelId);
+        return this.workflowNodeConversations.start({
+          ...input,
+          ...(resolved?.runtimeAgentId ? { runtimeId: resolved.runtimeAgentId } : {}),
+          ...(resolved?.channel.id ? { channelId: resolved.channel.id } : {}),
+          ...(resolved?.channel.apiFormat === "anthropic" || resolved?.runtimeAgentId === "claude"
+            ? { provider: "anthropic" }
+            : resolved?.channel.apiFormat?.startsWith("openai")
+              ? { provider: "openai" }
+              : {}),
+        });
+      },
       markWorkflowNodeConversationWaiting: (conversationId, question) => this.workflowNodeConversations.markWaitingForUser(conversationId, question),
       stopWorkflowNodeConversations: (workflowId, runId) => this.workflowNodeConversations.stopRun(workflowId, runId),
       createWorkflowV2Store: () => this.storagePath

--- a/src/automation/engine/main/hub/chat/agent-hub-run-events.ts
+++ b/src/automation/engine/main/hub/chat/agent-hub-run-events.ts
@@ -83,6 +83,13 @@ export function handleAgentEvent(input: {
     return;
   }
 
+  if (event.type === "usage") {
+    if (run.kind === "task") run.usage = { ...(run.usage ?? {}), ...event.usage };
+    run.updatedAt = Date.now();
+    input.emit();
+    return;
+  }
+
   if (event.type === "delta") {
     touchRuntimeState("running");
     if (!run.pendingAssistantMessageId) {

--- a/src/automation/engine/main/hub/persisted/agent-hub-state-restore.ts
+++ b/src/automation/engine/main/hub/persisted/agent-hub-state-restore.ts
@@ -238,5 +238,7 @@ export function restoreTaskState(raw: unknown, deps: RestoreTaskStateDeps): Task
     record.runtimeConversation === undefined ? undefined : deps.restoreRuntimeConversation(record.runtimeConversation);
   if (record.runtimeConversation !== undefined && !restoredRuntimeConversation) return null;
   task.runtimeConversation = restoredRuntimeConversation ? deps.cloneRuntimeConversation(restoredRuntimeConversation) : undefined;
+  const usage = record.usage;
+  if (usage && typeof usage === "object") task.usage = structuredClone(usage) as TaskState["usage"];
   return task;
 }

--- a/src/automation/engine/main/hub/runtime/executor/api/api-executor.ts
+++ b/src/automation/engine/main/hub/runtime/executor/api/api-executor.ts
@@ -1,4 +1,4 @@
-import { apiRequestBody, apiRequestUrl, extractApiContent, resolveApiModel } from "./api-protocol";
+import { apiRequestBody, apiRequestUrl, extractApiContent, extractApiUsage, resolveApiModel } from "./api-protocol";
 import type {
   AgentExecutionContext,
   AgentExecutor,
@@ -53,7 +53,9 @@ export class ApiAgentExecutor implements AgentExecutor {
       }
 
       const content = extractApiContent(channel, text);
+      const usage = extractApiUsage(channel, text);
       this.context.emit({ type: "delta", content });
+      if (usage) this.context.emit({ type: "usage", usage });
       this.context.emit({ type: "completed", content });
       this.context.onExit(0);
     } catch (error) {

--- a/src/automation/engine/main/hub/runtime/executor/api/api-protocol.ts
+++ b/src/automation/engine/main/hub/runtime/executor/api/api-protocol.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_MODEL_ID, runtimeModelId } from "../../../../../shared/models";
 import type { AgentChannel } from "../../../../../shared/types";
+import { normalizeAnthropicUsage, normalizeOpenAIUsage } from "../../../../../../../shared/runtime/usage";
 
 export function resolveApiModel(channel: AgentChannel, modelId: string): string | undefined {
   const model = runtimeModelId(modelId);
@@ -57,6 +58,13 @@ export function extractApiContent(channel: AgentChannel, text: string): string {
   const first = parsed.choices?.[0];
   const content = first?.message?.content ?? first?.text ?? parsed.output_text;
   return typeof content === "string" ? content : JSON.stringify(parsed, null, 2);
+}
+
+export function extractApiUsage(channel: AgentChannel, text: string) {
+  const parsed = JSON.parse(text) as Record<string, unknown>;
+  return channel.modelProvider === "anthropic-api"
+    ? normalizeAnthropicUsage(parsed.usage)
+    : normalizeOpenAIUsage(parsed.usage);
 }
 
 function chatCompletionsUrl(baseUrl: string): string {

--- a/src/automation/engine/main/hub/state/agent-hub-restore.test.ts
+++ b/src/automation/engine/main/hub/state/agent-hub-restore.test.ts
@@ -98,4 +98,33 @@ describe("agent hub workflow progress restore", () => {
     expect(progress).toMatchObject({ nodeId: "echo", status: "awaiting_input" });
     expect(progress?.inputRequest).toBeUndefined();
   });
+
+  test("restores node execution telemetry without requiring usage fields", () => {
+    const progress = restoreWorkflowRunProgressItem({
+      nodeId: "research",
+      title: "Research",
+      status: "completed",
+      telemetry: {
+        runtimeId: "codex",
+        channelId: "codex-openai",
+        modelId: "gpt-5.5",
+        attempt: 2,
+        startedAt: 10_000,
+        finishedAt: 25_000,
+        totalTokens: 1_540,
+        estimatedCost: 0.031,
+      },
+    });
+
+    expect(progress?.telemetry).toEqual({
+      runtimeId: "codex",
+      channelId: "codex-openai",
+      modelId: "gpt-5.5",
+      attempt: 2,
+      startedAt: 10_000,
+      finishedAt: 25_000,
+      totalTokens: 1_540,
+      estimatedCost: 0.031,
+    });
+  });
 });

--- a/src/automation/engine/main/hub/state/agent-hub-restore.ts
+++ b/src/automation/engine/main/hub/state/agent-hub-restore.ts
@@ -110,6 +110,29 @@ export function restoreWorkflowRunProgressItem(raw: unknown): WorkflowRunProgres
   }
   const outputs = asRecord(record.outputs);
   if (outputs) item.outputs = structuredClone(outputs);
+  const telemetry = asRecord(record.telemetry);
+  const telemetryAttempt = telemetry && typeof telemetry.attempt === "number" ? telemetry.attempt : undefined;
+  if (telemetry && telemetryAttempt !== undefined && Number.isSafeInteger(telemetryAttempt) && telemetryAttempt > 0) {
+    const startedAt = asNumber(telemetry.startedAt, Date.now());
+    item.telemetry = {
+      attempt: telemetryAttempt,
+      startedAt,
+      ...(telemetry.provider === "openai" || telemetry.provider === "anthropic" || typeof telemetry.provider === "string" ? { provider: telemetry.provider } : {}),
+      ...(asOptionalString(telemetry.runtimeId) ? { runtimeId: asOptionalString(telemetry.runtimeId) } : {}),
+      ...(asOptionalString(telemetry.channelId) ? { channelId: asOptionalString(telemetry.channelId) } : {}),
+      ...(asOptionalString(telemetry.modelId) ? { modelId: asOptionalString(telemetry.modelId) } : {}),
+      ...(typeof telemetry.finishedAt === "number" ? { finishedAt: telemetry.finishedAt } : {}),
+      ...(typeof telemetry.inputTokens === "number" ? { inputTokens: telemetry.inputTokens } : {}),
+      ...(typeof telemetry.outputTokens === "number" ? { outputTokens: telemetry.outputTokens } : {}),
+      ...(typeof telemetry.reasoningTokens === "number" ? { reasoningTokens: telemetry.reasoningTokens } : {}),
+      ...(typeof telemetry.cacheReadInputTokens === "number" ? { cacheReadInputTokens: telemetry.cacheReadInputTokens } : {}),
+      ...(typeof telemetry.cacheWriteInputTokens === "number" ? { cacheWriteInputTokens: telemetry.cacheWriteInputTokens } : {}),
+      ...(typeof telemetry.cacheWrite5mInputTokens === "number" ? { cacheWrite5mInputTokens: telemetry.cacheWrite5mInputTokens } : {}),
+      ...(typeof telemetry.cacheWrite1hInputTokens === "number" ? { cacheWrite1hInputTokens: telemetry.cacheWrite1hInputTokens } : {}),
+      ...(typeof telemetry.totalTokens === "number" ? { totalTokens: telemetry.totalTokens } : {}),
+      ...(typeof telemetry.estimatedCost === "number" ? { estimatedCost: telemetry.estimatedCost } : {}),
+    };
+  }
   const messages = asArray(record.messages)
     .map((message) => restoreWorkflowNodeHistoryMessage(message))
     .filter((message): message is WorkflowNodeMessage => Boolean(message));

--- a/src/automation/engine/main/hub/state/agent-hub-snapshot.ts
+++ b/src/automation/engine/main/hub/state/agent-hub-snapshot.ts
@@ -64,6 +64,7 @@ export function serializeTask(input: {
     progress: task.progress,
     running: task.running,
     ...(task.runtimeConversation ? { runtimeConversation: cloneConversation(task.runtimeConversation) } : {}),
+    ...(task.usage ? { usage: { ...task.usage } } : {}),
     messages: task.messages.map((message) => serializeMessage(message)),
     pendingAssistantMessageId: task.pendingAssistantMessageId,
     lastError: task.lastError,

--- a/src/automation/engine/main/hub/state/agent-hub-state.ts
+++ b/src/automation/engine/main/hub/state/agent-hub-state.ts
@@ -7,6 +7,7 @@ import type {
   ChatRuntimeSessionState,
   RuntimeConversation,
   RuntimeContinuationPolicy,
+  RuntimeUsage,
   TaskProgress,
   TaskRunStatus,
   TeamRunStatus,
@@ -45,6 +46,7 @@ export class TaskState {
   id: string = randomUUID();
   title: string;
   runtimeConversation: RuntimeConversation | undefined = undefined;
+  usage: RuntimeUsage | undefined = undefined;
   planningWorkflowId: string | undefined = undefined;
   workflowRunId: string | undefined = undefined;
   workflowNodeId: string | undefined = undefined;

--- a/src/automation/engine/main/hub/workflow/agent-hub-workflow-clone.ts
+++ b/src/automation/engine/main/hub/workflow/agent-hub-workflow-clone.ts
@@ -30,6 +30,7 @@ export function cloneWorkflowRunProgressItem(item: WorkflowRunProgressItem): Wor
     ...(item.inputRequest !== undefined ? { inputRequest: structuredClone(item.inputRequest) } : {}),
     ...(item.outputs !== undefined ? { outputs: structuredClone(item.outputs) } : {}),
     ...(item.messages !== undefined ? { messages: structuredClone(item.messages) } : {}),
+    ...(item.telemetry !== undefined ? { telemetry: structuredClone(item.telemetry) } : {}),
   };
 }
 

--- a/src/automation/engine/main/workflows/v2/workflow-v2-conversation-manager.test.ts
+++ b/src/automation/engine/main/workflows/v2/workflow-v2-conversation-manager.test.ts
@@ -65,6 +65,32 @@ describe("WorkflowV2ConversationManager", () => {
       expect.objectContaining({ role: "tool", eventType: "tool_result", name: "shell_command" }),
     ]);
   });
+
+  test("aggregates interactive usage and preserves it when the conversation is restored", async () => {
+    let emit!: (event: AgentEvent) => void;
+    const manager = new WorkflowV2ConversationManager({
+      now: () => 100,
+      createSession: (input) => {
+        emit = input.emit;
+        return { sendPrompt: async () => undefined, interrupt: async () => undefined, close: async () => undefined, runtimeConversation: () => undefined };
+      },
+    });
+    const started = await manager.start({
+      workflowId: "w", runId: "r", nodeId: "n", configuredAgentId: "a", modelId: "m", workDir: "C:/workspace", initialPrompt: "Start",
+      provider: "anthropic", runtimeId: "claude", channelId: "channel-1",
+    });
+    emit({ type: "usage", usage: { provider: "anthropic", inputTokens: 100, outputTokens: 20, cacheReadInputTokens: 10 } });
+    emit({ type: "usage", usage: { provider: "anthropic", inputTokens: 50, outputTokens: 5, cacheWrite5mInputTokens: 30 } });
+
+    expect(manager.get(started.conversationId)?.telemetry).toMatchObject({
+      provider: "anthropic", runtimeId: "claude", channelId: "channel-1", inputTokens: 150, outputTokens: 25,
+      cacheReadInputTokens: 10, cacheWrite5mInputTokens: 30,
+    });
+
+    const restored = new WorkflowV2ConversationManager({ now: () => 100, createSession: () => ({ sendPrompt: async () => undefined, interrupt: async () => undefined, close: async () => undefined, runtimeConversation: () => undefined }) });
+    restored.restore([manager.get(started.conversationId)]);
+    expect(restored.get(started.conversationId)?.telemetry).toMatchObject({ inputTokens: 150, outputTokens: 25, cacheWrite5mInputTokens: 30 });
+  });
   test("preserves live approval identity and resolves it after the runtime responds", async () => {
     let emit!: (event: AgentEvent) => void;
     const manager = new WorkflowV2ConversationManager({

--- a/src/automation/engine/main/workflows/v2/workflow-v2-conversation-manager.ts
+++ b/src/automation/engine/main/workflows/v2/workflow-v2-conversation-manager.ts
@@ -6,6 +6,8 @@ import type {
 } from "../../../shared/workflow-v2/conversation";
 import { workflowNodeConversationId } from "../../../shared/workflow-v2/conversation";
 import { isWorkflowV2WorkerOutput } from "../../../shared/workflow-v2/packets";
+import type { WorkflowRunNodeTelemetry } from "../../../shared/workflow/run";
+import { mergeRuntimeUsage } from "../../../../../shared/runtime/usage";
 
 export interface WorkflowNodeInteractiveSession {
   sendPrompt(prompt: string): Promise<void>;
@@ -24,6 +26,9 @@ export interface CreateWorkflowNodeConversationInput {
   initialPrompt: string;
   developerInstructions?: string;
   contextDocument?: string;
+  provider?: string;
+  runtimeId?: string;
+  channelId?: string;
 }
 
 export class WorkflowV2ConversationManager {
@@ -57,6 +62,14 @@ export class WorkflowV2ConversationManager {
       createdAt: now,
       updatedAt: now,
       lastActivityAt: now,
+      telemetry: {
+        ...(input.provider ? { provider: input.provider } : {}),
+        ...(input.runtimeId ? { runtimeId: input.runtimeId } : {}),
+        ...(input.channelId ? { channelId: input.channelId } : {}),
+        modelId: input.modelId,
+        attempt: 1,
+        startedAt: now,
+      },
     };
     const session = this.deps.createSession({ ...input, emit: (event) => this.recordEvent(conversationId, event) });
     this.conversations.set(conversationId, conversation);
@@ -243,11 +256,19 @@ export class WorkflowV2ConversationManager {
       }
     }
     if (event.type === "completed") {
+      if (conversation.telemetry) conversation.telemetry.finishedAt = this.deps.now();
       const completionTool = [...conversation.messages].reverse().find((message) => message.eventType === "tool_call" && message.name?.toLowerCase().includes("workflow_node_complete"));
       const finalContent = (completionTool?.content || event.content || (conversation.messages.at(-1)?.eventType === "delta" ? conversation.messages.at(-1)?.content : "") || "").trim();
       this.deps.onCompleted?.(structuredClone(conversation), finalContent);
     }
-    if (event.type === "error") conversation.status = "failed";
+    if (event.type === "error") {
+      conversation.status = "failed";
+      if (conversation.telemetry) conversation.telemetry.finishedAt = this.deps.now();
+    }
+    if (event.type === "usage") {
+      const current = conversation.telemetry ?? { modelId: conversation.modelId, attempt: 1, startedAt: conversation.createdAt };
+      conversation.telemetry = { ...current, ...mergeRuntimeUsage(current, event.usage) };
+    }
     this.syncRuntimeConversation(conversationId);
     this.changed(conversation, event.type === "delta" ? "stream" : "immediate");
   }
@@ -366,6 +387,7 @@ function restoreWorkflowNodeConversation(value: unknown): WorkflowNodeConversati
   const lastActivityAt = finiteNumber(record.lastActivityAt);
   if (createdAt === undefined || updatedAt === undefined || lastActivityAt === undefined) return undefined;
   const completionProposal = restoredCompletionProposal(record.completionProposal);
+  const telemetry = restoreWorkflowNodeTelemetry(record.telemetry, createdAt);
   const status = record.status === "completion_proposed" && !completionProposal ? "waiting_for_user" : record.status as WorkflowNodeConversation["status"];
   return {
     conversationId: record.conversationId as string,
@@ -378,14 +400,40 @@ function restoreWorkflowNodeConversation(value: unknown): WorkflowNodeConversati
     status,
     messages: record.messages.flatMap((message) => restoredWorkflowNodeMessage(message) ?? []),
     ...(completionProposal ? { completionProposal } : {}),
+    ...(telemetry ? { telemetry } : {}),
     createdAt,
     updatedAt,
     lastActivityAt,
   };
 }
 
+function restoreWorkflowNodeTelemetry(value: unknown, fallbackStartedAt: number): WorkflowRunNodeTelemetry | undefined {
+  const record = objectRecord(value);
+  const attempt = finiteNumber(record?.attempt);
+  if (!record || attempt === undefined || !Number.isSafeInteger(attempt) || attempt < 1) return undefined;
+  const numeric = (key: string): number | undefined => finiteNumber(record[key]);
+  return {
+    attempt,
+    startedAt: numeric("startedAt") ?? fallbackStartedAt,
+    ...(typeof record.provider === "string" ? { provider: record.provider } : {}),
+    ...(typeof record.runtimeId === "string" ? { runtimeId: record.runtimeId } : {}),
+    ...(typeof record.channelId === "string" ? { channelId: record.channelId } : {}),
+    ...(typeof record.modelId === "string" ? { modelId: record.modelId } : {}),
+    ...(numeric("finishedAt") !== undefined ? { finishedAt: numeric("finishedAt") } : {}),
+    ...(numeric("inputTokens") !== undefined ? { inputTokens: numeric("inputTokens") } : {}),
+    ...(numeric("outputTokens") !== undefined ? { outputTokens: numeric("outputTokens") } : {}),
+    ...(numeric("reasoningTokens") !== undefined ? { reasoningTokens: numeric("reasoningTokens") } : {}),
+    ...(numeric("cacheReadInputTokens") !== undefined ? { cacheReadInputTokens: numeric("cacheReadInputTokens") } : {}),
+    ...(numeric("cacheWriteInputTokens") !== undefined ? { cacheWriteInputTokens: numeric("cacheWriteInputTokens") } : {}),
+    ...(numeric("cacheWrite5mInputTokens") !== undefined ? { cacheWrite5mInputTokens: numeric("cacheWrite5mInputTokens") } : {}),
+    ...(numeric("cacheWrite1hInputTokens") !== undefined ? { cacheWrite1hInputTokens: numeric("cacheWrite1hInputTokens") } : {}),
+    ...(numeric("totalTokens") !== undefined ? { totalTokens: numeric("totalTokens") } : {}),
+    ...(numeric("estimatedCost") !== undefined ? { estimatedCost: numeric("estimatedCost") } : {}),
+  };
+}
+
 function workflowNodeChatEvent(event: AgentEvent, id: string, timestamp: number): ChatEvent | undefined {
-  if (event.type === "runtime_conversation" || event.type === "delta" || event.type === "completed") return undefined;
+  if (event.type === "runtime_conversation" || event.type === "usage" || event.type === "delta" || event.type === "completed") return undefined;
   if (event.type === "error") return { id, type: "error", content: event.error, timestamp };
   return {
     id,

--- a/src/automation/engine/main/workflows/v2/workflow-v2-run-executor.ts
+++ b/src/automation/engine/main/workflows/v2/workflow-v2-run-executor.ts
@@ -1,6 +1,7 @@
 import type { RunTaskRequest, TaskRun } from "../../../shared/types";
 import type { RuntimeConversation } from "../../../shared/runtime/conversation";
-import type { WorkflowEvent, WorkflowRunProgressItem } from "../../../shared/workflow/run";
+import { mergeRuntimeUsage } from "../../../../../shared/runtime/usage";
+import type { WorkflowEvent, WorkflowRunNodeTelemetry, WorkflowRunProgressItem } from "../../../shared/workflow/run";
 import type { WorkflowV2LLMNode, WorkflowV2ScriptNode } from "../../../shared/workflow-v2/definition";
 import type { WorkflowNodeMessage } from "../../../shared/workflow-v2/conversation";
 import type { WorkflowV2WorkerOutput } from "../../../shared/workflow-v2/packets";
@@ -23,6 +24,21 @@ import type { WorkflowRunRegistry } from "../workflow-run-registry";
 import { WorkflowV2RunPersistence } from "./workflow-v2-run-persistence";
 import type { ExecuteWorkflowV2RunInput, WorkflowV2RecoveryOverride } from "./workflow-v2-execution-contract";
 export type { WorkflowV2RecoveryOverride } from "./workflow-v2-execution-contract";
+
+function addNodeUsage(telemetry: WorkflowRunNodeTelemetry, usage: TaskRun["usage"]): WorkflowRunNodeTelemetry {
+  if (!usage) return telemetry;
+  return { ...telemetry, ...mergeRuntimeUsage(telemetry, usage) };
+}
+
+function startNodeAttempt(previous: WorkflowRunNodeTelemetry | undefined, next: WorkflowRunNodeTelemetry): WorkflowRunNodeTelemetry {
+  if (!previous) return next;
+  const merged = addNodeUsage(next, previous);
+  return {
+    ...merged,
+    attempt: next.attempt,
+    startedAt: previous.startedAt,
+  };
+}
 import type { WorkflowRuntimeDependencies } from "../workflow-runtime-ports";
 import type {
   WorkflowV2ExecutionLeaseState,
@@ -695,6 +711,25 @@ export class WorkflowV2RunExecutor {
       }
       const attempt = (runtimeAttemptByNodeId.get(request.node.id) ?? 0) + 1;
       runtimeAttemptByNodeId.set(request.node.id, attempt);
+      const configuredAgent = latestSnapshot.configuredAgents.find((item) => item.id === agentRoute.configuredAgentId);
+      const channel = configuredAgent?.channelId
+        ? latestSnapshot.channels.find((item) => item.id === configuredAgent.channelId)
+        : undefined;
+      const provider = channel?.apiFormat === "anthropic" || configuredAgent?.runtimeAgentId === "claude"
+        ? "anthropic"
+        : channel?.apiFormat?.startsWith("openai")
+          ? "openai"
+          : undefined;
+      const nextTelemetry: WorkflowRunNodeTelemetry = {
+        ...(provider ? { provider } : {}),
+        ...(configuredAgent?.runtimeAgentId ? { runtimeId: configuredAgent.runtimeAgentId } : {}),
+        ...(configuredAgent?.channelId ? { channelId: configuredAgent.channelId } : {}),
+        modelId: agentRoute.modelId,
+        attempt,
+        startedAt: Date.now(),
+      };
+      const previousTelemetry = latestProgress.find((item) => item.nodeId === request.node.id)?.telemetry;
+      const telemetry = startNodeAttempt(previousTelemetry, nextTelemetry);
       const task = await startModelTask(request.node.id, {
         prompt: effectivePrompt,
         developerInstructions: effectiveDeveloperInstructions,
@@ -707,7 +742,7 @@ export class WorkflowV2RunExecutor {
           : {}),
       }, true);
       consumedRecoveryNodeIds.add(request.node.id);
-      updateNode(request.node.id, { status: "running", detail: "Task running", taskId: task.id });
+      updateNode(request.node.id, { status: "running", detail: "Task running", taskId: task.id, telemetry });
 
       let taskIds = [task.id];
       const supervisorTaskIds: string[] = [];
@@ -728,15 +763,17 @@ export class WorkflowV2RunExecutor {
         // worker output passes structured validation. Archive it before parsing so
         // failed or malformed one-shot responses remain inspectable in run history.
         const historyMessages = workflowNodeHistoryMessages(completedTask);
+        const completedTelemetry = { ...addNodeUsage(telemetry, completedTask.usage), finishedAt: Date.now() };
         updateNode(request.node.id, {
           status: "running",
           detail: "Task output received",
           taskId: task.id,
+          telemetry: completedTelemetry,
           ...(historyMessages.length > 0 ? { messages: historyMessages } : {}),
         });
         const artifact = taskArtifact(completedTask);
         const output = parseWorkflowV2WorkerArtifact(request.node, artifact);
-        updateNode(request.node.id, { status: "running", detail: output.summary, taskId: task.id }, {
+        updateNode(request.node.id, { status: "running", detail: output.summary, taskId: task.id, telemetry: completedTelemetry }, {
           type: "node_output",
           nodeId: request.node.id,
           taskId: task.id,
@@ -752,14 +789,15 @@ export class WorkflowV2RunExecutor {
               .find((item): item is TaskRun => Boolean(item));
         if (taskForHistory) {
           const historyMessages = workflowNodeHistoryMessages(taskForHistory);
-          if (historyMessages.length > 0) {
-            updateNode(request.node.id, {
-              status: "running",
-              detail: "Task history archived",
-              taskId: taskForHistory.id,
-              messages: historyMessages,
-            });
-          }
+          updateNode(request.node.id, {
+            status: "running",
+            detail: "Task history archived",
+            taskId: taskForHistory.id,
+            telemetry: { ...addNodeUsage(telemetry, taskForHistory.usage), finishedAt: Date.now() },
+            ...(historyMessages.length > 0 ? { messages: historyMessages } : {}),
+          });
+        } else {
+          updateNode(request.node.id, { telemetry: { ...telemetry, finishedAt: Date.now() } });
         }
         if (error instanceof WorkflowV2OneShotInputRequestSignal) {
           await this.deps.stopTask(error.task.id);
@@ -824,6 +862,8 @@ export class WorkflowV2RunExecutor {
         ...(approvalGrant ? { approvalGrant } : {}),
       });
       this.runRegistry.get(runId)?.abortControllerByNodeId?.set(request.node.id, controller);
+      const telemetry: WorkflowRunNodeTelemetry = { attempt: 1, startedAt: Date.now() };
+      updateNode(request.node.id, { status: "running", detail: "Script running", telemetry });
       let output: WorkflowV2WorkerOutput;
       try {
         output = await executeAuthorizedWorkflowV2Script({ deps: this.deps, node: request.node, workDir: workflowWorkDir, upstreamOutputs: request.upstreamOutputs, timeoutMs, inputs: resolvedInput.values, controller,
@@ -846,7 +886,7 @@ export class WorkflowV2RunExecutor {
       } finally {
         this.runRegistry.get(runId)?.abortControllerByNodeId?.delete(request.node.id);
       }
-      updateNode(request.node.id, { status: "running", detail: output.summary }, {
+      updateNode(request.node.id, { status: "running", detail: output.summary, telemetry: { ...telemetry, finishedAt: Date.now() } }, {
         type: "node_output",
         nodeId: request.node.id,
         attempt: 1,

--- a/src/automation/engine/renderer/src/pages/workflow/WorkflowRunCenter.test.tsx
+++ b/src/automation/engine/renderer/src/pages/workflow/WorkflowRunCenter.test.tsx
@@ -73,6 +73,83 @@ describe("WorkflowRunCenter", () => {
     expect(html).toContain("Historical research answer");
   });
 
+  test("renders node execution telemetry for runtime, channel, model, attempts, tokens, cost, and duration", () => {
+    const observedRun = run({ runId: "observed-run", status: "completed", startedAt: 2_000, finishedAt: 62_000 });
+    (observedRun.progress[0] as WorkflowRunState["progress"][number] & { telemetry: unknown }).telemetry = {
+      provider: "anthropic",
+      runtimeId: "codex",
+      channelId: "codex-openai",
+      modelId: "gpt-5.5",
+      attempt: 2,
+      startedAt: 10_000,
+      finishedAt: 25_000,
+      inputTokens: 1_200,
+      outputTokens: 340,
+      reasoningTokens: 120,
+      cacheReadInputTokens: 80,
+      cacheWrite5mInputTokens: 40,
+      cacheWrite1hInputTokens: 20,
+      totalTokens: 1_540,
+      estimatedCost: 0.031,
+    };
+
+    const html = renderToStaticMarkup(<WorkflowRunCenter
+      runs={[observedRun]}
+      open
+      selectedRunId="observed-run"
+      onSelectRun={() => undefined}
+      onClose={() => undefined}
+    />);
+
+    expect(html).toContain("Runtime");
+    expect(html).toContain("codex");
+    expect(html).toContain("Channel");
+    expect(html).toContain("codex-openai");
+    expect(html).toContain("Attempts");
+    expect(html).toContain("2");
+    expect(html).toContain("Token usage");
+    expect(html).toContain("Input tokens");
+    expect(html).toContain("1,200");
+    expect(html).toContain("Reasoning tokens");
+    expect(html).toContain("120");
+    expect(html).toContain("Cache read");
+    expect(html).toContain("80");
+    expect(html).toContain("Cache write · 5 min");
+    expect(html).toContain("40");
+    expect(html).toContain("Cache write · 1 hour");
+    expect(html).toContain("20");
+    expect(html).toContain("1,540");
+    expect(html).toContain("$0.031");
+    expect(html).toContain("15s");
+  });
+
+  test("uses OpenAI cached-input semantics separately from Anthropic cache fields", () => {
+    const observedRun = run({ runId: "openai-run", status: "completed", startedAt: 2_000, finishedAt: 62_000 });
+    (observedRun.progress[0] as WorkflowRunState["progress"][number] & { telemetry: unknown }).telemetry = {
+      provider: "openai",
+      attempt: 1,
+      startedAt: 10_000,
+      finishedAt: 20_000,
+      inputTokens: 1_000,
+      cacheReadInputTokens: 400,
+      outputTokens: 200,
+      totalTokens: 1_200,
+    };
+
+    const html = renderToStaticMarkup(<WorkflowRunCenter
+      runs={[observedRun]}
+      open
+      selectedRunId="openai-run"
+      onSelectRun={() => undefined}
+      onClose={() => undefined}
+    />);
+
+    expect(html).toContain("Cached input (OpenAI)");
+    expect(html).toContain("400");
+    expect(html).toContain("Cache read (Anthropic)</b>—");
+    expect(html).toContain("Cache write · 5 min</b>—");
+  });
+
   test("shows persisted interactive conversation messages for the selected run node", () => {
     const html = renderToStaticMarkup(<WorkflowRunCenter
       runs={[run({ runId: "interactive-run", status: "completed", startedAt: 2_000, finishedAt: 62_000 })]}

--- a/src/automation/engine/renderer/src/pages/workflow/WorkflowRunCenter.tsx
+++ b/src/automation/engine/renderer/src/pages/workflow/WorkflowRunCenter.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { ArrowLeft, CalendarClock, CheckCircle2, ChevronRight, CircleAlert, CircleStop, Clock3, GitBranch, History, MessageSquareText, X } from "lucide-react";
 import type { WorkflowRunState, WorkflowStatus } from "../../../../shared/types";
+import type { WorkflowRunNodeTelemetry } from "../../../../shared/workflow/run";
 import type { WorkflowNodeConversation } from "../../../../shared/workflow-v2/conversation";
 
 interface WorkflowRunCenterProps {
@@ -38,6 +39,22 @@ function formatDuration(run: WorkflowRunState): string {
   const minutes = Math.floor(seconds / 60);
   const remainder = seconds % 60;
   return `${minutes}m ${remainder}s`;
+}
+
+function formatNodeDuration(telemetry: WorkflowRunNodeTelemetry | undefined): string {
+  if (!telemetry) return "—";
+  const end = telemetry.finishedAt ?? Date.now();
+  const seconds = Math.max(0, Math.round((end - telemetry.startedAt) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+function formatMetric(value: number | undefined): string {
+  return value === undefined ? "—" : value.toLocaleString();
+}
+
+function formatCost(telemetry: WorkflowRunNodeTelemetry | undefined, language: "en" | "zh"): string {
+  return telemetry?.estimatedCost === undefined ? (language === "zh" ? "未提供" : "Not provided") : `$${telemetry.estimatedCost.toFixed(3)}`;
 }
 
 function statusLabel(status: WorkflowStatus, language: "en" | "zh"): string {
@@ -102,8 +119,8 @@ export function WorkflowRunCenter({ runs, conversations = [], open, selectedRunI
   if (!open) return null;
 
   const labels = language === "zh"
-    ? { title: "运行历史", close: "关闭运行历史", empty: "还没有运行记录", choose: "选择一条运行记录查看详情", back: "返回运行列表", detail: "运行详情", timeline: "节点时间线", messages: "消息历史", config: "冻结配置", graph: "图版本", started: "开始", duration: "耗时", approvedBy: "确认人", nodes: "节点", noEvents: "暂无事件记录", notStarted: "未开始" }
-    : { title: "Run history", close: "Close run history", empty: "No runs yet", choose: "Select a run to view its details", back: "Back to run list", detail: "Run details", timeline: "Node timeline", messages: "Message history", config: "Frozen configuration", graph: "Graph version", started: "Started", duration: "Duration", approvedBy: "Approved by", nodes: "Nodes", noEvents: "No events recorded", notStarted: "Not started" };
+    ? { title: "运行历史", close: "关闭运行历史", empty: "还没有运行记录", choose: "选择一条运行记录查看详情", back: "返回运行列表", detail: "运行详情", timeline: "节点时间线", messages: "消息历史", config: "冻结配置", graph: "图版本", started: "开始", duration: "耗时", approvedBy: "确认人", nodes: "节点", noEvents: "暂无事件记录", notStarted: "未开始", runtime: "Runtime", channel: "Channel", model: "模型", attempts: "尝试次数", executionDetails: "执行明细", tokenUsage: "Token 用量", provider: "计量风格", inputTokens: "输入 tokens", outputTokens: "输出 tokens", reasoningTokens: "推理 tokens", cachedInput: "缓存输入（OpenAI）", cacheRead: "缓存读取（Anthropic）", cacheWrite: "缓存写入（Anthropic）", cacheWrite5m: "缓存写入 · 5 分钟", cacheWrite1h: "缓存写入 · 1 小时", totalTokens: "总 tokens", cost: "成本" }
+    : { title: "Run history", close: "Close run history", empty: "No runs yet", choose: "Select a run to view its details", back: "Back to run list", detail: "Run details", timeline: "Node timeline", messages: "Message history", config: "Frozen configuration", graph: "Graph version", started: "Started", duration: "Duration", approvedBy: "Approved by", nodes: "Nodes", noEvents: "No events recorded", notStarted: "Not started", runtime: "Runtime", channel: "Channel", model: "Model", attempts: "Attempts", executionDetails: "Execution details", tokenUsage: "Token usage", provider: "Accounting style", inputTokens: "Input tokens", outputTokens: "Output tokens", reasoningTokens: "Reasoning tokens", cachedInput: "Cached input (OpenAI)", cacheRead: "Cache read (Anthropic)", cacheWrite: "Cache write (Anthropic)", cacheWrite5m: "Cache write · 5 min", cacheWrite1h: "Cache write · 1 hour", totalTokens: "Total tokens", cost: "Cost" };
 
   return (
     <div className="workflow-run-center-backdrop" role="presentation" onClick={onClose}>
@@ -150,6 +167,7 @@ export function WorkflowRunCenter({ runs, conversations = [], open, selectedRunI
                       const eventError = [...events].reverse().find((event) => event.error)?.error;
                       const conversation = conversations.find((item) => item.runId === selectedRun.runId && item.nodeId === node.nodeId);
                       const messages = conversation?.messages.length ? conversation.messages : progress?.messages ?? [];
+                      const telemetry = progress?.telemetry ?? conversation?.telemetry;
                       return (
                         <article key={node.nodeId} className={`workflow-run-center-node ${progress ? `is-${progress.status}` : ""}`}>
                           <div className="workflow-run-center-node-head">
@@ -157,6 +175,32 @@ export function WorkflowRunCenter({ runs, conversations = [], open, selectedRunI
                             <strong>{node.title}</strong>
                             <small>{node.execModel} · {node.modelId ?? node.modelProfile}</small>
                           </div>
+                          <details className="workflow-run-center-node-telemetry">
+                            <summary><span>{labels.executionDetails}</span><em>{telemetry?.attempt ?? "—"} · {formatNodeDuration(telemetry)}</em></summary>
+                            <div className="workflow-run-center-node-telemetry-grid">
+                              <span><b>{labels.runtime}</b>{telemetry?.runtimeId ?? "—"}</span>
+                              <span><b>{labels.channel}</b>{telemetry?.channelId ?? "—"}</span>
+                              <span><b>{labels.model}</b>{telemetry?.modelId ?? node.modelId ?? node.modelProfile ?? "—"}</span>
+                              <span><b>{labels.attempts}</b>{telemetry?.attempt ?? "—"}</span>
+                              <span><b>{labels.duration}</b>{formatNodeDuration(telemetry)}</span>
+                              <span><b>{labels.cost}</b>{formatCost(telemetry, language)}</span>
+                            </div>
+                            <div className="workflow-run-center-node-token-usage">
+                              <strong>{labels.tokenUsage}</strong>
+                              <span className="workflow-run-center-node-token-provider">{labels.provider}: {telemetry?.provider ?? "—"}</span>
+                              <div className="workflow-run-center-node-telemetry-grid">
+                                <span><b>{labels.inputTokens}</b>{formatMetric(telemetry?.inputTokens)}</span>
+                                <span><b>{labels.outputTokens}</b>{formatMetric(telemetry?.outputTokens)}</span>
+                                <span><b>{labels.reasoningTokens}</b>{formatMetric(telemetry?.reasoningTokens)}</span>
+                                <span><b>{labels.cachedInput}</b>{telemetry?.provider === "openai" ? formatMetric(telemetry.cacheReadInputTokens) : "—"}</span>
+                                <span><b>{labels.cacheRead}</b>{telemetry?.provider === "anthropic" ? formatMetric(telemetry.cacheReadInputTokens) : "—"}</span>
+                                <span><b>{labels.cacheWrite}</b>{telemetry?.provider === "anthropic" ? formatMetric(telemetry.cacheWriteInputTokens) : "—"}</span>
+                                <span><b>{labels.cacheWrite5m}</b>{telemetry?.provider === "anthropic" ? formatMetric(telemetry.cacheWrite5mInputTokens) : "—"}</span>
+                                <span><b>{labels.cacheWrite1h}</b>{telemetry?.provider === "anthropic" ? formatMetric(telemetry.cacheWrite1hInputTokens) : "—"}</span>
+                                <span><b>{labels.totalTokens}</b>{formatMetric(telemetry?.totalTokens)}</span>
+                              </div>
+                            </div>
+                          </details>
                           {progress?.detail ? <p>{progress.detail}</p> : null}
                           {eventError ? <p className="is-error">{eventError}</p> : null}
                           {events.length > 0 ? (

--- a/src/automation/engine/shared/types.ts
+++ b/src/automation/engine/shared/types.ts
@@ -15,6 +15,7 @@ import type { WorkflowV2HumanIntervention, WorkflowV2InterventionAction } from "
 import type { RuntimeId } from "./runtime-catalog";
 import type { ResourceSourceType } from "./resource";
 import type { RuntimeConversation } from "./runtime/conversation";
+import type { RuntimeUsage } from "../../../shared/runtime/usage";
 import type { WorkflowNodeConversation } from "./workflow-v2/conversation";
 import type { ConfiguredAgent } from "./agent/types";
 import type { WorkflowDraftState, WorkflowGrillMessage, WorkflowStoreState } from "./workflow/draft";
@@ -37,6 +38,7 @@ export {
 } from "./workflow/run";
 export type { ResourceSourceType } from "./resource";
 export type { RuntimeConversation } from "./runtime/conversation";
+export type { RuntimeUsage } from "../../../shared/runtime/usage";
 export type { AgentRevision, AgentType, ConfiguredAgent } from "./agent/types";
 export type { AgentMcpBinding, McpServerDefinition, McpToolDefinition, McpTransport } from "./mcp/types";
 export type { EvaluationCaseResult, EvaluationDataset, EvaluationDatasetItem, EvaluationEvaluator, EvaluationExperiment, EvaluationRun, EvaluationRunPage, EvaluationRunSummary, EvaluationScore, EvaluatorKind, ListEvaluationRunsRequest } from "./evaluation/types";
@@ -349,6 +351,7 @@ export interface ChatRuntimeSessionState {
 
 export type AgentEvent =
   | { type: "runtime_conversation"; runtimeConversation: RuntimeConversation }
+  | { type: "usage"; usage: RuntimeUsage }
   | { type: "delta"; content: string }
   | { type: "meta"; content: string }
   | { type: "system"; content: string; metadata?: Record<string, unknown> }
@@ -432,6 +435,7 @@ export interface TaskRun {
   progress: TaskProgress;
   running: boolean;
   runtimeConversation?: RuntimeConversation;
+  usage?: RuntimeUsage;
   messages: ChatMessage[];
   pendingAssistantMessageId: string | undefined;
   lastError: string | undefined;

--- a/src/automation/engine/shared/workflow-v2/conversation.ts
+++ b/src/automation/engine/shared/workflow-v2/conversation.ts
@@ -1,5 +1,6 @@
 import type { AgentEvent, ChatEvent, RuntimeConversation } from "../types";
 import type { WorkflowV2WorkerOutput } from "./packets";
+import type { WorkflowRunNodeTelemetry } from "../workflow/run";
 
 export type WorkflowNodeConversationStatus =
   | "starting"
@@ -35,6 +36,7 @@ export interface WorkflowNodeConversation {
   modelId: string;
   workDir: string;
   runtimeConversation?: RuntimeConversation;
+  telemetry?: WorkflowRunNodeTelemetry;
   status: WorkflowNodeConversationStatus;
   messages: WorkflowNodeMessage[];
   completionProposal?: WorkflowNodeCompletionProposal;

--- a/src/automation/engine/shared/workflow/run.ts
+++ b/src/automation/engine/shared/workflow/run.ts
@@ -23,6 +23,33 @@ export interface WorkflowRunProgressItem {
   inputRequest?: WorkflowNodeInputRequest;
   outputs?: Record<string, unknown>;
   messages?: WorkflowNodeMessage[];
+  telemetry?: WorkflowRunNodeTelemetry;
+}
+
+export interface WorkflowRunNodeTelemetry {
+  provider?: "openai" | "anthropic" | string;
+  runtimeId?: string;
+  channelId?: string;
+  modelId?: string;
+  attempt: number;
+  startedAt: number;
+  finishedAt?: number;
+  /** Provider-reported input/prompt tokens; OpenAI includes cached prompt tokens here. */
+  inputTokens?: number;
+  /** Provider-reported output/completion tokens. */
+  outputTokens?: number;
+  /** Provider-reported reasoning tokens when exposed separately. */
+  reasoningTokens?: number;
+  /** OpenAI cached prompt tokens or Anthropic cache_read_input_tokens. */
+  cacheReadInputTokens?: number;
+  /** Anthropic cache_creation_input_tokens total. */
+  cacheWriteInputTokens?: number;
+  /** Anthropic cache_creation.ephemeral_5m_input_tokens. */
+  cacheWrite5mInputTokens?: number;
+  /** Anthropic cache_creation.ephemeral_1h_input_tokens. */
+  cacheWrite1hInputTokens?: number;
+  totalTokens?: number;
+  estimatedCost?: number;
 }
 
 export type WorkflowEventType =

--- a/src/renderer/src/styles/automation.css
+++ b/src/renderer/src/styles/automation.css
@@ -1222,6 +1222,18 @@
 .workflow-run-center-node-head > span { padding:2px 6px; border-radius:999px; background:var(--panel-bg); color:var(--text-muted); font-size:8px; font-weight:750; text-transform:uppercase; }
 .workflow-run-center-node-head strong { overflow:hidden; color:var(--text); font-size:11px; text-overflow:ellipsis; white-space:nowrap; }
 .workflow-run-center-node-head small,.workflow-run-center-no-events { color:var(--text-muted); font:9px/1.3 var(--mono); }
+.workflow-run-center-node-telemetry { overflow:hidden; border-top:1px solid var(--border-subtle); }
+.workflow-run-center-node-telemetry > summary { display:flex; align-items:center; justify-content:space-between; gap:8px; padding:5px 0 1px; color:var(--text-muted); cursor:pointer; font-size:9px; list-style:none; }
+.workflow-run-center-node-telemetry > summary::-webkit-details-marker { display:none; }
+.workflow-run-center-node-telemetry > summary::before { margin-right:5px; color:var(--text-faint); content:"▸"; }
+.workflow-run-center-node-telemetry[open] > summary::before { content:"▾"; }
+.workflow-run-center-node-telemetry > summary em { margin-left:auto; color:var(--text-faint); font:8px var(--mono); font-style:normal; }
+.workflow-run-center-node-telemetry-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(86px,1fr)); gap:5px; margin-top:6px; }
+.workflow-run-center-node-telemetry-grid span { display:grid; gap:3px; min-width:0; padding:5px 6px; border-radius:6px; background:var(--panel-bg); color:var(--text); font:9px/1.2 var(--mono); overflow-wrap:anywhere; }
+.workflow-run-center-node-telemetry-grid b { color:var(--text-faint); font:8px/1 var(--sans); letter-spacing:.04em; text-transform:uppercase; }
+.workflow-run-center-node-token-usage { margin-top:9px; padding-top:8px; border-top:1px solid var(--border-subtle); }
+.workflow-run-center-node-token-usage > strong { color:var(--text-muted); font-size:9px; }
+.workflow-run-center-node-token-provider { margin-left:8px; color:var(--text-faint); font:8px var(--mono); }
 .workflow-run-center-node p { margin:0; color:var(--text-muted); font-size:10px; line-height:1.45; }
 .workflow-run-center-node p.is-error { color:var(--danger); }
 .workflow-run-center-events { display:flex; flex-wrap:wrap; gap:5px; }

--- a/src/shared/runtime/usage.test.ts
+++ b/src/shared/runtime/usage.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+import { normalizeAnthropicUsage, normalizeOpenAIUsage } from "./usage";
+
+describe("runtime usage normalization", () => {
+  test("keeps OpenAI cached input separate from total prompt tokens", () => {
+    expect(normalizeOpenAIUsage({
+      input_tokens: 120,
+      output_tokens: 30,
+      total_tokens: 150,
+      input_tokens_details: { cached_tokens: 80 },
+      output_tokens_details: { reasoning_tokens: 10 },
+    })).toEqual({
+      provider: "openai",
+      inputTokens: 120,
+      outputTokens: 30,
+      reasoningTokens: 10,
+      cacheReadInputTokens: 80,
+      totalTokens: 150,
+    });
+  });
+
+  test("does not invent Anthropic cache totals when the provider omits them", () => {
+    expect(normalizeAnthropicUsage({ input_tokens: 10, output_tokens: 5 })).toEqual({
+      provider: "anthropic",
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+  });
+});

--- a/src/shared/runtime/usage.ts
+++ b/src/shared/runtime/usage.ts
@@ -9,11 +9,12 @@ export interface RuntimeUsage {
   cacheWrite5mInputTokens?: number;
   cacheWrite1hInputTokens?: number;
   totalTokens?: number;
+  estimatedCost?: number;
 }
 
 export function mergeRuntimeUsage(current: RuntimeUsage, next: RuntimeUsage): RuntimeUsage {
   const merged: RuntimeUsage = { ...current, ...(next.provider ? { provider: next.provider } : {}) };
-  for (const key of ["inputTokens", "outputTokens", "reasoningTokens", "cacheReadInputTokens", "cacheWriteInputTokens", "cacheWrite5mInputTokens", "cacheWrite1hInputTokens", "totalTokens"] as const) {
+  for (const key of ["inputTokens", "outputTokens", "reasoningTokens", "cacheReadInputTokens", "cacheWriteInputTokens", "cacheWrite5mInputTokens", "cacheWrite1hInputTokens", "totalTokens", "estimatedCost"] as const) {
     if (next[key] !== undefined) merged[key] = (current[key] ?? 0) + next[key];
   }
   return merged;

--- a/src/shared/runtime/usage.ts
+++ b/src/shared/runtime/usage.ts
@@ -1,0 +1,76 @@
+export interface RuntimeUsage {
+  provider?: "openai" | "anthropic" | string;
+  /** OpenAI prompt/input tokens include cached input; Anthropic input_tokens excludes cache read/write. */
+  inputTokens?: number;
+  outputTokens?: number;
+  reasoningTokens?: number;
+  cacheReadInputTokens?: number;
+  cacheWriteInputTokens?: number;
+  cacheWrite5mInputTokens?: number;
+  cacheWrite1hInputTokens?: number;
+  totalTokens?: number;
+}
+
+export function mergeRuntimeUsage(current: RuntimeUsage, next: RuntimeUsage): RuntimeUsage {
+  const merged: RuntimeUsage = { ...current, ...(next.provider ? { provider: next.provider } : {}) };
+  for (const key of ["inputTokens", "outputTokens", "reasoningTokens", "cacheReadInputTokens", "cacheWriteInputTokens", "cacheWrite5mInputTokens", "cacheWrite1hInputTokens", "totalTokens"] as const) {
+    if (next[key] !== undefined) merged[key] = (current[key] ?? 0) + next[key];
+  }
+  return merged;
+}
+
+function recordOf(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" ? value as Record<string, unknown> : undefined;
+}
+
+function numberAt(record: Record<string, unknown> | undefined, ...keys: string[]): number | undefined {
+  if (!record) return undefined;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value) && value >= 0) return value;
+  }
+  return undefined;
+}
+
+function hasUsage(value: RuntimeUsage): boolean {
+  return Object.keys(value).some((key) => key !== "provider");
+}
+
+function compactUsage(value: RuntimeUsage): RuntimeUsage {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined)) as RuntimeUsage;
+}
+
+export function normalizeOpenAIUsage(value: unknown): RuntimeUsage | undefined {
+  const usage = recordOf(value);
+  if (!usage) return undefined;
+  const inputDetails = recordOf(usage.prompt_tokens_details) ?? recordOf(usage.input_tokens_details);
+  const outputDetails = recordOf(usage.completion_tokens_details) ?? recordOf(usage.output_tokens_details);
+  const normalized: RuntimeUsage = {
+    provider: "openai",
+    inputTokens: numberAt(usage, "prompt_tokens", "input_tokens"),
+    outputTokens: numberAt(usage, "completion_tokens", "output_tokens"),
+    reasoningTokens: numberAt(outputDetails, "reasoning_tokens"),
+    cacheReadInputTokens: numberAt(inputDetails, "cached_tokens"),
+    totalTokens: numberAt(usage, "total_tokens", "totalTokens"),
+  };
+  const compacted = compactUsage(normalized);
+  return hasUsage(compacted) ? compacted : undefined;
+}
+
+export function normalizeAnthropicUsage(value: unknown): RuntimeUsage | undefined {
+  const usage = recordOf(value);
+  if (!usage) return undefined;
+  const cacheCreation = recordOf(usage.cache_creation);
+  const normalized: RuntimeUsage = {
+    provider: "anthropic",
+    inputTokens: numberAt(usage, "input_tokens"),
+    outputTokens: numberAt(usage, "output_tokens"),
+    cacheReadInputTokens: numberAt(usage, "cache_read_input_tokens"),
+    cacheWriteInputTokens: numberAt(usage, "cache_creation_input_tokens"),
+    cacheWrite5mInputTokens: numberAt(cacheCreation, "ephemeral_5m_input_tokens"),
+    cacheWrite1hInputTokens: numberAt(cacheCreation, "ephemeral_1h_input_tokens"),
+    totalTokens: numberAt(usage, "total_tokens", "totalTokens"),
+  };
+  const compacted = compactUsage(normalized);
+  return hasUsage(compacted) ? compacted : undefined;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,4 +1,6 @@
 import type { RuntimeConversation } from "./runtime/conversation";
+import type { RuntimeUsage } from "./runtime/usage";
+export type { RuntimeUsage } from "./runtime/usage";
 
 // Minimal compatibility barrel for shared workflow modules that still import
 // legacy names from src/shared/types.ts in the source repo.
@@ -33,6 +35,7 @@ export interface TaskRun {
   progress: TaskProgress;
   running: boolean;
   runtimeConversation?: RuntimeConversation;
+  usage?: RuntimeUsage;
   messages: ChatMessage[];
   pendingAssistantMessageId: string | undefined;
   lastError: string | undefined;

--- a/src/shared/workflow/run.ts
+++ b/src/shared/workflow/run.ts
@@ -22,6 +22,33 @@ export interface WorkflowRunProgressItem {
   intervention?: WorkflowV2HumanIntervention;
   inputRequest?: WorkflowNodeInputRequest;
   outputs?: Record<string, unknown>;
+  telemetry?: WorkflowRunNodeTelemetry;
+}
+
+export interface WorkflowRunNodeTelemetry {
+  provider?: "openai" | "anthropic" | string;
+  runtimeId?: string;
+  channelId?: string;
+  modelId?: string;
+  attempt: number;
+  startedAt: number;
+  finishedAt?: number;
+  /** Provider-reported input/prompt tokens; OpenAI includes cached prompt tokens here. */
+  inputTokens?: number;
+  /** Provider-reported output/completion tokens. */
+  outputTokens?: number;
+  /** Provider-reported reasoning tokens when exposed separately. */
+  reasoningTokens?: number;
+  /** OpenAI cached prompt tokens or Anthropic cache_read_input_tokens. */
+  cacheReadInputTokens?: number;
+  /** Anthropic cache_creation_input_tokens total. */
+  cacheWriteInputTokens?: number;
+  /** Anthropic cache_creation.ephemeral_5m_input_tokens. */
+  cacheWrite5mInputTokens?: number;
+  /** Anthropic cache_creation.ephemeral_1h_input_tokens. */
+  cacheWrite1hInputTokens?: number;
+  totalTokens?: number;
+  estimatedCost?: number;
 }
 
 export type WorkflowEventType =


### PR DESCRIPTION
  ## Summary

  - 为 Workflow 节点补充 Runtime、Channel、模型、Token、耗时和成本展示。
  - 支持 OpenAI、Anthropic、Codex app-server 的真实 usage 采集。
  - 支持失败、重试、暂停恢复和交互式节点的用量汇总。
  - Claude 支持 `modelUsage` 成本；Provider 未提供成本时明确显示“未提供”。
  - 区分 OpenAI 缓存输入与 Anthropic cache read、cache creation，并保留 5m/1h 字段。

  ## Test Plan

  - [x] 47 个相关测试通过
  - [x] `npm run typecheck`
  - [x] `npm run release-note:check`
  - [x] `git diff --check`