### PR TITLE
Feat/wsl session migration

### DIFF
--- a/.release-notes/feat-wsl-session-migration.md
+++ b/.release-notes/feat-wsl-session-migration.md
@@ -1,0 +1,5 @@
+# 支持 WSL 内 Claude Code 与 Codex 会话迁移
+
+## 新增功能
+
+- Windows 用户现在可以在同一个 WSL 发行版内，将 Claude Code 会话迁移到 Codex，或将 Codex 会话迁移到 Claude Code，并继续在 WSL 中恢复目标会话。

--- a/.release-notes/feat-wsl-session-migration.md
+++ b/.release-notes/feat-wsl-session-migration.md
@@ -3,3 +3,7 @@
 ## 新增功能
 
 - Windows 用户现在可以在同一个 WSL 发行版内，将 Claude Code 会话迁移到 Codex，或将 Codex 会话迁移到 Claude Code，并继续在 WSL 中恢复目标会话。
+
+## Bug 修复
+
+- 修复 Claude Code 会话迁移到 WSL Codex 后，Codex 会话列表未显示新会话的问题。

--- a/src/core/remote-sync.ts
+++ b/src/core/remote-sync.ts
@@ -1098,7 +1098,10 @@ def emit_codex_summary(path, stat, titles, source):
             first_question = parsed["content"]
   except Exception:
     return
-  indexed_title = titles.get(raw_id, ("", ""))[0]
+  indexed_title, indexed_updated_at = titles.get(raw_id, ("", ""))
+  indexed_timestamp = _iso_timestamp_ms(indexed_updated_at)
+  if indexed_timestamp is not None:
+    timestamp = max(timestamp, indexed_timestamp)
   emit({
     "kind": "codex-session",
     "source": source,

--- a/src/core/session-migration-writers.test.ts
+++ b/src/core/session-migration-writers.test.ts
@@ -13,7 +13,7 @@ import {
   parseCursorTranscriptPath,
   parseJsonlText,
 } from "./session-loader";
-import { targetFilePath, writeMigratedSession } from "./session-migration-writers";
+import { targetFilePath, targetFilePathForRemoteEnvironment, writeMigratedSession } from "./session-migration-writers";
 import type { LoadedSession, MigrationTarget, PortableSession, SessionSource } from "./types";
 
 const require = createRequire(import.meta.url);
@@ -420,6 +420,16 @@ describe("writeMigratedSession", () => {
     } finally {
       fs.rmSync(homeDir, { recursive: true, force: true });
     }
+  });
+
+  it("uses POSIX separators for paths written into WSL or SSH environments", () => {
+    expect(targetFilePathForRemoteEnvironment(
+      "claude",
+      "/home/alice/project",
+      SESSION_ID,
+      "/home/alice",
+      NOW,
+    )).toBe(`/home/alice/.claude/projects/-home-alice-project/${SESSION_ID}.jsonl`);
   });
 
   it.each([

--- a/src/core/session-migration-writers.ts
+++ b/src/core/session-migration-writers.ts
@@ -475,6 +475,16 @@ export function targetFilePath(
   return path.join(homeDir, root, "projects", encodeCodeBuddyProjectDir(projectPath), `${sessionId}.jsonl`);
 }
 
+export function targetFilePathForRemoteEnvironment(
+  target: MigrationTarget,
+  projectPath: string,
+  sessionId: string,
+  homeDir: string,
+  now: Date,
+): string {
+  return targetFilePath(target, projectPath, sessionId, homeDir, now).replaceAll("\\", "/");
+}
+
 const TARGET_ROOTS: Record<MigrationTarget, string> = {
   claude: ".claude",
   tclaude: ".tclaude",

--- a/src/core/session-migration.test.ts
+++ b/src/core/session-migration.test.ts
@@ -269,10 +269,21 @@ describe("session migration model", () => {
   it.each([
     { environmentKind: "ssh", environmentId: "remote" },
     { environmentKind: "local", environmentId: "imported-local" },
-  ] as const)("rejects a non-local session", (environment) => {
+  ] as const)("rejects an unsupported remote session", (environment) => {
     expect(() => portableSessionFrom(session("claude-cli", environment), messages)).toThrow(
-      "Remote session migration is not supported yet.",
+      "SSH session migration is not supported yet.",
     );
+  });
+
+  it("accepts a WSL session and preserves its Linux project path", () => {
+    expect(portableSessionFrom(session("claude-cli", {
+      environmentKind: "wsl",
+      environmentId: "wsl-ubuntu",
+      projectPath: "/home/alice/project",
+    }), messages)).toMatchObject({
+      sourceAgent: "claude",
+      projectPath: "/home/alice/project",
+    });
   });
 
   it("rejects an unsupported source", () => {
@@ -380,13 +391,13 @@ describe("migrateSession", () => {
       "remote session",
       session("claude-cli", { environmentKind: "ssh", environmentId: "remote" }),
       "codex",
-      "Remote session migration is not supported yet.",
+      "SSH session migration is not supported yet.",
     ],
     [
       "imported local session",
       session("claude-cli", { environmentKind: "local", environmentId: "imported-local" }),
       "codex",
-      "Remote session migration is not supported yet.",
+      "SSH session migration is not supported yet.",
     ],
     [
       "empty project path",

--- a/src/core/session-migration.ts
+++ b/src/core/session-migration.ts
@@ -83,8 +83,8 @@ export function portableSessionFrom(
   if (!sourceAgent) {
     throw new Error(`Session source ${session.source} cannot be migrated.`);
   }
-  if (!isLocalSessionEnvironment(session)) {
-    throw new Error("Remote session migration is not supported yet.");
+  if (!isLocalSessionEnvironment(session) && session.environmentKind !== "wsl") {
+    throw new Error("SSH session migration is not supported yet.");
   }
   if (!session.projectPath.trim()) {
     throw new Error("Session has no project path.");
@@ -249,8 +249,8 @@ async function validateMigrationRequest(
   if (!sourceAgent) {
     throw new Error(`Session source ${source.source} cannot be migrated.`);
   }
-  if (!isLocalSessionEnvironment(source)) {
-    throw new Error("Remote session migration is not supported yet.");
+  if (!isLocalSessionEnvironment(source) && source.environmentKind !== "wsl") {
+    throw new Error("SSH session migration is not supported yet.");
   }
   if (!isMigrationTarget(target)) {
     throw new Error(`Migration target ${target} is not supported.`);

--- a/src/core/wsl.ts
+++ b/src/core/wsl.ts
@@ -33,7 +33,14 @@ export function buildWslProcessSpec(distribution: string, remoteCommand: string)
   if (!normalized) throw new Error("WSL distribution is required.");
   return {
     command: "wsl.exe",
-    args: ["--distribution", normalized, "--exec", "bash", "-lc", remoteCommand],
+    args: [
+      "--distribution",
+      normalized,
+      "--exec",
+      "bash",
+      "-lc",
+      `if [ -s "$HOME/.nvm/nvm.sh" ]; then . "$HOME/.nvm/nvm.sh"; fi; ${remoteCommand}`,
+    ],
   };
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -70,16 +70,17 @@ import {
   type ToolExecutionResult,
 } from "../core/ai-assistant";
 import { applyMigrationLengthPolicy, createMigrationCompressor } from "../core/session-migration-compression";
-import { migrateSession } from "../core/session-migration";
+import { migrateSession, portableSessionFrom } from "../core/session-migration";
 import { runLocalSessionMigration } from "./local-session-migration";
 import { targetFilePath, writeMigratedSession } from "../core/session-migration-writers";
+import { assertMigrationTargetEnabled, isMigrationTarget, migrationTargetDescriptor } from "../core/migration-targets";
 import { writeDbPointer } from "../core/app-paths";
 import { routeResumeSession } from "../core/resume-router";
 import { diagnoseRemoteEnvironment, preflightRemoteSessionResume } from "../core/remote-health";
 import { buildRemoteSyncSshArgs, fetchRemoteSessionFilePayload, fetchRemoteSessionMessagePage, syncRemoteEnvironment } from "../core/remote-sync";
-import { REMOTE_PROCESS_EXEC_OPTIONS, runRemoteCommandWithInput } from "../core/remote-process";
+import { REMOTE_PROCESS_EXEC_OPTIONS, runRemoteCommand, runRemoteCommandWithInput } from "../core/remote-process";
 import { loadRemoteSessionDetailPayload, loadWslSessionDetailPayload } from "../core/remote-session-loader";
-import type { RemoteSessionRestoreDependencies } from "../core/remote-session-restore";
+import { restoreRemotePortableSession, type RemoteSessionRestoreDependencies } from "../core/remote-session-restore";
 import { RemoteEnvironmentLifecycle } from "../core/remote-environment-lifecycle";
 import { RemoteWatchManager } from "../core/remote-watch";
 import { SessionStore, type TraceEventQueryOptions } from "../core/session-store";
@@ -89,7 +90,7 @@ import { listWslDistributions } from "../core/wsl";
 import { deleteWslSessionFile } from "../core/wsl-session-actions";
 import { AUTO_INDEX_REFRESH_INTERVAL_MS, INITIAL_INDEX_DELAY_MS } from "../core/refresh-policy";
 import { globalShortcutLabel, normalizeGlobalShortcut } from "../core/shortcuts";
-import { isLocalSessionEnvironment, isLocalSessionStorage } from "../core/session-environment";
+import { isLocalSessionEnvironment, isLocalSessionStorage, remoteSessionKey } from "../core/session-environment";
 import { OPTIONAL_SESSION_SOURCE_DESCRIPTORS } from "../core/session-sources";
 import type { AppSettings, AppSettingsUpdate } from "../core/platform";
 import { APP_UPDATE_EVENTS } from "../shared/ipc/app-update";
@@ -1193,7 +1194,7 @@ async function createSourceRemoteRestoreDependencies(
     : null;
 
   return {
-    inspectCli: async () => undefined,
+    inspectCli: (target) => environment.kind === "wsl" ? inspectWslMigrationCli(environment, target) : undefined,
     prepare: (session, listener) => applyMigrationLengthPolicy(session, compressor, listener),
     write: (target, session) => writeMigratedSessionToSshEnvironment(environment, target, session),
     record: (record) => store.recordSessionMigration(record),
@@ -1203,7 +1204,11 @@ async function createSourceRemoteRestoreDependencies(
       });
       mainWindow?.webContents.send("environments-updated", store.listEnvironments());
     },
-    launch: async () => undefined,
+    launch: async (target, targetSessionId, projectPath) => {
+      if (environment.kind !== "wsl") return;
+      const session = migrationLaunchSession(environment, target, targetSessionId, projectPath);
+      await openResumeInTerminal(session, getSettings(), requireWslResumeOptions(session));
+    },
     resumeCommand: (target, targetSessionId, projectPath) =>
       remoteMigrationResumeDisplayCommand(environment, target, targetSessionId, projectPath),
     fallbackResumeCommand: (target, targetSessionId, projectPath) =>
@@ -1216,12 +1221,71 @@ async function createSourceRemoteRestoreDependencies(
   };
 }
 
+async function inspectWslMigrationCli(environment: SessionEnvironment, target: MigrationAgent): Promise<void> {
+  const settings = getSettings();
+  await inspectMigrationCli(
+    target,
+    { ...settings, claudeBinary: "claude", codexBinary: "codex" },
+    async (command, args) => runRemoteCommand(environment, [command, ...args].join(" ")),
+    { platform: "linux" },
+  );
+}
+
+function migrationLaunchSession(
+  environment: SessionEnvironment,
+  target: MigrationAgent,
+  sessionId: string,
+  projectPath: string,
+): SessionSearchResult {
+  const source = migrationTargetDescriptor(target).source;
+  return {
+    sessionKey: remoteSessionKey(environment, migrationTargetDescriptor(target).source, sessionId),
+    rawId: sessionId,
+    source,
+    projectPath,
+    filePath: "",
+    originalTitle: sessionId,
+    firstQuestion: "",
+    displayTitle: sessionId,
+    timestamp: Date.now(),
+    fileMtimeMs: 0,
+    fileSize: 0,
+    prUrl: null,
+    prNumber: null,
+    gitBranch: null,
+    isSubagent: false,
+    parentSessionId: null,
+    tokenUsage: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, reasoningOutputTokens: 0, totalTokens: 0 },
+    environmentId: environment.id,
+    environmentKind: "wsl",
+    environmentLabel: environment.label,
+    customTitle: null,
+    favorited: false,
+    hidden: false,
+    tags: [],
+    matchSnippet: null,
+    lastOpenedAt: null,
+    lastResumedAt: null,
+    lastActivityAt: 0,
+    messageCount: 0,
+    aiSummary: null,
+    aiSummaryStale: false,
+  };
+}
+
 function remoteMigrationResumeDisplayCommand(
   environment: SessionEnvironment,
   target: MigrationAgent,
   sessionId: string,
   projectPath: string,
 ): string {
+  if (environment.kind === "wsl") {
+    return getResumeCommand(
+      migrationLaunchSession(environment, target, sessionId, projectPath),
+      getSettings(),
+      requireWslResumeOptions(migrationLaunchSession(environment, target, sessionId, projectPath)),
+    );
+  }
   const remoteCommand = getMigrationResumeProcessSpec(target, sessionId, projectPath, getSettings(), { platform: "linux" }).displayCommand;
   return ["ssh", ...buildRemoteSyncSshArgs(environment, remoteCommand).map(quotePosixToken)].join(" ");
 }
@@ -1779,6 +1843,23 @@ function registerIpc(): void {
   ipcMain.handle("session:migrate", async (event, sessionKey: string, target: unknown) => {
     const session = store.getSession(sessionKey);
     if (!session) throw new Error("Session not found.");
+    if (session.environmentKind === "wsl") {
+      if (!isMigrationTarget(target)) throw new Error(`Migration target ${String(target)} is not supported.`);
+      const settings = await providerService.hydrateSettings();
+      assertMigrationTargetEnabled(target, settings);
+      await ensureRemoteSessionDetailsLoaded(sessionKey);
+      const environment = requireWslEnvironment(session);
+      const portable = portableSessionFrom(session, store.getAllMessages(sessionKey));
+      const progress = (item: SessionMigrationProgress): void => event.sender.send("session:migration-progress", item);
+      const deps = await createSourceRemoteRestoreDependencies(environment, progress);
+      return restoreRemotePortableSession({
+        remoteId: sessionKey,
+        portable,
+        target: target as MigrationAgent,
+        localProjectPath: portable.projectPath,
+        deps,
+      });
+    }
     const messages = store.getAllMessages(sessionKey);
     const settings = Object.freeze(await providerService.hydrateSettings());
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1348,6 +1348,7 @@ async function writeMigratedSessionToSshEnvironment(
     });
     if (target === "codex") {
       await updateRemoteCodexSessionIndex(environment, remoteHome, session, written.sessionId, now);
+      await updateRemoteCodexAppState(environment, remoteHome, remotePath, session, written.sessionId, now);
     }
     return { sessionId: written.sessionId, filePath: remotePath };
   } finally {
@@ -1370,6 +1371,34 @@ async function updateRemoteCodexSessionIndex(
     threadName: title,
     updatedAt: now.toISOString(),
   });
+}
+
+async function updateRemoteCodexAppState(
+  environment: SessionEnvironment,
+  remoteHome: string,
+  rolloutPath: string,
+  session: PortableSession,
+  sessionId: string,
+  now: Date,
+): Promise<void> {
+  try {
+    const title = session.title || session.messages.find((message) => message.role === "user")?.content || sessionId;
+    const firstUserMessage = session.messages.find((message) => message.role === "user")?.content || "";
+    await runRemotePython(environment, REMOTE_UPDATE_CODEX_STATE_SCRIPT, {
+      home: remoteHome,
+      id: sessionId,
+      rolloutPath,
+      cwd: session.projectPath,
+      title,
+      firstUserMessage,
+      createdAtMs: new Date(session.startedAt).getTime(),
+      updatedAtMs: now.getTime(),
+      modelProvider: "openai",
+    });
+  } catch {
+    // The Codex app-server may hold its state database open. The rollout file
+    // and session index remain authoritative when this display update fails.
+  }
 }
 
 async function remoteHomeDir(environment: SessionEnvironment): Promise<string> {
@@ -1463,6 +1492,51 @@ const REMOTE_UPDATE_CODEX_INDEX_SCRIPT = [
   "os.chmod(tmp, 0o600)",
   "os.replace(tmp, index)",
   "print(str(index))",
+].join("\n");
+
+const REMOTE_UPDATE_CODEX_STATE_SCRIPT = [
+  "import json, sqlite3, sys",
+  "from pathlib import Path",
+  "payload = json.load(sys.stdin)",
+  "home = Path(payload['home'])",
+  "candidates = sorted(home.glob('state_*.sqlite'), key=lambda item: item.stat().st_mtime, reverse=True)",
+  "if not candidates: print('Codex state database not found'); sys.exit(0)",
+  "db = sqlite3.connect(str(candidates[0]), timeout=5)",
+  "db.row_factory = sqlite3.Row",
+  "columns = {row[1] for row in db.execute('PRAGMA table_info(threads)')}",
+  "required = {'id', 'rollout_path', 'created_at', 'updated_at', 'source', 'model_provider', 'cwd', 'title', 'sandbox_policy', 'approval_mode'}",
+  "if not required.issubset(columns): db.close(); print('Codex state database schema not supported'); sys.exit(0)",
+  "existing = db.execute('SELECT * FROM threads WHERE id = ?', (payload['id'],)).fetchone()",
+  "order_column = 'updated_at_ms' if 'updated_at_ms' in columns else 'updated_at'",
+  "template = existing or db.execute(f'SELECT * FROM threads ORDER BY {order_column} DESC LIMIT 1').fetchone()",
+  "def value(name, fallback=None): return existing[name] if existing and name in existing.keys() and existing[name] is not None else (template[name] if template and name in template.keys() and template[name] is not None else fallback)",
+  "created_ms = int(payload['createdAtMs'])",
+  "updated_ms = int(payload['updatedAtMs'])",
+  "values = {",
+  "  'id': payload['id'], 'rollout_path': payload['rolloutPath'],",
+  "  'created_at': value('created_at', created_ms // 1000), 'updated_at': updated_ms // 1000,",
+  "  'source': 'vscode', 'model_provider': value('model_provider', payload['modelProvider']),",
+  "  'cwd': payload['cwd'], 'title': payload['title'],",
+  "  'sandbox_policy': value('sandbox_policy', '{}'), 'approval_mode': value('approval_mode', 'on-request'),",
+  "  'tokens_used': value('tokens_used', 0), 'has_user_event': 1, 'archived': value('archived', 0),",
+  "  'cli_version': 'migration', 'first_user_message': payload['firstUserMessage'],",
+  "  'memory_mode': value('memory_mode', 'enabled'), 'model': value('model'), 'reasoning_effort': value('reasoning_effort'),",
+  "  'agent_path': value('agent_path'), 'created_at_ms': value('created_at_ms', created_ms), 'updated_at_ms': updated_ms,",
+  "  'thread_source': 'user', 'preview': payload['title'], 'recency_at': updated_ms // 1000, 'recency_at_ms': updated_ms,",
+  "  'history_mode': 'legacy'",
+  "}",
+  "values = {key: value for key, value in values.items() if key in columns}",
+  "if existing:",
+  "    assignments = ', '.join(f'{key} = ?' for key in values if key != 'id')",
+  "    params = [values[key] for key in values if key != 'id'] + [payload['id']]",
+  "    db.execute(f'UPDATE threads SET {assignments} WHERE id = ?', params)",
+  "else:",
+  "    names = ', '.join(values)",
+  "    placeholders = ', '.join('?' for _ in values)",
+  "    db.execute(f'INSERT INTO threads ({names}) VALUES ({placeholders})', list(values.values()))",
+  "db.commit()",
+  "db.close()",
+  "print(str(candidates[0]))",
 ].join("\n");
 
 async function maybeAutoBackfillSummaries(): Promise<void> {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1499,7 +1499,7 @@ const REMOTE_UPDATE_CODEX_STATE_SCRIPT = [
   "from pathlib import Path",
   "payload = json.load(sys.stdin)",
   "home = Path(payload['home'])",
-  "candidates = sorted(home.glob('state_*.sqlite'), key=lambda item: item.stat().st_mtime, reverse=True)",
+  "candidates = sorted((home / '.codex').glob('state_*.sqlite'), key=lambda item: item.stat().st_mtime, reverse=True)",
   "if not candidates: print('Codex state database not found'); sys.exit(0)",
   "db = sqlite3.connect(str(candidates[0]), timeout=5)",
   "db.row_factory = sqlite3.Row",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1346,10 +1346,30 @@ async function writeMigratedSessionToSshEnvironment(
       path: remotePath,
       contentBase64: content.toString("base64"),
     });
+    if (target === "codex") {
+      await updateRemoteCodexSessionIndex(environment, remoteHome, session, written.sessionId, now);
+    }
     return { sessionId: written.sessionId, filePath: remotePath };
   } finally {
     await fs.rm(tempHome, { recursive: true, force: true });
   }
+}
+
+async function updateRemoteCodexSessionIndex(
+  environment: SessionEnvironment,
+  remoteHome: string,
+  session: PortableSession,
+  sessionId: string,
+  now: Date,
+): Promise<void> {
+  const indexPath = `${remoteHome.replace(/[\\/]+$/, "")}/.codex/session_index.jsonl`;
+  const title = session.title || session.messages.find((message) => message.role === "user")?.content || sessionId;
+  await runRemotePython(environment, REMOTE_UPDATE_CODEX_INDEX_SCRIPT, {
+    path: indexPath,
+    id: sessionId,
+    threadName: title,
+    updatedAt: now.toISOString(),
+  });
 }
 
 async function remoteHomeDir(environment: SessionEnvironment): Promise<string> {
@@ -1424,6 +1444,25 @@ const REMOTE_WRITE_FILE_SCRIPT = [
   "os.chmod(tmp, 0o600)",
   "os.replace(tmp, target)",
   "print(str(target))",
+].join("\n");
+
+const REMOTE_UPDATE_CODEX_INDEX_SCRIPT = [
+  "import json, os, sys, uuid",
+  "from pathlib import Path",
+  "payload = json.load(sys.stdin)",
+  "index = Path(payload['path'])",
+  "rows = []",
+  "if index.exists():",
+  "    for line in index.read_text(encoding='utf-8').splitlines():",
+  "        if line.strip(): rows.append(json.loads(line))",
+  "rows = [row for row in rows if not isinstance(row, dict) or row.get('id') != payload['id']]",
+  "rows.append({'id': payload['id'], 'thread_name': payload['threadName'], 'updated_at': payload['updatedAt']})",
+  "index.parent.mkdir(parents=True, exist_ok=True)",
+  "tmp = index.with_name(index.name + '.tmp-' + uuid.uuid4().hex)",
+  "tmp.write_text(''.join(json.dumps(row, ensure_ascii=False) + '\\n' for row in rows), encoding='utf-8')",
+  "os.chmod(tmp, 0o600)",
+  "os.replace(tmp, index)",
+  "print(str(index))",
 ].join("\n");
 
 async function maybeAutoBackfillSummaries(): Promise<void> {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -72,7 +72,7 @@ import {
 import { applyMigrationLengthPolicy, createMigrationCompressor } from "../core/session-migration-compression";
 import { migrateSession, portableSessionFrom } from "../core/session-migration";
 import { runLocalSessionMigration } from "./local-session-migration";
-import { targetFilePath, writeMigratedSession } from "../core/session-migration-writers";
+import { targetFilePathForRemoteEnvironment, writeMigratedSession } from "../core/session-migration-writers";
 import { assertMigrationTargetEnabled, isMigrationTarget, migrationTargetDescriptor } from "../core/migration-targets";
 import { writeDbPointer } from "../core/app-paths";
 import { routeResumeSession } from "../core/resume-router";
@@ -1340,7 +1340,7 @@ async function writeMigratedSessionToSshEnvironment(
   try {
     const written = await writeMigratedSession({ target, session, homeDir: tempHome, now });
     const remoteHome = await remoteHomeDir(environment);
-    const remotePath = targetFilePath(target, session.projectPath, written.sessionId, remoteHome, now);
+    const remotePath = targetFilePathForRemoteEnvironment(target, session.projectPath, written.sessionId, remoteHome, now);
     const content = await fs.readFile(written.filePath);
     await runRemotePython(environment, REMOTE_WRITE_FILE_SCRIPT, {
       path: remotePath,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2006,9 +2006,9 @@ export function App(): ReactElement {
           onSummarize={() => void summarizeDetail(detail)}
           summarizing={summarizing}
           canResume={supportsResumeSource(detail.source)}
-          canMigrate={!isRemoteSession(detail) && supportsMigrationSource(detail.source)}
+          canMigrate={detail.environmentKind !== "ssh" && supportsMigrationSource(detail.source)}
           migrationTitle={
-            isRemoteSession(detail)
+            detail.environmentKind === "ssh"
               ? remoteMigrationTitle(language)
               : supportsMigrationSource(detail.source)
                 ? t("Migrate session to…", "迁移会话到…")
@@ -2095,7 +2095,7 @@ export function App(): ReactElement {
           revealLabel={FILE_MANAGER_LABEL}
           showMacActions={IS_MAC}
           canResume={supportsResumeSource(contextMenu.session.source)}
-          canMigrate={!isRemoteSession(contextMenu.session) && supportsMigrationSource(contextMenu.session.source)}
+          canMigrate={contextMenu.session.environmentKind !== "ssh" && supportsMigrationSource(contextMenu.session.source)}
           onRename={() => beginRename(contextMenu.session)}
           onAddTag={() => beginAddTag(contextMenu.session)}
           onFavorite={() =>
@@ -2418,10 +2418,11 @@ function ContextMenu({
 }): ReactElement {
   const l = (en: string, zh: string) => localize(language, en, zh);
   const menu = useClampedContextMenuStyle(state);
-  const localOnlyDisabled = isRemoteSession(state.session);
+  const localOnlyDisabled = state.session.environmentKind !== "local";
+  const migrationDisabled = state.session.environmentKind === "ssh";
   const revealTitle = localOnlyDisabled ? remoteRevealTitle(language) : l(`Show in ${revealLabel}`, `在${revealLabel}中显示`);
   const openAppTitle = localOnlyDisabled ? remoteOpenAppTitle(language) : l("Open native app", "打开原生应用");
-  const migrateTitle = localOnlyDisabled
+  const migrateTitle = migrationDisabled
     ? remoteMigrationTitle(language)
     : canMigrate
       ? l("Migrate session to…", "迁移会话到…")
@@ -2457,7 +2458,7 @@ function ContextMenu({
           <AppWindow size={14} /> Open App
         </button>
       ) : null}
-      <button onClick={onMigrate} disabled={!canMigrate || localOnlyDisabled} title={migrateTitle}>
+      <button onClick={onMigrate} disabled={!canMigrate || migrationDisabled} title={migrateTitle}>
         <ArrowRightLeft size={14} /> {l("Migrate to…", "迁移到…")}
       </button>
       {canResume ? (

--- a/src/renderer/src/components/session-migration-dialog.tsx
+++ b/src/renderer/src/components/session-migration-dialog.tsx
@@ -7,7 +7,7 @@ import type {
   SessionSearchResult,
 } from "../../../core/types";
 import { localize, type LanguageMode } from "../language";
-import { isRemoteSession, migrationAgentLabel } from "../session-ui";
+import { migrationAgentLabel } from "../session-ui";
 
 export function SessionMigrationDialog({
   session,
@@ -27,8 +27,8 @@ export function SessionMigrationDialog({
   onClose: () => void;
 }): ReactElement {
   const l = (en: string, zh: string) => localize(language, en, zh);
-  const remote = isRemoteSession(session);
-  const availableTargets = remote ? [] : targets;
+  const ssh = session.environmentKind === "ssh";
+  const availableTargets = ssh ? [] : targets;
 
   return (
     <div className="dialog-backdrop" onMouseDown={onClose}>
@@ -40,9 +40,11 @@ export function SessionMigrationDialog({
           </button>
         </div>
         <p className="dialog-copy">
-          {l("Create a new local target-agent session from", "从当前会话创建新的本地目标 Agent 会话：")} <strong>{session.displayTitle}</strong>
+          {session.environmentKind === "wsl"
+            ? l("Create a new WSL target-agent session from", "从当前会话创建新的 WSL 目标 Agent 会话：")
+            : l("Create a new local target-agent session from", "从当前会话创建新的本地目标 Agent 会话：")} <strong>{session.displayTitle}</strong>
         </p>
-        {remote ? <p className="dialog-copy danger-copy">{l("Remote session migration is not supported yet.", "首版仅支持本地会话迁移。")}</p> : null}
+        {ssh ? <p className="dialog-copy danger-copy">{l("SSH session migration is not supported yet.", "暂不支持 SSH 会话迁移。")}</p> : null}
         {busy ? <MigrationProgressPanel progress={progress ?? null} language={language} /> : null}
         <div className="migration-targets">
           {availableTargets.length === 0 ? (

--- a/src/renderer/src/session-ui.ts
+++ b/src/renderer/src/session-ui.ts
@@ -142,6 +142,9 @@ export function migrationTargetsForSession(
   session: Pick<SessionSearchResult, "source" | "environmentId" | "environmentKind">,
   settings: MigrationTargetSettings,
 ): MigrationTarget[] {
+  if (session.environmentKind === "wsl") {
+    return migrationTargetsForSource(session.source, settings).filter((target) => target === "claude" || target === "codex");
+  }
   return isLocalSessionEnvironment(session) ? migrationTargetsForSource(session.source, settings) : [];
 }
 


### PR DESCRIPTION
## 变更概述

支持在同一个 WSL 发行版内迁移 Claude Code 与 Codex 会话。

本次变更包括：

- 支持 WSL Claude Code → Codex、Codex → Claude Code；
- 在 WSL 内生成目标 Agent 会话文件；
- 同步 Codex 的 `session_index.jsonl` 和 VSCode 状态索引；
- 修复迁移后 AgentRecall 和 Codex 会话列表无法及时显示的问题；
- 迁移完成后自动刷新 AgentRecall 索引并启动目标会话；
- 当前不支持 WSL 与 Windows 本地环境之间的迁移，也不支持跨 WSL 发行版迁移。

## 更新说明检查

- [x] 本分支已新增且仅新增一个 `.release-notes/<branch-slug>.md`
- [x] 更新说明包含面向用户的“新增功能”或“Bug 修复”列表
- [x] 更新说明已移除 MR、分支、CI、发布流程、内部服务、路径及其他不应暴露的实现或敏感信息
- [ ] 已运行 `npm run release-note:check`

## 验证

- `npm run typecheck` ✅
- `npm run build` ✅
- WSL Claude Code → Codex 实际迁移验证 ✅
- WSL Codex → Claude Code 实际迁移验证 ✅
- Codex `session_index.jsonl` 同步验证 ✅
- VSCode Codex `state_*.sqlite` 同步验证 ✅
- AgentRecall WSL 索引刷新验证 ✅
- `node scripts/release-notes.mjs check-range upstream/main HEAD` ✅