### PR TITLE
fix installed OpenViking runtime download

### DIFF
--- a/.release-notes/openviking-installed-runtime-download.md
+++ b/.release-notes/openviking-installed-runtime-download.md
@@ -1,0 +1,5 @@
+# 修复已安装版本的 OpenViking 下载
+
+## Bug 修复
+
+- 全局安装的 agent-recall-v2 现在会下载与当前版本匹配的 OpenViking 运行环境，不再误用 Electron 版本号或尝试调用仅源码仓库存在的构建脚本。

--- a/apps/main-2.0/bin/agent-recall.cjs
+++ b/apps/main-2.0/bin/agent-recall.cjs
@@ -49,7 +49,7 @@ async function scheduleUpdate(manifest, { stopApp }) {
 function launchApp() {
   // The `electron` dependency resolves to the path of the Electron executable.
   const electronPath = require("electron");
-  const appEntry = path.join(__dirname, "..", "out", "main", "index.js");
+  const appPath = path.join(__dirname, "..");
   const environment = { ...process.env };
   environment.AGENT_RECALL_NODE_PATH = process.execPath;
   if (environment.AGENT_RECALL_SOURCE_BUILD !== "1") {
@@ -58,7 +58,7 @@ function launchApp() {
     delete environment.AGENT_RECALL_RELEASE_BUILD;
   }
   delete environment.ELECTRON_RUN_AS_NODE;
-  const child = spawn(electronPath, [appEntry], { detached: true, stdio: "ignore", env: environment });
+  const child = spawn(electronPath, [appPath], { detached: true, stdio: "ignore", env: environment });
   child.on("error", (error) => {
     console.error("Failed to launch AgentRecall:", error.message);
     process.exitCode = 1;

--- a/apps/main-2.0/scripts/update-client.test.mjs
+++ b/apps/main-2.0/scripts/update-client.test.mjs
@@ -267,6 +267,9 @@ test("skips the same update version until a newer version is released", async ()
 test("terminal launcher marks npm-installed launches as release builds", () => {
   assert.match(launcherSource, /environment\.AGENT_RECALL_RELEASE_BUILD = "1"/);
   assert.match(launcherSource, /environment\.AGENT_RECALL_SOURCE_BUILD !== "1"/);
+  assert.match(launcherSource, /const appPath = path\.join\(__dirname, "\.\."\)/);
+  assert.match(launcherSource, /spawn\(electronPath, \[appPath\]/);
+  assert.doesNotMatch(launcherSource, /spawn\(electronPath, \[appEntry\]/);
 });
 
 test("terminal launcher continues with a validated Electron runtime after repair errors", () => {

--- a/apps/main-2.0/src/main/index.ts
+++ b/apps/main-2.0/src/main/index.ts
@@ -180,7 +180,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PRODUCT_NAME = "agent-recall-v2";
 const TRAY_ICON_RELATIVE_PATH = path.join("assets", "tray-iconTemplate.png");
 const APP_ICON_RELATIVE_PATH = path.join("assets", "app-icon.png");
-const releaseUpdateRuntime = false;
+const releaseUpdateRuntime = process.env.AGENT_RECALL_RELEASE_BUILD === "1";
 
 const OPTIONAL_SOURCE_SETTINGS = OPTIONAL_SESSION_SOURCE_DESCRIPTORS.map((descriptor) => ({
   key: descriptor.optionalSetting,

--- a/apps/main-2.0/src/main/openviking-main-wiring.test.ts
+++ b/apps/main-2.0/src/main/openviking-main-wiring.test.ts
@@ -16,6 +16,12 @@ describe("OpenViking main-process wiring", () => {
     expect(mainSource).toContain("developmentFallback");
     expect(mainSource).toContain("allowLocalRuntime: !releaseUpdateRuntime");
     expect(mainSource).toContain(
+      'const releaseUpdateRuntime = process.env.AGENT_RECALL_RELEASE_BUILD === "1"',
+    );
+    expect(mainSource).toContain(
+      "developmentFallback: releaseUpdateRuntime",
+    );
+    expect(mainSource).toContain(
       'codexAuthBootstrapPath: codexAuthPath(process.env, app.getPath("home"))',
     );
     expect(mainSource.indexOf("store = new SessionStore")).toBeLessThan(


### PR DESCRIPTION
## Summary

- Launch the npm-installed Electron app from its package root so app.getVersion() uses the AgentRecall V2 version.
- Honor the release-build marker so installed builds never invoke source-only OpenViking build scripts.
- Add regression coverage and a user-facing release note.

## Root cause

The CLI launched out/main/index.js directly, so Electron reported its own version instead of the application version. OpenViking consequently requested a non-existent release tag. The main process also ignored the release-build environment marker and incorrectly entered the development fallback, whose build script is intentionally absent from the npm package.

## Validation

- npm --prefix apps/main-2.0 test
- npm run package:smoke:v2
- npm run release-note:check
- git diff --check