### PR TITLE
fix: sync AGENTS.md rules in digital assets panel

### DIFF
--- a/.release-notes/rules-agents-md.md
+++ b/.release-notes/rules-agents-md.md
@@ -1,0 +1,6 @@
+# Rules 同步支持 AGENTS.md
+
+## Bug 修复
+
+- 数字资产的 Rules 同步现在会识别 AGENTS.md：包括全局 `~/.codex/AGENTS.md`、项目根目录和子目录里的 AGENTS.md，可以像 CLAUDE.md 一样上传到云端并在另一台设备还原。
+- 老用户重跑一次 Rules 初始化 SQL 即可解锁 AGENTS.md 上传；上传遇到旧表约束时会给出明确的重跑 SQL 提示，而不是晦涩的数据库报错。

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ agent-recall
 
 - **远程同步**：配置同一个 Supabase URL 与 anon key 后，另一台设备可以搜索、查看云端会话，并恢复到 Claude Code、Codex、CodeBuddy、CodeWiz 或 Cursor；支持手动上传，也可以安装 Claude Code / Codex Hook 自动记录待同步会话。同步按个人项目设计，删除云端副本不会影响本地会话。
 - **MCP 工具**：内置 `agent-recall-mcp`，让 Claude Code、Codex、CodeBuddy 等在对话中搜索和读取历史会话，并管理标签、收藏、可见性或执行跨 Agent 迁移。
-- **Skills 与数字资产**：查看、筛选和管理本机 Codex / Claude Code Skills，并通过 Supabase 在多台机器间同步 Skills、Rules（如 `CLAUDE.md`、Qoder rules）和 Memories（Qoder / Codex 记忆）。
+- **Skills 与数字资产**：查看、筛选和管理本机 Codex / Claude Code Skills，并通过 Supabase 在多台机器间同步 Skills、Rules（如 `CLAUDE.md`、`AGENTS.md`、Qoder rules）和 Memories（Qoder / Codex 记忆）。
 
 这些能力复用应用内的同一份 Supabase 配置，适合个人跨设备使用。
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -79,7 +79,7 @@ After launch, the app stays in the menu bar or system tray; settings, theme, lan
 
 - **Remote sync**: After configuring the same Supabase URL and anon key, another device can search and view cloud sessions and restore them into Claude Code, Codex, CodeBuddy, CodeWiz, or Cursor; upload manually, or install the Claude Code / Codex hooks to record pending sessions automatically. Sync is designed for personal projects, and deleting a cloud copy never affects the local session.
 - **MCP tools**: The built-in `agent-recall-mcp` lets Claude Code, Codex, CodeBuddy, and others search and read session history in chat, manage tags, favorites, and visibility, or run cross-agent migration.
-- **Skills and digital assets**: View, filter, and manage local Codex / Claude Code Skills, and sync Skills, Rules (such as `CLAUDE.md` and Qoder rules), and Memories (Qoder / Codex memories) across machines through Supabase.
+- **Skills and digital assets**: View, filter, and manage local Codex / Claude Code Skills, and sync Skills, Rules (such as `CLAUDE.md`, `AGENTS.md`, and Qoder rules), and Memories (Qoder / Codex memories) across machines through Supabase.
 
 These capabilities share the same Supabase configuration inside the app and are designed for personal cross-device use. Setup steps and details are in the [User Guide](./guide.en.md).
 

--- a/docs/guide.en.md
+++ b/docs/guide.en.md
@@ -104,7 +104,7 @@ Supabase sync is designed for personal projects. It does not create tables autom
 
 Click the database icon in the toolbar to open the Digital Assets panel, which manages Rules and Memories sync across devices:
 
-- **Rules sync**: Scans local Claude `CLAUDE.md` (global) and Qoder `.qoder/rules/*.md` (project-level), uploads/downloads via Supabase.
+- **Rules sync**: Scans local Claude `CLAUDE.md` (global and project-level, including nested files), Codex `AGENTS.md` (global `~/.codex/AGENTS.md` and project-level, including nested files), and Qoder `.qoder/rules/*.md` (project-level), uploads/downloads via Supabase. If your rules table was created before AGENTS.md support, re-run the latest Rules setup SQL once to allow the new agent type.
 - **Memories sync**: Scans local Qoder long-term memories (`~/.qoder/memories/`) and Codex memories (`~/.codex/memories_1.sqlite`), uploads/downloads via Supabase.
 
 Each tab shows local assets (with sync status: synced / modified / not synced) and remote assets, supporting upload all, per-item upload, and remote deletion. Reuses the Supabase URL and anon key from Skills sync settings. Enable the "Rules sync" and "Memories sync" toggles in Settings to get started.

--- a/src/core/rules-sync.test.ts
+++ b/src/core/rules-sync.test.ts
@@ -68,8 +68,11 @@ describe("rules sync", () => {
   it("builds setup SQL with table, unique index, and RLS", () => {
     const sql = buildRulesSyncSetupSql();
     expect(sql).toContain("create table if not exists public.agent_recall_rules");
-    expect(sql).toContain("agent in ('claude', 'qoder')");
+    expect(sql).toContain("agent in ('claude', 'qoder', 'codex')");
     expect(sql).toContain("scope in ('global', 'project')");
+    expect(sql).toContain("drop constraint if exists agent_recall_rules_agent_check");
+    expect(sql).toContain("add constraint agent_recall_rules_agent_check");
+    expect(sql).toContain('drop policy if exists "agent_recall_rules_anon_all"');
     expect(sql).toContain("agent_recall_rules_identity_idx");
     expect(sql).toContain("(agent, scope, name, project_path)");
     expect(sql).toContain("enable row level security");
@@ -256,5 +259,72 @@ describe("rules sync", () => {
     expect(fs.readFileSync(path.join(projectDir, "packages", "core", "CLAUDE.md"), "utf8")).toBe("# New core rules from remote");
     expect(fs.readFileSync(path.join(projectDir, "packages", "core", "CLAUDE.md.bak"), "utf8")).toBe("# Old core rules");
     fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("scans global and project AGENTS.md as codex rules", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "rules-agents-scan-"));
+    const projectDir = path.join(homeDir, "my-project");
+
+    fs.mkdirSync(path.join(homeDir, ".codex"), { recursive: true });
+    fs.writeFileSync(path.join(homeDir, ".codex", "AGENTS.md"), "# Global agent rules", "utf8");
+
+    fs.mkdirSync(path.join(projectDir, "packages", "core"), { recursive: true });
+    fs.mkdirSync(path.join(projectDir, "node_modules", "dep"), { recursive: true });
+    fs.writeFileSync(path.join(projectDir, "AGENTS.md"), "# Project agent rules", "utf8");
+    fs.writeFileSync(path.join(projectDir, "packages", "core", "AGENTS.md"), "# Core agent rules", "utf8");
+    fs.writeFileSync(path.join(projectDir, "node_modules", "dep", "AGENTS.md"), "# Should be skipped", "utf8");
+
+    const rules = scanLocalRules({ homeDir, projectDirs: [projectDir] });
+    const codexRules = rules.filter((r) => r.agent === "codex");
+    expect(codexRules).toHaveLength(3);
+
+    const codexGlobal = codexRules.find((r) => r.scope === "global");
+    expect(codexGlobal).toMatchObject({ name: "AGENTS.md", projectPath: "", content: "# Global agent rules" });
+    expect(ruleIdentity(codexGlobal!)).toBe("codex:global:AGENTS.md");
+
+    const projectNames = codexRules.filter((r) => r.scope === "project").map((r) => r.name).sort();
+    expect(projectNames).toEqual(["AGENTS.md", "packages/core/AGENTS.md"]);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("keeps CLAUDE.md and AGENTS.md in the same directory as separate rules", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "rules-mixed-scan-"));
+    const projectDir = path.join(homeDir, "mixed");
+    fs.mkdirSync(path.join(projectDir, "sub"), { recursive: true });
+    fs.writeFileSync(path.join(projectDir, "sub", "CLAUDE.md"), "Claude sub", "utf8");
+    fs.writeFileSync(path.join(projectDir, "sub", "AGENTS.md"), "Agents sub", "utf8");
+
+    const rules = scanLocalRules({ homeDir, projectDirs: [projectDir] });
+    expect(rules.find((r) => r.agent === "claude" && r.name === "sub/CLAUDE.md")).toBeDefined();
+    expect(rules.find((r) => r.agent === "codex" && r.name === "sub/AGENTS.md")).toBeDefined();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("restores a global codex AGENTS.md rule to ~/.codex/AGENTS.md", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "rules-agents-restore-"));
+    const remoteRule = makeRemoteRule({ agent: "codex", name: "AGENTS.md", content: "# Restored agent rules" });
+    const result = restoreRules([remoteRule], { homeDir });
+    expect(result.restored).toEqual(["AGENTS.md"]);
+    expect(fs.readFileSync(path.join(homeDir, ".codex", "AGENTS.md"), "utf8")).toBe("# Restored agent rules");
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("suggests re-running setup SQL when upload hits the stale agent check constraint", async () => {
+    const fetchImpl = (async () =>
+      new Response(
+        JSON.stringify({ message: 'new row for relation "agent_recall_rules" violates check constraint "agent_recall_rules_agent_check"' }),
+        { status: 400 },
+      )) as typeof fetch;
+    const client = new SupabaseRulesSyncClient({ url: "https://example.supabase.co", anonKey: "anon", fetchImpl });
+    const rule: AgentRule = {
+      agent: "codex",
+      scope: "global",
+      name: "AGENTS.md",
+      content: "# Rules",
+      contentHash: "hash",
+      projectPath: "",
+      filePath: "/tmp/AGENTS.md",
+    };
+    await expect(client.uploadRule(rule)).rejects.toThrow(/Re-run the latest Rules setup SQL/);
   });
 });

--- a/src/core/rules-sync.ts
+++ b/src/core/rules-sync.ts
@@ -8,7 +8,7 @@ import { assetIdentity } from "./asset-identity";
 // Types
 // ---------------------------------------------------------------------------
 
-export type RulesAgent = "claude" | "qoder";
+export type RulesAgent = "claude" | "qoder" | "codex";
 export type RulesScope = "global" | "project";
 
 export interface AgentRule {
@@ -81,6 +81,11 @@ export function scanLocalRules(options: ScanLocalRulesOptions = {}): AgentRule[]
   const claudeGlobal = readRuleFile(claudeGlobalPath, "claude", "global", "CLAUDE.md", "");
   if (claudeGlobal) rules.push(claudeGlobal);
 
+  // Codex global AGENTS.md
+  const codexGlobalPath = path.join(homeDir, ".codex", "AGENTS.md");
+  const codexGlobal = readRuleFile(codexGlobalPath, "codex", "global", "AGENTS.md", "");
+  if (codexGlobal) rules.push(codexGlobal);
+
   // Per-project rules
   for (const projectDir of projectDirs) {
     const projectBasename = path.basename(projectDir);
@@ -90,10 +95,16 @@ export function scanLocalRules(options: ScanLocalRulesOptions = {}): AgentRule[]
     const claudeProject = readRuleFile(claudeProjectPath, "claude", "project", "CLAUDE.md", projectBasename);
     if (claudeProject) rules.push(claudeProject);
 
-    // Nested CLAUDE.md files (name is relative path from project root)
-    for (const nested of findNestedClaudeMd(projectDir, maxDepth)) {
+    // Root-level AGENTS.md
+    const codexProjectPath = path.join(projectDir, "AGENTS.md");
+    const codexProject = readRuleFile(codexProjectPath, "codex", "project", "AGENTS.md", projectBasename);
+    if (codexProject) rules.push(codexProject);
+
+    // Nested CLAUDE.md / AGENTS.md files (name is relative path from project root)
+    for (const nested of findNestedRuleFiles(projectDir, maxDepth)) {
       const relativePath = path.relative(projectDir, nested).replace(/\\/g, "/");
-      const rule = readRuleFile(nested, "claude", "project", relativePath, projectBasename);
+      const agent = path.basename(nested) === "AGENTS.md" ? "codex" as const : "claude" as const;
+      const rule = readRuleFile(nested, agent, "project", relativePath, projectBasename);
       if (rule) rules.push(rule);
     }
 
@@ -117,10 +128,12 @@ export function scanLocalRules(options: ScanLocalRulesOptions = {}): AgentRule[]
 }
 
 /**
- * Recursively finds CLAUDE.md files in subdirectories of projectDir,
- * skipping the root (already handled) and common build/dependency dirs.
+ * Recursively finds CLAUDE.md and AGENTS.md files in subdirectories of
+ * projectDir, skipping the root (already handled) and common build/dependency dirs.
  */
-function findNestedClaudeMd(projectDir: string, maxDepth: number): string[] {
+const NESTED_RULE_FILE_NAMES = ["CLAUDE.md", "AGENTS.md"];
+
+function findNestedRuleFiles(projectDir: string, maxDepth: number): string[] {
   const results: string[] = [];
   function scan(dir: string, depth: number): void {
     if (depth > maxDepth) return;
@@ -134,9 +147,11 @@ function findNestedClaudeMd(projectDir: string, maxDepth: number): string[] {
       if (!entry.isDirectory()) continue;
       if (SKIP_DIRS.has(entry.name)) continue;
       const subDir = path.join(dir, entry.name);
-      const claudeMd = path.join(subDir, "CLAUDE.md");
-      if (fs.existsSync(claudeMd)) {
-        results.push(claudeMd);
+      for (const fileName of NESTED_RULE_FILE_NAMES) {
+        const ruleFile = path.join(subDir, fileName);
+        if (fs.existsSync(ruleFile)) {
+          results.push(ruleFile);
+        }
       }
       scan(subDir, depth + 1);
     }
@@ -180,7 +195,7 @@ export function buildRulesSyncSetupSql(tableName = AGENT_RECALL_RULES_TABLE): st
   return [
     `create table if not exists public.${tableName} (`,
     "  id uuid primary key default gen_random_uuid(),",
-    "  agent text not null check (agent in ('claude', 'qoder')),",
+    "  agent text not null check (agent in ('claude', 'qoder', 'codex')),",
     "  scope text not null check (scope in ('global', 'project')),",
     "  name text not null,",
     "  content text not null,",
@@ -191,11 +206,17 @@ export function buildRulesSyncSetupSql(tableName = AGENT_RECALL_RULES_TABLE): st
     "  updated_at timestamptz not null default now()",
     ");",
     "",
+    "-- Upgrade tables created before AGENTS.md support to accept the codex agent.",
+    `alter table public.${tableName} drop constraint if exists ${tableName}_agent_check;`,
+    `alter table public.${tableName} add constraint ${tableName}_agent_check`,
+    "  check (agent in ('claude', 'qoder', 'codex'));",
+    "",
     `create unique index if not exists ${tableName}_identity_idx`,
     `  on public.${tableName} (agent, scope, name, project_path);`,
     "",
     `alter table public.${tableName} enable row level security;`,
     "",
+    `drop policy if exists "${tableName}_anon_all" on public.${tableName};`,
     `create policy "${tableName}_anon_all" on public.${tableName}`,
     "  for all to anon using (true) with check (true);",
     "",
@@ -266,7 +287,14 @@ export class SupabaseRulesSyncClient {
       body: JSON.stringify(payload),
     });
     const body = await readResponseBody(response);
-    if (!response.ok) throw new Error(supabaseErrorMessage(response.status, body));
+    if (!response.ok) {
+      const message = supabaseErrorMessage(response.status, body);
+      // Tables created before AGENTS.md support reject agent='codex' via CHECK.
+      if (/violates check constraint/i.test(message) && /agent/i.test(message)) {
+        throw new Error(`${message} Re-run the latest Rules setup SQL to allow AGENTS.md sync.`);
+      }
+      throw new Error(message);
+    }
     const rows = parseRuleRows(body);
     if (rows.length === 0) throw new Error("Supabase did not return the uploaded rule.");
     return rows[0];
@@ -374,6 +402,7 @@ export function restoreRules(remoteRules: RemoteRule[], options: RestoreRulesOpt
 function resolveRulePath(rule: RemoteRule, homeDir: string, projectDirs: string[]): string | null {
   if (rule.scope === "global") {
     if (rule.agent === "claude" && rule.name === "CLAUDE.md") return path.join(homeDir, ".claude", "CLAUDE.md");
+    if (rule.agent === "codex" && rule.name === "AGENTS.md") return path.join(homeDir, ".codex", "AGENTS.md");
     return null;
   }
   // Project scope: match remote project_path (basename) to a local project dir


### PR DESCRIPTION
## 变更概述

数字资产面板同步 Rules 的时候只认 CLAUDE.md 和 Qoder rules，很多 Agent（Codex 等）都用 AGENTS.md 做规则文件

1. 扫描全局 `~/.codex/AGENTS.md`、项目根目录和子目录里的 AGENTS.md（与 CLAUDE.md 共用同一次目录遍历和跳过规则）
2. 云端恢复支持把全局 AGENTS.md 还原到 `~/.codex/AGENTS.md`
3. Supabase 建表 SQL 的 agent 约束加入 codex，并且脚本改成幂等的：老用户重跑一次最新 SQL 就能升级；没升级前上传 AGENTS.md 会给出"请重跑 SQL"的明确提示，而不是裸的数据库报错

本地已验证
