### PR TITLE
mac 端 workflow界面无法正常关闭

### DIFF
--- a/.release-notes/fix-macos-workflow-close.md
+++ b/.release-notes/fix-macos-workflow-close.md
@@ -1,0 +1,6 @@
+# 修复 macOS Workflow 画布关闭
+<!-- release-target: v2 -->
+
+## Bug 修复
+
+- 修复 macOS 上展开 Workflow 画布后关闭按钮无法正常点击的问题。

--- a/apps/main-2.0/src/automation/engine/renderer/src/pages/workflow/WorkflowPage.test.tsx
+++ b/apps/main-2.0/src/automation/engine/renderer/src/pages/workflow/WorkflowPage.test.tsx
@@ -1,7 +1,11 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, test } from "vitest";
 import type { WorkflowController } from "./workflow-controller";
 import { WorkflowPage } from "./WorkflowPage";
+
+const workflowStyles = readFileSync(resolve("src/renderer/src/styles/automation-upstream/part-02.css"), "utf8");
 
 function controller(definitionReady: boolean): WorkflowController {
   return {
@@ -12,6 +16,14 @@ function controller(definitionReady: boolean): WorkflowController {
     onObjectiveChange: () => undefined, onSelectConfiguredAgent: () => undefined, onSelectReviewerConfiguredAgent: () => undefined, onBuildDefinition: () => undefined, onReplyChange: () => undefined, onSendReply: () => undefined, onUpdateNode: () => undefined, onRunWorkflow: () => undefined, onResetSession: () => undefined,
   };
 }
+
+describe("WorkflowPage macOS interactions", () => {
+  test("keeps the expanded graph close button clickable inside the macOS titlebar drag area", () => {
+    const closeRule = workflowStyles.match(/\.workflow-graph-close\s*\{([^}]*)\}/)?.[1];
+
+    expect(closeRule).toContain("-webkit-app-region: no-drag");
+  });
+});
 
 describe("WorkflowPage input ownership", () => {
   test("renders the planning composer before a workflow graph exists", () => {

--- a/apps/main-2.0/src/renderer/src/styles/automation-upstream/part-02.css
+++ b/apps/main-2.0/src/renderer/src/styles/automation-upstream/part-02.css
@@ -793,6 +793,7 @@
   z-index: 100;
   background: var(--panel);
   box-shadow: 0 12px 30px color-mix(in srgb, var(--ink) 20%, transparent);
+  -webkit-app-region: no-drag;
 }
 
 .workflow-graph-layer {


### PR DESCRIPTION
## 问题

macOS 使用隐藏式标题栏，Workflow 展开画布的关闭按钮固定在窗口顶部拖拽区域内。该按钮没有声明为非拖拽区域，Electron 会优先把点击识别为拖动窗口，导致关闭操作不生效。

## 修复

- 将展开画布的关闭按钮标记为 `no-drag`，确保 macOS 上能够正常接收点击。
- 增加 macOS 标题栏拖拽区域回归测试。
- 添加仅面向 V2 的用户 release note。

V1 不包含该 Workflow 界面，因此无需修改。

## 验证

- V2 全量测试：274 个测试文件通过，2312 个测试通过，1 个跳过。
- V2 脚本测试：96 个通过。
- 双应用 `typecheck` 通过。
- 仓库测试与 `release-note:check` 通过。
- `git diff --check` 通过。

Fixes #258
