### PR TITLE
fix: remove Claude/Codex Internal optional session sources

### DIFF
--- a/.release-notes/feat-remove-claude-codex-internal.md
+++ b/.release-notes/feat-remove-claude-codex-internal.md
@@ -2,4 +2,4 @@
 
 ## Bug 修复
 
-- 设置中不再提供 Claude Code Internal 与 Codex Internal 可选会话来源及迁移目标。
+- 设置中不再提供 Claude Code Internal 与 Codex Internal 可选会话来源及迁移目标。若仍需要这两类会话，请继续使用 v0.31.7 及更早版本。

--- a/.release-notes/feat-remove-claude-codex-internal.md
+++ b/.release-notes/feat-remove-claude-codex-internal.md
@@ -1,0 +1,5 @@
+# 移除 Claude / Codex Internal 可选来源
+
+## Bug 修复
+
+- 设置中不再提供 Claude Code Internal 与 Codex Internal 可选会话来源及迁移目标。

--- a/.release-notes/feat-remove-claude-codex-internal.md
+++ b/.release-notes/feat-remove-claude-codex-internal.md
@@ -1,5 +1,5 @@
 # 移除 Claude / Codex Internal 可选来源
 
-## Bug 修复
+## 新增功能
 
 - 设置中不再提供 Claude Code Internal 与 Codex Internal 可选会话来源及迁移目标。若仍需要这两类会话，请继续使用 v0.31.7 及更早版本。

--- a/bin/agent-recall-mcp.mjs
+++ b/bin/agent-recall-mcp.mjs
@@ -492,11 +492,11 @@ async function runServer() {
         "典型场景：用户说「把这个会话迁移到 Claude/Codex/CodeBuddy」「把当前对话搬过去」「迁移会话」时调用此工具。" +
         "流程：先用 search_sessions 找到源会话的 sessionKey，再调用本工具传入 sessionKey 和 target。" +
         "迁移完成后返回 resumeCommand（如 cd /repo && claude --resume <id>），launched 恒为 false，需要用户自行在终端执行该命令。" +
-        "四个可选目标 tclaude、tcodex、claude-internal、codex-internal 必须先在 Settings > Optional sources 中启用。" +
+        "两个可选目标 tclaude、tcodex 必须先在 Settings > Optional sources 中启用。" +
         "仅支持本地会话（environmentKind=local），远程会话不可迁移。",
       inputSchema: {
         sessionKey: z.string().describe("要迁移的源会话 sessionKey，可通过 search_sessions 获取。"),
-        target: migrateTargetSchema.describe("目标 Agent：claude、codex、codebuddy、codewiz、cursor、tclaude、tcodex、claude-internal 或 codex-internal。四个可选目标需先在 Settings > Optional sources 启用。"),
+        target: migrateTargetSchema.describe("目标 Agent：claude、codex、codebuddy、codewiz、cursor、tclaude 或 tcodex。两个可选目标需先在 Settings > Optional sources 启用。"),
       },
     },
     async (args) => {

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -50,8 +50,6 @@
 | Claude Desktop app | `~/Library/Application Support/Claude/claude-code-sessions/**/local_*.json` plus Claude Code project logs |
 | TClaude CLI | Optional in settings; reads `~/.tclaude/projects/*/*.jsonl` (a Claude Code fork sharing the same format); supports Resume |
 | TCodex CLI | Optional in settings; reads `~/.tcodex/sessions/**/*.jsonl` (a Codex fork sharing the same format); supports Resume |
-| Claude Code Internal | Optional in settings; reads `~/.claude-internal/projects/*/*.jsonl` |
-| Codex Internal | Optional in settings; reads `~/.codex-internal/sessions/**/*.jsonl` |
 | CodeBuddy CLI | Optional in settings; reads `~/.codebuddy/projects/**/*.jsonl` |
 | OpenClaw | Optional in settings; reads `~/.openclaw/agents/*/sessions/*.jsonl`, legacy `~/.clawdbot/agents/*/sessions/*.jsonl`, excluding `*.trajectory.jsonl` |
 | Hermes | Optional in settings; reads `~/.hermes/state.db` |
@@ -65,7 +63,7 @@
 
 Codex title metadata is read from `~/.codex/session_index.jsonl` when that file exists. If no upstream title is available, the app uses the first meaningful user question as the default title.
 
-CodeBuddy CLI, TClaude, TCodex, Claude Code Internal, Codex Internal, OpenClaw, Hermes, OpenCode, ZCode, Cursor Agent, Trae, and Qoder are off by default and can be selected from Settings -> Optional sources. Once enabled, they support local indexing, search, details, and source filtering. Because TClaude / TCodex share the Claude Code / Codex formats, they additionally support Resume and one-click launch (invoking the `tclaude` / `tcodex` commands respectively). WSL environments support only Codex and Claude Code search, details, and Resume; WSL session migration is not supported yet. ZCode also includes local tool-call records and time-ranged token statistics; it does not support Resume, migration, SSH, remote sync, opening ZCode, or quota lookup. Deleting a ZCode session removes only the explicitly selected session and its related records, never the shared database file. For the other sources, Resume, SSH remote sync, and provider-specific usage stats are intentionally separate follow-up work. Trae and Qoder also support open-state detection.
+CodeBuddy CLI, TClaude, TCodex, OpenClaw, Hermes, OpenCode, ZCode, Cursor Agent, Trae, and Qoder are off by default and can be selected from Settings -> Optional sources. Once enabled, they support local indexing, search, details, and source filtering. Because TClaude / TCodex share the Claude Code / Codex formats, they additionally support Resume and one-click launch (invoking the `tclaude` / `tcodex` commands respectively). WSL environments support only Codex and Claude Code search, details, and Resume; WSL session migration is not supported yet. ZCode also includes local tool-call records and time-ranged token statistics; it does not support Resume, migration, SSH, remote sync, opening ZCode, or quota lookup. Deleting a ZCode session removes only the explicitly selected session and its related records, never the shared database file. For the other sources, Resume, SSH remote sync, and provider-specific usage stats are intentionally separate follow-up work. Trae and Qoder also support open-state detection.
 
 ## Remote Session Sync
 

--- a/src/core/indexer.test.ts
+++ b/src/core/indexer.test.ts
@@ -216,10 +216,8 @@ describe("indexer", () => {
   it.each([
     { target: "claude", source: "claude-cli" },
     { target: "tclaude", source: "tclaude-cli" },
-    { target: "claude-internal", source: "claude-internal" },
     { target: "codex", source: "codex-cli" },
     { target: "tcodex", source: "tcodex-cli" },
-    { target: "codex-internal", source: "codex-internal" },
     { target: "codebuddy", source: "codebuddy-cli" },
     { target: "codewiz", source: "codewiz-cli" },
     { target: "cursor", source: "cursor-agent" },

--- a/src/core/mcp-migration.test.ts
+++ b/src/core/mcp-migration.test.ts
@@ -83,8 +83,6 @@ const allMigrationTargetsEnabled = {
   ...defaultSettings,
   includeTclaude: true,
   includeTcodex: true,
-  includeClaudeInternal: true,
-  includeCodexInternal: true,
 };
 
 const targetSources: Record<MigrationTarget, SessionSource> = {
@@ -95,8 +93,6 @@ const targetSources: Record<MigrationTarget, SessionSource> = {
   cursor: "cursor-agent",
   tclaude: "tclaude-cli",
   tcodex: "tcodex-cli",
-  "claude-internal": "claude-internal",
-  "codex-internal": "codex-internal",
 };
 
 describe("migrateSessionForMcp — happy path", () => {
@@ -138,39 +134,6 @@ describe("migrateSessionForMcp — happy path", () => {
       }
     },
   );
-
-  it("migrates a TClaude source to Codex Internal with a scoped safe resume command", async () => {
-    const store = createInMemoryStore();
-    const projectPath = makeProjectDir();
-    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-mig-home-"));
-    const { sessionKey } = seedLocalSession(store, {
-      sessionKey: "tclaude:source-1",
-      rawId: "source-1",
-      source: "tclaude-cli",
-      projectPath,
-    });
-    try {
-      const result = await migrateSessionForMcp(
-        { sessionKey, target: "codex-internal" },
-        { store, settings: allMigrationTargetsEnabled, inspectCli: noOpInspect, homeDir },
-      );
-
-      expect(result).toMatchObject({ target: "codex-internal", launched: false, indexed: true });
-      expect(result.targetFilePath).toContain(path.join(homeDir, ".codex-internal"));
-      const indexed = store.getSession(`codex-internal:${result.targetSessionId}`);
-      expect(indexed?.source).toBe("codex-internal");
-      expect(store.listSessionMigrations(sessionKey)[0]).toMatchObject({
-        sourceAgent: "claude",
-        targetAgent: "codex-internal",
-      });
-      expect(result.resumeCommand).toContain(`CODEX_HOME=${path.join(homeDir, ".codex-internal")}`);
-      expect(result.resumeCommand).toContain(result.targetSessionId);
-    } finally {
-      store.close();
-      fs.rmSync(homeDir, { recursive: true, force: true });
-      fs.rmSync(projectPath, { recursive: true, force: true });
-    }
-  });
 
   it("migrates a Claude source to Codex and registers the native Codex index entry", async () => {
     const store = createInMemoryStore();

--- a/src/core/mcp-server.test.ts
+++ b/src/core/mcp-server.test.ts
@@ -376,7 +376,7 @@ describe("MCP migrate_session tool", () => {
   const migrateSession = mcp.migrateSession as (db: Db, args: Record<string, unknown>) => Promise<MigrationResult>;
   const migrationTargetSchema = mcp.migrationTargetSchema as (zod: typeof z) => Promise<ReturnType<typeof z.enum>>;
 
-  it("uses the nine-target schema for the real migrate_session tool contract", async () => {
+  it("uses the seven-target schema for the real migrate_session tool contract", async () => {
     const schema = await migrationTargetSchema(z);
     expect(schema.parse("codewiz")).toBe("codewiz");
     expect(schema.parse("tclaude")).toBe("tclaude");
@@ -389,8 +389,6 @@ describe("MCP migrate_session tool", () => {
       "cursor",
       "tclaude",
       "tcodex",
-      "claude-internal",
-      "codex-internal",
     ]);
   });
 

--- a/src/core/migration-targets.test.ts
+++ b/src/core/migration-targets.test.ts
@@ -12,8 +12,6 @@ import {
 const allDisabled: MigrationTargetSettings = {
   includeTclaude: false,
   includeTcodex: false,
-  includeClaudeInternal: false,
-  includeCodexInternal: false,
 };
 
 describe("migration target registry", () => {
@@ -26,8 +24,6 @@ describe("migration target registry", () => {
       "cursor",
       "tclaude",
       "tcodex",
-      "claude-internal",
-      "codex-internal",
     ]);
     expect(new Set(MIGRATION_TARGET_IDS).size).toBe(MIGRATION_TARGET_IDS.length);
     expect(MIGRATION_TARGETS.map(({ id }) => id)).toEqual(MIGRATION_TARGET_IDS);
@@ -74,7 +70,7 @@ describe("migration target registry", () => {
     ]);
   });
 
-  it("maps the four optional migration targets", () => {
+  it("maps the two optional migration targets", () => {
     expect(MIGRATION_TARGETS.slice(5)).toEqual([
       {
         id: "tclaude",
@@ -90,20 +86,6 @@ describe("migration target registry", () => {
         source: "tcodex-cli",
         enabledSetting: "includeTcodex",
       },
-      {
-        id: "claude-internal",
-        label: "Claude Code Internal",
-        family: "claude",
-        source: "claude-internal",
-        enabledSetting: "includeClaudeInternal",
-      },
-      {
-        id: "codex-internal",
-        label: "Codex Internal",
-        family: "codex",
-        source: "codex-internal",
-        enabledSetting: "includeCodexInternal",
-      },
     ]);
   });
 
@@ -118,8 +100,6 @@ describe("migration target registry", () => {
     expect(enabledMigrationTargets({
       includeTclaude: true,
       includeTcodex: true,
-      includeClaudeInternal: true,
-      includeCodexInternal: true,
     })).toEqual(MIGRATION_TARGET_IDS);
   });
 
@@ -129,8 +109,8 @@ describe("migration target registry", () => {
   });
 
   it("rejects disabled optional targets with their display label", () => {
-    expect(() => assertMigrationTargetEnabled("claude-internal", allDisabled)).toThrow(
-      "Claude Code Internal migration target is disabled in Settings.",
+    expect(() => assertMigrationTargetEnabled("tclaude", allDisabled)).toThrow(
+      "TClaude migration target is disabled in Settings.",
     );
     expect(() => assertMigrationTargetEnabled("claude", allDisabled)).not.toThrow();
   });

--- a/src/core/migration-targets.ts
+++ b/src/core/migration-targets.ts
@@ -2,9 +2,7 @@ import type { MigrationAgent, MigrationTarget, SessionSource } from "./types";
 
 export type OptionalMigrationTargetSetting =
   | "includeTclaude"
-  | "includeTcodex"
-  | "includeClaudeInternal"
-  | "includeCodexInternal";
+  | "includeTcodex";
 
 export type MigrationTargetSettings = Record<OptionalMigrationTargetSetting, boolean>;
 
@@ -54,20 +52,6 @@ export const MIGRATION_TARGETS: readonly MigrationTargetDescriptor[] = [
     source: "tcodex-cli",
     enabledSetting: "includeTcodex",
   },
-  {
-    id: "claude-internal",
-    label: "Claude Code Internal",
-    family: "claude",
-    source: "claude-internal",
-    enabledSetting: "includeClaudeInternal",
-  },
-  {
-    id: "codex-internal",
-    label: "Codex Internal",
-    family: "codex",
-    source: "codex-internal",
-    enabledSetting: "includeCodexInternal",
-  },
 ] as const satisfies readonly MigrationTargetDescriptor[];
 
 export const MIGRATION_TARGET_IDS = [
@@ -78,8 +62,6 @@ export const MIGRATION_TARGET_IDS = [
   "cursor",
   "tclaude",
   "tcodex",
-  "claude-internal",
-  "codex-internal",
 ] as const satisfies readonly MigrationTarget[];
 
 export const BASE_MIGRATION_TARGETS = ["claude", "codex", "codebuddy", "codewiz", "cursor"] as const satisfies readonly MigrationTarget[];

--- a/src/core/platform.test.ts
+++ b/src/core/platform.test.ts
@@ -102,8 +102,6 @@ describe("platform application resolution", () => {
   });
 
   it("starts fresh installs with only Claude Code and Codex sources enabled", () => {
-    expect(defaultSettings.includeClaudeInternal).toBe(false);
-    expect(defaultSettings.includeCodexInternal).toBe(false);
     expect(defaultSettings.includeTclaude).toBe(false);
     expect(defaultSettings.includeTcodex).toBe(false);
     expect(defaultSettings.includeCodeBuddyCli).toBe(false);
@@ -184,7 +182,6 @@ describe("resume commands", () => {
   it.each([
     ["codex-cli", "openai"],
     ["tcodex-cli", "tencent"],
-    ["codex-internal", "codebuddy"],
   ] as const)("supplies the matching provider for a legacy %s migration", (source, provider) => {
     const directory = mkdtempSync(path.join(tmpdir(), "agent-session-resume-provider-"));
     const filePath = path.join(directory, "legacy-codex.jsonl");
@@ -618,15 +615,15 @@ describe("API settings", () => {
     ).toMatchObject({ customApiKey: "" });
   });
 
-  it("preserves disabled optional internal sources", () => {
+  it("preserves disabled optional Tencent-fork sources", () => {
     expect(
       mergeAppSettings(
-        { ...defaultSettings, includeClaudeInternal: true, includeCodexInternal: true },
-        { includeClaudeInternal: false, includeCodexInternal: false },
+        { ...defaultSettings, includeTclaude: true, includeTcodex: true },
+        { includeTclaude: false, includeTcodex: false },
       ),
     ).toMatchObject({
-      includeClaudeInternal: false,
-      includeCodexInternal: false,
+      includeTclaude: false,
+      includeTcodex: false,
     });
   });
 
@@ -846,91 +843,6 @@ describe("reveal in file manager", () => {
 });
 
 describe("resume process specs", () => {
-  it("uses the concrete Claude Internal binary for ordinary resume", () => {
-    const session = {
-      source: "claude-internal",
-      rawId: "internal-claude-1",
-      projectPath: "/repo",
-    } as SessionSearchResult;
-    const settings = { ...defaultSettings, claudeInternalBinary: "/opt/Internal CLI/claude-internal" };
-
-    expect(getResumeProcessSpec(session, settings, { platform: "darwin" })).toMatchObject({
-      command: "/opt/Internal CLI/claude-internal",
-      args: ["--resume", "internal-claude-1"],
-      cwd: "/repo",
-      env: undefined,
-      displayCommand: "cd /repo && '/opt/Internal CLI/claude-internal' --resume internal-claude-1",
-    });
-  });
-
-  it("keeps ordinary Codex Internal resume in its scoped CODEX_HOME", () => {
-    const session = {
-      source: "codex-internal",
-      rawId: "internal-codex-1",
-      projectPath: "/repo with spaces",
-    } as SessionSearchResult;
-    const settings = { ...defaultSettings, codexBinary: "/opt/Codex CLI/codex" };
-    const options = { platform: "darwin" as const, homeDir: "/Users/internal user" };
-
-    expect(getResumeProcessSpec(session, settings, options)).toEqual({
-      command: "/opt/Codex CLI/codex",
-      args: ["resume", "internal-codex-1"],
-      cwd: "/repo with spaces",
-      env: { CODEX_HOME: "/Users/internal user/.codex-internal" },
-      displayCommand:
-        "cd '/repo with spaces' && CODEX_HOME='/Users/internal user/.codex-internal' '/opt/Codex CLI/codex' resume internal-codex-1",
-    });
-  });
-
-  it("scopes ordinary Codex Internal display commands in POSIX, PowerShell, and Cmd", () => {
-    const session = {
-      source: "codex-internal",
-      rawId: "internal id",
-      projectPath: "C:\\repo & tools",
-    } as SessionSearchResult;
-    const homeDir = "C:\\Users\\Internal User";
-    const options = { platform: "win32" as const, homeDir };
-    const powershell = getResumeCommand(session, { ...defaultSettings, defaultTerminal: "PowerShell" }, options);
-    const cmd = getResumeCommand(session, { ...defaultSettings, defaultTerminal: "Cmd" }, options);
-    const posix = getResumeCommand(
-      { ...session, projectPath: "/repo with spaces" },
-      defaultSettings,
-      { platform: "linux", homeDir: "/home/internal user" },
-    );
-
-    expect(posix).toBe(
-      "cd '/repo with spaces' && CODEX_HOME='/home/internal user/.codex-internal' codex resume 'internal id'",
-    );
-    expect(powershell).toContain("try { $env:CODEX_HOME = 'C:\\Users\\Internal User\\.codex-internal'");
-    expect(powershell).toContain("codex resume 'internal id'");
-    expect(cmd).toContain('setlocal & set "CODEX_HOME=C:\\Users\\Internal User\\.codex-internal"');
-    expect(cmd).toContain('cd /d "C:\\repo & tools" && codex resume "internal id" & endlocal');
-  });
-
-  it("keeps dangerous ordinary Codex Internal values encoded in the Windows launch chain", () => {
-    const session = {
-      source: "codex-internal",
-      rawId: "id-%PATH%-!TEMP!-&|<>^\"",
-      projectPath: "C:\\repo\\%PATH%\\!TEMP! & source",
-    } as SessionSearchResult;
-    const settings = {
-      ...defaultSettings,
-      defaultTerminal: "Cmd" as const,
-      codexBinary: "C:\\Tools\\%PATH%\\!TEMP!\\codex & helper.exe",
-    };
-    const plan = buildWindowsResumeLaunchPlan(session, settings, {
-      terminal: "Cmd",
-      platform: "win32",
-      homeDir: "C:\\Users\\%PATH%\\!TEMP!",
-    });
-
-    const command = plan[0].args.at(-1) ?? "";
-    expect(command).toMatch(/^setlocal DisableDelayedExpansion & powershell\.exe -NoLogo -NoProfile -EncodedCommand [A-Za-z0-9+/=]+ & endlocal$/);
-    expect(decodeEncodedCmdPowerShell(command)).toBe(
-      "$ErrorActionPreference = 'Stop'; $env:CODEX_HOME = 'C:\\Users\\%PATH%\\!TEMP!\\.codex-internal'; & 'C:\\Tools\\%PATH%\\!TEMP!\\codex & helper.exe' resume 'id-%PATH%-!TEMP!-&|<>^\"'",
-    );
-  });
-
   it("builds Codex resume as binary args with cwd instead of shell text", () => {
     const session = {
       source: "codex-cli",
@@ -1060,34 +972,17 @@ describe("migration cli process specs", () => {
       codeBuddyBinary: "/cli/codebuddy safe",
       tclaudeBinary: "/cli/tclaude safe",
       tcodexBinary: "/cli/tcodex safe",
-      claudeInternalBinary: "/cli/claude-internal safe",
     };
 
-    for (const target of ["claude", "codex", "codebuddy", "tclaude", "tcodex", "claude-internal", "codex-internal"] as const) {
+    for (const target of ["claude", "codex", "codebuddy", "tclaude", "tcodex"] as const) {
       const command = getSafeMigrationResumeCommand(target, "id with space", "/repo with space", settings, {
         platform: "linux",
         homeDir: "/home/me",
       });
       expect(command).toContain("cd '/repo with space' &&");
       expect(command).toContain("'id with space'");
-      expect(command).toContain(["codex", "tcodex", "codex-internal"].includes(target) ? " resume " : " --resume ");
+      expect(command).toContain(["codex", "tcodex"].includes(target) ? " resume " : " --resume ");
     }
-  });
-
-  it("keeps Codex Internal CODEX_HOME scoped in safe POSIX, PowerShell, and Cmd commands", () => {
-    const posix = getSafeMigrationResumeCommand("codex-internal", "id", "/repo", defaultSettings, {
-      platform: "linux", homeDir: "/home/me",
-    });
-    const powershell = getSafeMigrationResumeCommand("codex-internal", "id", "C:\\repo", {
-      ...defaultSettings, defaultTerminal: "PowerShell",
-    }, { platform: "win32", homeDir: "C:\\Users\\me" });
-    const cmd = getSafeMigrationResumeCommand("codex-internal", "id", "C:\\repo", {
-      ...defaultSettings, defaultTerminal: "Cmd",
-    }, { platform: "win32", homeDir: "C:\\Users\\me" });
-
-    expect(posix).toContain("CODEX_HOME=/home/me/.codex-internal");
-    expect(powershell).toContain("try { $env:CODEX_HOME = 'C:\\Users\\me\\.codex-internal'");
-    expect(cmd).toContain('setlocal & set "CODEX_HOME=C:\\Users\\me\\.codex-internal"');
   });
 
   it("encodes dangerous safe-fallback Cmd command, argv, and cwd values as literal PowerShell payload", () => {
@@ -1108,23 +1003,6 @@ describe("migration cli process specs", () => {
     );
   });
 
-  it("encodes dangerous Codex Internal CODEX_HOME only inside the PowerShell child payload", () => {
-    const settings = {
-      ...defaultSettings,
-      defaultTerminal: "Cmd" as const,
-      codexBinary: "C:\\Tools\\codex.exe",
-    };
-    const command = getSafeMigrationResumeCommand("codex-internal", "id", "C:\\repo", settings, {
-      platform: "win32",
-      homeDir: "C:\\Users\\%PATH%\\!TEMP!\\\"quoted\" &|<>^\r\nme",
-    });
-
-    expect(command).toMatch(/^setlocal DisableDelayedExpansion & powershell\.exe -NoLogo -NoProfile -EncodedCommand [A-Za-z0-9+/=]+ & endlocal$/);
-    expect(command).not.toContain("CODEX_HOME=");
-    expect(decodeEncodedCmdPowerShell(command)).toBe(
-      "$ErrorActionPreference = 'Stop'; $env:CODEX_HOME = 'C:\\Users\\%PATH%\\!TEMP!\\\"quoted\" &|<>^\r\nme\\.codex-internal'; Set-Location -LiteralPath 'C:\\repo'; & 'C:\\Tools\\codex.exe' 'resume' 'id'",
-    );
-  });
   it("maps each migration target to its configured binary", () => {
     const settings = {
       ...defaultSettings,
@@ -1134,7 +1012,6 @@ describe("migration cli process specs", () => {
       cursorBinary: "/opt/Cursor CLI/cursor-agent",
       tclaudeBinary: "/opt/Tencent CLI/tclaude",
       tcodexBinary: "/opt/Tencent CLI/tcodex",
-      claudeInternalBinary: "/opt/Internal CLI/claude-internal",
     };
 
     expect(migrationBinary("claude", settings)).toBe("/opt/Claude CLI/claude");
@@ -1143,8 +1020,6 @@ describe("migration cli process specs", () => {
     expect(migrationBinary("cursor", settings)).toBe("/opt/Cursor CLI/cursor-agent");
     expect(migrationBinary("tclaude", settings)).toBe("/opt/Tencent CLI/tclaude");
     expect(migrationBinary("tcodex", settings)).toBe("/opt/Tencent CLI/tcodex");
-    expect(migrationBinary("claude-internal", settings)).toBe("/opt/Internal CLI/claude-internal");
-    expect(migrationBinary("codex-internal", settings)).toBe("/opt/Codex CLI/codex");
   });
 
   it("uses Codex resume args for the Codex family and Claude resume args for the other targets", () => {
@@ -1156,16 +1031,15 @@ describe("migration cli process specs", () => {
       cursorBinary: "/cli/cursor-agent",
       tclaudeBinary: "/cli/tclaude",
       tcodexBinary: "/cli/tcodex",
-      claudeInternalBinary: "/cli/claude-internal",
     };
 
-    for (const target of ["codex", "tcodex", "codex-internal"] as const) {
+    for (const target of ["codex", "tcodex"] as const) {
       expect(getMigrationResumeProcessSpec(target, "id", "/repo", settings, { homeDir: "/home/me" }).args).toEqual([
         "resume",
         "id",
       ]);
     }
-    for (const target of ["claude", "tclaude", "claude-internal", "codebuddy", "cursor"] as const) {
+    for (const target of ["claude", "tclaude", "codebuddy", "cursor"] as const) {
       expect(getMigrationResumeProcessSpec(target, "id", "/repo", settings).args).toEqual(["--resume", "id"]);
     }
   });
@@ -1232,62 +1106,6 @@ describe("migration cli process specs", () => {
     });
   });
 
-  it.each(["darwin", "linux"] as const)("scopes Codex Internal CODEX_HOME in its %s process spec and POSIX display command", (platform) => {
-    const settings = { ...defaultSettings, codexBinary: "/opt/Codex CLI/codex" };
-
-    expect(
-      getMigrationResumeProcessSpec(
-        "codex-internal",
-        "session 'one'; echo nope",
-        "/repo it's safe",
-        settings,
-        { homeDir: "/Users/a user", platform },
-      ),
-    ).toEqual({
-      command: "/opt/Codex CLI/codex",
-      args: ["resume", "session 'one'; echo nope"],
-      cwd: "/repo it's safe",
-      env: { CODEX_HOME: "/Users/a user/.codex-internal" },
-      displayCommand:
-        "cd '/repo it'\\''s safe' && CODEX_HOME='/Users/a user/.codex-internal' '/opt/Codex CLI/codex' resume 'session '\\''one'\\''; echo nope'",
-    });
-    expect(getMigrationResumeProcessSpec("codex", "id", "/repo", settings, { homeDir: "/Users/a user" }).env).toBeUndefined();
-  });
-
-  it("restores or removes CODEX_HOME after the Codex Internal PowerShell command", () => {
-    const settings = {
-      ...defaultSettings,
-      defaultTerminal: "PowerShell" as const,
-      codexBinary: "C:\\Program Files\\Codex CLI\\codex.exe",
-    };
-
-    expect(
-      getMigrationResumeProcessSpec("codex-internal", "id 'quoted'", "C:\\repo & tools", settings, {
-        homeDir: "C:\\Users\\A User",
-        platform: "win32",
-      }).displayCommand,
-    ).toBe(
-      "$__assHadCodexHome = Test-Path Env:CODEX_HOME; $__assCodexHome = $env:CODEX_HOME; try { $env:CODEX_HOME = 'C:\\Users\\A User\\.codex-internal'; cd 'C:\\repo & tools'; & 'C:\\Program Files\\Codex CLI\\codex.exe' resume 'id ''quoted''' } finally { if ($__assHadCodexHome) { $env:CODEX_HOME = $__assCodexHome } else { Remove-Item Env:CODEX_HOME -ErrorAction SilentlyContinue } }",
-    );
-  });
-
-  it("uses cmd setlocal/endlocal for Codex Internal without leaking CODEX_HOME", () => {
-    const settings = {
-      ...defaultSettings,
-      defaultTerminal: "Cmd" as const,
-      codexBinary: "C:\\Program Files\\Codex CLI\\codex.exe",
-    };
-
-    expect(
-      getMigrationResumeProcessSpec("codex-internal", "id & next", "C:\\repo with spaces", settings, {
-        homeDir: "C:\\Users\\A User",
-        platform: "win32",
-      }).displayCommand,
-    ).toBe(
-      'setlocal & set "CODEX_HOME=C:\\Users\\A User\\.codex-internal" & cd /d "C:\\repo with spaces" && "C:\\Program Files\\Codex CLI\\codex.exe" resume "id & next" & endlocal',
-    );
-  });
-
   it("encodes ordinary Cmd migration values so percent and delayed expansion cannot rewrite them", () => {
     const settings = {
       ...defaultSettings,
@@ -1301,26 +1119,6 @@ describe("migration cli process specs", () => {
 
     expect(
       getMigrationResumeProcessSpec("codex", sessionId, projectPath, settings, { platform: "win32" }).displayCommand,
-    ).toBe(encodedCmdPowerShell(expectedScript));
-  });
-
-  it("encodes Codex Internal Cmd values while keeping CODEX_HOME child-scoped", () => {
-    const settings = {
-      ...defaultSettings,
-      defaultTerminal: "Cmd" as const,
-      codexBinary: "C:\\Tools\\%PATH%\\!TEMP!\\codex ^ internal.exe",
-    };
-    const expectedScript =
-      "$ErrorActionPreference = 'Stop'; $env:CODEX_HOME = 'C:\\Users\\%PATH%\\!TEMP!\\.codex-internal'; Set-Location -LiteralPath 'C:\\repo\\%PATH%\\!TEMP! | source'; & 'C:\\Tools\\%PATH%\\!TEMP!\\codex ^ internal.exe' resume 'id-%PATH%-!TEMP!-<next>'";
-
-    expect(
-      getMigrationResumeProcessSpec(
-        "codex-internal",
-        "id-%PATH%-!TEMP!-<next>",
-        "C:\\repo\\%PATH%\\!TEMP! | source",
-        settings,
-        { homeDir: "C:\\Users\\%PATH%\\!TEMP!", platform: "win32" },
-      ).displayCommand,
     ).toBe(encodedCmdPowerShell(expectedScript));
   });
 
@@ -1443,13 +1241,6 @@ describe("migration cli process specs", () => {
         "@tencent/tcodex 0.0.13",
       ].join("\n")),
     ).resolves.toBeUndefined();
-    await expect(
-      inspectMigrationCli("claude-internal", defaultSettings, async () => [
-        "claude: 2.1.154",
-        "claude-internal: 1.1.9",
-      ].join("\n")),
-    ).resolves.toBeUndefined();
-    await expect(inspectMigrationCli("codex-internal", defaultSettings, async () => "codex-cli 0.141.0")).resolves.toBeUndefined();
   });
 
   it.each([
@@ -1458,8 +1249,6 @@ describe("migration cli process specs", () => {
     ["codex", "codex 0.141"],
     ["tclaude", "@tencent/tclaude 0.0.9garbage\n@anthropic-ai/claude-code 2.1.154"],
     ["tclaude", "@tencent/tclaude 0.0.9\n@anthropic-ai/claude-code 2.1.154-preview"],
-    ["claude-internal", "claude-internal: 1.1.9junk\nclaude: 2.1.154"],
-    ["claude-internal", "claude-internal: 1.1.9\nclaude: 2.1.154-preview"],
   ] as const)("rejects non-release version text for %s", async (target, output) => {
     await expect(inspectMigrationCli(target, defaultSettings, async () => output)).rejects.toThrow(/version/i);
   });
@@ -1474,39 +1263,6 @@ describe("migration cli process specs", () => {
     await expect(
       inspectMigrationCli("tcodex", defaultSettings, async () => "@tencent/tcodex 0.0.13"),
     ).rejects.toThrow("@openai/codex version");
-    await expect(
-      inspectMigrationCli("claude-internal", defaultSettings, async () => "claude: 2.1.154"),
-    ).rejects.toThrow("claude-internal version");
-  });
-
-  it("passes a scoped CODEX_HOME only to Codex Internal version inspection", async () => {
-    const calls: Array<{ command: string; args: string[]; env?: Record<string, string> }> = [];
-    const runner = async (command: string, args: string[], env?: Record<string, string>) => {
-      calls.push({ command, args, env });
-      return "Codex CLI 0.141.0";
-    };
-
-    await inspectMigrationCli("codex-internal", defaultSettings, runner, { homeDir: "/Users/a user" });
-    await inspectMigrationCli("codex", defaultSettings, runner, { homeDir: "/Users/a user" });
-
-    expect(calls).toEqual([
-      { command: "codex", args: ["--version"], env: { CODEX_HOME: "/Users/a user/.codex-internal" } },
-      { command: "codex", args: ["--version"], env: undefined },
-    ]);
-  });
-
-  it("uses Windows path semantics for the Codex Internal version environment", async () => {
-    const calls: Array<{ env?: Record<string, string> }> = [];
-    await inspectMigrationCli(
-      "codex-internal",
-      defaultSettings,
-      async (_command, _args, env) => {
-        calls.push({ env });
-        return "codex-cli 0.141.0";
-      },
-      { homeDir: "C:\\Users\\A User", platform: "win32" },
-    );
-    expect(calls).toEqual([{ env: { CODEX_HOME: "C:\\Users\\A User\\.codex-internal" } }]);
   });
 
   it("merges child process env overrides without dropping the parent environment", () => {

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -46,9 +46,6 @@ export interface ResumeProcessSpec {
   command: string;
   args: string[];
   cwd?: string;
-  // Child-process environment overrides only. Execution boundaries must merge
-  // this map over process.env rather than treating it as a complete env.
-  env?: Record<string, string>;
   displayCommand: string;
 }
 
@@ -74,9 +71,6 @@ export interface AppSettings {
   cursorBinary: string;
   tclaudeBinary: string;
   tcodexBinary: string;
-  claudeInternalBinary: string;
-  includeClaudeInternal: boolean;
-  includeCodexInternal: boolean;
   includeTclaude: boolean;
   includeTcodex: boolean;
   includeCodeBuddyCli: boolean;
@@ -135,9 +129,6 @@ export const defaultSettings: AppSettings = {
   cursorBinary: "cursor-agent",
   tclaudeBinary: "tclaude",
   tcodexBinary: "tcodex",
-  claudeInternalBinary: "claude-internal",
-  includeClaudeInternal: false,
-  includeCodexInternal: false,
   includeTclaude: false,
   includeTcodex: false,
   includeCodeBuddyCli: false,
@@ -223,7 +214,6 @@ export function migrationBinary(target: MigrationTarget, settings: AppSettings):
   if (target === "claude") return settings.claudeBinary;
   if (target === "tclaude") return settings.tclaudeBinary;
   if (target === "tcodex") return settings.tcodexBinary;
-  if (target === "claude-internal") return settings.claudeInternalBinary;
   if (target === "codebuddy") return settings.codeBuddyBinary;
   if (target === "codewiz") return settings.codeWizBinary;
   if (target === "cursor") return settings.cursorBinary;
@@ -234,8 +224,6 @@ function migrationTargetDisplayName(target: MigrationTarget): string {
   if (target === "claude") return "Claude";
   if (target === "tclaude") return "TClaude";
   if (target === "tcodex") return "TCodex";
-  if (target === "claude-internal") return "Claude Internal";
-  if (target === "codex-internal") return "Codex Internal";
   if (target === "codebuddy") return "CodeBuddy";
   if (target === "codewiz") return "CodeWiz";
   if (target === "cursor") return "Cursor";
@@ -243,7 +231,7 @@ function migrationTargetDisplayName(target: MigrationTarget): string {
 }
 
 function migrationResumeArgs(target: MigrationTarget, sessionId: string): string[] {
-  return target === "codex" || target === "tcodex" || target === "codex-internal"
+  return target === "codex" || target === "tcodex"
     ? ["resume", sessionId]
     : target === "codewiz"
       ? ["--session", sessionId]
@@ -292,24 +280,14 @@ const MIGRATION_CLI_VERSION_RULES: Record<MigrationTarget, VersionRule[]> = {
     { label: "@tencent/tcodex", pattern: /^\s*@tencent\/tcodex\s*:?[ \t]*v?(\d+\.\d+\.\d+)[ \t]*$/im, minimum: version(0, 0, 13) },
     { label: "@openai/codex", pattern: /^\s*@openai\/codex\s*:?[ \t]*v?(\d+\.\d+\.\d+)[ \t]*$/im, minimum: version(0, 142, 4) },
   ],
-  "claude-internal": [
-    { label: "claude-internal", pattern: /^\s*claude-internal\s*:?[ \t]*v?(\d+\.\d+\.\d+)[ \t]*$/im, minimum: version(1, 1, 9) },
-    { label: "claude", pattern: /^\s*claude\s*:?[ \t]*v?(\d+\.\d+\.\d+)[ \t]*$/im, minimum: version(2, 1, 154) },
-  ],
-  "codex-internal": [{ label: "codex", pattern: /^\s*(?:codex(?:-cli)?|Codex(?: CLI)?)\s*:?[ \t]*v?(\d+\.\d+\.\d+)[ \t]*$/im, minimum: version(0, 141, 0) }],
 };
-
-function migrationCodexHome(homeDir: string, platform: NodeJS.Platform): string {
-  const platformPath = platform === "win32" ? path.win32 : path.posix;
-  return platformPath.join(homeDir, ".codex-internal");
-}
 
 function migrationTargetForResumeSource(source: SessionSource): MigrationTarget | null {
   return sessionSourceDescriptor(source).resumeTarget;
 }
 
 function legacyMigratedCodexProvider(session: SessionSearchResult, target: MigrationTarget): string | null {
-  if (target !== "codex" && target !== "tcodex" && target !== "codex-internal") return null;
+  if (target !== "codex" && target !== "tcodex") return null;
   let descriptor: number | null = null;
   try {
     descriptor = openSync(session.filePath, "r");
@@ -329,7 +307,6 @@ function legacyMigratedCodexProvider(session: SessionSearchResult, target: Migra
       return null;
     }
     if (target === "tcodex") return "tencent";
-    if (target === "codex-internal") return "codebuddy";
     return "openai";
   } catch {
     return null;
@@ -342,8 +319,6 @@ function buildResumeRuntimeProcessSpec(
   session: SessionSearchResult,
   settings: AppSettings,
   skipPermissions: boolean,
-  platform: NodeJS.Platform,
-  homeDir: string,
 ): Omit<ResumeProcessSpec, "displayCommand"> {
   const target = migrationTargetForResumeSource(session.source);
   if (!target) {
@@ -354,9 +329,9 @@ function buildResumeRuntimeProcessSpec(
   const legacyProvider = legacyMigratedCodexProvider(session, target);
   if (legacyProvider) args.splice(1, 0, "-c", `model_provider=${JSON.stringify(legacyProvider)}`);
   if (skipPermissions) {
-    if (target === "claude" || target === "tclaude" || target === "claude-internal") {
+    if (target === "claude" || target === "tclaude") {
       args.push("--dangerously-skip-permissions");
-    } else if (target === "codex" || target === "tcodex" || target === "codex-internal") {
+    } else if (target === "codex" || target === "tcodex") {
       args.push("--dangerously-bypass-approvals-and-sandbox");
     }
   }
@@ -365,7 +340,6 @@ function buildResumeRuntimeProcessSpec(
     command: migrationBinary(target, settings),
     args,
     cwd: session.projectPath || undefined,
-    env: target === "codex-internal" ? { CODEX_HOME: migrationCodexHome(homeDir, platform) } : undefined,
   };
 }
 
@@ -415,7 +389,7 @@ function buildResumeShellCommand(
   settings: AppSettings,
   opts: Required<Pick<ResumeOptions, "withCwd" | "skipPermissions" | "platform">> & { shell: ShellKind; homeDir?: string },
 ): string {
-  const spec = buildResumeRuntimeProcessSpec(session, settings, opts.skipPermissions, opts.platform, opts.homeDir ?? homedir());
+  const spec = buildResumeRuntimeProcessSpec(session, settings, opts.skipPermissions);
   return buildMigrationResumeShellCommand(spec, session.projectPath ?? "", opts.shell, opts.withCwd);
 }
 
@@ -425,28 +399,11 @@ function buildMigrationResumeShellCommand(
   shell: ShellKind,
   withCwd = true,
 ): string {
-  const codexHome = spec.env?.CODEX_HOME;
   if (shell === "cmd" && requiresEncodedCmdCommand(spec, projectPath, withCwd)) {
     return buildEncodedCmdCommand(spec, projectPath, withCwd);
   }
 
-  const invocation = buildShellCommand(spec.command, spec.args, projectPath, {
-    shell,
-    withCwd: withCwd && !spec.env?.CODEX_HOME,
-  });
-  if (!codexHome) return invocation;
-
-  if (shell === "posix") {
-    const scopedInvocation = `CODEX_HOME=${shellTokenQuote(codexHome, shell)} ${buildShellCommand(spec.command, spec.args, projectPath, { shell, withCwd: false })}`;
-    return withCwd && projectPath ? `${buildCdPrefix(projectPath, shell)}${scopedInvocation}` : scopedInvocation;
-  }
-  if (shell === "powershell") {
-    const command = buildShellCommand(spec.command, spec.args, projectPath, { shell, withCwd });
-    return `$__assHadCodexHome = Test-Path Env:CODEX_HOME; $__assCodexHome = $env:CODEX_HOME; try { $env:CODEX_HOME = ${powershellQuote(codexHome)}; ${command} } finally { if ($__assHadCodexHome) { $env:CODEX_HOME = $__assCodexHome } else { Remove-Item Env:CODEX_HOME -ErrorAction SilentlyContinue } }`;
-  }
-
-  const command = buildShellCommand(spec.command, spec.args, projectPath, { shell, withCwd });
-  return `setlocal & set "CODEX_HOME=${codexHome.replace(/"/g, '""')}" & ${command} & endlocal`;
+  return buildShellCommand(spec.command, spec.args, projectPath, { shell, withCwd });
 }
 
 function requiresEncodedCmdCommand(
@@ -454,7 +411,7 @@ function requiresEncodedCmdCommand(
   projectPath: string,
   withCwd: boolean,
 ): boolean {
-  const values = [spec.command, ...spec.args, spec.env?.CODEX_HOME, withCwd ? projectPath : undefined];
+  const values = [spec.command, ...spec.args, withCwd ? projectPath : undefined];
   // `%NAME%` is expanded by cmd.exe even inside quotes, while `!NAME!` is
   // expanded when delayed expansion is enabled by the parent shell. Embedded
   // quotes/newlines can also escape the token boundary. Avoid cmd's parser for
@@ -468,9 +425,6 @@ function buildEncodedCmdCommand(
   withCwd: boolean,
 ): string {
   const statements = ["$ErrorActionPreference = 'Stop'"];
-  if (spec.env?.CODEX_HOME) {
-    statements.push(`$env:CODEX_HOME = ${powershellQuote(spec.env.CODEX_HOME)}`);
-  }
   if (withCwd && projectPath) {
     statements.push(`Set-Location -LiteralPath ${powershellQuote(projectPath)}`);
   }
@@ -497,19 +451,18 @@ export function getResumeCommand(
   settings: AppSettings = defaultSettings,
   opts: ResumeOptions = {},
 ): string {
-  const { withCwd = true, skipPermissions = false, platform = process.platform, homeDir = homedir() } = opts;
+  const { withCwd = true, skipPermissions = false, platform = process.platform } = opts;
   const sshArgs = resolveSshArgs(opts);
   const wslDistribution = resolveWslDistribution(opts);
   const shell = localShellKind(platform, settings);
   if (wslDistribution) {
-    const spec = buildResumeRuntimeProcessSpec(session, settings, skipPermissions, "linux", homeDir);
+    const spec = buildResumeRuntimeProcessSpec(session, settings, skipPermissions);
     const innerCommand = buildMigrationResumeShellCommand(spec, session.projectPath ?? "", "posix", withCwd);
     return shell === "powershell"
       ? formatPowershellWslDisplay(wslDistribution, innerCommand)
       : formatWslDisplayCommand(wslDistribution, innerCommand, platform);
   }
-  const runtimePlatform = sshArgs ? "linux" : platform;
-  const spec = buildResumeRuntimeProcessSpec(session, settings, skipPermissions, runtimePlatform, homeDir);
+  const spec = buildResumeRuntimeProcessSpec(session, settings, skipPermissions);
   if (sshArgs) {
     // The remote command body always targets a POSIX shell; only the outer ssh
     // invocation is quoted for the local terminal (cmd carets vs PowerShell).
@@ -720,7 +673,7 @@ export function getResumeProcessSpec(
   const sshArgs = resolveSshArgs(opts);
   const wslDistribution = resolveWslDistribution(opts);
   if (wslDistribution) {
-    const spec = buildResumeRuntimeProcessSpec(session, settings, skipPermissions, "linux", homeDir);
+    const spec = buildResumeRuntimeProcessSpec(session, settings, skipPermissions);
     const innerCommand = buildMigrationResumeShellCommand(spec, session.projectPath ?? "", "posix", true);
     return {
       command: "wsl.exe",
@@ -734,8 +687,7 @@ export function getResumeProcessSpec(
       }),
     };
   }
-  const runtimePlatform = sshArgs ? "linux" : platform;
-  const spec = buildResumeRuntimeProcessSpec(session, settings, skipPermissions, runtimePlatform, homeDir);
+  const spec = buildResumeRuntimeProcessSpec(session, settings, skipPermissions);
 
   if (sshArgs) {
     const innerCommand = buildMigrationResumeShellCommand(spec, session.projectPath ?? "", "posix", true);
@@ -768,14 +720,10 @@ export function getMigrationResumeProcessSpec(
 ): ResumeProcessSpec {
   const platform = options.platform ?? process.platform;
   const shell = localShellKind(platform, settings);
-  const env = target === "codex-internal"
-    ? { CODEX_HOME: migrationCodexHome(options.homeDir ?? homedir(), platform) }
-    : undefined;
   const spec = {
     command: migrationBinary(target, settings),
     args: migrationResumeArgs(target, sessionId),
     cwd: projectPath || undefined,
-    env,
   };
   const commands = buildMigrationResumeCommands(spec, projectPath, true);
   const displayCommand = shell === "powershell" ? commands.powershell : shell === "cmd" ? commands.cmd : commands.posix;
@@ -796,26 +744,19 @@ export function getSafeMigrationResumeCommand(
   const platform = options.platform ?? process.platform;
   const command = migrationBinary(target, settings);
   const args = migrationResumeArgs(target, sessionId);
-  const codexHome = target === "codex-internal"
-    ? migrationCodexHome(options.homeDir ?? homedir(), platform)
-    : null;
 
   if (platform !== "win32") {
     const invocation = [safePosixMigrationToken(command), ...args.map(safePosixMigrationToken)].join(" ");
-    const scoped = codexHome ? `CODEX_HOME=${safePosixMigrationToken(codexHome)} ${invocation}` : invocation;
-    return projectPath ? `cd ${safePosixMigrationToken(projectPath)} && ${scoped}` : scoped;
+    return projectPath ? `cd ${safePosixMigrationToken(projectPath)} && ${invocation}` : invocation;
   }
 
   if (settings.defaultTerminal === "PowerShell") {
     const invocation = `& ${[command, ...args].map(safePowerShellMigrationToken).join(" ")}`;
-    const located = projectPath ? `Set-Location -LiteralPath ${safePowerShellMigrationToken(projectPath)}; ${invocation}` : invocation;
-    if (!codexHome) return located;
-    return `$__assHadCodexHome = Test-Path Env:CODEX_HOME; $__assCodexHome = $env:CODEX_HOME; try { $env:CODEX_HOME = ${safePowerShellMigrationToken(codexHome)}; ${located} } finally { if ($__assHadCodexHome) { $env:CODEX_HOME = $__assCodexHome } else { Remove-Item Env:CODEX_HOME -ErrorAction SilentlyContinue } }`;
+    return projectPath ? `Set-Location -LiteralPath ${safePowerShellMigrationToken(projectPath)}; ${invocation}` : invocation;
   }
 
-  if ([command, ...args, projectPath, codexHome].some((value) => value != null && /[%!"\r\n&|<>^]/.test(value))) {
+  if ([command, ...args, projectPath].some((value) => value != null && /[%!"\r\n&|<>^]/.test(value))) {
     const statements = ["$ErrorActionPreference = 'Stop'"];
-    if (codexHome) statements.push(`$env:CODEX_HOME = ${safePowerShellMigrationToken(codexHome)}`);
     if (projectPath) statements.push(`Set-Location -LiteralPath ${safePowerShellMigrationToken(projectPath)}`);
     statements.push(`& ${[command, ...args].map(safePowerShellMigrationToken).join(" ")}`);
     const encoded = Buffer.from(statements.join("; "), "utf16le").toString("base64");
@@ -823,10 +764,7 @@ export function getSafeMigrationResumeCommand(
   }
 
   const invocation = [command, ...args].map(safeCmdMigrationToken).join(" ");
-  const located = projectPath ? `cd /d ${safeCmdMigrationToken(projectPath)} && ${invocation}` : invocation;
-  return codexHome
-    ? `setlocal & set "CODEX_HOME=${codexHome.replace(/[%!"]/g, (value) => value === "%" ? "%%" : value === "!" ? "^!" : '""')}" & ${located} & endlocal`
-    : located;
+  return projectPath ? `cd /d ${safeCmdMigrationToken(projectPath)} && ${invocation}` : invocation;
 }
 
 function safePosixMigrationToken(value: string): string {
@@ -1413,13 +1351,9 @@ export async function inspectMigrationCli(
     }
     return;
   }
-  const platform = options.platform ?? process.platform;
-  const env = target === "codex-internal"
-    ? { CODEX_HOME: migrationCodexHome(options.homeDir ?? homedir(), platform) }
-    : undefined;
   let versionOutput: string;
   try {
-    versionOutput = await runner(binary, ["--version"], env);
+    versionOutput = await runner(binary, ["--version"]);
   } catch (error) {
     throw new Error(migrationCliVersionErrorMessage(target, binary, error));
   }

--- a/src/core/session-loader.test.ts
+++ b/src/core/session-loader.test.ts
@@ -645,8 +645,8 @@ describe("Codex session loading", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("loads Codex internal sessions with a separate source and session key namespace", () => {
-    const codexDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-codex-internal-"));
+  it("loads TCodex sessions with a separate source and session key namespace", () => {
+    const codexDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-tcodex-"));
     const sessionDir = path.join(codexDir, "sessions", "2026", "06", "01");
     fs.mkdirSync(sessionDir, { recursive: true });
     fs.writeFileSync(
@@ -655,7 +655,7 @@ describe("Codex session loading", () => {
         JSON.stringify({
           type: "session_meta",
           timestamp: "2026-06-01T10:00:00Z",
-          payload: { id: "codex-internal-1", cwd: "/internal", git: { branch: "feat/internal" } },
+          payload: { id: "tcodex-1", cwd: "/internal", git: { branch: "feat/internal" } },
         }),
         JSON.stringify({
           type: "response_item",
@@ -665,13 +665,13 @@ describe("Codex session loading", () => {
       ].join("\n"),
     );
 
-    const loaded = loadCodexSessions(codexDir, "codex-internal");
+    const loaded = loadCodexSessions(codexDir, "tcodex-cli");
 
     expect(loaded).toHaveLength(1);
     expect(loaded[0].session).toMatchObject({
-      sessionKey: "codex-internal:codex-internal-1",
-      rawId: "codex-internal-1",
-      source: "codex-internal",
+      sessionKey: "tcodex:tcodex-1",
+      rawId: "tcodex-1",
+      source: "tcodex-cli",
       projectPath: "/internal",
       gitBranch: "feat/internal",
     });
@@ -731,11 +731,11 @@ describe("Claude session loading", () => {
           message: { role: "user", content: "真实问题" },
         },
       ],
-      { rawId: "claude-title", source: "claude-internal" },
+      { rawId: "claude-title", source: "tclaude-cli" },
     );
 
     expect(loaded?.session).toMatchObject({
-      source: "claude-internal",
+      source: "tclaude-cli",
       originalTitle: "Claude 标题 ✨",
     });
     expect(loaded?.messages.map((message) => message.content)).toEqual(["真实问题"]);
@@ -781,31 +781,31 @@ describe("Claude session loading", () => {
     fs.rmSync(claudeDir, { recursive: true, force: true });
   });
 
-  it("loads Claude internal sessions with a separate source and session key namespace", () => {
-    const claudeDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-claude-internal-"));
+  it("loads TClaude sessions with a separate source and session key namespace", () => {
+    const claudeDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-tclaude-"));
     const projectDir = path.join(claudeDir, "projects", "-repo");
     fs.mkdirSync(projectDir, { recursive: true });
     fs.writeFileSync(
-      path.join(projectDir, "claude-internal-1.jsonl"),
+      path.join(projectDir, "tclaude-1.jsonl"),
       [
         JSON.stringify({
           type: "user",
           timestamp: "2026-06-01T10:00:00Z",
           cwd: "/repo",
-          sessionId: "claude-internal-1",
+          sessionId: "tclaude-1",
           gitBranch: "feat/internal",
           message: { role: "user", content: "内部 Claude 会话" },
         }),
       ].join("\n"),
     );
 
-    const loaded = loadClaudeCliSessions(claudeDir, "claude-internal");
+    const loaded = loadClaudeCliSessions(claudeDir, "tclaude-cli");
 
     expect(loaded).toHaveLength(1);
     expect(loaded[0].session).toMatchObject({
-      sessionKey: "claude-internal:claude-internal-1",
-      rawId: "claude-internal-1",
-      source: "claude-internal",
+      sessionKey: "tclaude:tclaude-1",
+      rawId: "tclaude-1",
+      source: "tclaude-cli",
       projectPath: "/repo",
       gitBranch: "feat/internal",
     });

--- a/src/core/session-loader.ts
+++ b/src/core/session-loader.ts
@@ -25,8 +25,6 @@ const require = createRequire(import.meta.url);
 const { DatabaseSync } = require("node:sqlite") as { DatabaseSync: new (path: string, options?: { readOnly?: boolean }) => import("node:sqlite").DatabaseSync };
 
 const CODEX_APP_ORIGINATORS = new Set(["Codex Desktop", "codex_work_desktop"]);
-const CLAUDE_INTERNAL_DIR = ".claude-internal";
-const CODEX_INTERNAL_DIR = ".codex-internal";
 const TCLAUDE_DIR = ".tclaude";
 const TCODEX_DIR = ".tcodex";
 const CODEBUDDY_DIR = ".codebuddy";
@@ -36,8 +34,6 @@ const TRAE_DIR_NAMES = [".trae", ".trae-cn"] as const;
 
 export interface SessionLoadOptions {
   homeDir?: string;
-  includeClaudeInternal?: boolean;
-  includeCodexInternal?: boolean;
   includeTclaude?: boolean;
   includeTcodex?: boolean;
   includeCodeBuddyCli?: boolean;
@@ -765,7 +761,7 @@ function firstClaudeGitBranch(rows: unknown[]): string | null {
 }
 
 function createIndexedSession(input: {
-  keyPrefix: "claude" | "codex" | "claude-internal" | "codex-internal" | "tclaude" | "tcodex" | "codebuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder";
+  keyPrefix: "claude" | "codex" | "tclaude" | "tcodex" | "codebuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder";
   rawId: string;
   source: SessionSource;
   projectPath: string;
@@ -856,7 +852,7 @@ export function loadCodexSessionRows(
   const question = firstQuestion(messages);
   const source: SessionSource = options.sourceOverride || (CODEX_APP_ORIGINATORS.has(meta.originator || "") ? "codex-app" : "codex-cli");
   const session = createIndexedSession({
-    keyPrefix: source === "codex-internal" ? "codex-internal" : source === "tcodex-cli" ? "tcodex" : "codex",
+    keyPrefix: source === "tcodex-cli" ? "tcodex" : "codex",
     rawId: meta.id,
     source,
     projectPath: meta.projectPath,
@@ -967,7 +963,7 @@ export function loadClaudeCliSessionRows(
   const gitBranch = firstClaudeGitBranch(rows);
   return {
     session: createIndexedSession({
-      keyPrefix: options.source === "claude-internal" ? "claude-internal" : options.source === "tclaude-cli" ? "tclaude" : "claude",
+      keyPrefix: options.source === "tclaude-cli" ? "tclaude" : "claude",
       rawId,
       source: options.source ?? "claude-cli",
       projectPath: options.cwd || embeddedCwd || "",
@@ -2522,8 +2518,6 @@ export function* loadDefaultSessionsIterator(options: SessionLoadOptions = {}): 
     for (const dirName of TRAE_DIR_NAMES) yield* loadTraeSessionsIterator(path.join(homeDir, dirName), options);
   }
   if (options.includeQoder) yield* loadQoderSessionsIterator(path.join(homeDir, QODER_DIR), options);
-  if (options.includeClaudeInternal) yield* loadClaudeCliSessionsIterator(path.join(homeDir, CLAUDE_INTERNAL_DIR), "claude-internal", options);
-  if (options.includeCodexInternal) yield* loadCodexSessionsIterator(path.join(homeDir, CODEX_INTERNAL_DIR), "codex-internal", options);
   if (options.includeTclaude) yield* loadClaudeCliSessionsIterator(path.join(homeDir, TCLAUDE_DIR), "tclaude-cli", options);
   if (options.includeTcodex) yield* loadCodexSessionsIterator(path.join(homeDir, TCODEX_DIR), "tcodex-cli", options);
   if (options.includeCodeBuddyCli) yield* loadCodeBuddyCliSessionsIterator(path.join(homeDir, CODEBUDDY_DIR), options);

--- a/src/core/session-migration-writers.test.ts
+++ b/src/core/session-migration-writers.test.ts
@@ -31,10 +31,8 @@ const NOW = new Date("2026-06-23T06:07:08.901Z");
 const TARGETS = [
   { target: "claude", root: ".claude", source: "claude-cli", family: "claude" },
   { target: "tclaude", root: ".tclaude", source: "tclaude-cli", family: "claude" },
-  { target: "claude-internal", root: ".claude-internal", source: "claude-internal", family: "claude" },
   { target: "codex", root: ".codex", source: "codex-cli", family: "codex" },
   { target: "tcodex", root: ".tcodex", source: "tcodex-cli", family: "codex" },
-  { target: "codex-internal", root: ".codex-internal", source: "codex-internal", family: "codex" },
   { target: "codebuddy", root: ".codebuddy", source: "codebuddy-cli", family: "codebuddy" },
   { target: "cursor", root: ".cursor", source: "cursor-agent", family: "cursor" },
 ] as const satisfies readonly {
@@ -124,7 +122,7 @@ function loadWrittenSession(
       : undefined;
     return loadCursorTranscriptFile(filePath, undefined, workspacePathMap);
   }
-  if (target === "codex" || target === "tcodex" || target === "codex-internal") {
+  if (target === "codex" || target === "tcodex") {
     return loadCodexSessionRows(filePath, rows, { sourceOverride: source });
   }
   return loadClaudeCliSessionRows(filePath, rows, { source });
@@ -283,7 +281,6 @@ describe("writeMigratedSession", () => {
   it.each([
     ["codex", "openai"],
     ["tcodex", "tencent"],
-    ["codex-internal", "openai"],
   ] as const)("writes the resumable $target model provider", async (target, modelProvider) => {
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), `migration-writer-provider-${target}-`));
     try {
@@ -305,7 +302,6 @@ describe("writeMigratedSession", () => {
   it.each([
     ["codex", ".codex"],
     ["tcodex", ".tcodex"],
-    ["codex-internal", ".codex-internal"],
   ] as const)("updates the native session index for $target", async (target, root) => {
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), `migration-writer-index-${target}-`));
     try {
@@ -435,7 +431,6 @@ describe("writeMigratedSession", () => {
   it.each([
     ["codex", ".codex", "custom-codex"],
     ["tcodex", ".tcodex", "custom-tcodex"],
-    ["codex-internal", ".codex-internal", "custom-codex-internal"],
   ] as const)("uses the active provider from the $target config", async (target, root, modelProvider) => {
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), `migration-writer-configured-provider-${target}-`));
     try {
@@ -463,7 +458,7 @@ describe("writeMigratedSession", () => {
   it("ignores profile-scoped Codex providers when no active provider is configured", async () => {
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "migration-writer-profile-provider-"));
     try {
-      const targetHome = path.join(homeDir, ".codex-internal");
+      const targetHome = path.join(homeDir, ".codex");
       fs.mkdirSync(targetHome, { recursive: true });
       fs.writeFileSync(
         path.join(targetHome, "config.toml"),
@@ -471,7 +466,7 @@ describe("writeMigratedSession", () => {
       );
 
       const result = await writeMigratedSession({
-        target: "codex-internal",
+        target: "codex",
         session: portable(),
         homeDir,
         now: NOW,
@@ -580,7 +575,6 @@ describe("writeMigratedSession", () => {
   it.each([
     ["claude", ".claude", "configured-claude-model"],
     ["tclaude", ".tclaude", "configured-tclaude-model"],
-    ["claude-internal", ".claude-internal", "configured-claude-internal-model"],
   ] as const)("uses the routed model from the $target settings", async (target, root, model) => {
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), `migration-writer-configured-model-${target}-`));
     try {
@@ -631,12 +625,12 @@ describe("writeMigratedSession", () => {
   it("falls back when the Claude settings are malformed", async () => {
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "migration-writer-malformed-claude-settings-"));
     try {
-      const targetHome = path.join(homeDir, ".claude-internal");
+      const targetHome = path.join(homeDir, ".claude");
       fs.mkdirSync(targetHome, { recursive: true });
       fs.writeFileSync(path.join(targetHome, "settings.json"), "{\n");
 
       const result = await writeMigratedSession({
-        target: "claude-internal",
+        target: "claude",
         session: portable(),
         homeDir,
         now: NOW,
@@ -845,7 +839,7 @@ async function expectTamperedSessionRejected(
         session: portable(),
         homeDir,
         now: NOW,
-        idFactory: idFactory(target === "codex" || target === "tcodex" || target === "codex-internal" || target === "cursor"
+        idFactory: idFactory(target === "codex" || target === "tcodex" || target === "cursor"
           ? [SESSION_ID]
           : [SESSION_ID, ...MESSAGE_IDS]),
         beforeValidate: (filePath) => {

--- a/src/core/session-migration-writers.ts
+++ b/src/core/session-migration-writers.ts
@@ -488,10 +488,8 @@ export function targetFilePathForRemoteEnvironment(
 const TARGET_ROOTS: Record<MigrationTarget, string> = {
   claude: ".claude",
   tclaude: ".tclaude",
-  "claude-internal": ".claude-internal",
   codex: ".codex",
   tcodex: ".tcodex",
-  "codex-internal": ".codex-internal",
   codebuddy: ".codebuddy",
   codewiz: path.join(".local", "share", "codewiz"),
   cursor: ".cursor",

--- a/src/core/session-migration.test.ts
+++ b/src/core/session-migration.test.ts
@@ -175,11 +175,9 @@ describe("session migration model", () => {
   it.each([
     ["claude-cli", "claude"],
     ["claude-app", "claude"],
-    ["claude-internal", "claude"],
     ["tclaude-cli", "claude"],
     ["codex-cli", "codex"],
     ["codex-app", "codex"],
-    ["codex-internal", "codex"],
     ["tcodex-cli", "codex"],
     ["codebuddy-cli", "codebuddy"],
     ["codewiz-cli", "codewiz"],
@@ -197,11 +195,9 @@ describe("session migration model", () => {
   it.each([
     "claude-cli",
     "claude-app",
-    "claude-internal",
     "tclaude-cli",
     "codex-cli",
     "codex-app",
-    "codex-internal",
     "tcodex-cli",
     "codebuddy-cli",
     "codewiz-cli",
@@ -214,8 +210,6 @@ describe("session migration model", () => {
       "cursor",
       "tclaude",
       "tcodex",
-      "claude-internal",
-      "codex-internal",
     ] as const satisfies readonly MigrationTarget[];
 
     expect(supportedMigrationTargets(source, enabledTargets)).toEqual(enabledTargets);
@@ -316,17 +310,17 @@ describe("migrateSession", () => {
     const result = await migrateSession({
       source: session("tclaude-cli"),
       messages,
-      target: "codex-internal",
+      target: "tcodex",
       deps,
     });
 
-    expect(result.target).toBe("codex-internal");
-    expect(inspectCli).toHaveBeenCalledWith("codex-internal");
-    expect(write).toHaveBeenCalledWith("codex-internal", expect.objectContaining({ sourceAgent: "claude" }));
-    expect(refreshIndex).toHaveBeenCalledWith("codex-internal", "/tmp/target-session-1.jsonl", "target-session-1");
-    expect(launch).toHaveBeenCalledWith("codex-internal", "target-session-1", "/repo");
+    expect(result.target).toBe("tcodex");
+    expect(inspectCli).toHaveBeenCalledWith("tcodex");
+    expect(write).toHaveBeenCalledWith("tcodex", expect.objectContaining({ sourceAgent: "claude" }));
+    expect(refreshIndex).toHaveBeenCalledWith("tcodex", "/tmp/target-session-1.jsonl", "target-session-1");
+    expect(launch).toHaveBeenCalledWith("tcodex", "target-session-1", "/repo");
     expect(seenRecords).toEqual([
-      expect.objectContaining({ sourceAgent: "claude", targetAgent: "codex-internal" }),
+      expect.objectContaining({ sourceAgent: "claude", targetAgent: "tcodex" }),
     ]);
   });
 

--- a/src/core/session-sources.test.ts
+++ b/src/core/session-sources.test.ts
@@ -11,10 +11,8 @@ import type { SessionSource } from "./types";
 const ALL_SOURCES = [
   "claude-cli",
   "claude-app",
-  "claude-internal",
   "codex-cli",
   "codex-app",
-  "codex-internal",
   "tclaude-cli",
   "tcodex-cli",
   "codebuddy-cli",
@@ -48,8 +46,6 @@ describe("session source capability registry", () => {
 
   it("owns optional settings, live families, portable agents, and remote collector gates", () => {
     expect(OPTIONAL_SESSION_SOURCE_DESCRIPTORS.map(({ optionalSetting }) => optionalSetting)).toEqual([
-      "includeClaudeInternal",
-      "includeCodexInternal",
       "includeTclaude",
       "includeTcodex",
       "includeCodeBuddyCli",

--- a/src/core/session-sources.ts
+++ b/src/core/session-sources.ts
@@ -1,8 +1,6 @@
 import type { LiveSessionFamily, MigrationAgent, MigrationTarget, SessionFormat, SessionSource } from "./types";
 
 export type OptionalSessionSourceSetting =
-  | "includeClaudeInternal"
-  | "includeCodexInternal"
   | "includeTclaude"
   | "includeTcodex"
   | "includeCodeBuddyCli"
@@ -77,11 +75,6 @@ export const SESSION_SOURCE_REGISTRY = {
     optionalSetting: null, pendingKey: null, remoteCollectorOptional: false, liveFamily: "claude", migrationAgent: "claude",
     resumeTarget: "claude", remoteFamily: "claude", nativeAppFamily: "claude", capabilities: fullCapabilities(),
   },
-  "claude-internal": {
-    id: "claude-internal", label: "Claude Code Internal", format: "claude", family: "claude", uiFamily: "claude", statsGroup: null,
-    optionalSetting: "includeClaudeInternal", pendingKey: "claude", remoteCollectorOptional: false, liveFamily: "claude", migrationAgent: "claude",
-    resumeTarget: "claude-internal", remoteFamily: "claude", nativeAppFamily: "claude", capabilities: fullCapabilities(),
-  },
   "codex-cli": {
     id: "codex-cli", label: "Codex", format: "codex", family: "codex", uiFamily: "codex", statsGroup: "codex",
     optionalSetting: null, pendingKey: null, remoteCollectorOptional: false, liveFamily: "codex", migrationAgent: "codex",
@@ -91,11 +84,6 @@ export const SESSION_SOURCE_REGISTRY = {
     id: "codex-app", label: "Codex", format: "codex", family: "codex", uiFamily: "codex", statsGroup: "codex",
     optionalSetting: null, pendingKey: null, remoteCollectorOptional: false, liveFamily: "codex", migrationAgent: "codex",
     resumeTarget: "codex", remoteFamily: "codex", nativeAppFamily: "codex", capabilities: fullCapabilities(),
-  },
-  "codex-internal": {
-    id: "codex-internal", label: "Codex Internal", format: "codex", family: "codex", uiFamily: "codex", statsGroup: null,
-    optionalSetting: "includeCodexInternal", pendingKey: "codex", remoteCollectorOptional: false, liveFamily: "codex", migrationAgent: "codex",
-    resumeTarget: "codex-internal", remoteFamily: "codex", nativeAppFamily: "codex", capabilities: fullCapabilities(),
   },
   "tclaude-cli": {
     id: "tclaude-cli", label: "TClaude", format: "claude", family: "tclaude", uiFamily: "other", statsGroup: null,

--- a/src/core/session-store.test.ts
+++ b/src/core/session-store.test.ts
@@ -1494,12 +1494,12 @@ describe("SessionStore", () => {
     const store = createInMemoryStore();
     store.upsertIndexedSession(sampleSession({ sessionKey: "claude:regular", rawId: "regular", source: "claude-cli" }), messages);
     store.upsertIndexedSession(
-      sampleSession({ sessionKey: "claude-internal:internal", rawId: "internal", source: "claude-internal" }),
+      sampleSession({ sessionKey: "tclaude:personal", rawId: "personal", source: "tclaude-cli" }),
       messages,
     );
     store.upsertIndexedSession(sampleSession({ sessionKey: "codex:regular", rawId: "codex-regular", source: "codex-cli" }), messages);
     store.upsertIndexedSession(
-      sampleSession({ sessionKey: "codex-internal:internal", rawId: "codex-internal", source: "codex-internal" }),
+      sampleSession({ sessionKey: "tcodex:personal", rawId: "codex-personal", source: "tcodex-cli" }),
       messages,
     );
     store.upsertIndexedSession(
@@ -1509,23 +1509,23 @@ describe("SessionStore", () => {
 
     expect(store.searchSessions({ source: "claude" }).map((session) => session.source)).toEqual(["claude-cli"]);
     expect(store.searchSessions({ source: "codex" }).map((session) => session.source)).toEqual(["codex-cli"]);
-    expect(store.searchSessions({ source: "claude-internal" }).map((session) => session.sessionKey)).toEqual(["claude-internal:internal"]);
-    expect(store.searchSessions({ source: "codex-internal" }).map((session) => session.sessionKey)).toEqual(["codex-internal:internal"]);
+    expect(store.searchSessions({ source: "tclaude-cli" }).map((session) => session.sessionKey)).toEqual(["tclaude:personal"]);
+    expect(store.searchSessions({ source: "tcodex-cli" }).map((session) => session.sessionKey)).toEqual(["tcodex:personal"]);
     expect(store.searchSessions({ source: "codebuddy-cli" }).map((session) => session.sessionKey)).toEqual(["codebuddy:regular"]);
   });
 
   it("deletes indexed sessions by source and removes unused tags", () => {
     const store = createInMemoryStore();
-    store.upsertIndexedSession(sampleSession({ sessionKey: "claude-internal:one", rawId: "one", source: "claude-internal" }), messages);
-    store.addTag("claude-internal:one", "internal");
+    store.upsertIndexedSession(sampleSession({ sessionKey: "tclaude:one", rawId: "one", source: "tclaude-cli" }), messages);
+    store.addTag("tclaude:one", "personal");
     store.upsertIndexedSession(sampleSession({ sessionKey: "codebuddy:one", rawId: "codebuddy-one", source: "codebuddy-cli" }), messages);
     store.addTag("codebuddy:one", "codebuddy");
     store.upsertIndexedSession(sampleSession({ sessionKey: "zcode:one", rawId: "zcode-one", source: "zcode-cli" }), messages);
     store.addTag("zcode:one", "zcode");
 
-    store.deleteSessionsBySource(["claude-internal", "codebuddy-cli", "zcode-cli"]);
+    store.deleteSessionsBySource(["tclaude-cli", "codebuddy-cli", "zcode-cli"]);
 
-    expect(store.searchSessions({ source: "claude-internal" })).toEqual([]);
+    expect(store.searchSessions({ source: "tclaude-cli" })).toEqual([]);
     expect(store.searchSessions({ source: "codebuddy-cli" })).toEqual([]);
     expect(store.searchSessions({ source: "zcode-cli" })).toEqual([]);
     expect(store.listTags()).toEqual([]);

--- a/src/core/store/schema.test.ts
+++ b/src/core/store/schema.test.ts
@@ -356,4 +356,42 @@ describe("session store schema", () => {
       db.close();
     }
   });
+
+  it("removes claude-internal and codex-internal sessions, their FTS rows, and orphaned tags exactly once", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      migrateSessionStore(db);
+      db.prepare("DELETE FROM data_migrations WHERE id = 'remove-claude-codex-internal-sources-v1'").run();
+      const insert = db.prepare(`
+        INSERT INTO sessions (
+          session_key, raw_id, source, project_path, file_path,
+          original_title, first_question, timestamp, file_mtime_ms, file_size
+        ) VALUES (?, ?, ?, '/repo', ?, 'Title', 'Question', 1, ?, 10)
+      `);
+      insert.run("claude-internal:one", "one", "claude-internal", "/tmp/claude-internal.jsonl", 123);
+      insert.run("codex-internal:two", "two", "codex-internal", "/tmp/codex-internal.jsonl", 456);
+      insert.run("claude:unchanged", "unchanged", "claude-cli", "/tmp/claude.jsonl", 789);
+      db.prepare(
+        "INSERT INTO session_fts (session_key, title, first_question, content_text, project_path) VALUES ('claude-internal:one', 'Title', 'Question', '', '/repo')",
+      ).run();
+      db.prepare("INSERT INTO tags (name) VALUES ('only-on-internal')").run();
+      const orphanTag = db.prepare("SELECT id FROM tags WHERE name = 'only-on-internal'").get() as { id: number };
+      db.prepare("INSERT INTO session_tags (session_key, tag_id) VALUES ('claude-internal:one', ?)").run(orphanTag.id);
+      db.prepare("INSERT INTO tags (name) VALUES ('shared')").run();
+      const sharedTag = db.prepare("SELECT id FROM tags WHERE name = 'shared'").get() as { id: number };
+      db.prepare("INSERT INTO session_tags (session_key, tag_id) VALUES ('claude:unchanged', ?)").run(sharedTag.id);
+
+      migrateSessionStore(db);
+
+      expect(db.prepare("SELECT session_key FROM sessions WHERE source IN ('claude-internal', 'codex-internal')").all()).toEqual([]);
+      expect(db.prepare("SELECT 1 FROM session_fts WHERE session_key = 'claude-internal:one'").get()).toBeUndefined();
+      expect(db.prepare("SELECT name FROM tags WHERE name = 'only-on-internal'").get()).toBeUndefined();
+      expect(db.prepare("SELECT name FROM tags WHERE name = 'shared'").get()).toEqual({ name: "shared" });
+      expect(db.prepare("SELECT session_key FROM sessions WHERE session_key = 'claude:unchanged'").get()).toEqual({
+        session_key: "claude:unchanged",
+      });
+    } finally {
+      db.close();
+    }
+  });
 });

--- a/src/core/store/schema.ts
+++ b/src/core/store/schema.ts
@@ -281,7 +281,7 @@ export function migrateSessionStore(db: SessionStoreDatabase): void {
   if (addedSubagentColumn) {
     db
       .prepare(
-        "UPDATE sessions SET file_mtime_ms = 0 WHERE source IN ('claude-cli', 'claude-app', 'claude-internal', 'tclaude-cli', 'codex-cli', 'codex-app', 'codex-internal', 'tcodex-cli')",
+        "UPDATE sessions SET file_mtime_ms = 0 WHERE source IN ('claude-cli', 'claude-app', 'tclaude-cli', 'codex-cli', 'codex-app', 'tcodex-cli')",
       )
       .run();
   }
@@ -292,6 +292,7 @@ export function migrateSessionStore(db: SessionStoreDatabase): void {
   runCursorComposerMetadataMigration(db);
   runCursorRuntimeEnvironmentMigration(db);
   runCursorEmptyComposerShellsMigration(db);
+  runRemoveClaudeCodexInternalSourcesMigration(db);
   addColumnIfMissing(db, "skill_sync_bindings", "remote_version", "INTEGER NOT NULL DEFAULT 1");
   addColumnIfMissing(db, "skill_sync_bindings", "portable_identity", "TEXT NOT NULL DEFAULT ''");
   addColumnIfMissing(db, "skill_sync_bindings", "last_content_hash", "TEXT NOT NULL DEFAULT ''");
@@ -359,11 +360,9 @@ function runSessionRelationBranchMetadataMigration(db: SessionStoreDatabase): vo
   const reparsedSources = [
     "claude-cli",
     "claude-app",
-    "claude-internal",
     "tclaude-cli",
     "codex-cli",
     "codex-app",
-    "codex-internal",
     "tcodex-cli",
   ];
   const placeholders = reparsedSources.map(() => "?").join(", ");
@@ -497,6 +496,34 @@ function runCursorEmptyComposerShellsMigration(db: SessionStoreDatabase): void {
   }
 }
 
+
+// claude-internal / codex-internal support was removed; delete any sessions
+// indexed from those internal-tooling sources along with their FTS rows and
+// any tags left orphaned once those sessions are gone.
+function runRemoveClaudeCodexInternalSourcesMigration(db: SessionStoreDatabase): void {
+  const migrationId = "remove-claude-codex-internal-sources-v1";
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    const applied = db.prepare("SELECT 1 FROM data_migrations WHERE id = ?").get(migrationId);
+    if (!applied) {
+      db.prepare(
+        `
+          DELETE FROM session_fts
+          WHERE session_key IN (
+            SELECT session_key FROM sessions WHERE source IN ('claude-internal', 'codex-internal')
+          )
+        `,
+      ).run();
+      db.prepare("DELETE FROM sessions WHERE source IN ('claude-internal', 'codex-internal')").run();
+      db.prepare("DELETE FROM tags WHERE NOT EXISTS (SELECT 1 FROM session_tags WHERE session_tags.tag_id = tags.id)").run();
+      db.prepare("INSERT INTO data_migrations (id, applied_at) VALUES (?, ?)").run(migrationId, Date.now());
+    }
+    db.exec("COMMIT");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    throw error;
+  }
+}
 
 function upgradeFtsTokenizer(db: SessionStoreDatabase): void {
   const row = db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='session_fts'").get() as

--- a/src/core/store/sessions.ts
+++ b/src/core/store/sessions.ts
@@ -38,8 +38,8 @@ import { deleteZcodeSession } from "../zcode-session-writer";
 
 const LIVE_SESSION_KEY_SQL = `
   CASE
-    WHEN source IN ('claude-cli', 'claude-app', 'claude-internal') THEN 'claude:' || raw_id
-    WHEN source IN ('codex-cli', 'codex-app', 'codex-internal') THEN 'codex:' || raw_id
+    WHEN source IN ('claude-cli', 'claude-app') THEN 'claude:' || raw_id
+    WHEN source IN ('codex-cli', 'codex-app') THEN 'codex:' || raw_id
     WHEN source = 'tclaude-cli' THEN 'tclaude:' || raw_id
     WHEN source = 'tcodex-cli' THEN 'tcodex:' || raw_id
     WHEN source = 'codebuddy-cli' THEN 'codebuddy:' || raw_id

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,10 +1,8 @@
 export type SessionSource =
   | "claude-cli"
   | "claude-app"
-  | "claude-internal"
   | "codex-cli"
   | "codex-app"
-  | "codex-internal"
   | "tclaude-cli"
   | "tcodex-cli"
   | "codebuddy-cli"
@@ -87,7 +85,7 @@ export interface SessionMessageEvent {
 }
 
 export type MigrationAgent = "claude" | "codex" | "codebuddy" | "codewiz" | "cursor";
-export type MigrationTarget = MigrationAgent | "tclaude" | "tcodex" | "claude-internal" | "codex-internal";
+export type MigrationTarget = MigrationAgent | "tclaude" | "tcodex";
 export type SessionMigrationStrategy = "complete" | "ai-compressed" | "locally-truncated";
 export type SessionMigrationStage = "reading" | "compressing" | "writing" | "indexing" | "launching";
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1053,8 +1053,6 @@ async function runIndexSync(): Promise<IndexStatus> {
     batchSize: 50,
     timeBudgetMs: 8,
     loadOptions: {
-      includeClaudeInternal: settings.includeClaudeInternal,
-      includeCodexInternal: settings.includeCodexInternal,
       includeTclaude: settings.includeTclaude,
       includeTcodex: settings.includeTcodex,
       includeCodeBuddyCli: settings.includeCodeBuddyCli,
@@ -2068,7 +2066,7 @@ function registerIpc(): void {
     if (!exportPath) return { exported: false };
 
     let codexRequest: CodexRequestExport | null = null;
-    const isCodexSession = ["codex-cli", "codex-app", "codex-internal", "tcodex-cli"].includes(session.source);
+    const isCodexSession = ["codex-cli", "codex-app", "tcodex-cli"].includes(session.source);
     if (isCodexSession && isLocalSessionEnvironment(session)) {
       if (format === "openai_responses") {
         codexRequest = await resolveCodexResponsesRequest({

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -142,8 +142,6 @@ const FILE_MANAGER_LABEL = IS_MAC ? "Finder" : RUNTIME_PLATFORM === "win32" ? "E
 const DEFAULT_MIGRATION_TARGET_SETTINGS = {
   includeTclaude: false,
   includeTcodex: false,
-  includeClaudeInternal: false,
-  includeCodexInternal: false,
 } satisfies MigrationTargetSettings;
 
 type ViewMode = "default" | "favorites" | "hidden";

--- a/src/renderer/src/features/settings/settings-dialog.tsx
+++ b/src/renderer/src/features/settings/settings-dialog.tsx
@@ -538,32 +538,6 @@ export function SettingsDialog({
                 </label>
                 <label className="settings-field settings-toggle">
                   <div className="settings-field-text">
-                    <span className="settings-field-title">Include ~/.claude-internal</span>
-                    <span className="settings-field-sub">{l("Indexes Claude Code Internal sessions and allows migration to that CLI.", "索引 Claude Code Internal 会话，并允许迁移到该 CLI。")}</span>
-                  </div>
-                  <input
-                    type="checkbox"
-                    className="switch"
-                    checked={Boolean(settings?.includeClaudeInternal)}
-                    disabled={!settings || saving}
-                    onChange={(event) => onSettingsChange({ includeClaudeInternal: event.currentTarget.checked })}
-                  />
-                </label>
-                <label className="settings-field settings-toggle">
-                  <div className="settings-field-text">
-                    <span className="settings-field-title">Include ~/.codex-internal</span>
-                    <span className="settings-field-sub">{l("Indexes Codex Internal sessions and allows migration to that CLI.", "索引 Codex Internal 会话，并允许迁移到该 CLI。")}</span>
-                  </div>
-                  <input
-                    type="checkbox"
-                    className="switch"
-                    checked={Boolean(settings?.includeCodexInternal)}
-                    disabled={!settings || saving}
-                    onChange={(event) => onSettingsChange({ includeCodexInternal: event.currentTarget.checked })}
-                  />
-                </label>
-                <label className="settings-field settings-toggle">
-                  <div className="settings-field-text">
                     <span className="settings-field-title">Include ~/.tclaude</span>
                     <span className="settings-field-sub">{l("Indexes TClaude CLI sessions and allows migration to that CLI.", "索引 TClaude CLI 会话，并允许迁移到该 CLI。")}</span>
                   </div>


### PR DESCRIPTION
## Summary
- 移除 Claude Code Internal / Codex Internal 可选会话来源与迁移目标，设置中对应开关一并去掉
- 启动时清理本地索引中残留的这两类会话记录
- 发版说明提示：若仍需要这两类会话，请继续使用 **v0.31.7 及更早**版本
