### PR TITLE
fix OpenViking release shell compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,14 +57,13 @@ jobs:
             gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
               --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name'
           )"
-          mapfile -t published_tags <<< "$published_tags_output"
           latest_v2_tag=""
-          for tag in "${published_tags[@]}"; do
+          while IFS= read -r tag; do
             if [[ "$tag" =~ ^v2-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               latest_v2_tag="$tag"
               break
             fi
-          done
+          done < <(printf '%s\n' "$published_tags_output")
           if [ -z "$latest_v2_tag" ]; then
             latest_v2_tag="$V2_BOOTSTRAP_TAG"
           fi

--- a/.release-notes/v2-openviking-runtime-portable-shell.md
+++ b/.release-notes/v2-openviking-runtime-portable-shell.md
@@ -1,0 +1,7 @@
+# 修复 macOS OpenViking 下载
+
+<!-- release-target: v2 -->
+
+## Bug 修复
+
+- 修复 macOS 上仍可能无法下载 OpenViking 运行环境的问题。

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -171,8 +171,13 @@ test("workflows require branch notes and publish accumulated changes every day o
 
 test("V2 releases publish the complete OpenViking runtime set", async () => {
   const releaseWorkflow = await readFile(".github/workflows/release.yml", "utf8");
+  const runtimeJob = releaseWorkflow.slice(
+    releaseWorkflow.indexOf("  openviking-runtime:"),
+    releaseWorkflow.indexOf("  release:"),
+  );
 
   assert.match(releaseWorkflow, /^\s{2}openviking-runtime:\s*$/m);
+  assert.doesNotMatch(runtimeJob, /\bmapfile\b/);
   assert.match(releaseWorkflow, /runner:\s*macos-15[\s\S]*platform:\s*darwin[\s\S]*arch:\s*arm64/);
   assert.match(releaseWorkflow, /runner:\s*macos-15-intel[\s\S]*platform:\s*darwin[\s\S]*arch:\s*x64/);
   assert.match(releaseWorkflow, /runner:\s*windows-2025[\s\S]*platform:\s*win32[\s\S]*arch:\s*x64/);


### PR DESCRIPTION
## What changed
- replace Bash 4-only `mapfile` in the OpenViking release matrix
- keep paginated V2 release detection working with the Bash 3.2 shipped on macOS runners
- add a regression assertion for portable runtime-job shell code

## Root cause
The first urgent release run failed before building OpenViking because the macOS runner uses Bash 3.2, which does not provide `mapfile`.

## Validation
- reproduced in Actions run 30383122965
- verified the replacement with macOS `/bin/bash` 3.2.57
- node --test scripts/release-notes.test.mjs
- npm run release-note:check
- YAML parse and git diff --check