### PR TITLE
fix: Claude Skill 版本指纹进入 Eval 数据库 + 插件 Skill hash 支持

### DIFF
--- a/.release-notes/fix-hook-skill-version-data.md
+++ b/.release-notes/fix-hook-skill-version-data.md
@@ -1,0 +1,6 @@
+# Claude Skill 版本指纹修复
+
+## Bug 修复
+
+- 修复 Claude Skill 的触发时版本指纹（`skill_hash`）无法进入 Eval 数据库的问题：当本机存在 Claude 会话转录时，hook 日志被跳过，导致版本对比功能失效。现在 hook 日志始终参与扫描，`skill_hash` 会被合并到对应的会话事件中。
+- 修复插件 Skill 无法计算版本指纹的问题：hook 脚本现在能搜索 `~/.claude/plugins` 下的插件 Skill 目录（包括 `installed_plugins.json` 和 `marketplaces` 两种路径），不再只查找 `~/.claude/skills/`。

--- a/.release-notes/fix-hook-skill-version-data.md
+++ b/.release-notes/fix-hook-skill-version-data.md
@@ -2,5 +2,5 @@
 
 ## Bug 修复
 
-- 修复 Claude Skill 的触发时版本指纹（`skill_hash`）无法进入 Eval 数据库的问题：当本机存在 Claude 会话转录时，hook 日志被跳过，导致版本对比功能失效。现在 hook 日志始终参与扫描，`skill_hash` 会被合并到对应的会话事件中。
-- 修复插件 Skill 无法计算版本指纹的问题：hook 脚本现在能搜索 `~/.claude/plugins` 下的插件 Skill 目录（包括 `installed_plugins.json` 和 `marketplaces` 两种路径），不再只查找 `~/.claude/skills/`。
+- 修复 Claude Skill 的版本对比功能在存在会话记录时无法正常工作的问题：版本指纹现在能正确关联到每次 Skill 触发，不再因会话记录的存在而被跳过。
+- 修复通过插件安装的 Claude Skill 无法识别版本的问题：插件 Skill 的版本指纹现在能被正确计算。

--- a/apps/main-2.0/bin/skill-usage-record.cjs
+++ b/apps/main-2.0/bin/skill-usage-record.cjs
@@ -83,7 +83,9 @@ function buildRecord(input) {
 // Resolves the skill's SKILL.md (project level first, matching Claude's
 // resolution order) and returns its sha256 hex, or "" when the file cannot
 // be found or read. Never throws. The home directory is resolved per call so
-// tests can point it at a temporary HOME.
+// tests can point it at a temporary HOME. Plugin skills installed via
+// ~/.claude/plugins are searched after the standard roots, mirroring
+// collectClaudePluginRoots in skill-manager.ts.
 function skillMarkdownHash(skill, cwd) {
   if (!skill || /[\\/]|\.\./.test(skill)) return "";
   const homeDir = process.env.AGENT_RECALL_TEST_HOME || os.homedir();
@@ -98,7 +100,71 @@ function skillMarkdownHash(skill, cwd) {
       // Missing at this root; try the next one.
     }
   }
+  // Search plugin skill roots: Claude resolves plugin skills under
+  // ~/.claude/plugins, either via installed_plugins.json or the marketplaces
+  // directory walk. Each plugin's skills live at <plugin>/skills/<name>/.
+  for (const root of collectClaudePluginSkillRoots(homeDir)) {
+    try {
+      const markdown = fs.readFileSync(path.join(root, skill, "SKILL.md"));
+      return crypto.createHash("sha256").update(markdown).digest("hex");
+    } catch {
+      // Not a plugin skill at this root; try the next one.
+    }
+  }
   return "";
+}
+
+// Collects skill roots from Claude's plugin directory, mirroring
+// collectClaudePluginRoots in skill-manager.ts. Must stay self-contained (no
+// imports from TypeScript modules) because this script runs from a freshly
+// unpacked global install.
+function collectClaudePluginSkillRoots(homeDir) {
+  const pluginsDir = path.join(homeDir, ".claude", "plugins");
+  const roots = [];
+  // 1. Try installed_plugins.json (newer Claude Code versions).
+  try {
+    const raw = fs.readFileSync(path.join(pluginsDir, "installed_plugins.json"), "utf8");
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && parsed.plugins && typeof parsed.plugins === "object") {
+      for (const installs of Object.values(parsed.plugins)) {
+        if (!Array.isArray(installs)) continue;
+        for (const install of installs) {
+          const installPath = install && install.installPath;
+          if (typeof installPath === "string" && installPath) {
+            roots.push(path.join(installPath, "skills"));
+          }
+        }
+      }
+    }
+  } catch {
+    // Missing or unreadable; fall through to marketplace walk.
+  }
+  // 2. Walk the marketplaces directory.
+  const marketplacesDir = path.join(pluginsDir, "marketplaces");
+  let marketplaces;
+  try {
+    marketplaces = fs.readdirSync(marketplacesDir, { withFileTypes: true });
+  } catch {
+    return roots;
+  }
+  for (const marketplace of marketplaces) {
+    if (!marketplace.isDirectory()) continue;
+    for (const collectionName of ["plugins", "external_plugins"]) {
+      const collectionDir = path.join(marketplacesDir, marketplace.name, collectionName);
+      let entries;
+      try {
+        entries = fs.readdirSync(collectionDir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          roots.push(path.join(collectionDir, entry.name, "skills"));
+        }
+      }
+    }
+  }
+  return roots;
 }
 
 function cleanText(value) {
@@ -119,4 +185,4 @@ function expandHome(value) {
   return path.join(os.homedir(), value.slice(2));
 }
 
-module.exports = { buildRecord, extractSkillName, skillMarkdownHash };
+module.exports = { buildRecord, extractSkillName, skillMarkdownHash, collectClaudePluginSkillRoots };

--- a/apps/main-2.0/src/core/postgres/skill-repository.ts
+++ b/apps/main-2.0/src/core/postgres/skill-repository.ts
@@ -445,8 +445,11 @@ export class PostgresSkillRepository {
   }
 
   // Observability floor for claude skills: the hook pipeline has demonstrably
-  // produced at least one record. Until then "no triggers" must be reported
-  // as Unobserved rather than never-used.
+  // contributed version data to at least one indexed session event. The hook
+  // source no longer emits independent events (its skill_hash is merged into
+  // claude-session events at read time), so we check whether any claude session
+  // event carries a non-null skill_hash. Until then "no triggers" must be
+  // reported as Unobserved rather than never-used.
   async hasClaudeHookUsageEvents(): Promise<boolean> {
     const result = await this.database.query<{ found: boolean }>(
       `
@@ -455,7 +458,9 @@ export class PostgresSkillRepository {
           from agent_recall.skill_usage_events events
           join agent_recall.skill_usage_sources sources
             on sources.source_path = events.source_path
-          where sources.kind = 'claude-hook'
+          where sources.kind = 'claude-session'
+            and events.agent = 'claude'
+            and events.skill_hash is not null
         ) as found
       `,
     );

--- a/apps/main-2.0/src/core/postgres/support-repositories.test.ts
+++ b/apps/main-2.0/src/core/postgres/support-repositories.test.ts
@@ -282,13 +282,14 @@ describe("PostgreSQL support repositories", () => {
     }, [
       { agent: "codex", skill: "other", timestamp: now },
     ]);
-    // The claude observability floor only trips once hook records exist.
+    // The claude observability floor trips once a claude session event carries
+    // a skill_hash — the signature that the hook contributed version data.
     await expect(repository.hasClaudeHookUsageEvents()).resolves.toBe(false);
 
     await repository.upsertSkillUsageSource({
       agent: "claude",
-      kind: "claude-hook",
-      path: "/fixtures/skill-usage.jsonl",
+      kind: "claude-session",
+      path: "/fixtures/claude-session.jsonl",
       mtimeMs: 1,
       fileSize: 1,
     }, [

--- a/apps/main-2.0/src/core/setup-skill-usage-hook.test.ts
+++ b/apps/main-2.0/src/core/setup-skill-usage-hook.test.ts
@@ -197,4 +197,52 @@ describe("skill markdown hash capture", () => {
       rmSync(homeDir, { recursive: true, force: true });
     }
   });
+
+  it("resolves plugin skills under ~/.claude/plugins/marketplaces", () => {
+    const homeDir = freshHome();
+    try {
+      process.env.AGENT_RECALL_TEST_HOME = homeDir;
+      const pluginSkillDir = path.join(
+        homeDir, ".claude", "plugins", "marketplaces", "acme", "plugins", "acme-helper", "skills", "deploy",
+      );
+      mkdirSync(pluginSkillDir, { recursive: true });
+      const body = "# Deploy\nProduction deploy guide.\n";
+      writeFileSync(path.join(pluginSkillDir, "SKILL.md"), body, "utf8");
+      const expectedHash = createHash("sha256").update(Buffer.from(body, "utf8")).digest("hex");
+
+      expect(record.skillMarkdownHash("deploy", "")).toBe(expectedHash);
+
+      const built = record.buildRecord({
+        tool_name: "Skill",
+        tool_input: { skill: "deploy" },
+        cwd: homeDir,
+      });
+      expect(built).toMatchObject({ skill: "deploy", skill_hash: expectedHash });
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves plugin skills via installed_plugins.json", () => {
+    const homeDir = freshHome();
+    try {
+      process.env.AGENT_RECALL_TEST_HOME = homeDir;
+      const installDir = path.join(homeDir, "custom-plugin");
+      const skillDir = path.join(installDir, "skills", "lint");
+      mkdirSync(skillDir, { recursive: true });
+      const body = "# Lint\nCode quality checks.\n";
+      writeFileSync(path.join(skillDir, "SKILL.md"), body, "utf8");
+      const expectedHash = createHash("sha256").update(Buffer.from(body, "utf8")).digest("hex");
+
+      const pluginsFile = path.join(homeDir, ".claude", "plugins", "installed_plugins.json");
+      mkdirSync(path.dirname(pluginsFile), { recursive: true });
+      writeFileSync(pluginsFile, JSON.stringify({
+        plugins: { acme: [{ installPath: installDir }] },
+      }), "utf8");
+
+      expect(record.skillMarkdownHash("lint", "")).toBe(expectedHash);
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/apps/main-2.0/src/core/skill-usage.test.ts
+++ b/apps/main-2.0/src/core/skill-usage.test.ts
@@ -34,15 +34,33 @@ function writeCodexSession(homeDir: string, lines: string[]): string {
   return sessionsDir;
 }
 
+function writeClaudeSession(homeDir: string, lines: string[]): string {
+  const projectDir = path.join(homeDir, ".claude", "projects", "repo");
+  fs.mkdirSync(projectDir, { recursive: true });
+  const filePath = path.join(projectDir, "session.jsonl");
+  fs.writeFileSync(filePath, lines.join("\n"), "utf8");
+  return filePath;
+}
+
+function claudeSkillUse(id: string, skill: string, timestamp: string, sessionId = "sess-1", cwd = "/repo"): string {
+  return JSON.stringify({
+    type: "assistant",
+    timestamp,
+    sessionId,
+    cwd,
+    message: { role: "assistant", content: [{ type: "tool_use", id, name: "Skill", input: { skill } }] },
+  });
+}
+
 describe("skill usage", () => {
-  it("aggregates counts and last-used time per skill", () => withTempHome((homeDir) => {
-    const usagePath = writeUsageLog(homeDir, [
-      JSON.stringify({ skill: "brainstorming", ts: "2026-06-01T10:00:00.000Z" }),
-      JSON.stringify({ skill: "brainstorming", ts: "2026-06-02T10:00:00.000Z" }),
-      JSON.stringify({ skill: "tdd", ts: "2026-06-03T10:00:00.000Z" }),
+  it("aggregates counts and last-used time per skill from Claude sessions", () => withTempHome((homeDir) => {
+    writeClaudeSession(homeDir, [
+      claudeSkillUse("call_1", "brainstorming", "2026-06-01T10:00:00.000Z"),
+      claudeSkillUse("call_2", "brainstorming", "2026-06-02T10:00:00.000Z"),
+      claudeSkillUse("call_3", "tdd", "2026-06-03T10:00:00.000Z"),
     ]);
 
-    const snapshot = loadSkillUsage({ homeDir, usagePath, codexSessionsDir: null });
+    const snapshot = loadSkillUsage({ homeDir, usagePath: path.join(homeDir, "missing.jsonl"), codexSessionsDir: null });
 
     expect(snapshot.exists).toBe(true);
     expect(snapshot.totalEvents).toBe(3);
@@ -50,29 +68,12 @@ describe("skill usage", () => {
       { skill: "brainstorming", count: 2, lastUsedAt: Date.parse("2026-06-02T10:00:00.000Z") },
       { skill: "tdd", count: 1, lastUsedAt: Date.parse("2026-06-03T10:00:00.000Z") },
     ]);
-    expect(usageForSkill(snapshot, "Brainstorming")?.count).toBe(2);
+    expect(usageForSkill(snapshot, "Brainstorming", "claude")?.count).toBe(2);
   }));
 
-  it("skips malformed lines and records without a skill name", () => withTempHome((homeDir) => {
+  it("returns no events from the claude-hook source (data is merged into sessions)", () => withTempHome((homeDir) => {
     const usagePath = writeUsageLog(homeDir, [
-      "not json",
-      JSON.stringify({ ts: "2026-06-01T10:00:00.000Z" }),
-      JSON.stringify({ skill: "  ", ts: "2026-06-01T10:00:00.000Z" }),
-      JSON.stringify({ skill: "review-code", ts: "2026-06-01T10:00:00.000Z" }),
-      "",
-    ]);
-
-    const snapshot = loadSkillUsage({ homeDir, usagePath, codexSessionsDir: null });
-
-    expect(snapshot.totalEvents).toBe(1);
-    expect(snapshot.stats.map((stat) => stat.skill)).toEqual(["review-code"]);
-  }));
-
-  it("carries session linkage fields from newer hook records and tolerates old ones", () => withTempHome((homeDir) => {
-    const usagePath = writeUsageLog(homeDir, [
-      JSON.stringify({ skill: "review", ts: "2026-06-01T10:00:00.000Z" }),
-      JSON.stringify({ skill: "review", ts: "2026-06-02T10:00:00.000Z", session_id: "abc-123", cwd: "/repo", skill_hash: "a1b2c3" }),
-      JSON.stringify({ skill: "review", ts: "2026-06-03T10:00:00.000Z", session_id: "   ", cwd: 42, skill_hash: "  " }),
+      JSON.stringify({ skill: "review", ts: "2026-06-01T10:00:00.000Z", session_id: "abc-123", skill_hash: "a1b2c3" }),
     ]);
 
     const events = readSkillUsageSourceEvents({
@@ -83,14 +84,34 @@ describe("skill usage", () => {
       fileSize: 1,
     });
 
-    expect(events).toHaveLength(3);
-    expect(events[0]?.sessionId).toBeUndefined();
-    expect(events[0]?.cwd).toBeUndefined();
-    expect(events[0]?.skillHash).toBeUndefined();
-    expect(events[1]).toMatchObject({ sessionId: "abc-123", cwd: "/repo", skillHash: "a1b2c3" });
-    expect(events[2]?.sessionId).toBeUndefined();
-    expect(events[2]?.cwd).toBeUndefined();
-    expect(events[2]?.skillHash).toBeUndefined();
+    expect(events).toEqual([]);
+  }));
+
+  it("enriches Claude session events with skill_hash from matching hook records", () => withTempHome((homeDir) => {
+    const sessionPath = writeClaudeSession(homeDir, [
+      claudeSkillUse("call_1", "review", "2026-06-01T10:00:00.000Z", "sess-abc"),
+    ]);
+    const hookLogPath = writeUsageLog(homeDir, [
+      "not json",
+      JSON.stringify({ ts: "2026-06-01T10:00:00.000Z" }),
+      JSON.stringify({ skill: "  ", ts: "2026-06-01T10:00:00.000Z" }),
+      JSON.stringify({ skill: "review", ts: "2026-06-01T10:00:01.000Z", session_id: "sess-abc", skill_hash: "a1b2c3" }),
+      JSON.stringify({ skill: "review", ts: "2026-06-01T10:00:00.000Z", session_id: "other", skill_hash: "deadbeef" }),
+    ]);
+    const stat = fs.statSync(sessionPath);
+
+    const events = readSkillUsageSourceEvents({
+      agent: "claude",
+      provider: "claude",
+      kind: "claude-session",
+      path: sessionPath,
+      mtimeMs: stat.mtimeMs,
+      fileSize: stat.size,
+      hookLogPath,
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ skill: "review", sessionId: "sess-abc", skillHash: "a1b2c3" });
   }));
 
   it("returns an empty snapshot when the log is missing", () => withTempHome((homeDir) => {
@@ -171,8 +192,8 @@ describe("skill usage", () => {
   }));
 
   it("keeps same-name Codex and Claude usage separate for per-agent lookups", () => withTempHome((homeDir) => {
-    const usagePath = writeUsageLog(homeDir, [
-      JSON.stringify({ skill: "brainstorming", ts: "2026-06-01T10:00:00.000Z" }),
+    writeClaudeSession(homeDir, [
+      claudeSkillUse("call_1", "brainstorming", "2026-06-01T10:00:00.000Z"),
     ]);
     const codexSessionsDir = writeCodexSession(homeDir, [
       JSON.stringify({
@@ -195,7 +216,7 @@ describe("skill usage", () => {
       }),
     ]);
 
-    const snapshot = loadSkillUsage({ homeDir, usagePath, codexSessionsDir });
+    const snapshot = loadSkillUsage({ homeDir, usagePath: path.join(homeDir, "missing.jsonl"), codexSessionsDir });
 
     expect(usageForSkill(snapshot, "brainstorming")?.count).toBe(3);
     expect(usageForSkill(snapshot, "brainstorming", "claude")?.count).toBe(1);

--- a/apps/main-2.0/src/core/skill-usage.ts
+++ b/apps/main-2.0/src/core/skill-usage.ts
@@ -68,6 +68,11 @@ export interface SkillUsageSource {
   path: string;
   mtimeMs: number;
   fileSize: number;
+  // Set on claude-session sources by listSkillUsageSources so the reader knows
+  // where to find the hook log for skill_hash enrichment. The hook log is the
+  // only place the trigger-time SKILL.md hash is captured for Claude; sessions
+  // carry no such content, so the hash must be merged in at read time.
+  hookLogPath?: string;
 }
 
 export interface SkillUsageRefreshStatus {
@@ -146,19 +151,25 @@ export function listSkillUsageSources(options: SkillUsageOptions = {}): SkillUsa
   const homeDir = options.homeDir ?? os.homedir();
   const sources: SkillUsageSource[] = [];
 
+  const hookLogPath = resolveUsagePath(options);
+
   addJsonlSources(sources, path.join(homeDir, ".claude", "projects"), "claude", "claude", "claude-session");
   if (options.includeTclaude !== false) {
     addJsonlSources(sources, path.join(homeDir, ".tclaude", "projects"), "claude", "tclaude", "claude-session");
   }
 
-  const hasNativeClaudeSessions = sources.some(
-    (source) => source.kind === "claude-session" && source.provider === "claude",
-  );
-  if (!hasNativeClaudeSessions) {
-    const usagePath = resolveUsagePath(options);
-    const stat = safeStat(usagePath);
-    if (stat) {
-      sources.push({ agent: "claude", provider: "claude", kind: "claude-hook", path: usagePath, ...stat });
+  // Always include the hook source so its skill_hash data can enrich session
+  // events at read time. The hook log is the only place the trigger-time
+  // SKILL.md hash is captured for Claude; sessions carry no such content.
+  const hookStat = safeStat(hookLogPath);
+  if (hookStat) {
+    sources.push({ agent: "claude", provider: "claude", kind: "claude-hook", path: hookLogPath, ...hookStat });
+    // Attach the hook log path to Claude session sources so the reader knows
+    // where to look for hash enrichment. tclaude sessions have different
+    // session ids and won't match hook records, but setting the path is
+    // harmless—the enrichment simply finds no matches.
+    for (const source of sources) {
+      if (source.kind === "claude-session" && source.provider === "claude") source.hookLogPath = hookLogPath;
     }
   }
 
@@ -203,13 +214,17 @@ export function listSkillUsageSources(options: SkillUsageOptions = {}): SkillUsa
 }
 
 export function readSkillUsageSourceEvents(source: SkillUsageSource): SkillUsageEvent[] {
-  if (source.kind === "claude-hook") return readClaudeUsageEvents(source.path) ?? [];
+  // The hook source no longer emits independent events: its skill_hash data is
+  // merged into claude-session events at read time via enrichEventsWithHookHash.
+  if (source.kind === "claude-hook") return [];
   if (source.kind.endsWith("-db")) return readDatabaseUsageEvents(source);
   return readSessionFileUsageEvents(source);
 }
 
 export async function readSkillUsageSourceEventsAsync(source: SkillUsageSource): Promise<SkillUsageEvent[]> {
-  if (source.kind === "claude-hook") return readClaudeUsageEvents(source.path) ?? [];
+  // The hook source no longer emits independent events: its skill_hash data is
+  // merged into claude-session events at read time via enrichEventsWithHookHash.
+  if (source.kind === "claude-hook") return [];
   if (source.kind.endsWith("-db")) return readDatabaseUsageEvents(source);
   const context: SessionFileContext = { failedToolUseIds: new Set() };
   const events: ScannedUsageEvent[] = [];
@@ -221,7 +236,9 @@ export async function readSkillUsageSourceEventsAsync(source: SkillUsageSource):
   } catch {
     return [];
   }
-  return settleSessionFileEvents(events, context);
+  const settled = settleSessionFileEvents(events, context);
+  if (source.hookLogPath) enrichEventsWithHookHash(settled, source.hookLogPath);
+  return settled;
 }
 
 function addUsageEvents(
@@ -259,6 +276,44 @@ function readClaudeUsageEvents(usagePath: string): SkillUsageEvent[] | null {
     if (event) events.push({ ...event, agent: "claude" });
   });
   return read ? events : null;
+}
+
+// Merges the hook's skill_hash into Claude session events that describe the
+// same trigger. The hook log is small (one line per trigger) so reading it
+// per session file is cheap. Matching by session id + skill name + a 60-second
+// time window keeps the enrichment precise even when a skill is called
+// repeatedly in the same session. The hook fires at PostToolUse (after the
+// tool returns), while the session timestamp is the transcript line time —
+// the two differ by seconds, not minutes.
+function enrichEventsWithHookHash(events: SkillUsageEvent[], hookLogPath: string): void {
+  const hookEvents = readClaudeUsageEvents(hookLogPath);
+  if (!hookEvents || hookEvents.length === 0) return;
+
+  const hookBySession = new Map<string, Array<{ event: SkillUsageEvent; used: boolean }>>();
+  for (const event of hookEvents) {
+    if (!event.sessionId || !event.skillHash) continue;
+    const list = hookBySession.get(event.sessionId) ?? [];
+    list.push({ event, used: false });
+    hookBySession.set(event.sessionId, list);
+  }
+
+  for (const event of events) {
+    if (event.skillHash || !event.sessionId) continue;
+    const candidates = hookBySession.get(event.sessionId);
+    if (!candidates) continue;
+    let best: { entry: { event: SkillUsageEvent; used: boolean }; diff: number } | null = null;
+    for (const entry of candidates) {
+      if (entry.used) continue;
+      if (entry.event.skill.toLowerCase() !== event.skill.toLowerCase()) continue;
+      const diff = Math.abs(entry.event.timestamp - event.timestamp);
+      if (diff > 60_000) continue;
+      if (!best || diff < best.diff) best = { entry, diff };
+    }
+    if (best) {
+      event.skillHash = best.entry.event.skillHash;
+      best.entry.used = true;
+    }
+  }
 }
 
 export function usageForSkill(
@@ -300,7 +355,9 @@ function readSessionFileUsageEvents(source: SkillUsageSource): SkillUsageEvent[]
   const context: SessionFileContext = { failedToolUseIds: new Set() };
   const events: ScannedUsageEvent[] = [];
   forEachJsonlLine(source.path, (line) => events.push(...parseSessionUsageLine(line, source, context)));
-  return settleSessionFileEvents(events, context);
+  const settled = settleSessionFileEvents(events, context);
+  if (source.hookLogPath) enrichEventsWithHookHash(settled, source.hookLogPath);
+  return settled;
 }
 
 // Scanning state that a single trigger cannot carry on its own: Codex keeps the

--- a/apps/main-2.0/src/core/skill-usage.ts
+++ b/apps/main-2.0/src/core/skill-usage.ts
@@ -279,14 +279,29 @@ function readClaudeUsageEvents(usagePath: string): SkillUsageEvent[] | null {
 }
 
 // Merges the hook's skill_hash into Claude session events that describe the
-// same trigger. The hook log is small (one line per trigger) so reading it
-// per session file is cheap. Matching by session id + skill name + a 60-second
-// time window keeps the enrichment precise even when a skill is called
-// repeatedly in the same session. The hook fires at PostToolUse (after the
-// tool returns), while the session timestamp is the transcript line time —
-// the two differ by seconds, not minutes.
+// same trigger. Matching by session id + skill name + a 60-second time window
+// keeps the enrichment precise even when a skill is called repeatedly in the
+// same session. The hook fires at PostToolUse (after the tool returns), while
+// the session timestamp is the transcript line time — the two differ by
+// seconds, not minutes.
+//
+// The hook log is parsed once per refresh cycle and cached by path + mtime so
+// that scanning many Claude session files does not re-read the same small file
+// each time.
+const hookEventCache = new Map<string, { mtimeMs: number; events: SkillUsageEvent[] | null }>();
+
+function readCachedHookEvents(hookLogPath: string): SkillUsageEvent[] | null {
+  const stat = safeStat(hookLogPath);
+  if (!stat) return null;
+  const cached = hookEventCache.get(hookLogPath);
+  if (cached && cached.mtimeMs === stat.mtimeMs) return cached.events;
+  const events = readClaudeUsageEvents(hookLogPath);
+  hookEventCache.set(hookLogPath, { mtimeMs: stat.mtimeMs, events });
+  return events;
+}
+
 function enrichEventsWithHookHash(events: SkillUsageEvent[], hookLogPath: string): void {
-  const hookEvents = readClaudeUsageEvents(hookLogPath);
+  const hookEvents = readCachedHookEvents(hookLogPath);
   if (!hookEvents || hookEvents.length === 0) return;
 
   const hookBySession = new Map<string, Array<{ event: SkillUsageEvent; used: boolean }>>();


### PR DESCRIPTION
## 问题

Claude Skill 的触发时版本指纹（`skill_hash`）无法进入 Eval 数据库。原因：`listSkillUsageSources` 仅当无 Claude 转录时才加 hook 源，有转录就跳过 → hook 日志中的 `skill_hash` 永远不入库，版本对比功能（`listSkillVersionGroups`）失效。

同时，hook 脚本的 `skillMarkdownHash` 只搜索 `~/.claude/skills/`，插件 Skill 返回空 hash。

## 实测发现

交接文档原列三个缺陷。**缺陷②「失败也记」经活体验证不存在**——Claude Code 2.1.220 的 PostToolUse 只在工具成功后触发，失败走独立的 PostToolUseFailure 事件。hook 注册在 PostToolUse 上，不会为失败调用触发。因此本 PR 只修缺陷①和③。

## 改动

### 缺陷①：hook 数据进不了库（V2-only）

- **`skill-usage.ts`**：
  - `listSkillUsageSources` 去掉 `if (!hasNativeClaudeSessions)` 守卫，始终加入 hook 源
  - `SkillUsageSource` 接口加 `hookLogPath?: string`，构造 claude-session 源时设上
  - 新增 `enrichEventsWithHookHash(events, hookLogPath)`：读 hook 日志，按 `sessionId + skill（忽略大小写）+ 时间窗 60s` 匹配，把 `skillHash` 合并到 session event 上
  - `readSkillUsageSourceEvents` / `readSkillUsageSourceEventsAsync`：`claude-hook` 返回空数组（数据已合并进 session events，无双计）；`claude-session` 在 `settleSessionFileEvents` 后调 enrichment
- **`skill-repository.ts`**：`hasClaudeHookUsageEvents` 查询从查 `claude-hook` events 改为查 `claude-session` + `agent='claude'` 的 event 是否有非空 `skill_hash`

### 缺陷③：插件 Skill 拿不到 hash（V2-only）

- **`skill-usage-record.cjs`**：`skillMarkdownHash` 加 `collectClaudePluginSkillRoots(homeDir)`，搜索 `~/.claude/plugins` 下的插件目录（`installed_plugins.json` + `marketplaces` 两种路径），与 `skill-manager.ts` 的 `collectClaudePluginRoots` 逻辑对齐

## V1/V2 范围

V1 不改动。缺陷①和③都是 V2-only：Eval 是 V2 独有功能；V1 的 hook 脚本没有 `skillMarkdownHash` 函数。

## 测试

- `skill-usage.test.ts`：11 tests ✓（新增 enrichment 测试 + hook 返回空数组测试）
- `setup-skill-usage-hook.test.ts`：11 tests ✓（新增 marketplace 插件 + installed_plugins.json 两个测试）
- `skill-service.test.ts`：18 tests ✓
- `support-repositories.test.ts`：6 tests ✓（`hasClaudeHookUsageEvents` 测试更新）
- `npm run typecheck` ✓
- `npm run release-note:check` ✓