### PR TITLE
fix: respect Claude Code custom titles

### DIFF
--- a/.release-notes/fix-claude-custom-title.md
+++ b/.release-notes/fix-claude-custom-title.md
@@ -1,0 +1,5 @@
+# Claude Code 会话重命名显示修复
+
+## Bug 修复
+
+- 修复在 Claude Code 中使用 `/rename` 后，AgentRecall 仍显示 AI 自动标题的问题。

--- a/apps/main-1.0/src/core/session-loader.test.ts
+++ b/apps/main-1.0/src/core/session-loader.test.ts
@@ -853,6 +853,27 @@ describe("Claude session loading", () => {
     expect(loaded?.messages.map((message) => message.content)).toEqual(["真实问题"]);
   });
 
+  it("prefers the latest Claude Code custom title over the AI title", () => {
+    const loaded = loadClaudeCliSessionRows(
+      "/tmp/claude-custom-title.jsonl",
+      [
+        { type: "ai-title", aiTitle: "自动生成标题", sessionId: "claude-custom-title" },
+        { type: "custom-title", customTitle: "第一次重命名", sessionId: "claude-custom-title" },
+        {
+          type: "user",
+          timestamp: "2026-07-29T02:35:40Z",
+          cwd: "/repo",
+          message: { role: "user", content: "真实问题" },
+        },
+        { type: "custom-title", customTitle: "最终会话名称", sessionId: "claude-custom-title" },
+      ],
+      { rawId: "claude-custom-title" },
+    );
+
+    expect(loaded?.session.originalTitle).toBe("最终会话名称");
+    expect(loaded?.messages.map((message) => message.content)).toEqual(["真实问题"]);
+  });
+
   it("extracts branch metadata from Claude Code jsonl rows", () => {
     const claudeDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-claude-"));
     const projectDir = path.join(claudeDir, "projects", "-repo");

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -1064,6 +1064,13 @@ export function loadClaudeCliSessionRows(
   const traceEvents = options.includeTraceEvents === false ? [] : extractTraceEvents(visibleRows, "claude");
   const tokenUsage = tokenUsageFromEvents(tokenEvents);
   const question = firstQuestion(messages);
+  let customTitle = "";
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const row = rows[index];
+    if (!isRecord(row) || row.type !== "custom-title") continue;
+    customTitle = stringField(row, "customTitle").trim();
+    if (customTitle) break;
+  }
   const aiTitle = firstAiTitle(rows);
   const embeddedCwd = (rows.find((row) => row && typeof row === "object" && "cwd" in row) as ClaudeConversationLine | undefined)?.cwd;
   const gitBranch = firstClaudeGitBranch(rows);
@@ -1074,7 +1081,7 @@ export function loadClaudeCliSessionRows(
       source: options.source ?? "claude-cli",
       projectPath: options.cwd || embeddedCwd || "",
       filePath,
-      originalTitle: aiTitle || cleanTitle(question) || "Untitled Session",
+      originalTitle: customTitle || aiTitle || cleanTitle(question) || "Untitled Session",
       firstQuestion: cleanTitle(question),
       timestamp: options.startedAt || 0,
       gitBranch,

--- a/apps/main-2.0/src/core/session-loader.test.ts
+++ b/apps/main-2.0/src/core/session-loader.test.ts
@@ -853,6 +853,27 @@ describe("Claude session loading", () => {
     expect(loaded?.messages.map((message) => message.content)).toEqual(["真实问题"]);
   });
 
+  it("prefers the latest Claude Code custom title over the AI title", () => {
+    const loaded = loadClaudeCliSessionRows(
+      "/tmp/claude-custom-title.jsonl",
+      [
+        { type: "ai-title", aiTitle: "自动生成标题", sessionId: "claude-custom-title" },
+        { type: "custom-title", customTitle: "第一次重命名", sessionId: "claude-custom-title" },
+        {
+          type: "user",
+          timestamp: "2026-07-29T02:35:40Z",
+          cwd: "/repo",
+          message: { role: "user", content: "真实问题" },
+        },
+        { type: "custom-title", customTitle: "最终会话名称", sessionId: "claude-custom-title" },
+      ],
+      { rawId: "claude-custom-title" },
+    );
+
+    expect(loaded?.session.originalTitle).toBe("最终会话名称");
+    expect(loaded?.messages.map((message) => message.content)).toEqual(["真实问题"]);
+  });
+
   it("extracts branch metadata from Claude Code jsonl rows", () => {
     const claudeDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-claude-"));
     const projectDir = path.join(claudeDir, "projects", "-repo");

--- a/apps/main-2.0/src/core/session-loader.ts
+++ b/apps/main-2.0/src/core/session-loader.ts
@@ -834,6 +834,13 @@ export function loadClaudeCliSessionRows(
   const traceEvents = options.includeTraceEvents === false ? [] : extractTraceEvents(visibleRows, "claude");
   const tokenUsage = tokenUsageFromEvents(tokenEvents);
   const question = firstQuestion(messages);
+  let customTitle = "";
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const row = rows[index];
+    if (!isRecord(row) || row.type !== "custom-title") continue;
+    customTitle = stringField(row, "customTitle").trim();
+    if (customTitle) break;
+  }
   const aiTitle = firstAiTitle(rows);
   const embeddedCwd = (rows.find((row) => row && typeof row === "object" && "cwd" in row) as ClaudeConversationLine | undefined)?.cwd;
   const gitBranch = firstClaudeGitBranch(rows);
@@ -844,7 +851,7 @@ export function loadClaudeCliSessionRows(
       source: options.source ?? "claude-cli",
       projectPath: options.cwd || embeddedCwd || "",
       filePath,
-      originalTitle: aiTitle || cleanTitle(question) || "Untitled Session",
+      originalTitle: customTitle || aiTitle || cleanTitle(question) || "Untitled Session",
       firstQuestion: cleanTitle(question),
       timestamp: options.startedAt || 0,
       gitBranch,


### PR DESCRIPTION
## 变更概述

修复 #236：Claude Code 执行 `/rename` 后，AgentRecall 现在会读取 transcript 中最后一个非空 `custom-title`，并优先于先前生成的 `ai-title` 展示。V1 与 V2 同步修复；CodeBuddy 及其他会话来源的标题选择逻辑保持不变。

根因是 Claude Code 会把 `/rename` 结果追加为 `type: "custom-title"` 的元数据行，而现有加载器只读取 `type: "ai-title"`，因此会话进入索引前就已选回自动标题。

Closes #236

## 更新说明检查

- [x] 本分支已新增且仅新增一个 `.release-notes/<branch-slug>.md`
- [x] 更新说明包含面向用户的“新增功能”或“Bug 修复”列表
- [x] 更新说明已移除 MR、分支、CI、发布流程、内部服务、路径及其他不应暴露的实现或敏感信息
- [x] 已运行 `npm run release-note:check`

## 验证

- `npm exec vitest run src/core/session-loader.test.ts`（V1：38/38；V2：38/38）
- `npm run typecheck`
- `npm run release-note:check`
- `npm test`（宿主环境：repo 23/23；V1 1105 通过、1 跳过；V2 2230 通过、1 跳过；两套脚本测试均通过）
