### PR TITLE
fix(v2): support auth headers for HTTP MCP servers

### DIFF
--- a/.release-notes/fix-mcp-http-headers.md
+++ b/.release-notes/fix-mcp-http-headers.md
@@ -1,0 +1,6 @@
+# HTTP MCP Server 支持鉴权请求头
+
+## Bug 修复
+
+- HTTP 类型的 MCP Server 现在可以配置自定义请求头（如 `Authorization`）：在 MCP 页面填写请求头名称并引用宿主机环境变量，密钥值不会保存到数据库。此前 HTTP Server 只能填 URL，需要鉴权的远程 MCP 服务无法接入。
+- 配置的请求头会在连接测试和 Codex、Claude Code、Hermes、OpenCode、OpenClaw 会话中一并生效；从 JSON 导入含 `headers` 的 HTTP Server 时会保留请求头名称，等待补填环境变量引用。

--- a/apps/main-2.0/src/automation/engine/main/hub/runtime/executor/runtime-mcp.test.ts
+++ b/apps/main-2.0/src/automation/engine/main/hub/runtime/executor/runtime-mcp.test.ts
@@ -38,6 +38,7 @@ const servers: BoundMcpServer[] = [
       args: [],
       url: "https://example.test/mcp",
       env: {},
+      headers: { Authorization: "HOST_HTTP_TOKEN" },
       enabled: true,
       tools: [],
       status: "connected",
@@ -50,7 +51,7 @@ const servers: BoundMcpServer[] = [
 
 describe("runtime MCP configuration", () => {
   test("builds Codex overrides without exposing secret values in argv", () => {
-    const config = codexMcpLaunchConfig(servers, { HOST_API_TOKEN: "secret-value" });
+    const config = codexMcpLaunchConfig(servers, { HOST_API_TOKEN: "secret-value", HOST_HTTP_TOKEN: "http-secret" });
     const argv = config.args.join("\n");
 
     expect(argv).toContain("mcp_servers.agent_recall_");
@@ -58,20 +59,22 @@ describe("runtime MCP configuration", () => {
     expect(argv).toContain('env_vars=["API_TOKEN"]');
     expect(argv).toContain('enabled_tools=["read_file"]');
     expect(argv).toContain('url="https://example.test/mcp"');
+    expect(argv).toContain('env_http_headers={"Authorization" = "HOST_HTTP_TOKEN"}');
     expect(argv).not.toContain("secret-value");
-    expect(config.env).toMatchObject({ API_TOKEN: "secret-value" });
+    expect(argv).not.toContain("http-secret");
+    expect(config.env).toMatchObject({ API_TOKEN: "secret-value", HOST_HTTP_TOKEN: "http-secret" });
   });
 
   test("builds Claude and ACP server definitions for both transports", () => {
-    const claude = claudeMcpServers(servers, { HOST_API_TOKEN: "secret-value" });
+    const claude = claudeMcpServers(servers, { HOST_API_TOKEN: "secret-value", HOST_HTTP_TOKEN: "http-secret" });
     expect(Object.values(claude ?? {})).toEqual(expect.arrayContaining([
       expect.objectContaining({ command: "node", args: ["server.js", "C:\\workspace"], env: { API_TOKEN: "secret-value" } }),
-      expect.objectContaining({ type: "http", url: "https://example.test/mcp" }),
+      expect.objectContaining({ type: "http", url: "https://example.test/mcp", headers: { Authorization: "http-secret" } }),
     ]));
 
-    expect(acpMcpServers(servers, { HOST_API_TOKEN: "secret-value" })).toEqual(expect.arrayContaining([
+    expect(acpMcpServers(servers, { HOST_API_TOKEN: "secret-value", HOST_HTTP_TOKEN: "http-secret" })).toEqual(expect.arrayContaining([
       expect.objectContaining({ name: expect.stringMatching(/^agent_recall_/), command: "node", env: [{ name: "API_TOKEN", value: "secret-value" }] }),
-      expect.objectContaining({ type: "http", name: expect.stringMatching(/^agent_recall_/), url: "https://example.test/mcp", headers: [] }),
+      expect.objectContaining({ type: "http", name: expect.stringMatching(/^agent_recall_/), url: "https://example.test/mcp", headers: [{ name: "Authorization", value: "http-secret" }] }),
     ]));
   });
 

--- a/apps/main-2.0/src/automation/engine/main/hub/runtime/executor/runtime-mcp.ts
+++ b/apps/main-2.0/src/automation/engine/main/hub/runtime/executor/runtime-mcp.ts
@@ -22,6 +22,26 @@ function resolvedEnvironment(
 }
 
 /**
+ * Header entries whose header name and host environment reference are both
+ * filled in. Values stay as host variable names here; resolve them at the
+ * launch boundary so secrets never end up in persisted launch configs.
+ */
+function headerReferences(server: McpServerDefinition): [string, string][] {
+  return Object.entries(server.headers ?? {}).filter(
+    ([name, hostName]) => name.trim() && hostName.trim(),
+  );
+}
+
+function resolvedHeaders(
+  server: McpServerDefinition,
+  environment: NodeJS.ProcessEnv,
+): Record<string, string> {
+  return Object.fromEntries(
+    headerReferences(server).map(([name, hostName]) => [name, environment[hostName] ?? ""]),
+  );
+}
+
+/**
  * Combine the per-binding allowlist with the server-level disabled tools to
  * decide which tool names an Agent may actually use. `restricted` is false only
  * when every discovered tool is allowed (no allowlist and nothing disabled), in
@@ -60,6 +80,16 @@ export function codexMcpLaunchConfig(
       }
     } else if (server.transport === "http" && server.url?.trim()) {
       args.push("-c", `${prefix}.url=${JSON.stringify(server.url.trim())}`);
+      const headers = headerReferences(server);
+      if (headers.length > 0) {
+        // env_http_headers keeps secret values out of argv: Codex reads each
+        // header value from its own process environment at connect time.
+        args.push(
+          "-c",
+          `${prefix}.env_http_headers={${headers.map(([name, hostName]) => `${JSON.stringify(name)} = ${JSON.stringify(hostName)}`).join(", ")}}`,
+        );
+        for (const [, hostName] of headers) env[hostName] = environment[hostName] ?? "";
+      }
     } else {
       continue;
     }
@@ -94,9 +124,11 @@ export function claudeMcpServers(
         ...(tools ? { tools } : {}),
       };
     } else if (server.transport === "http" && server.url?.trim()) {
+      const headers = resolvedHeaders(server, environment);
       result[name] = {
         type: "http",
         url: server.url.trim(),
+        ...(Object.keys(headers).length > 0 ? { headers } : {}),
         ...(tools ? { tools } : {}),
       };
     }
@@ -119,7 +151,12 @@ export function acpMcpServers(
         env: Object.entries(resolvedEnvironment(server, environment)).map(([name, value]) => ({ name, value })),
       });
     } else if (server.transport === "http" && server.url?.trim()) {
-      result.push({ type: "http", name, url: server.url.trim(), headers: [] });
+      result.push({
+        type: "http",
+        name,
+        url: server.url.trim(),
+        headers: Object.entries(resolvedHeaders(server, environment)).map(([headerName, value]) => ({ name: headerName, value })),
+      });
     }
   }
   return result;

--- a/apps/main-2.0/src/automation/engine/main/mcp-client.ts
+++ b/apps/main-2.0/src/automation/engine/main/mcp-client.ts
@@ -10,7 +10,9 @@ export async function discoverMcpTools(
 ): Promise<McpToolDefinition[]> {
   const client = new Client({ name: "agent-recall-v2", version: "0.1.0" });
   const transport = server.transport === "http"
-    ? new StreamableHTTPClientTransport(new URL(required(server.url, "HTTP URL")))
+    ? new StreamableHTTPClientTransport(new URL(required(server.url, "HTTP URL")), {
+        requestInit: { headers: resolvedHeaders(server) },
+      })
     : new StdioClientTransport({
         command: required(server.command, "command"),
         args: server.args,
@@ -32,6 +34,15 @@ export async function discoverMcpTools(
 function required(value: string | undefined, label: string): string {
   if (!value?.trim()) throw new Error(`MCP ${label} is required`);
   return value.trim();
+}
+
+// Header values reference host environment variable names, mirroring `env`.
+function resolvedHeaders(server: McpServerDefinition): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(server.headers ?? {})
+      .filter(([name, hostName]) => name.trim() && hostName.trim())
+      .map(([name, hostName]) => [name, process.env[hostName] ?? ""]),
+  );
 }
 
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {

--- a/apps/main-2.0/src/automation/engine/main/mcp-registry-store.test.ts
+++ b/apps/main-2.0/src/automation/engine/main/mcp-registry-store.test.ts
@@ -84,4 +84,24 @@ describe("PostgreSQL MCP registry", () => {
     const [stored] = await store.list();
     expect(stored?.disabledTools).toEqual(["write_file"]);
   });
+
+  it("round-trips HTTP header references without storing secret values", async () => {
+    await store.upsert({
+      id: "remote",
+      name: "Remote search",
+      transport: "http",
+      args: [],
+      url: "https://example.test/mcp",
+      env: {},
+      headers: { Authorization: "HOST_HTTP_TOKEN" },
+      enabled: true,
+      tools: [],
+      status: "untested",
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    });
+
+    const [stored] = await store.list();
+    expect(stored?.headers).toEqual({ Authorization: "HOST_HTTP_TOKEN" });
+  });
 });

--- a/apps/main-2.0/src/automation/engine/main/mcp-registry-store.ts
+++ b/apps/main-2.0/src/automation/engine/main/mcp-registry-store.ts
@@ -17,10 +17,10 @@ export class McpRegistryStore {
     await this.database.transaction(async (transaction) => {
       await transaction.query(
         `insert into agent_recall.mcp_servers (
-          id, name, transport, command, args, url, env, enabled, disabled_tools, status,
+          id, name, transport, command, args, url, env, headers, enabled, disabled_tools, status,
           last_error, last_tested_at, created_at, updated_at
         ) values (
-          $1, $2, $3, $4, $5::jsonb, $6, $7::jsonb, $8, $9::jsonb, $10, $11, $12, $13, $14
+          $1, $2, $3, $4, $5::jsonb, $6, $7::jsonb, $8::jsonb, $9, $10::jsonb, $11, $12, $13, $14, $15
         )
         on conflict (id) do update set
           name = excluded.name,
@@ -29,6 +29,7 @@ export class McpRegistryStore {
           args = excluded.args,
           url = excluded.url,
           env = excluded.env,
+          headers = excluded.headers,
           enabled = excluded.enabled,
           disabled_tools = excluded.disabled_tools,
           status = excluded.status,
@@ -43,6 +44,7 @@ export class McpRegistryStore {
           JSON.stringify(server.args),
           server.url?.trim() || null,
           JSON.stringify(server.env),
+          JSON.stringify(server.headers ?? {}),
           server.enabled,
           JSON.stringify(disabledToolNames(server)),
           server.status,
@@ -127,6 +129,7 @@ export class McpRegistryStore {
       args: jsonArray(row.args),
       ...(row.url ? { url: String(row.url) } : {}),
       env: jsonStringRecord(row.env),
+      headers: jsonStringRecord(row.headers),
       enabled: Boolean(row.enabled),
       tools: tools.rows.map((tool) => ({
         name: String(tool.name),

--- a/apps/main-2.0/src/automation/engine/renderer/src/pages/mcp/McpPage.tsx
+++ b/apps/main-2.0/src/automation/engine/renderer/src/pages/mcp/McpPage.tsx
@@ -343,40 +343,53 @@ export function McpPage({
                     </div>
                   ) : null}
                 </WorkbenchSection>
-                {draft.managed ? null : (
+                {draft.managed ? null : (() => {
+                  const isHttp = draft.transport === "http";
+                  const references = isHttp ? (draft.headers ?? {}) : draft.env;
+                  const setReferences = (next: Record<string, string>) =>
+                    model.update(isHttp ? { ...draft, headers: next } : { ...draft, env: next });
+                  return (
                 <WorkbenchSection
-                  title={zh ? "环境变量引用" : "Environment references"}
+                  title={
+                    isHttp
+                      ? zh ? "请求头引用" : "Header references"
+                      : zh ? "环境变量引用" : "Environment references"
+                  }
                   description={
                     zh
-                      ? "右侧填写宿主机环境变量名，不在数据库中保存密钥值。"
-                      : "Reference host environment variable names; secret values are not stored."
+                      ? isHttp
+                        ? "左侧填写请求头名称（如 Authorization），右侧填写宿主机环境变量名，不在数据库中保存密钥值。"
+                        : "右侧填写宿主机环境变量名，不在数据库中保存密钥值。"
+                      : isHttp
+                        ? "Map header names (e.g. Authorization) to host environment variable names; secret values are not stored."
+                        : "Reference host environment variable names; secret values are not stored."
                   }
                   action={
                     <button
                       type="button"
                       className="control-btn compact secondary"
                       onClick={() =>
-                        model.update({
-                          ...draft,
-                          env: { ...draft.env, NEW_VARIABLE: "" },
+                        setReferences({
+                          ...references,
+                          [isHttp ? "Authorization" : "NEW_VARIABLE"]: "",
                         })
                       }
                     >
-                      + Variable
+                      {isHttp ? "+ Header" : "+ Variable"}
                     </button>
                   }
                 >
                   <div className="mcp-env-list">
-                    {Object.entries(draft.env).map(([key, value]) => (
+                    {Object.entries(references).map(([key, value]) => (
                       <div key={key}>
                         <input
-                          aria-label="Environment key"
+                          aria-label={isHttp ? "Header name" : "Environment key"}
                           value={key}
                           onChange={(event) => {
-                            const env = { ...draft.env };
-                            delete env[key];
-                            env[event.target.value] = value;
-                            model.update({ ...draft, env });
+                            const next = { ...references };
+                            delete next[key];
+                            next[event.target.value] = value;
+                            setReferences(next);
                           }}
                         />
                         <span>←</span>
@@ -385,25 +398,26 @@ export function McpPage({
                           value={value}
                           placeholder="HOST_ENV_NAME"
                           onChange={(event) =>
-                            model.update({
-                              ...draft,
-                              env: { ...draft.env, [key]: event.target.value },
-                            })
+                            setReferences({ ...references, [key]: event.target.value })
                           }
                         />
                         <button
                           className="icon-btn"
                           type="button"
                           aria-label={
-                            zh ? "删除环境变量" : "Delete environment variable"
+                            isHttp
+                              ? zh ? "删除请求头" : "Delete header"
+                              : zh ? "删除环境变量" : "Delete environment variable"
                           }
                           title={
-                            zh ? "删除环境变量" : "Delete environment variable"
+                            isHttp
+                              ? zh ? "删除请求头" : "Delete header"
+                              : zh ? "删除环境变量" : "Delete environment variable"
                           }
                           onClick={() => {
-                            const env = { ...draft.env };
-                            delete env[key];
-                            model.update({ ...draft, env });
+                            const next = { ...references };
+                            delete next[key];
+                            setReferences(next);
                           }}
                         >
                           <Trash2 size={12} />
@@ -412,7 +426,8 @@ export function McpPage({
                     ))}
                   </div>
                 </WorkbenchSection>
-                )}
+                  );
+                })()}
                 <WorkbenchSection
                   title={zh ? "已发现工具" : "Discovered tools"}
                   description={

--- a/apps/main-2.0/src/automation/engine/renderer/src/pages/mcp/mcp-import.ts
+++ b/apps/main-2.0/src/automation/engine/renderer/src/pages/mcp/mcp-import.ts
@@ -11,6 +11,7 @@ interface RawMcpEntry {
   args?: unknown;
   url?: unknown;
   env?: unknown;
+  headers?: unknown;
   disabledTools?: unknown;
 }
 
@@ -30,6 +31,16 @@ function asStringArray(value: unknown): string[] {
 function toEnvReferences(value: unknown): Record<string, string> {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {};
   return Object.fromEntries(Object.keys(value as Record<string, unknown>).map((key) => [key, key]));
+}
+
+/**
+ * Pasted configs usually carry literal header values (often secrets), which
+ * AgentRecall never persists. Import only the header names with an empty host
+ * environment reference for the user to fill in afterwards.
+ */
+function toHeaderReferences(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return Object.fromEntries(Object.keys(value as Record<string, unknown>).map((key) => [key, ""]));
 }
 
 function resolveTransport(entry: RawMcpEntry): McpTransport {
@@ -85,7 +96,8 @@ export function parseMcpServersJson(text: string): McpImportResult {
       ...(transport === "stdio" ? { command } : {}),
       args: transport === "stdio" ? asStringArray(entry.args) : [],
       ...(transport === "http" ? { url } : {}),
-      env: toEnvReferences(entry.env),
+      env: transport === "stdio" ? toEnvReferences(entry.env) : {},
+      ...(transport === "http" ? { headers: toHeaderReferences(entry.headers) } : {}),
       enabled: true,
       tools: [],
       disabledTools: asStringArray(entry.disabledTools),

--- a/apps/main-2.0/src/automation/engine/shared/mcp/types.ts
+++ b/apps/main-2.0/src/automation/engine/shared/mcp/types.ts
@@ -14,6 +14,12 @@ export interface McpServerDefinition {
   args: string[];
   url?: string;
   env: Record<string, string>;
+  /**
+   * HTTP request headers sent to `http` transport servers. Values are host
+   * environment variable names resolved at launch time, mirroring `env`, so
+   * secrets such as Authorization tokens are never stored in the database.
+   */
+  headers?: Record<string, string>;
   enabled: boolean;
   tools: McpToolDefinition[];
   /**

--- a/apps/main-2.0/src/core/postgres/schema.ts
+++ b/apps/main-2.0/src/core/postgres/schema.ts
@@ -485,6 +485,7 @@ export const POSTGRES_MIGRATIONS: readonly PostgresMigration[] = [{
         args jsonb NOT NULL,
         url text,
         env jsonb NOT NULL,
+        headers jsonb NOT NULL DEFAULT '{}'::jsonb,
         enabled boolean NOT NULL DEFAULT true,
         disabled_tools jsonb NOT NULL DEFAULT '[]'::jsonb,
         status text NOT NULL DEFAULT 'untested',
@@ -1279,6 +1280,15 @@ export const POSTGRES_MIGRATIONS: readonly PostgresMigration[] = [{
 
       ALTER TABLE agent_recall.token_events
         ADD COLUMN IF NOT EXISTS source_turn_id text;
+    `,
+  ],
+}, {
+  version: 24,
+  name: "store HTTP header references for MCP servers",
+  statements: [
+    `
+      ALTER TABLE agent_recall.mcp_servers
+        ADD COLUMN IF NOT EXISTS headers jsonb NOT NULL DEFAULT '{}'::jsonb;
     `,
   ],
 }];

--- a/apps/main-2.0/src/main/automation-ipc.test.ts
+++ b/apps/main-2.0/src/main/automation-ipc.test.ts
@@ -100,6 +100,37 @@ describe("registerAutomationIpc", () => {
     expect([...handlers.keys()].every((channel) => channel.startsWith("automation:"))).toBe(true);
   });
 
+  it("keeps HTTP header references through the IPC schema for save and test", async () => {
+    const { invoke, registry } = setup();
+    const server: McpServerDefinition = {
+      id: "remote-http",
+      name: "Remote HTTP",
+      transport: "http",
+      args: [],
+      url: "https://example.test/mcp",
+      env: {},
+      headers: { Authorization: "HOST_HTTP_TOKEN" },
+      enabled: true,
+      tools: [],
+      disabledTools: [],
+      status: "untested",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    await invoke(AUTOMATION_CHANNELS.mcpSave, server);
+    expect(registry.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ headers: { Authorization: "HOST_HTTP_TOKEN" } }),
+    );
+
+    await invoke(AUTOMATION_CHANNELS.mcpTest, server);
+    expect(registry.recordTest).toHaveBeenCalledWith(
+      expect.objectContaining({ headers: { Authorization: "HOST_HTTP_TOKEN" } }),
+      [],
+      undefined,
+    );
+  });
+
   it("validates portable Workflow identifiers and mapping payloads", async () => {
     const { invoke, service } = setup();
     const portable = service.portableWorkflows;

--- a/apps/main-2.0/src/main/ipc/automation.ts
+++ b/apps/main-2.0/src/main/ipc/automation.ts
@@ -187,6 +187,7 @@ const mcpServerSchema = z.object({
   args: z.array(z.string().max(8_192)).max(200),
   url: z.string().trim().max(8_192).optional(),
   env: z.record(z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/), z.string().max(512)),
+  headers: z.record(z.string().max(512), z.string().max(512)).optional(),
   enabled: z.boolean(),
   tools: z.array(mcpToolSchema).max(5_000),
   disabledTools: z.array(z.string().max(8_192)).max(5_000).optional(),


### PR DESCRIPTION
# 问题

HTTP 类型的 MCP Server 之前无法配置鉴权：

- MCP 页面对 HTTP Server 也显示"环境变量引用"一栏，但填了完全不生效——连接测试和所有运行时注入路径在 HTTP 分支只传 URL（ACP 侧 headers 甚至写死为 []）；
- 整条链路都没有自定义请求头的概念，需要 Authorization 头的远程 MCP 服务完全接不进来，只能用无鉴权的本地/内网服务。

# 改动

- 数据模型：McpServerDefinition 新增 headers 字段，语义与 env 一致——值是宿主机环境变量名引用，启动时解析，密钥不落库；数据库迁移 v24 为 mcp_servers 增加 headers 列（IF NOT EXISTS，与 v14 disabled_tools 同模式），基表建表语句同步更新。
- 连接测试（mcp-client.ts）：HTTP 传输通过 requestInit.headers 发送解析后的请求头。
  - Codex：生成 env_http_headers 配置，请求头值由 Codex 进程从环境变量读取，密钥不出现在 argv；
  - Claude：SDK http 配置携带 headers；
  - ACP（Hermes / OpenCode / OpenClaw）：注入真实的 headers 数组。
- UI（McpPage.tsx）：引用编辑区按传输方式切换——STDIO 仍为"环境变量引用"，HTTP 变为"请求头引用"（请求头名 ← 宿主环境变量名），不再展示对 HTTP 无效的 env 编辑。
- JSON 导入（mcp-import.ts）：识别 http 条目的 headers，只导入请求头名，值（通常是明文密钥）不导入，留空待用户补填环境变量引用。

# 测试

- runtime-mcp.test.ts：新增三条注入链路的 headers 断言，包含"密钥值不进入 Codex argv"；
- mcp-registry-store.test.ts：新增 headers 持久化往返用例（PGlite 跑全量迁移）；
- vitest run mcp 相关 11 个文件 77 个用例全部通过；tsc --noEmit 通过；release-note:check 通过。