### PR TITLE
fix: 补齐 Skill 安装目标 IPC 契约的 codebuddy 和 qoder 选项

### DIFF
--- a/.release-notes/fix-skill-install-targets.md
+++ b/.release-notes/fix-skill-install-targets.md
@@ -1,4 +1,5 @@
 # Skill 安装目标保存修复
 
 ## Bug 修复
-- 修复了在 Skill 管理面板中选择 Qoder 或 CodeBuddy 作为安装目标时无法保存的问题
+
+- 修复了在 Skills 管理窗口中选择 Qoder 或 CodeBuddy 作为安装目标时无法保存的问题

--- a/.release-notes/fix-skill-install-targets.md
+++ b/.release-notes/fix-skill-install-targets.md
@@ -1,0 +1,4 @@
+# Skill 安装目标保存修复
+
+## Bug 修复
+- 修复了在 Skill 管理面板中选择 Qoder 或 CodeBuddy 作为安装目标时无法保存的问题

--- a/apps/main-2.0/src/shared/ipc/skills.ts
+++ b/apps/main-2.0/src/shared/ipc/skills.ts
@@ -9,8 +9,8 @@ const pathListInput = z.array(pathInput).min(1).max(500);
 const managedSkillIdInput = z.string().trim().min(1).max(80)
   .regex(/^[a-z0-9._-]+$/)
   .refine((value) => value !== "." && value !== "..", "Invalid managed Skill id.");
-const installTargetInput = z.enum(["codex", "claude", "trae"]);
-const installTargetsInput = z.array(installTargetInput).max(3);
+const installTargetInput = z.enum(["codex", "claude", "codebuddy", "qoder", "trae"]);
+const installTargetsInput = z.array(installTargetInput).max(5);
 const discoveryQueryInput = z.object({
   page: z.number().int().min(0).max(10_000),
   query: z.string().max(500).transform((value) => value.trim()),

--- a/apps/main-2.0/src/shared/ipc/skills.ts
+++ b/apps/main-2.0/src/shared/ipc/skills.ts
@@ -10,7 +10,7 @@ const managedSkillIdInput = z.string().trim().min(1).max(80)
   .regex(/^[a-z0-9._-]+$/)
   .refine((value) => value !== "." && value !== "..", "Invalid managed Skill id.");
 const installTargetInput = z.enum(["codex", "claude", "codebuddy", "qoder", "trae"]);
-const installTargetsInput = z.array(installTargetInput).max(5);
+const installTargetsInput = z.array(installTargetInput).max(installTargetInput.options.length);
 const discoveryQueryInput = z.object({
   page: z.number().int().min(0).max(10_000),
   query: z.string().max(500).transform((value) => value.trim()),


### PR DESCRIPTION
## 问题

在 Skill 管理面板中选择 Qoder 或 CodeBuddy 作为安装目标并保存时，报错：

`Error invoking remote method 'skills:update-targets': IpcInputError: Invalid input for IPC channel "skills:update-targets": 1.1: Invalid option: expected one of "codex"|"claude"|"trae"`

## 根因

IPC 契约层 `installTargetInput` 的 Zod enum 只定义了 `["codex", "claude", "trae"]` 三个值，而 Core 层的 `SkillInstallTarget` 类型和 UI 层的 `TARGET_LABELS` 都支持 5 个值（codex / claude / codebuddy / qoder / trae）。当用户选择 Qoder 或 CodeBuddy 时，IPC 校验拒绝了这两个值。

## 修复

将 IPC 契约的 `installTargetInput` enum 补齐为 5 个值，与 Core 类型和 UI 对齐；同时将 `installTargetsInput` 的 `.max(3)` 改为 `.max(5)`。

## 测试

- 类型检查通过
- 现有 29 个相关测试全部通过