### PR TITLE
fix: keep saved Custom Codex config when reopening the API config dialog

### DIFF
--- a/.release-notes/custom-config-save.md
+++ b/.release-notes/custom-config-save.md
@@ -1,0 +1,5 @@
+# 修复 Custom 配置保存后丢失
+
+## Bug 修复
+
+- 修复 API 配置里"仅保存到应用"的 Codex Custom 配置在重新打开对话框后被翻回 Official、字段被 config.toml 内容覆盖的问题：应用内已保存的 Custom 配置现在始终是表单基线，当前 config.toml 状态只在"当前配置"区展示，不再悄悄冲掉你保存的内容。

--- a/src/renderer/src/features/providers/api-config-dialog.tsx
+++ b/src/renderer/src/features/providers/api-config-dialog.tsx
@@ -196,7 +196,12 @@ export function ApiConfigDialog({
       const hydrationKey = `${snapshot.configPath}:${snapshot.activeProviderId}:${snapshot.activeModel}:${snapshot.providers.map((provider) => `${provider.id}:${provider.baseUrl}`).join("|")}`;
       if (hydrationKey !== codexConfigHydrationRef.current) {
         codexConfigHydrationRef.current = hydrationKey;
-        hydrateDraftFromCodexConfig(snapshot);
+        // A Custom provider saved in-app is the draft baseline. Hydrating over it
+        // from config.toml would flip a saved-but-not-applied Custom draft back to
+        // Official (or overwrite its fields) every time the dialog reopens; the
+        // snapshot then only drives the "Active config" visualizer.
+        const savedCustom = settings?.apiConfig?.activeProvider === "custom" && hasCustomProviderValues(settings.apiConfig);
+        if (!savedCustom) hydrateDraftFromCodexConfig(snapshot);
       }
     } catch (error) {
       setCodexConfigError(error instanceof Error ? error.message : String(error));


### PR DESCRIPTION
## 变更概述

API 配置里选 Custom 填好 baseUrl/model 后点"仅保存到应用"，关掉对话框再打开，表单被翻回 Official 了（config.toml 没写入过时），配置丢了；这时再点一次保存会真的把 Official 写进设置，彻底冲掉之前保存的 Custom。根因是对话框每次打开都会无条件用 ~/.codex/config.toml 快照覆盖草稿。

修复：应用内已保存的 Custom 配置始终作为表单基线，config.toml 快照只用于"当前配置"状态区展示；没有保存过 Custom 时维持原行为（首次打开自动识别 config.toml）。
