### PR TITLE
fix OpenViking Intel runtime build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,12 +86,22 @@ jobs:
         if: steps.pending.outputs.publish == 'true'
         run: npm run setup:v2
 
+      - name: Prepare isolated Rust toolchain
+        if: steps.pending.outputs.publish == 'true'
+        shell: bash
+        env:
+          RUSTUP_HOME: ${{ runner.temp }}/openviking-rustup
+          CARGO_HOME: ${{ runner.temp }}/openviking-cargo
+        run: rustup default stable
+
       - name: Build isolated OpenViking runtime
         if: steps.pending.outputs.publish == 'true'
         shell: bash
         env:
           BUILD_HOME: ${{ runner.temp }}/openviking-build-home
           OUTPUT_DIR: ${{ runner.temp }}/openviking-release
+          RUSTUP_HOME: ${{ runner.temp }}/openviking-rustup
+          CARGO_HOME: ${{ runner.temp }}/openviking-cargo
           PYTHON_URL: ${{ matrix.python_url }}
           PYTHON_SHA256: ${{ matrix.python_sha256 }}
         run: |

--- a/.release-notes/v2-openviking-intel-runtime.md
+++ b/.release-notes/v2-openviking-intel-runtime.md
@@ -1,0 +1,7 @@
+# 修复 Intel Mac OpenViking 下载
+
+<!-- release-target: v2 -->
+
+## Bug 修复
+
+- 修复 Intel Mac 无法获得 OpenViking 运行环境的问题。

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -182,6 +182,9 @@ test("V2 releases publish the complete OpenViking runtime set", async () => {
   assert.match(releaseWorkflow, /runner:\s*macos-15-intel[\s\S]*platform:\s*darwin[\s\S]*arch:\s*x64/);
   assert.match(releaseWorkflow, /runner:\s*windows-2025[\s\S]*platform:\s*win32[\s\S]*arch:\s*x64/);
   assert.match(releaseWorkflow, /apps\/main-2\.0\/scripts\/build-openviking-runtime\.mjs/);
+  assert.match(runtimeJob, /name:\s*Prepare isolated Rust toolchain[\s\S]*rustup default stable/);
+  assert.match(runtimeJob, /RUSTUP_HOME:\s*\$\{\{ runner\.temp \}\}\/openviking-rustup/);
+  assert.match(runtimeJob, /CARGO_HOME:\s*\$\{\{ runner\.temp \}\}\/openviking-cargo/);
   assert.match(releaseWorkflow, /pattern:\s*openviking-runtime-\*/);
   assert.match(releaseWorkflow, /apps\/main-2\.0\/scripts\/verify-openviking-runtime-assets\.mjs/);
   assert.match(


### PR DESCRIPTION
## What changed
- prepare a Rust toolchain inside runner-owned temporary directories
- pass the isolated Cargo and rustup homes into OpenViking runtime builds
- add release-workflow regression coverage

## Root cause
OpenViking requires cryptography 48 or newer. That dependency no longer publishes an Intel macOS wheel, so pip compiles it from source. The isolated build HOME hid the runner Rust default, causing rustup to fail before Cargo started.

## Validation
- reproduced from Actions job 90356235932
- node --test scripts/release-notes.test.mjs
- npm run release-note:check
- YAML parse and git diff --check