### PR TITLE
fix: surface manual Claude Code routes in the API config dialog

### DIFF
--- a/.release-notes/claude-manual-config.md
+++ b/.release-notes/claude-manual-config.md
@@ -1,0 +1,6 @@
+# Claude Code 手动配置适配
+
+## Bug 修复
+
+- API 配置的 Claude Code 页现在会显示 `~/.claude/settings.json` 里的当前路由状态（官方认证或第三方供应商、模型和配置文件路径），和 Codex 页保持一致。
+- 手动在 settings.json 里配置过第三方 API 的用户，选择 Custom 时会自动带出已有的 Base URL、模型和 Key 环境变量作为基线，不再需要逐项重新填写；写入配置后状态区会自动刷新。

--- a/src/core/claude-profile.test.ts
+++ b/src/core/claude-profile.test.ts
@@ -7,7 +7,7 @@ import {
   defaultClaudeApiConfig,
   normalizeClaudeApiConfig,
 } from "./api-config";
-import { applyClaudeApiConfig, loadClaudeApiConfigDefaults } from "./claude-profile";
+import { applyClaudeApiConfig, loadClaudeApiConfigDefaults, loadClaudeConfigSnapshot } from "./claude-profile";
 
 async function withClaudeHome<T>(run: (claudeHome: string) => Promise<T>): Promise<T> {
   const claudeHome = await mkdtemp(path.join(tmpdir(), "agent-recall-claude-"));
@@ -82,6 +82,41 @@ describe("Claude Code provider switching", () => {
         customOpusModel: "kimi-k2.6",
         customApiKeyField: "ANTHROPIC_AUTH_TOKEN",
       });
+    });
+  });
+
+  it("loads a Claude config snapshot with the manual route and settings path", async () => {
+    await withClaudeHome(async (claudeHome) => {
+      await writeFile(
+        path.join(claudeHome, "settings.json"),
+        JSON.stringify({
+          env: {
+            ANTHROPIC_BASE_URL: "https://api.example.com/anthropic",
+            ANTHROPIC_AUTH_TOKEN: "sk-manual",
+            ANTHROPIC_MODEL: "custom-model",
+          },
+        }),
+      );
+
+      const snapshot = await loadClaudeConfigSnapshot(claudeHome);
+      expect(snapshot.claudeHome).toBe(claudeHome);
+      expect(snapshot.settingsPath).toBe(path.join(claudeHome, "settings.json"));
+      expect(snapshot.exists).toBe(true);
+      expect(snapshot.route).toMatchObject({
+        activeProvider: "custom",
+        customProviderName: "api.example.com",
+        customBaseUrl: "https://api.example.com/anthropic",
+        customApiKey: "sk-manual",
+        customModel: "custom-model",
+      });
+    });
+  });
+
+  it("loads an empty Claude config snapshot when settings.json is missing", async () => {
+    await withClaudeHome(async (claudeHome) => {
+      const snapshot = await loadClaudeConfigSnapshot(claudeHome);
+      expect(snapshot.exists).toBe(false);
+      expect(snapshot.route).toEqual({});
     });
   });
 

--- a/src/core/claude-profile.ts
+++ b/src/core/claude-profile.ts
@@ -16,6 +16,14 @@ export interface ApplyClaudeProfileResult {
   backupPaths: string[];
 }
 
+export interface ClaudeConfigSnapshot {
+  claudeHome: string;
+  settingsPath: string;
+  exists: boolean;
+  /** Route currently written in settings.json, normalized to ClaudeApiConfig fields. */
+  route: Partial<ClaudeApiConfig>;
+}
+
 const CLAUDE_ROUTE_ENV_KEYS = [
   "ANTHROPIC_BASE_URL",
   "ANTHROPIC_AUTH_TOKEN",
@@ -58,6 +66,17 @@ export async function loadClaudeApiConfigDefaults(claudeHome = path.join(os.home
     customApiFormat: preset?.apiFormat ?? "anthropic",
     customApiKeyField: apiKey && !token ? "ANTHROPIC_API_KEY" : (preset?.apiKeyField ?? "ANTHROPIC_AUTH_TOKEN"),
   });
+}
+
+export async function loadClaudeConfigSnapshot(claudeHome = path.join(os.homedir(), ".claude")): Promise<ClaudeConfigSnapshot> {
+  const settingsPath = path.join(claudeHome, "settings.json");
+  const text = await readOptionalFile(settingsPath);
+  return {
+    claudeHome,
+    settingsPath,
+    exists: Boolean(text?.trim()),
+    route: await loadClaudeApiConfigDefaults(claudeHome),
+  };
 }
 
 export async function applyClaudeApiConfig(options: {

--- a/src/main/ipc/providers.ts
+++ b/src/main/ipc/providers.ts
@@ -1,5 +1,5 @@
 import type { ApiConfig, ClaudeApiConfig } from "../../core/api-config";
-import type { ApplyClaudeProfileResult } from "../../core/claude-profile";
+import type { ApplyClaudeProfileResult, ClaudeConfigSnapshot } from "../../core/claude-profile";
 import type { CodexChatProxyStatus } from "../../core/codex-chat-proxy";
 import type { ApplyCodexProfileResult, CodexConfigSnapshot, CodexModelProbeResult } from "../../core/codex-profile";
 import { PROVIDERS_IPC, type CodexModelProbeRequest, type ProviderKeyTarget } from "../../shared/ipc/providers";
@@ -7,6 +7,7 @@ import { combineIpcDisposers, registerIpcHandler, type IpcMainRegistrar } from "
 
 export interface ProvidersIpcService {
   getCodexConfig(): Promise<CodexConfigSnapshot>;
+  getClaudeConfig(): Promise<ClaudeConfigSnapshot>;
   probeCodexModels(input: CodexModelProbeRequest): Promise<CodexModelProbeResult>;
   applyCodexProfile(apiConfig: Partial<ApiConfig>): Promise<ApplyCodexProfileResult>;
   applyClaudeProfile(apiConfig: Partial<ClaudeApiConfig>): Promise<ApplyClaudeProfileResult>;
@@ -18,6 +19,7 @@ export interface ProvidersIpcService {
 export function registerProvidersIpc(ipc: IpcMainRegistrar, service: ProvidersIpcService): () => void {
   return combineIpcDisposers([
     registerIpcHandler(ipc, PROVIDERS_IPC.getCodexConfig, () => service.getCodexConfig()),
+    registerIpcHandler(ipc, PROVIDERS_IPC.getClaudeConfig, () => service.getClaudeConfig()),
     registerIpcHandler(ipc, PROVIDERS_IPC.probeCodexModels, (_event, input) => service.probeCodexModels(input)),
     registerIpcHandler(ipc, PROVIDERS_IPC.applyCodexProfile, (_event, input) => service.applyCodexProfile(input)),
     registerIpcHandler(ipc, PROVIDERS_IPC.applyClaudeProfile, (_event, input) => service.applyClaudeProfile(input)),

--- a/src/main/services/provider-service.test.ts
+++ b/src/main/services/provider-service.test.ts
@@ -52,6 +52,12 @@ function createHarness(settings: AppSettings = cloneSettings()) {
   const operations: ProviderServiceOperations = {
     loadCodexProfileDefaults: vi.fn(async () => ({})),
     loadClaudeApiConfigDefaults: vi.fn(async () => ({})),
+    loadClaudeConfigSnapshot: vi.fn(async () => ({
+      claudeHome: "/tmp/claude",
+      settingsPath: "/tmp/claude/settings.json",
+      exists: false,
+      route: {},
+    })),
     loadCodexConfigSnapshot: vi.fn(async () => ({
       codexHome: "/tmp/codex",
       configPath: "/tmp/codex/config.toml",
@@ -308,5 +314,15 @@ describe("ProviderService Claude profile", () => {
     const config: Partial<ClaudeApiConfig> = { activeProvider: "official" };
     await harness.service.applyClaudeProfile(config);
     expect(harness.operations.applyClaudeApiConfig).toHaveBeenCalledWith({ apiConfig: config });
+  });
+
+  it("exposes the current Claude settings.json route as a config snapshot", async () => {
+    const harness = createHarness();
+    await expect(harness.service.getClaudeConfig()).resolves.toMatchObject({
+      settingsPath: "/tmp/claude/settings.json",
+      exists: false,
+      route: {},
+    });
+    expect(harness.operations.loadClaudeConfigSnapshot).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/main/services/provider-service.ts
+++ b/src/main/services/provider-service.ts
@@ -6,7 +6,7 @@ import {
   type ApiConfig,
   type ClaudeApiConfig,
 } from "../../core/api-config";
-import { applyClaudeApiConfig, loadClaudeApiConfigDefaults, type ApplyClaudeProfileResult } from "../../core/claude-profile";
+import { applyClaudeApiConfig, loadClaudeApiConfigDefaults, loadClaudeConfigSnapshot, type ApplyClaudeProfileResult, type ClaudeConfigSnapshot } from "../../core/claude-profile";
 import { CodexChatProxy, type CodexChatProxyOptions, type CodexChatProxyStatus } from "../../core/codex-chat-proxy";
 import {
   applyCodexApiConfig,
@@ -40,6 +40,7 @@ export interface CodexChatProxyPort {
 export interface ProviderServiceOperations {
   loadCodexProfileDefaults: typeof loadCodexProfileDefaults;
   loadClaudeApiConfigDefaults: typeof loadClaudeApiConfigDefaults;
+  loadClaudeConfigSnapshot: typeof loadClaudeConfigSnapshot;
   loadCodexConfigSnapshot: typeof loadCodexConfigSnapshot;
   probeCodexModels: typeof probeCodexModels;
   applyCodexApiConfig: typeof applyCodexApiConfig;
@@ -58,6 +59,7 @@ export interface ProviderServiceDependencies {
 const defaultOperations: ProviderServiceOperations = {
   loadCodexProfileDefaults,
   loadClaudeApiConfigDefaults,
+  loadClaudeConfigSnapshot,
   loadCodexConfigSnapshot,
   probeCodexModels,
   applyCodexApiConfig,
@@ -161,6 +163,10 @@ export class ProviderService {
 
   getCodexConfig(): Promise<CodexConfigSnapshot> {
     return this.operations.loadCodexConfigSnapshot();
+  }
+
+  getClaudeConfig(): Promise<ClaudeConfigSnapshot> {
+    return this.operations.loadClaudeConfigSnapshot();
   }
 
   probeCodexModels(input: CodexModelProbeRequest): Promise<CodexModelProbeResult> {

--- a/src/preload/providers.ts
+++ b/src/preload/providers.ts
@@ -1,6 +1,6 @@
 import type { IpcRenderer } from "electron";
 import type { ApiConfig, ClaudeApiConfig } from "../core/api-config";
-import type { ApplyClaudeProfileResult } from "../core/claude-profile";
+import type { ApplyClaudeProfileResult, ClaudeConfigSnapshot } from "../core/claude-profile";
 import type { CodexChatProxyStatus } from "../core/codex-chat-proxy";
 import type { ApplyCodexProfileResult, CodexConfigSnapshot, CodexModelProbeResult } from "../core/codex-profile";
 import { PROVIDERS_IPC, type ProviderKeyTarget } from "../shared/ipc/providers";
@@ -11,6 +11,8 @@ export function createProvidersApi(ipc: ProvidersIpcRenderer) {
   return {
     getCodexConfig: (): Promise<CodexConfigSnapshot> =>
       ipc.invoke(PROVIDERS_IPC.getCodexConfig.channel),
+    getClaudeConfig: (): Promise<ClaudeConfigSnapshot> =>
+      ipc.invoke(PROVIDERS_IPC.getClaudeConfig.channel),
     probeCodexModels: (input: { baseUrl: string; apiKey: string; providerId?: string }): Promise<CodexModelProbeResult> =>
       ipc.invoke(PROVIDERS_IPC.probeCodexModels.channel, input),
     applyCodexProfile: (apiConfig: ApiConfig): Promise<ApplyCodexProfileResult> =>

--- a/src/renderer/src/features/providers/api-config-dialog.tsx
+++ b/src/renderer/src/features/providers/api-config-dialog.tsx
@@ -12,6 +12,7 @@ import {
   type ClaudeApiProviderPresetId,
 } from "../../../../core/api-config";
 import type { AppSettings, AppSettingsUpdate } from "../../../../core/platform";
+import type { ClaudeConfigSnapshot } from "../../../../core/claude-profile";
 import type { CodexConfigSnapshot } from "../../../../core/codex-profile";
 import type { SettingsFeedback } from "../../app-types";
 import { localize, type LanguageMode } from "../../language";
@@ -105,6 +106,8 @@ export function ApiConfigDialog({
   const [draftSummarySource, setDraftSummarySource] = useState<AppSettings["summarySource"]>(() => buildSummarySourceFromSettings(settings));
   const [codexConfig, setCodexConfig] = useState<CodexConfigSnapshot | null>(null);
   const [codexConfigError, setCodexConfigError] = useState("");
+  const [claudeConfig, setClaudeConfig] = useState<ClaudeConfigSnapshot | null>(null);
+  const [claudeConfigError, setClaudeConfigError] = useState("");
   const [selectedCodexConfigProviderId, setSelectedCodexConfigProviderId] = useState("");
   const [codexModelOptions, setCodexModelOptions] = useState<string[]>([]);
   const [codexModelMenuOpen, setCodexModelMenuOpen] = useState(false);
@@ -234,6 +237,15 @@ export function ApiConfigDialog({
     }
   };
 
+  const refreshClaudeConfig = async () => {
+    setClaudeConfigError("");
+    try {
+      setClaudeConfig(await window.sessionSearch.getClaudeConfig());
+    } catch (error) {
+      setClaudeConfigError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
   const selectClaudeApiPreset = async (presetId: ClaudeApiProviderPresetId) => {
     const selectionId = ++claudeApiPresetSelectionRef.current;
     const preset = CLAUDE_API_PROVIDER_PRESETS.find((item) => item.id === presetId) ?? CLAUDE_API_PROVIDER_PRESETS[0];
@@ -241,12 +253,22 @@ export function ApiConfigDialog({
     if (selectionId !== claudeApiPresetSelectionRef.current) return;
     setDraftClaudeApiConfig((current) => {
       if (preset.id === "custom") {
+        // Seed empty fields from the manual route in ~/.claude/settings.json so a
+        // hand-configured third-party provider becomes the Custom baseline.
+        const route = claudeConfig?.route.activeProvider === "custom" ? claudeConfig.route : null;
         return {
           ...current,
           activeProvider: "custom",
           customProviderId: "custom",
-          customProviderName: current.customProviderName || preset.providerName,
-          customApiKey: apiKey,
+          customProviderName: current.customProviderName || route?.customProviderName || preset.providerName,
+          customBaseUrl: current.customBaseUrl || route?.customBaseUrl || "",
+          customApiKey: apiKey || route?.customApiKey || current.customApiKey,
+          customModel: current.customModel || route?.customModel || "",
+          customHaikuModel: current.customHaikuModel || route?.customHaikuModel || "",
+          customSonnetModel: current.customSonnetModel || route?.customSonnetModel || "",
+          customOpusModel: current.customOpusModel || route?.customOpusModel || "",
+          customApiFormat: route?.customApiFormat ?? current.customApiFormat,
+          customApiKeyField: route?.customApiKeyField ?? current.customApiKeyField,
         };
       }
       return {
@@ -306,6 +328,7 @@ export function ApiConfigDialog({
 
   useEffect(() => {
     if (apiTarget === "codex") void refreshCodexConfig();
+    if (apiTarget === "claude") void refreshClaudeConfig();
   }, [apiTarget]);
 
   const runCodexAction = (action: "save" | "apply") => {
@@ -350,7 +373,10 @@ export function ApiConfigDialog({
     if (apiTarget === "codex") {
       runCodexAction("apply");
     }
-    else if (apiTarget === "claude") onApplyToClaude(draftClaudeApiConfig);
+    else if (apiTarget === "claude") {
+      onApplyToClaude(draftClaudeApiConfig);
+      window.setTimeout(() => void refreshClaudeConfig(), 600);
+    }
   };
 
   return (
@@ -636,6 +662,26 @@ export function ApiConfigDialog({
                   )}
                 </p>
               </header>
+              <div className="codex-config-visualizer">
+                <div>
+                  <span>{l("Active route", "当前路由")}</span>
+                  <strong>
+                    {claudeConfig?.route.activeProvider === "custom"
+                      ? claudeConfig.route.customProviderName || l("Custom route", "自定义路径")
+                      : l("Official", "官方认证")}
+                  </strong>
+                  <em>
+                    {claudeConfig?.route.activeProvider === "custom"
+                      ? claudeConfig.route.customModel || claudeConfig.route.customBaseUrl || ""
+                      : l("Default Anthropic route", "默认 Anthropic 路由")}
+                  </em>
+                </div>
+                <div>
+                  <span>{l("Config file", "配置文件")}</span>
+                  <strong>{claudeConfig?.settingsPath ?? "~/.claude/settings.json"}</strong>
+                  <em>{claudeConfigError || (claudeConfig?.exists ? l("Detected", "已检测到") : l("Not created yet", "尚未创建"))}</em>
+                </div>
+              </div>
               <div
                 className="api-provider-switch api-provider-switch--compact"
                 role="group"

--- a/src/shared/ipc/providers.ts
+++ b/src/shared/ipc/providers.ts
@@ -41,6 +41,7 @@ export type CodexModelProbeRequest = z.infer<typeof codexModelProbeInput>;
 
 export const PROVIDERS_IPC = {
   getCodexConfig: defineIpcRequest("codex-config:get", z.tuple([])),
+  getClaudeConfig: defineIpcRequest("claude-config:get", z.tuple([])),
   probeCodexModels: defineIpcRequest("codex-config:probe-models", z.tuple([codexModelProbeInput])),
   applyCodexProfile: defineIpcRequest("codex-profile:apply", z.tuple([apiConfigInput])),
   applyClaudeProfile: defineIpcRequest("claude-profile:apply", z.tuple([claudeApiConfigInput])),


### PR DESCRIPTION
## 变更概述

API 配置的 Codex 页有"当前配置"状态区，还能把 config.toml 里手动配置的供应商选为 Custom 基线，但 Claude Code 页什么都没有：手动在 ~/.claude/settings.json 里配过第三方 API 的用户，打开对话框选 Custom 得逐项重填。本次改动补齐：

1. core 新增 `loadClaudeConfigSnapshot`，读取 settings.json 当前路由（复用已有的 env 解析逻辑），经 IPC `claude-config:get` 暴露给渲染进程
2. Claude Code 页新增"当前路由 / 配置文件"状态区，与 Codex 页对称；写入配置后自动刷新
3. 选择 Custom 时，用 settings.json 里的手动路由填充空字段（Base URL、模型、三档模型、Key 环境变量），已填写的草稿值不覆盖

本地已验证
