### PR TITLE
fix: strip Qoder wrapper tags so session titles show user query

### DIFF
--- a/.release-notes/fix-qoder-title-wrapper-tags.md
+++ b/.release-notes/fix-qoder-title-wrapper-tags.md
@@ -1,0 +1,5 @@
+# 修复 Qoder 会话标题显示为路径或乱码
+
+## Bug 修复
+
+- 修复 Qoder 数据源会话标题显示为路径或哈希乱码的问题，根因是 `qoderContentFromRow` 未剥离 Qoder 特有的 `<system-reminder>`/`<attached_files>`/`<user_query>` 包装标签，导致 `isMeaningfulUserMessage` 误判所有用户消息为系统消息而跳过，标题回退到 rawId

--- a/src/core/session-loader-extra-sources.test.ts
+++ b/src/core/session-loader-extra-sources.test.ts
@@ -305,6 +305,64 @@ describe("extra session sources", () => {
     fs.rmSync(root, { recursive: true, force: true });
   });
 
+  it("strips Qoder wrapper tags and uses user_query as title", () => {
+    const root = tmpDir("qoder-wrapped");
+    const filePath = path.join(root, "cache", "projects", "demo-app-1a2b3c4d", "conversation-history", "task-wrap", "task-wrap.jsonl");
+    writeJsonl(filePath, [
+      {
+        role: "user",
+        message: {
+          content: [
+            {
+              type: "text",
+              text: "<system-reminder>\n[IMPORTANT] You must always respond in 中文.\n</system-reminder>\n\n<user_query>\n我的目标在：D:\\oss-contrib\\giki\\IMPROVEMENT-LOOP.md\n</user_query>",
+            },
+          ],
+        },
+      },
+      { role: "assistant", message: { content: [{ type: "text", text: "明白，开始执行。" }] } },
+    ]);
+
+    const loaded = loadQoderSessions(root);
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].session.originalTitle).toBe("我的目标在：D:\\oss-contrib\\giki\\IMPROVEMENT-LOOP.md");
+    expect(loaded[0].session.firstQuestion).toBe("我的目标在：D:\\oss-contrib\\giki\\IMPROVEMENT-LOOP.md");
+    expect(loaded[0].messages[0].content).toBe("我的目标在：D:\\oss-contrib\\giki\\IMPROVEMENT-LOOP.md");
+    // system-reminder content should not appear in searchable message text
+    expect(loaded[0].messages[0].content).not.toContain("system-reminder");
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("strips attached_files wrapper from Qoder messages without user_query", () => {
+    const root = tmpDir("qoder-attached");
+    const filePath = path.join(root, "cache", "projects", "proj-aabbccdd", "conversation-history", "task-att", "task-att.jsonl");
+    writeJsonl(filePath, [
+      {
+        role: "user",
+        message: {
+          content: [
+            {
+              type: "text",
+              text: "<attached_files>\n#file:d:\\project\\architecture.zip\n#file:d:\\project\\ux-report.md\n</attached_files>\n\n直接帮我重构这个模块",
+            },
+          ],
+        },
+      },
+      { role: "assistant", message: { content: [{ type: "text", text: "好的。" }] } },
+    ]);
+
+    const loaded = loadQoderSessions(root);
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].session.originalTitle).toBe("直接帮我重构这个模块");
+    expect(loaded[0].messages[0].content).toBe("直接帮我重构这个模块");
+    expect(loaded[0].messages[0].content).not.toContain("attached_files");
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
   it("loads Hermes sessions from state.db without writing to the source database", () => {
     const root = tmpDir("hermes");
     const dbPath = path.join(root, "state.db");

--- a/src/core/session-loader.ts
+++ b/src/core/session-loader.ts
@@ -1452,11 +1452,28 @@ function qoderContentFromRow(row: Record<string, unknown>): string {
   if (!isRecord(message)) return "";
   const content = message.content;
   if (!Array.isArray(content)) return "";
-  return content
+  const raw = content
     .filter((item): item is Record<string, unknown> => isRecord(item) && stringField(item, "type") === "text")
     .map((item) => stringField(item, "text"))
     .filter(Boolean)
     .join("\n");
+  return stripQoderWrapperTags(raw);
+}
+
+/**
+ * Strips Qoder-specific wrapper tags so that downstream title generation
+ * and search see the actual user query instead of XML envelopes.
+ *
+ * - `<system-reminder>…</system-reminder>` — metadata, removed entirely
+ * - `<attached_files>…</attached_files>` — file list, removed entirely
+ * - `<user_query>…</user_query>` — the actual user input, inner text kept
+ */
+function stripQoderWrapperTags(text: string): string {
+  const withoutSystemReminder = text.replace(/<system-reminder>[\s\S]*?<\/system-reminder>/gi, "");
+  const withoutAttachedFiles = withoutSystemReminder.replace(/<attached_files>[\s\S]*?<\/attached_files>/gi, "");
+  const userQueryMatch = withoutAttachedFiles.match(/<user_query>([\s\S]*?)<\/user_query>/i);
+  if (userQueryMatch) return userQueryMatch[1].trim();
+  return withoutAttachedFiles.trim();
 }
 
 function loadQoderConversationFile(filePath: string, slug: string, stat: VirtualSessionFileStat): LoadedSession | null {


### PR DESCRIPTION
## 变更概述

Qoder 数据源的会话标题一直显示为路径或哈希乱码（如 `agent-session-search-1e1534d4/task-929`），而不是用户的第一句话。虽然搜索能搜出来，但是每个会话的辨识度很不好

根因：Qoder 的用户消息被包裹在 `<system-reminder>` + `<user_query>` 标签里，现有 `isMeaningfulUserMessage` 检测到 `<system-reminder>` 前缀就把整条消息当系统消息跳过了，`firstQuestion` 返回空，标题回退到 rawId。

修复：在 `qoderContentFromRow` 中增加 `stripQoderWrapperTags`，剥离 `<system-reminder>`/`<attached_files>` 块并提取 `<user_query>` 内的实际用户输入。这样标题、搜索、消息内容都拿到干净的用户查询文本。

2 个新测试覆盖：system-reminder + user_query 包装、attached_files 包装。

## 验证

- `npx vitest run src/core/session-loader-extra-sources.test.ts`：19 passed（含 2 个新测试）
- `npm run typecheck`：改动文件零错误
- `node scripts/release-notes.mjs check-range upstream/main HEAD`：通过（1 fix）

注意：已索引的旧 Qoder 会话需要重建索引才能看到新标题。
