### PR TITLE
修复 Windows OpenViking 运行环境构建

### DIFF
--- a/.release-notes/fix-openviking-windows-runtime.md
+++ b/.release-notes/fix-openviking-windows-runtime.md
@@ -1,0 +1,6 @@
+# 修复 Windows 版 OpenViking 运行环境
+<!-- release-target: v2 -->
+
+## Bug 修复
+
+- 修复 Windows 版无法正常提供内置 OpenViking 运行环境的问题。

--- a/apps/main-2.0/scripts/build-openviking-runtime.mjs
+++ b/apps/main-2.0/scripts/build-openviking-runtime.mjs
@@ -17,6 +17,13 @@ import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
 import * as tar from "tar";
 
+const WINDOWS_X64_LLAMA_CPP_WHEEL = [
+  "llama-cpp-python @ ",
+  "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.34/",
+  "llama_cpp_python-0.3.34-py3-none-win_amd64.whl",
+  "#sha256=6526fff614e5ef7e439e6369e076a78073e45e1d791dbe1d5e5d42661f46ca1a",
+].join("");
+
 export function runtimeArtifactName({ version, platform, arch }) {
   assertToken(version, "version");
   assertToken(platform, "platform");
@@ -67,6 +74,9 @@ export function buildRuntimePlan(input) {
       "pip",
       "install",
       "--disable-pip-version-check",
+      ...(input.platform === "win32" && input.arch === "x64"
+        ? [WINDOWS_X64_LLAMA_CPP_WHEEL]
+        : []),
       `openviking[local-embed]==${input.version}`,
     ],
   };

--- a/apps/main-2.0/scripts/build-openviking-runtime.test.mjs
+++ b/apps/main-2.0/scripts/build-openviking-runtime.test.mjs
@@ -52,6 +52,33 @@ test("runtime builds require explicit isolated HOME and output directories", asy
   }
 });
 
+test("Windows runtime builds use the pinned prebuilt llama.cpp wheel", () => {
+  const root = path.join(tmpdir(), "agent-recall-runtime-windows-plan");
+  const plan = buildRuntimePlan({
+    version: "0.4.11",
+    platform: "win32",
+    arch: "x64",
+    buildHome: path.join(root, "home"),
+    outputDir: path.join(root, "output"),
+    pythonArchive: path.join(root, "cpython.tar.gz"),
+    pythonSha256: "a".repeat(64),
+  });
+
+  assert.deepEqual(plan.pipArgs, [
+    "-m",
+    "pip",
+    "install",
+    "--disable-pip-version-check",
+    [
+      "llama-cpp-python @ ",
+      "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.34/",
+      "llama_cpp_python-0.3.34-py3-none-win_amd64.whl",
+      "#sha256=6526fff614e5ef7e439e6369e076a78073e45e1d791dbe1d5e5d42661f46ca1a",
+    ].join(""),
+    "openviking[local-embed]==0.4.11",
+  ]);
+});
+
 test("runtime build rejects an invalid standalone Python checksum", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "agent-recall-runtime-checksum-"));
   try {


### PR DESCRIPTION
## 问题

Publish Daily Release 在 Windows runner 构建 OpenViking 运行环境时，从 PyPI 获取了 llama-cpp-python 源码包。CMake 随后无法在 runner 中找到 C/C++ 编译器，导致构建失败并取消其余矩阵任务。

失败运行：https://github.com/zszz3/AgentRecall/actions/runs/30515542622

## 修复

- Windows x64 构建明确安装上游 v0.3.34 预编译 CPU wheel
- 使用 GitHub Release 提供的 SHA-256 固定并校验 wheel
- 保持 macOS 与 V1 构建路径不变
- 添加 Windows 构建计划回归测试和 V2 release note

## 验证

- npm run test:v2
- npm run typecheck
- npm run test:repo
- npm run release-note:check
- 流式下载 wheel 并核对 SHA-256