### PR TITLE
fix: rules sync handles nested CLAUDE.md and project-scope restore

### DIFF
--- a/.release-notes/fix-rules-identity-nested-claude-md.md
+++ b/.release-notes/fix-rules-identity-nested-claude-md.md
@@ -1,0 +1,6 @@
+# Rules 同步修复嵌套 CLAUDE.md 和项目级还原
+
+## Bug 修复
+
+- 修复同项目多个 CLAUDE.md 不可见和身份冲突的问题：扫描器递归子目录（深度 3，跳过 node_modules 等），name 字段改为相对路径（如 `packages/core/CLAUDE.md`），identity 不再冲突
+- 还原功能从仅支持全局扩展到支持项目级规则：通过远端 project_path 匹配本地已索引项目目录，拼接相对路径写入文件

--- a/src/core/rules-sync.test.ts
+++ b/src/core/rules-sync.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import {
   buildRulesSyncSetupSql,
-  restoreGlobalRules,
+  restoreRules,
   ruleIdentity,
   scanLocalRules,
   SupabaseRulesSyncClient,
@@ -142,7 +142,7 @@ describe("rules sync", () => {
 
   it("restores a global rule when the local file does not exist", () => {
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "rules-restore-new-"));
-    const result = restoreGlobalRules([makeRemoteRule()], { homeDir });
+    const result = restoreRules([makeRemoteRule()], { homeDir });
     expect(result.restored).toEqual(["CLAUDE.md"]);
     expect(result.skipped).toEqual([]);
     expect(result.backedUp).toEqual([]);
@@ -156,7 +156,7 @@ describe("rules sync", () => {
     fs.mkdirSync(claudeDir, { recursive: true });
     fs.writeFileSync(path.join(claudeDir, "CLAUDE.md"), "# Restored Rules", "utf8");
     const hash = require("node:crypto").createHash("sha256").update("# Restored Rules").digest("hex");
-    const result = restoreGlobalRules([makeRemoteRule({ content_hash: hash })], { homeDir });
+    const result = restoreRules([makeRemoteRule({ content_hash: hash })], { homeDir });
     expect(result.skipped).toEqual(["CLAUDE.md"]);
     expect(result.restored).toEqual([]);
     expect(fs.existsSync(path.join(claudeDir, "CLAUDE.md.bak"))).toBe(false);
@@ -168,7 +168,7 @@ describe("rules sync", () => {
     const claudeDir = path.join(homeDir, ".claude");
     fs.mkdirSync(claudeDir, { recursive: true });
     fs.writeFileSync(path.join(claudeDir, "CLAUDE.md"), "# Old local content", "utf8");
-    const result = restoreGlobalRules([makeRemoteRule()], { homeDir });
+    const result = restoreRules([makeRemoteRule()], { homeDir });
     expect(result.restored).toEqual(["CLAUDE.md"]);
     expect(result.backedUp).toEqual(["CLAUDE.md"]);
     expect(fs.readFileSync(path.join(claudeDir, "CLAUDE.md"), "utf8")).toBe("# Restored Rules");
@@ -176,15 +176,85 @@ describe("rules sync", () => {
     fs.rmSync(homeDir, { recursive: true, force: true });
   });
 
-  it("skips project-scope rules and unknown agents", () => {
+  it("skips project-scope rules when no matching projectDir is provided", () => {
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "rules-restore-skip2-"));
-    const result = restoreGlobalRules([
+    const result = restoreRules([
       makeRemoteRule({ scope: "project", project_path: "my-app" }),
       makeRemoteRule({ agent: "qoder", name: "some-rule.md" }),
     ], { homeDir });
     expect(result.restored).toEqual([]);
     expect(result.skipped).toEqual([]);
     expect(result.backedUp).toEqual([]);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("scans nested CLAUDE.md files with relative path as name", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "rules-nested-scan-"));
+    const projectDir = path.join(homeDir, "monorepo");
+    fs.mkdirSync(path.join(projectDir, "packages", "core"), { recursive: true });
+    fs.mkdirSync(path.join(projectDir, "packages", "api"), { recursive: true });
+    fs.mkdirSync(path.join(projectDir, "node_modules", "dep"), { recursive: true });
+    fs.writeFileSync(path.join(projectDir, "CLAUDE.md"), "# Root rules", "utf8");
+    fs.writeFileSync(path.join(projectDir, "packages", "core", "CLAUDE.md"), "# Core rules", "utf8");
+    fs.writeFileSync(path.join(projectDir, "packages", "api", "CLAUDE.md"), "# API rules", "utf8");
+    fs.writeFileSync(path.join(projectDir, "node_modules", "dep", "CLAUDE.md"), "# Should be skipped", "utf8");
+
+    const rules = scanLocalRules({ homeDir, projectDirs: [projectDir] });
+    const claudeProjectRules = rules.filter((r) => r.agent === "claude" && r.scope === "project");
+    expect(claudeProjectRules).toHaveLength(3);
+    expect(claudeProjectRules.map((r) => r.name).sort()).toEqual(["CLAUDE.md", "packages/api/CLAUDE.md", "packages/core/CLAUDE.md"]);
+    // node_modules should be skipped
+    expect(claudeProjectRules.find((r) => r.name.includes("node_modules"))).toBeUndefined();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("assigns different identities to root and nested CLAUDE.md", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "rules-nested-id-"));
+    const projectDir = path.join(homeDir, "myapp");
+    fs.mkdirSync(path.join(projectDir, "sub"), { recursive: true });
+    fs.writeFileSync(path.join(projectDir, "CLAUDE.md"), "Root", "utf8");
+    fs.writeFileSync(path.join(projectDir, "sub", "CLAUDE.md"), "Sub", "utf8");
+
+    const rules = scanLocalRules({ homeDir, projectDirs: [projectDir] });
+    const identities = rules.filter((r) => r.agent === "claude").map((r) => ruleIdentity(r));
+    expect(new Set(identities).size).toBe(identities.length);
+    expect(identities).toContain("claude:project:myapp:CLAUDE.md");
+    expect(identities).toContain("claude:project:myapp:sub/CLAUDE.md");
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("restores a project-scope rule to the matching local project directory", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "rules-restore-proj-"));
+    const projectDir = path.join(homeDir, "my-project");
+    fs.mkdirSync(projectDir, { recursive: true });
+    const remoteRule = makeRemoteRule({
+      scope: "project",
+      name: "CLAUDE.md",
+      project_path: "my-project",
+      content: "# Project rules from remote",
+    });
+    const result = restoreRules([remoteRule], { homeDir, projectDirs: [projectDir] });
+    expect(result.restored).toEqual(["CLAUDE.md"]);
+    expect(fs.readFileSync(path.join(projectDir, "CLAUDE.md"), "utf8")).toBe("# Project rules from remote");
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("restores a nested project-scope rule using relative path name", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "rules-restore-nested-"));
+    const projectDir = path.join(homeDir, "mono");
+    fs.mkdirSync(path.join(projectDir, "packages", "core"), { recursive: true });
+    fs.writeFileSync(path.join(projectDir, "packages", "core", "CLAUDE.md"), "# Old core rules", "utf8");
+    const remoteRule = makeRemoteRule({
+      scope: "project",
+      name: "packages/core/CLAUDE.md",
+      project_path: "mono",
+      content: "# New core rules from remote",
+    });
+    const result = restoreRules([remoteRule], { homeDir, projectDirs: [projectDir] });
+    expect(result.restored).toEqual(["packages/core/CLAUDE.md"]);
+    expect(result.backedUp).toEqual(["packages/core/CLAUDE.md"]);
+    expect(fs.readFileSync(path.join(projectDir, "packages", "core", "CLAUDE.md"), "utf8")).toBe("# New core rules from remote");
+    expect(fs.readFileSync(path.join(projectDir, "packages", "core", "CLAUDE.md.bak"), "utf8")).toBe("# Old core rules");
     fs.rmSync(homeDir, { recursive: true, force: true });
   });
 });

--- a/src/core/rules-sync.ts
+++ b/src/core/rules-sync.ts
@@ -64,11 +64,16 @@ const DEFAULT_RULES_SYNC_TIMEOUT_MS = 15_000;
 export interface ScanLocalRulesOptions {
   homeDir?: string;
   projectDirs?: string[];
+  /** Max subdirectory depth for recursive CLAUDE.md scanning (default 3). */
+  maxScanDepth?: number;
 }
+
+const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "out", ".next", "build", ".output", ".qoder"]);
 
 export function scanLocalRules(options: ScanLocalRulesOptions = {}): AgentRule[] {
   const homeDir = options.homeDir ?? os.homedir();
   const projectDirs = options.projectDirs ?? [];
+  const maxDepth = options.maxScanDepth ?? 3;
   const rules: AgentRule[] = [];
 
   // Claude global CLAUDE.md
@@ -80,10 +85,17 @@ export function scanLocalRules(options: ScanLocalRulesOptions = {}): AgentRule[]
   for (const projectDir of projectDirs) {
     const projectBasename = path.basename(projectDir);
 
-    // Project-level CLAUDE.md
+    // Root-level CLAUDE.md (name stays "CLAUDE.md" for backward compat)
     const claudeProjectPath = path.join(projectDir, "CLAUDE.md");
     const claudeProject = readRuleFile(claudeProjectPath, "claude", "project", "CLAUDE.md", projectBasename);
     if (claudeProject) rules.push(claudeProject);
+
+    // Nested CLAUDE.md files (name is relative path from project root)
+    for (const nested of findNestedClaudeMd(projectDir, maxDepth)) {
+      const relativePath = path.relative(projectDir, nested).replace(/\\/g, "/");
+      const rule = readRuleFile(nested, "claude", "project", relativePath, projectBasename);
+      if (rule) rules.push(rule);
+    }
 
     // Qoder project rules: .qoder/rules/*.md
     const qoderRulesDir = path.join(projectDir, ".qoder", "rules");
@@ -102,6 +114,35 @@ export function scanLocalRules(options: ScanLocalRulesOptions = {}): AgentRule[]
   }
 
   return rules;
+}
+
+/**
+ * Recursively finds CLAUDE.md files in subdirectories of projectDir,
+ * skipping the root (already handled) and common build/dependency dirs.
+ */
+function findNestedClaudeMd(projectDir: string, maxDepth: number): string[] {
+  const results: string[] = [];
+  function scan(dir: string, depth: number): void {
+    if (depth > maxDepth) return;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (SKIP_DIRS.has(entry.name)) continue;
+      const subDir = path.join(dir, entry.name);
+      const claudeMd = path.join(subDir, "CLAUDE.md");
+      if (fs.existsSync(claudeMd)) {
+        results.push(claudeMd);
+      }
+      scan(subDir, depth + 1);
+    }
+  }
+  scan(projectDir, 1);
+  return results;
 }
 
 function readRuleFile(filePath: string, agent: RulesAgent, scope: RulesScope, name: string, projectPath: string): AgentRule | null {
@@ -296,17 +337,23 @@ export interface RestoreResult {
   backedUp: string[];
 }
 
+export interface RestoreRulesOptions {
+  homeDir?: string;
+  /** Local project directories, used to resolve project-scoped rules. */
+  projectDirs?: string[];
+}
+
 /**
- * Restores global-scope remote rules to their local filesystem paths.
+ * Restores remote rules (global and project scope) to their local filesystem paths.
  * Conflict policy: identical content is skipped; differing local files are
  * backed up to `<path>.bak` before being overwritten.
  */
-export function restoreGlobalRules(remoteRules: RemoteRule[], options: { homeDir?: string } = {}): RestoreResult {
+export function restoreRules(remoteRules: RemoteRule[], options: RestoreRulesOptions = {}): RestoreResult {
   const homeDir = options.homeDir ?? os.homedir();
+  const projectDirs = options.projectDirs ?? [];
   const result: RestoreResult = { restored: [], skipped: [], backedUp: [] };
   for (const rule of remoteRules) {
-    if (rule.scope !== "global") continue;
-    const targetPath = resolveGlobalRulePath(rule, homeDir);
+    const targetPath = resolveRulePath(rule, homeDir, projectDirs);
     if (!targetPath) continue;
     if (fs.existsSync(targetPath)) {
       const localContent = fs.readFileSync(targetPath, "utf8");
@@ -324,9 +371,16 @@ export function restoreGlobalRules(remoteRules: RemoteRule[], options: { homeDir
   return result;
 }
 
-function resolveGlobalRulePath(rule: RemoteRule, homeDir: string): string | null {
-  if (rule.agent === "claude" && rule.name === "CLAUDE.md") return path.join(homeDir, ".claude", "CLAUDE.md");
-  return null;
+function resolveRulePath(rule: RemoteRule, homeDir: string, projectDirs: string[]): string | null {
+  if (rule.scope === "global") {
+    if (rule.agent === "claude" && rule.name === "CLAUDE.md") return path.join(homeDir, ".claude", "CLAUDE.md");
+    return null;
+  }
+  // Project scope: match remote project_path (basename) to a local project dir
+  const match = projectDirs.find((dir) => path.basename(dir) === rule.project_path);
+  if (!match) return null;
+  // rule.name may be a relative path (e.g. "packages/core/CLAUDE.md") or just a filename
+  return path.join(match, rule.name);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -119,7 +119,7 @@ import {
   type SessionSyncHookSetup,
 } from "./services/remote-session-service";
 import { buildMemoriesSyncSetupSql, memoryIdentity, scanLocalMemories, SupabaseMemoriesSyncClient } from "../core/memories-sync";
-import { buildRulesSyncSetupSql, restoreGlobalRules, ruleIdentity, scanLocalRules, SupabaseRulesSyncClient } from "../core/rules-sync";
+import { buildRulesSyncSetupSql, restoreRules, ruleIdentity, scanLocalRules, SupabaseRulesSyncClient } from "../core/rules-sync";
 import { SkillService, type SkillUsageHookSetup } from "./services/skill-service";
 import type {
   EnvironmentUpsertInput,
@@ -382,10 +382,10 @@ function createRulesSyncService(): RulesIpcService {
     copySetupSql() {
       clipboard.writeText(buildRulesSyncSetupSql());
     },
-    async restoreGlobal() {
+    async restore() {
       const client = createClient();
       const remoteRules = await client.listRemoteRules();
-      return restoreGlobalRules(remoteRules);
+      return restoreRules(remoteRules, { projectDirs: projectDirs() });
     },
   };
 }

--- a/src/main/ipc/rules.ts
+++ b/src/main/ipc/rules.ts
@@ -8,7 +8,7 @@ export interface RulesIpcService {
   uploadAll(): Promise<{ uploaded: number; skipped: number }>;
   deleteRemote(remoteId: string): Promise<boolean>;
   copySetupSql(): void;
-  restoreGlobal(): Promise<RestoreResult>;
+  restore(): Promise<RestoreResult>;
 }
 
 export function registerRulesIpc(ipc: IpcMainRegistrar, service: RulesIpcService): () => void {
@@ -18,6 +18,6 @@ export function registerRulesIpc(ipc: IpcMainRegistrar, service: RulesIpcService
     registerIpcHandler(ipc, RULES_IPC.uploadAll, () => service.uploadAll()),
     registerIpcHandler(ipc, RULES_IPC.deleteRemote, (_event, id) => service.deleteRemote(id)),
     registerIpcHandler(ipc, RULES_IPC.copySetupSql, () => service.copySetupSql()),
-    registerIpcHandler(ipc, RULES_IPC.restoreGlobal, () => service.restoreGlobal()),
+    registerIpcHandler(ipc, RULES_IPC.restore, () => service.restore()),
   ]);
 }

--- a/src/preload/rules.ts
+++ b/src/preload/rules.ts
@@ -11,7 +11,7 @@ export function createRulesApi(ipc: RulesIpcRenderer) {
     uploadAllRulesToSync: (): Promise<{ uploaded: number; skipped: number }> => ipc.invoke(RULES_IPC.uploadAll.channel),
     deleteRemoteRule: (remoteId: string): Promise<boolean> => ipc.invoke(RULES_IPC.deleteRemote.channel, remoteId),
     copyRulesSyncSetupSql: (): Promise<void> => ipc.invoke(RULES_IPC.copySetupSql.channel),
-    restoreGlobalRules: (): Promise<RestoreResult> => ipc.invoke(RULES_IPC.restoreGlobal.channel),
+    restoreRules: (): Promise<RestoreResult> => ipc.invoke(RULES_IPC.restore.channel),
   };
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2313,7 +2313,7 @@ export function App(): ReactElement {
           onRulesUpload={(identity) => window.sessionSearch.uploadRuleToSync(identity)}
           onRulesDelete={(remoteId) => window.sessionSearch.deleteRemoteRule(remoteId)}
           onRulesCopySql={() => void window.sessionSearch.copyRulesSyncSetupSql()}
-          onRulesRestore={() => window.sessionSearch.restoreGlobalRules()}
+          onRulesRestore={() => window.sessionSearch.restoreRules()}
           onMemoriesUploadAll={() => window.sessionSearch.uploadAllMemoriesToSync()}
           onMemoriesUpload={(identity) => window.sessionSearch.uploadMemoryToSync(identity)}
           onMemoriesDelete={(remoteId) => window.sessionSearch.deleteRemoteMemory(remoteId)}

--- a/src/shared/ipc/rules.ts
+++ b/src/shared/ipc/rules.ts
@@ -10,5 +10,5 @@ export const RULES_IPC = {
   uploadAll: defineIpcRequest("rules:sync-upload-all", noInput),
   deleteRemote: defineIpcRequest("rules:sync-delete", z.tuple([ruleIdentityInput])),
   copySetupSql: defineIpcRequest("rules:sync-copy-setup-sql", noInput),
-  restoreGlobal: defineIpcRequest("rules:sync-restore-global", noInput),
+  restore: defineIpcRequest("rules:sync-restore", noInput),
 } as const;


### PR DESCRIPTION
## 变更概述

数字资产 Rules 同步有两个问题：

1. 同一个项目里如果有多个 CLAUDE.md（比如 `packages/core/CLAUDE.md`、`packages/api/CLAUDE.md`），扫描器只看根目录的，子目录的完全不可见。即使手动加上，name 字段都是 "CLAUDE.md"，identity 冲突，上传时互相覆盖。

2. 还原功能只支持全局 CLAUDE.md，项目级的远端规则无法下载到新设备。

修复：
1. 扫描器递归子目录（深度 3，跳过 node_modules/.git/dist 等），name 字段改为相对路径（如 `packages/core/CLAUDE.md`），identity 不再冲突
2. `restoreGlobalRules` → `restoreRules`，支持 global + project 两种 scope。项目级还原通过远端 project_path (basename) 匹配本地已索引的项目目录，拼接相对路径写入文件
3. IPC 全栈改名 `restoreGlobal` → `restore`

5 个新测试：嵌套扫描、identity 唯一性、项目级还原写入、嵌套还原备份覆盖、无匹配项目跳过。

本地已回归
