### PR TITLE
Accept Windows line endings in release checks

### DIFF
--- a/.release-notes/windows-release-workflow-check.md
+++ b/.release-notes/windows-release-workflow-check.md
@@ -1,0 +1,7 @@
+# 修复 Windows 发布检查
+
+<!-- release-target: both -->
+
+## Bug 修复
+
+- 修复 Windows 环境下 V1 与 V2 独立发布被错误拦截的问题。

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -118,7 +118,10 @@ test("workflows require branch notes and publish accumulated changes every day o
   assert.doesNotMatch(releaseWorkflow, /^\s{2}push:/m);
   assert.match(releaseWorkflow, /gh api --paginate "repos\/\$\{GITHUB_REPOSITORY\}\/releases\?per_page=100"/);
   assert.match(releaseWorkflow, /published_tags_output="\$\([\s\S]*gh api --paginate/);
-  assert.match(releaseWorkflow, /\n\s*\)"\n\s*mapfile -t published_tags <<< "\$published_tags_output"/);
+  const capturedTagsAssignment = /\r?\n\s*\)"\r?\n\s*mapfile -t published_tags <<< "\$published_tags_output"/;
+  assert.match(releaseWorkflow, capturedTagsAssignment);
+  const windowsReleaseWorkflow = releaseWorkflow.replaceAll("\n", "\r\n");
+  assert.match(windowsReleaseWorkflow, capturedTagsAssignment);
   assert.match(releaseWorkflow, /mapfile -t published_tags <<< "\$published_tags_output"/);
   assert.doesNotMatch(releaseWorkflow, /mapfile -t published_tags < <\(/);
   assert.match(releaseWorkflow, /select\(\.draft == false and \.prerelease == false\)/);

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -120,7 +120,7 @@ test("workflows require branch notes and publish accumulated changes every day o
   assert.match(releaseWorkflow, /published_tags_output="\$\([\s\S]*gh api --paginate/);
   const capturedTagsAssignment = /\r?\n\s*\)"\r?\n\s*mapfile -t published_tags <<< "\$published_tags_output"/;
   assert.match(releaseWorkflow, capturedTagsAssignment);
-  const windowsReleaseWorkflow = releaseWorkflow.replaceAll("\n", "\r\n");
+  const windowsReleaseWorkflow = releaseWorkflow.replaceAll("\r\n", "\n").replaceAll("\n", "\r\n");
   assert.match(windowsReleaseWorkflow, capturedTagsAssignment);
   assert.match(releaseWorkflow, /mapfile -t published_tags <<< "\$published_tags_output"/);
   assert.doesNotMatch(releaseWorkflow, /mapfile -t published_tags < <\(/);


### PR DESCRIPTION
## What changed

- Make the release workflow regression assertion accept both LF and CRLF line endings.
- Exercise the same assertion against a synthetic Windows checkout.

## Root cause

The workflow shell syntax was fixed, but the regression expression itself required LF immediately after the closing quote. GitHub Windows checkout converted the file to CRLF, causing a false failure.

## User impact

Windows validation no longer incorrectly blocks V1 and V2 independent publishing.

## Validation

- reproduced with synthetic CRLF workflow text
- `node --test scripts/release-notes.test.mjs`
- `npm run release-note:check`
- `git diff --check`