### PR TITLE
feat: 支持删除 Agent 且不被自动重建，Agent 列表去重

### DIFF
--- a/.release-notes/feat-agent-delete.md
+++ b/.release-notes/feat-agent-delete.md
@@ -1,0 +1,8 @@
+# 优化 Runtime 页的 Agent 管理
+
+<!-- release-target: v2 -->
+
+## 新增功能
+
+- Agent 支持删除，删除后不会在保存或重启时被自动重建。
+- Agent 列表只显示名称与 Runtime 徽标，不再重复显示执行配置名称。

--- a/apps/main-2.0/src/automation/engine/main/hub/agent-hub.test.ts
+++ b/apps/main-2.0/src/automation/engine/main/hub/agent-hub.test.ts
@@ -818,6 +818,7 @@ describe("AgentHub chat sessions", () => {
     // Omitting a managed agent from the saved list must delete it.
     hub.updateConfiguredAgents(
       hub.snapshot().configuredAgents.filter((agent) => agent.id !== "runtime-agent:codex-glm"),
+      { detectDeletedManagedAgents: true },
     );
     expect(hub.snapshot().configuredAgents.find((agent) => agent.id === "runtime-agent:codex-glm")).toBeUndefined();
 
@@ -845,7 +846,7 @@ describe("AgentHub chat sessions", () => {
       },
     ];
 
-    hub.updateConfiguredAgents([]);
+    hub.updateConfiguredAgents([], { detectDeletedManagedAgents: true });
     expect(hub.snapshot().configuredAgents).toEqual([]);
 
     (hub as any).installRestoredConfiguredAgents([]);
@@ -867,7 +868,7 @@ describe("AgentHub chat sessions", () => {
         models: [{ id: DEFAULT_MODEL_ID, label: "Default" }],
       },
     ];
-    hub.updateConfiguredAgents([]);
+    hub.updateConfiguredAgents([], { detectDeletedManagedAgents: true });
     expect((hub as any).deletedManagedConfiguredAgentIds.has("default-agent")).toBe(true);
 
     // Removing the channel prunes the marker so a future channel with the same id can be seeded again.

--- a/apps/main-2.0/src/automation/engine/main/hub/agent-hub.test.ts
+++ b/apps/main-2.0/src/automation/engine/main/hub/agent-hub.test.ts
@@ -798,6 +798,84 @@ describe("AgentHub chat sessions", () => {
     expect(hub.snapshot().configuredAgents.find((agent) => agent.id === "sol-agent")?.reasoningEffort).toBe("xhigh");
   });
 
+  test("keeps a deleted managed agent deleted across saves, reseeds, and restores", () => {
+    const hub = new AgentHub();
+    (hub as any).channels = [
+      {
+        id: "codex-openai",
+        agentId: "codex",
+        label: "Codex Official",
+        models: [{ id: DEFAULT_MODEL_ID, label: "Default" }],
+      },
+      {
+        id: "codex-glm",
+        agentId: "codex",
+        label: "Codex GLM",
+        models: [{ id: DEFAULT_MODEL_ID, label: "Default" }],
+      },
+    ];
+
+    // Omitting a managed agent from the saved list must delete it.
+    hub.updateConfiguredAgents(
+      hub.snapshot().configuredAgents.filter((agent) => agent.id !== "runtime-agent:codex-glm"),
+    );
+    expect(hub.snapshot().configuredAgents.find((agent) => agent.id === "runtime-agent:codex-glm")).toBeUndefined();
+
+    // Re-seeding from scratch must not recreate the deleted agent while keeping other managed agents.
+    (hub as any).installRestoredConfiguredAgents([]);
+    expect(hub.snapshot().configuredAgents.find((agent) => agent.id === "runtime-agent:codex-glm")).toBeUndefined();
+    expect(hub.snapshot().configuredAgents.find((agent) => agent.id === "default-agent")).toBeDefined();
+
+    // The deletion survives a persistence round-trip.
+    const payload = (hub as any).buildPersistedPayload();
+    const restoredHub = new AgentHub();
+    expect((restoredHub as any).restorePersistedState(payload)).toBe(true);
+    expect(restoredHub.snapshot().configuredAgents.find((agent) => agent.id === "runtime-agent:codex-glm")).toBeUndefined();
+    expect(restoredHub.snapshot().configuredAgents.find((agent) => agent.id === "default-agent")).toBeDefined();
+  });
+
+  test("allows deleting every configured agent without forcing a default agent back", () => {
+    const hub = new AgentHub();
+    (hub as any).channels = [
+      {
+        id: "codex-openai",
+        agentId: "codex",
+        label: "Codex Official",
+        models: [{ id: DEFAULT_MODEL_ID, label: "Default" }],
+      },
+    ];
+
+    hub.updateConfiguredAgents([]);
+    expect(hub.snapshot().configuredAgents).toEqual([]);
+
+    (hub as any).installRestoredConfiguredAgents([]);
+    expect(hub.snapshot().configuredAgents).toEqual([]);
+
+    const payload = (hub as any).buildPersistedPayload();
+    const restoredHub = new AgentHub();
+    expect((restoredHub as any).restorePersistedState(payload)).toBe(true);
+    expect(restoredHub.snapshot().configuredAgents).toEqual([]);
+  });
+
+  test("prunes deleted markers when their channel no longer exists", () => {
+    const hub = new AgentHub();
+    (hub as any).channels = [
+      {
+        id: "codex-openai",
+        agentId: "codex",
+        label: "Codex Official",
+        models: [{ id: DEFAULT_MODEL_ID, label: "Default" }],
+      },
+    ];
+    hub.updateConfiguredAgents([]);
+    expect((hub as any).deletedManagedConfiguredAgentIds.has("default-agent")).toBe(true);
+
+    // Removing the channel prunes the marker so a future channel with the same id can be seeded again.
+    (hub as any).channels = [];
+    (hub as any).installRestoredConfiguredAgents([]);
+    expect((hub as any).deletedManagedConfiguredAgentIds.has("default-agent")).toBe(false);
+  });
+
   test("refreshes workflow agent timeout after activity", () => {
     vi.useFakeTimers();
     try {

--- a/apps/main-2.0/src/automation/engine/main/hub/agent-hub.ts
+++ b/apps/main-2.0/src/automation/engine/main/hub/agent-hub.ts
@@ -386,6 +386,7 @@ export class AgentHub {
   private scheduledWorkflowSchedules = new Map<string, ScheduledWorkflowSchedule>();
   private scheduledWorkflowRuns = new Map<string, ScheduledWorkflowRun>();
   private configuredAgents = new Map<string, ConfiguredAgent>();
+  private deletedManagedConfiguredAgentIds = new Set<string>();
   private mcpServers: McpServerDefinition[] = [];
   private activeScheduledWorkflowId: string | undefined;
   private scheduledWorkflowRunnerConfig: ScheduledWorkflowRunnerConfig = { baseUrl: "" };
@@ -800,6 +801,7 @@ export class AgentHub {
 
   updateConfiguredAgents(agents: ConfiguredAgent[]): AppSnapshot {
     assertWorkflowV2ConfiguredAgentReplacement([...this.workflowStore.workflows.values()].map((workflow) => workflow.definition), this.configuredAgents.values(), agents);
+    this.syncDeletedManagedConfiguredAgentIds(agents);
     this.installRestoredConfiguredAgents(agents);
     this.normalizeRunSelections();
     this.emit();
@@ -2984,6 +2986,11 @@ export class AgentHub {
     if (Array.isArray(record.channels)) {
       this.channels = normalizeConfigChannelsForStorage(normalizeChannels(record.channels));
     }
+    this.deletedManagedConfiguredAgentIds = new Set(
+      Array.isArray(record.deletedConfiguredAgentIds)
+        ? record.deletedConfiguredAgentIds.filter((id): id is string => typeof id === "string")
+        : [],
+    );
 
     this.installRestoredConfiguredAgents(Array.isArray(record.configuredAgents) ? record.configuredAgents : []);
     const restored = restorePersistedCollections(record, {
@@ -3009,6 +3016,7 @@ export class AgentHub {
   }
 
   private reinitializePersistedState(): void {
+    this.deletedManagedConfiguredAgentIds.clear();
     this.installRestoredConfiguredAgents([]);
     this.installRestoredChats([], undefined, undefined);
     this.installRestoredTasks([], undefined);
@@ -3018,6 +3026,7 @@ export class AgentHub {
   }
 
   private installRestoredConfiguredAgents(rawAgents: unknown[]): void {
+    this.pruneDeletedManagedConfiguredAgentIds();
     this.configuredAgents.clear();
     const now = Date.now();
     for (const rawAgent of rawAgents) {
@@ -3026,6 +3035,7 @@ export class AgentHub {
     }
     for (const channel of this.channels) {
       const id = managedRuntimeAgentId(channel);
+      if (this.deletedManagedConfiguredAgentIds.has(id)) continue;
       if (this.configuredAgents.has(id)) continue;
       this.configuredAgents.set(id, {
         id,
@@ -3042,8 +3052,30 @@ export class AgentHub {
     }
     if (this.configuredAgents.size === 0) {
       const agent = createDefaultConfiguredAgent(this.channels, now);
-      this.configuredAgents.set(agent.id, { ...agent, managed: true });
+      if (!this.deletedManagedConfiguredAgentIds.has(agent.id)) {
+        this.configuredAgents.set(agent.id, { ...agent, managed: true });
+      }
     }
+  }
+
+  private pruneDeletedManagedConfiguredAgentIds(): void {
+    const managedIds = new Set(this.channels.map(managedRuntimeAgentId));
+    for (const id of [...this.deletedManagedConfiguredAgentIds]) {
+      if (!managedIds.has(id)) this.deletedManagedConfiguredAgentIds.delete(id);
+    }
+  }
+
+  private syncDeletedManagedConfiguredAgentIds(agents: ConfiguredAgent[]): void {
+    const providedIds = new Set(agents.map((agent) => agent.id));
+    const managedIds = new Set(this.channels.map(managedRuntimeAgentId));
+    for (const id of managedIds) {
+      if (providedIds.has(id)) {
+        this.deletedManagedConfiguredAgentIds.delete(id);
+      } else {
+        this.deletedManagedConfiguredAgentIds.add(id);
+      }
+    }
+    this.pruneDeletedManagedConfiguredAgentIds();
   }
 
   private restoreConfiguredAgent(raw: unknown, now = Date.now()): ConfiguredAgent | undefined {
@@ -3345,6 +3377,7 @@ export class AgentHub {
       teams: this.teams.values(),
       teamRuns: this.teamRuns.values(),
       configuredAgents: this.listConfiguredAgents(),
+      deletedConfiguredAgentIds: [...this.deletedManagedConfiguredAgentIds],
       artifacts: this.artifacts,
       cloneConversation: (conversation) => this.runtimeRouter.cloneConversation(conversation),
       workflowStore: this.cloneWorkflowStore(),

--- a/apps/main-2.0/src/automation/engine/main/hub/agent-hub.ts
+++ b/apps/main-2.0/src/automation/engine/main/hub/agent-hub.ts
@@ -799,9 +799,12 @@ export class AgentHub {
     }));
   }
 
-  updateConfiguredAgents(agents: ConfiguredAgent[]): AppSnapshot {
+  updateConfiguredAgents(
+    agents: ConfiguredAgent[],
+    options: { detectDeletedManagedAgents?: boolean } = {},
+  ): AppSnapshot {
     assertWorkflowV2ConfiguredAgentReplacement([...this.workflowStore.workflows.values()].map((workflow) => workflow.definition), this.configuredAgents.values(), agents);
-    this.syncDeletedManagedConfiguredAgentIds(agents);
+    if (options.detectDeletedManagedAgents) this.syncDeletedManagedConfiguredAgentIds(agents);
     this.installRestoredConfiguredAgents(agents);
     this.normalizeRunSelections();
     this.emit();

--- a/apps/main-2.0/src/automation/engine/main/hub/persisted/agent-hub-persisted-payload.ts
+++ b/apps/main-2.0/src/automation/engine/main/hub/persisted/agent-hub-persisted-payload.ts
@@ -37,6 +37,7 @@ export function buildPersistedPayload(input: {
   teams: Iterable<AgentTeamState>;
   teamRuns: Iterable<TeamRunState>;
   configuredAgents: ConfiguredAgent[];
+  deletedConfiguredAgentIds: string[];
   artifacts: RegisteredArtifact[];
   cloneConversation: (conversation: RuntimeConversation) => RuntimeConversation;
   workflowStore: WorkflowStoreState;
@@ -179,6 +180,7 @@ export function buildPersistedPayload(input: {
     teams,
     teamRuns,
     configuredAgents: input.configuredAgents,
+    deletedConfiguredAgentIds: input.deletedConfiguredAgentIds,
     workflowStore: input.workflowStore,
     scheduledWorkflowStore: input.scheduledWorkflowStore,
     workflowNodeConversations: input.workflowNodeConversations.map((conversation) => structuredClone(conversation)),

--- a/apps/main-2.0/src/automation/engine/main/hub/persisted/agent-hub-persistence.ts
+++ b/apps/main-2.0/src/automation/engine/main/hub/persisted/agent-hub-persistence.ts
@@ -137,6 +137,7 @@ export interface PersistedAppStateV5 {
   scheduledWorkflowStore?: ScheduledWorkflowStoreState;
   channels?: AgentChannel[];
   configuredAgents?: ConfiguredAgent[];
+  deletedConfiguredAgentIds?: string[];
   workflowNodeConversations?: WorkflowNodeConversation[];
 }
 

--- a/apps/main-2.0/src/automation/engine/renderer/src/pages/agent/AgentPage.tsx
+++ b/apps/main-2.0/src/automation/engine/renderer/src/pages/agent/AgentPage.tsx
@@ -1,4 +1,4 @@
-import { Plus, Save } from "lucide-react";
+import { Plus, Save, Trash2 } from "lucide-react";
 import { agentAccent, agentLabel, resolveConfiguredAgentChannel } from "../../app/agents";
 import type { Language } from "../../app/language";
 import { DEFAULT_MODEL_ID } from "../../../../shared/models";
@@ -16,6 +16,7 @@ interface AgentPageProps {
   onAddConfiguredAgent: () => MaybePromise;
   onSelectConfiguredAgent: (agentId: string) => void;
   onUpdateConfiguredAgent: (agentId: string, updater: (agent: ConfiguredAgent) => ConfiguredAgent) => void;
+  onDeleteConfiguredAgent?: (agentId: string) => void;
 }
 
 function configTextFor(language: Language) {
@@ -33,6 +34,7 @@ function configTextFor(language: Language) {
         descriptionField: "描述",
         emptyAgent: "新建 Agent 后可编辑名称、描述、执行配置和标签。",
         newAgent: "新建 Agent",
+        deleteAgent: "删除 Agent",
       }
     : {
         title: "Agent Assembly",
@@ -47,6 +49,7 @@ function configTextFor(language: Language) {
         descriptionField: "Description",
         emptyAgent: "Create an agent to edit its profile, execution config, and tags.",
         newAgent: "New agent",
+        deleteAgent: "Delete agent",
       };
 }
 
@@ -67,6 +70,7 @@ export function AgentPage({
   onAddConfiguredAgent,
   onSelectConfiguredAgent,
   onUpdateConfiguredAgent,
+  onDeleteConfiguredAgent,
 }: AgentPageProps) {
   const configText = configTextFor(language);
   const selectedConfiguredAgent =
@@ -101,9 +105,23 @@ export function AgentPage({
                 <div>
                   <h3>Agents</h3>
                 </div>
-                <button className="icon-btn" type="button" onClick={() => void onAddConfiguredAgent()} aria-label={configText.newAgent}>
-                  <Plus size={14} />
-                </button>
+                <div className="configured-agent-editor-actions">
+                  <button className="icon-btn" type="button" onClick={() => void onAddConfiguredAgent()} aria-label={configText.newAgent}>
+                    <Plus size={14} />
+                  </button>
+                  {onDeleteConfiguredAgent ? (
+                    <button
+                      className="icon-btn danger"
+                      type="button"
+                      aria-label={configText.deleteAgent}
+                      title={configText.deleteAgent}
+                      disabled={!selectedConfiguredAgent || configuredAgents.length === 0}
+                      onClick={() => onDeleteConfiguredAgent(selectedConfiguredAgent!.id)}
+                    >
+                      <Trash2 size={13} />
+                    </button>
+                  ) : null}
+                </div>
               </div>
               <div className="configured-agent-list">
                 {configuredAgents.map((agent) => (
@@ -115,7 +133,6 @@ export function AgentPage({
                   >
                     <span className={`agent-badge mini ${agentAccent(agent.runtimeAgentId)}`}>{agentLabel(agent.runtimeAgentId)}</span>
                     <strong>{agent.name || agent.id}</strong>
-                    <span>{channels.find((channel) => channel.id === agent.channelId)?.label ?? agent.channelId}</span>
                   </button>
                 ))}
               </div>

--- a/apps/main-2.0/src/main/automation-ipc.test.ts
+++ b/apps/main-2.0/src/main/automation-ipc.test.ts
@@ -141,7 +141,7 @@ describe("registerAutomationIpc", () => {
 
     await expect(invoke(AUTOMATION_CHANNELS.runtimeSaveAgents, [agent]))
       .resolves.toEqual({ configuredAgents: [agent] });
-    expect(hub.updateConfiguredAgents).toHaveBeenCalledWith([agent]);
+    expect(hub.updateConfiguredAgents).toHaveBeenCalledWith([agent], { detectDeletedManagedAgents: true });
 
     await expect(invoke(AUTOMATION_CHANNELS.runtimeSaveAgents, [{
       ...agent,

--- a/apps/main-2.0/src/main/ipc/automation.ts
+++ b/apps/main-2.0/src/main/ipc/automation.ts
@@ -250,7 +250,10 @@ export function registerAutomationIpc({
   ready(AUTOMATION_CHANNELS.runtimeSaveChannels, (value: unknown) =>
     service.runtime.saveModelChannels(z.array(channelSchema).max(500).parse(value) as AgentChannel[]));
   ready(AUTOMATION_CHANNELS.runtimeSaveAgents, (value: unknown) =>
-    service.runtime.updateConfiguredAgents(z.array(agentSchema).max(500).parse(value) as ConfiguredAgent[]));
+    service.runtime.updateConfiguredAgents(
+      z.array(agentSchema).max(500).parse(value) as ConfiguredAgent[],
+      { detectDeletedManagedAgents: true },
+    ));
   ready(AUTOMATION_CHANNELS.runtimeTestChannel, (value: unknown) =>
     service.runtime.testRuntimeChannel(idSchema.parse(value), (event) => send(AUTOMATION_CHANNELS.runtimeTestEvent, event)));
   ready(AUTOMATION_CHANNELS.runtimeTestAgent, (value: unknown) =>

--- a/apps/main-2.0/src/renderer/src/features/automation/runtime-feature-page.tsx
+++ b/apps/main-2.0/src/renderer/src/features/automation/runtime-feature-page.tsx
@@ -108,6 +108,14 @@ export function RuntimeFeaturePage({
     setAgentStatus("");
   };
 
+  const deleteAgent = (agentId: string): void => {
+    const remaining = editableAgents.filter((agent) => agent.id !== agentId);
+    setEditableAgents(remaining);
+    if (selectedAgentId === agentId) setSelectedAgentId(remaining[0]?.id ?? "");
+    setAgentDirty(true);
+    setAgentStatus("");
+  };
+
   return (
     <div className="automation-page automation-runtime-page" data-page="runtimes" onClick={() => manager.setConfigContextMenu(undefined)}>
       <header className="app-page-head automation-page-head">
@@ -180,6 +188,7 @@ export function RuntimeFeaturePage({
               onAddConfiguredAgent={addAgent}
               onSelectConfiguredAgent={setSelectedAgentId}
               onUpdateConfiguredAgent={updateAgent}
+              onDeleteConfiguredAgent={deleteAgent}
             />
           )}
         </div>

--- a/apps/main-2.0/src/renderer/src/styles/automation-upstream/part-03.css
+++ b/apps/main-2.0/src/renderer/src/styles/automation-upstream/part-03.css
@@ -1076,21 +1076,11 @@
   background: var(--accent-soft);
 }
 
-.configured-agent-pick strong,
-.configured-agent-pick span:last-child {
+.configured-agent-pick strong {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.configured-agent-pick strong {
   font-size: 12px;
-}
-
-.configured-agent-pick span:last-child {
-  grid-column: 2;
-  color: var(--muted);
-  font-size: 11px;
 }
 
 .configured-agent-editor {


### PR DESCRIPTION
## 变更内容

- **Agent 列表去重**：每行只显示 Runtime 徽标 + 名称，去掉重复的执行配置（channel）标签行。
- **Agent 可删除**：Runtime → Agent 页工具栏新增删除按钮，删除后保存或重启都不会再被自动重建（后端记录并持久化被删除的 managed agent id）。
- **api 执行配置**：保持现状——api runtime 已直接通过 fetch 请求接口，聊天/任务以自动生成的 agent profile 作为入口。

## 测试

- `agent-hub.test.ts` 120 通过（含 3 个新增用例：删除后不重建、全删不强制重建默认 agent、channel 移除后清理删除标记）
- persisted / useRuntimeConfigManager / automation 相关测试通过
- `tsc --noEmit` 通过
- `npm run release-note:check` 通过