### PR TITLE
修复 Windows OpenViking 发布并精简 CI

### DIFF
--- a/.github/workflows/openviking-runtime-check.yml
+++ b/.github/workflows/openviking-runtime-check.yml
@@ -1,0 +1,91 @@
+name: OpenViking Runtime Check
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+    paths:
+      - .github/workflows/openviking-runtime-check.yml
+      - .github/workflows/release.yml
+      - apps/main-2.0/package.json
+      - apps/main-2.0/package-lock.json
+      - apps/main-2.0/scripts/build-openviking-runtime.mjs
+      - apps/main-2.0/scripts/build-openviking-runtime.test.mjs
+      - apps/main-2.0/scripts/verify-openviking-runtime-inputs.mjs
+      - apps/main-2.0/scripts/verify-openviking-runtime-inputs.test.mjs
+      - scripts/setup-app.mjs
+
+permissions:
+  contents: read
+
+jobs:
+  verify-runtime:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15
+            platform: darwin
+            arch: arm64
+            python_url: https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.12.13%2B20260510-aarch64-apple-darwin-install_only_stripped.tar.gz
+            python_sha256: 55bc1a5edbc8ac4da0081f4f5731ed2d1ed10c57cb37a820b2a0dbc7cad742e9
+          - runner: macos-15-intel
+            platform: darwin
+            arch: x64
+            python_url: https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.12.13%2B20260510-x86_64-apple-darwin-install_only_stripped.tar.gz
+            python_sha256: 6bab7fa97d4f2ddba86da0e05acff66c53b5edaca1df8edcf00ddca785a9c59b
+          - runner: windows-2025
+            platform: win32
+            arch: x64
+            python_url: https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.12.13%2B20260510-x86_64-pc-windows-msvc-install_only_stripped.tar.gz
+            python_sha256: 24168aff2e7d93784c6a436124c4ebb79b076a4e289bde4902c08333507b71d0
+    runs-on: ${{ matrix.runner }}
+    env:
+      ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+      npm_config_audit: "false"
+      npm_config_cache: ${{ github.workspace }}/.ci-npm-cache
+      npm_config_fund: "false"
+      npm_config_prefer_offline: "true"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: apps/main-2.0/package-lock.json
+
+      - name: Install runtime build dependencies
+        run: |
+          npm ci
+          npm run setup:v2
+
+      - name: Prepare isolated Rust toolchain
+        shell: bash
+        env:
+          RUSTUP_HOME: ${{ runner.temp }}/openviking-rustup
+          CARGO_HOME: ${{ runner.temp }}/openviking-cargo
+        run: rustup default stable
+
+      - name: Build isolated OpenViking runtime
+        shell: bash
+        env:
+          BUILD_HOME: ${{ runner.temp }}/openviking-build-home
+          OUTPUT_DIR: ${{ runner.temp }}/openviking-release
+          RUSTUP_HOME: ${{ runner.temp }}/openviking-rustup
+          CARGO_HOME: ${{ runner.temp }}/openviking-cargo
+          PYTHON_URL: ${{ matrix.python_url }}
+          PYTHON_SHA256: ${{ matrix.python_sha256 }}
+        run: |
+          node apps/main-2.0/scripts/build-openviking-runtime.mjs \
+            --version 0.4.11-r4 \
+            --platform "${{ matrix.platform }}" \
+            --arch "${{ matrix.arch }}" \
+            --build-home "$BUILD_HOME" \
+            --output-dir "$OUTPUT_DIR" \
+            --python-url "$PYTHON_URL" \
+            --python-sha256 "$PYTHON_SHA256"

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -40,22 +40,16 @@ jobs:
       - name: Validate release note
         run: node scripts/release-notes.mjs check-range "origin/${{ github.base_ref }}" HEAD
 
-      - name: Test
-        if: runner.os != 'Windows'
+      - name: Test complete application suites
+        if: runner.os == 'Linux'
         run: npm test
 
-      - name: Test update and install scripts (Windows)
-        if: runner.os == 'Windows'
+      - name: Test platform-specific scripts
+        if: runner.os != 'Linux'
         run: npm run test:scripts
 
-      - name: Typecheck
-        run: npm run typecheck
-
-      - name: Build
-        run: npm run build
-
-      - name: Smoke-test packaged V1 install
+      - name: Build and smoke-test packaged V1 install
         run: npm run package:smoke
 
-      - name: Smoke-test packaged V2 install
+      - name: Build and smoke-test packaged V2 install
         run: npm run package:smoke:v2

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -55,8 +55,5 @@ jobs:
         if: runner.os != 'Linux'
         run: npm run test:scripts
 
-      - name: Build and smoke-test packaged V1 install
-        run: npm run package:smoke
-
-      - name: Build and smoke-test packaged V2 install
-        run: npm run package:smoke:v2
+      - name: Build and smoke-test packaged applications
+        run: npm run package:smoke:all

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -16,6 +16,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    env:
+      ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+      npm_config_audit: "false"
+      npm_config_cache: ${{ github.workspace }}/.ci-npm-cache
+      npm_config_fund: "false"
+      npm_config_prefer_offline: "true"
+      AGENT_RECALL_TEST_NPM_CACHE: ${{ github.workspace }}/.ci-npm-cache
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   openviking-runtime:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - runner: macos-15

--- a/.release-notes/optimize-ci-fix-openviking-release.md
+++ b/.release-notes/optimize-ci-fix-openviking-release.md
@@ -1,0 +1,7 @@
+# 修复 Windows OpenViking 运行时发布
+
+<!-- release-target: v2 -->
+
+## Bug 修复
+
+- Windows 用户现在可以正常获取并使用随应用发布的 OpenViking 运行时。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,18 @@
 
 ### 提交 Pull Request
 
+发布相关改动在提交前可以先运行本地预检：
+
+```bash
+# 快速检查发布所用的 macOS/Windows OpenViking wheel 是否仍兼容当前补丁
+npm run release:preflight:openviking
+
+# 完整检查 release note，并构建、隔离安装 V1/V2 发布包
+npm run release:preflight
+```
+
+修改 OpenViking 运行时构建、V2 依赖或发布流水线时，PR 会额外执行与正式发布相同的 macOS Arm、macOS Intel 和 Windows 运行时构建，但不会上传或发布产物。
+
 1. 提交前同步上游最新代码，解决冲突
 
    ```bash

--- a/apps/main-2.0/package.json
+++ b/apps/main-2.0/package.json
@@ -41,6 +41,7 @@
     "test:workflow-transaction": "vitest run src/automation/engine/shared/workflow-v2 src/automation/engine/main/workflows/v2 src/automation/engine/main/workflows/workflow-runtime.test.ts src/automation/engine/main/hub/agent-hub-workflow-activation.test.ts src/automation/engine/main/hub/workflow/agent-hub-workflow-clone.test.ts src/automation/engine/main/hub/workflow/agent-hub-workflow-restore.test.ts src/automation/engine/main/hub/workflow/agent-hub-workflow-v2.test.ts src/automation/engine/renderer/src/pages/workflow/WorkflowPage.test.tsx src/automation/engine/renderer/src/pages/workflow/WorkflowRunCenter.test.tsx",
     "test:watch": "vitest",
     "package:smoke": "npm run build && node scripts/package-smoke.mjs",
+    "release:preflight:openviking": "node scripts/verify-openviking-runtime-inputs.mjs",
     "release-note:check": "node scripts/release-notes.mjs check-range",
     "prepare": "npm run build:mcp && electron-vite build",
     "build:mcp": "node scripts/build-mcp-bundle.mjs",

--- a/apps/main-2.0/scripts/build-openviking-runtime.mjs
+++ b/apps/main-2.0/scripts/build-openviking-runtime.mjs
@@ -95,11 +95,12 @@ export function patchCodexResponsesAdapter(source) {
   if (parts.length !== 2) {
     throw new Error("Cannot patch unsupported OpenViking Codex adapter.");
   }
+  const newline = source.includes("\r\n") ? "\r\n" : "\n";
   return [
     parts[0],
-    '        reasoning_effort = kwargs.get("reasoning_effort")\n',
-    "        if reasoning_effort:\n",
-    `            ${marker}\n`,
+    `        reasoning_effort = kwargs.get("reasoning_effort")${newline}`,
+    `        if reasoning_effort:${newline}`,
+    `            ${marker}${newline}`,
     anchor,
     parts[1],
   ].join("");
@@ -110,22 +111,26 @@ export function patchVlmReasoningEffortConfig(source) {
   const forwardingMarker = '            "reasoning_effort": self.reasoning_effort,';
   if (source.includes(fieldMarker) && source.split(forwardingMarker).length === 3) return source;
 
-  const thinkingField = /^    thinking: bool = Field\(.*\)$/mu;
+  const thinkingField = /^(    thinking: bool = Field\([^\r\n]*\))(\r?\n)/mu;
   if (!thinkingField.test(source)) {
     throw new Error("Cannot patch unsupported OpenViking VLM config.");
   }
-  const resultAnchor = '            "thinking": self.thinking,\n';
-  if (source.split(resultAnchor).length !== 3) {
+  const resultAnchor = /^(            "thinking": self\.thinking,)(\r?\n)/gmu;
+  if ([...source.matchAll(resultAnchor)].length !== 2) {
     throw new Error("Cannot patch unsupported OpenViking VLM config.");
   }
   return source
     .replace(
       thinkingField,
-      (line) => `${line}\n    reasoning_effort: str = Field(default="low", description="OpenAI reasoning effort")`,
+      (_line, field, newline) => [
+        field,
+        '    reasoning_effort: str = Field(default="low", description="OpenAI reasoning effort")',
+        "",
+      ].join(newline),
     )
     .replaceAll(
       resultAnchor,
-      `${resultAnchor}${forwardingMarker}\n`,
+      (_line, anchor, newline) => `${anchor}${newline}${forwardingMarker}${newline}`,
     );
 }
 

--- a/apps/main-2.0/scripts/build-openviking-runtime.test.mjs
+++ b/apps/main-2.0/scripts/build-openviking-runtime.test.mjs
@@ -18,21 +18,25 @@ import {
 } from "./build-openviking-runtime.mjs";
 
 test("runtime patch forwards configured reasoning effort to Codex Responses", () => {
-  const source = [
-    "        response_kwargs: Dict[str, Any] = {",
-    '            "model": model,',
-    "        }",
-    '        tools = _convert_tools_for_responses(kwargs.get("tools"))',
-    "        if tools:",
-    '            response_kwargs["tools"] = tools',
-    "        stream = client.responses.create(**response_kwargs, stream=True)",
-    "",
-  ].join("\n");
+  for (const newline of ["\n", "\r\n"]) {
+    const source = [
+      "        response_kwargs: Dict[str, Any] = {",
+      '            "model": model,',
+      "        }",
+      '        tools = _convert_tools_for_responses(kwargs.get("tools"))',
+      "        if tools:",
+      '            response_kwargs["tools"] = tools',
+      "        stream = client.responses.create(**response_kwargs, stream=True)",
+      "",
+    ].join(newline);
 
-  const patched = patchCodexResponsesAdapter(source);
+    const patched = patchCodexResponsesAdapter(source);
 
-  assert.match(patched, /reasoning_effort = kwargs\.get\("reasoning_effort"\)/u);
-  assert.match(patched, /response_kwargs\["reasoning"\] = \{"effort": reasoning_effort\}/u);
+    assert.match(patched, /reasoning_effort = kwargs\.get\("reasoning_effort"\)/u);
+    assert.match(patched, /response_kwargs\["reasoning"\] = \{"effort": reasoning_effort\}/u);
+    assert.equal(patchCodexResponsesAdapter(patched), patched);
+    if (newline === "\r\n") assert.doesNotMatch(patched.replaceAll("\r\n", ""), /\n/u);
+  }
   assert.throws(
     () => patchCodexResponsesAdapter("unexpected source"),
     /unsupported OpenViking Codex adapter/u,
@@ -40,28 +44,32 @@ test("runtime patch forwards configured reasoning effort to Codex Responses", ()
 });
 
 test("runtime patch accepts and forwards configured VLM reasoning effort", () => {
-  const source = [
-    "    thinking: bool = Field(default=False, description=\"Enable thinking mode\")",
-    "",
-    "    def _build_vlm_config_dict_for_credential(self, credential):",
-    "        result = {",
-    '            "thinking": self.thinking,',
-    "        }",
-    "",
-    "    def _build_vlm_config_dict(self):",
-    "        result = {",
-    '            "thinking": self.thinking,',
-    "        }",
-    "",
-  ].join("\n");
+  for (const newline of ["\n", "\r\n"]) {
+    const source = [
+      "    thinking: bool = Field(default=False, description=\"Enable thinking mode\")",
+      "",
+      "    def _build_vlm_config_dict_for_credential(self, credential):",
+      "        result = {",
+      '            "thinking": self.thinking,',
+      "        }",
+      "",
+      "    def _build_vlm_config_dict(self):",
+      "        result = {",
+      '            "thinking": self.thinking,',
+      "        }",
+      "",
+    ].join(newline);
 
-  const patched = patchVlmReasoningEffortConfig(source);
+    const patched = patchVlmReasoningEffortConfig(source);
 
-  assert.match(patched, /reasoning_effort: str = Field\(default="low"/u);
-  assert.equal(
-    patched.match(/"reasoning_effort": self\.reasoning_effort/g)?.length,
-    2,
-  );
+    assert.match(patched, /reasoning_effort: str = Field\(default="low"/u);
+    assert.equal(
+      patched.match(/"reasoning_effort": self\.reasoning_effort/g)?.length,
+      2,
+    );
+    assert.equal(patchVlmReasoningEffortConfig(patched), patched);
+    if (newline === "\r\n") assert.doesNotMatch(patched.replaceAll("\r\n", ""), /\n/u);
+  }
   assert.throws(
     () => patchVlmReasoningEffortConfig("unexpected source"),
     /unsupported OpenViking VLM config/u,

--- a/apps/main-2.0/scripts/verify-openviking-runtime-inputs.mjs
+++ b/apps/main-2.0/scripts/verify-openviking-runtime-inputs.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+import { inflateRawSync } from "node:zlib";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  patchCodexResponsesAdapter,
+  patchVlmReasoningEffortConfig,
+} from "./build-openviking-runtime.mjs";
+
+const OPENVIKING_VERSION = "0.4.11";
+const PYPI_METADATA_URL = `https://pypi.org/pypi/openviking/${OPENVIKING_VERSION}/json`;
+const PATCH_INPUTS = [
+  { key: "codex", suffix: "/codex_responses_adapter.py", patch: patchCodexResponsesAdapter },
+  { key: "vlm", suffix: "/openviking_cli/utils/config/vlm_config.py", patch: patchVlmReasoningEffortConfig },
+];
+
+export const OPENVIKING_RUNTIME_WHEELS = [
+  {
+    platform: "darwin",
+    arch: "arm64",
+    filename: "openviking-0.4.11-cp310-abi3-macosx_14_0_arm64.whl",
+    sha256: "4a0389f2c3de0eb41cc2f26ccedb89566d8719393c3ab37d2ee2895cf9a8ebee",
+    size: 18_980_965,
+  },
+  {
+    platform: "darwin",
+    arch: "x64",
+    filename: "openviking-0.4.11-cp310-abi3-macosx_15_0_x86_64.whl",
+    sha256: "f3ed8d86917fe3cd94421019fb997bb874ef1f95fd97bada614a10b1516aba77",
+    size: 21_346_489,
+  },
+  {
+    platform: "win32",
+    arch: "x64",
+    filename: "openviking-0.4.11-cp310-abi3-win_amd64.whl",
+    sha256: "858f3d7bf2ecb102744d6de704551f9df9b4fa4ab9adc2bdcdd500f8881bf6c8",
+    size: 25_023_612,
+  },
+];
+
+export async function verifyOpenVikingRuntimeInputs({
+  fetchImpl = fetch,
+  metadataUrl = PYPI_METADATA_URL,
+  wheels = OPENVIKING_RUNTIME_WHEELS,
+} = {}) {
+  const metadataResponse = await fetchImpl(metadataUrl, { headers: { accept: "application/json" } });
+  if (!metadataResponse.ok) {
+    throw new Error(`Could not load OpenViking package metadata (${metadataResponse.status}).`);
+  }
+  const metadata = await metadataResponse.json();
+  const publishedFiles = new Map(metadata.urls?.map((entry) => [entry.filename, entry]) ?? []);
+  return await Promise.all(wheels.map(async (wheel) => {
+    const published = publishedFiles.get(wheel.filename);
+    if (
+      published?.packagetype !== "bdist_wheel"
+      || published?.digests?.sha256 !== wheel.sha256
+      || published?.size !== wheel.size
+    ) {
+      throw new Error(`OpenViking ${wheel.platform}-${wheel.arch} wheel metadata changed.`);
+    }
+    const url = new URL(published.url);
+    if (url.protocol !== "https:" || url.hostname !== "files.pythonhosted.org") {
+      throw new Error(`OpenViking ${wheel.platform}-${wheel.arch} wheel URL is not trusted.`);
+    }
+
+    const entries = await readRemoteZipEntries({
+      fetchImpl,
+      url,
+      archiveSize: wheel.size,
+      suffixes: PATCH_INPUTS.map(({ suffix }) => suffix),
+    });
+    const newlineStyles = {};
+    for (const input of PATCH_INPUTS) {
+      const source = entries.get(input.suffix)?.toString("utf8");
+      if (!source) {
+        throw new Error(`OpenViking ${wheel.platform}-${wheel.arch} wheel is missing ${input.suffix}.`);
+      }
+      const patched = input.patch(source);
+      if (input.patch(patched) !== patched) {
+        throw new Error(`OpenViking ${wheel.platform}-${wheel.arch} ${input.key} patch is not idempotent.`);
+      }
+      newlineStyles[input.key] = source.includes("\r\n") ? "crlf" : "lf";
+    }
+    return { platform: wheel.platform, arch: wheel.arch, newlineStyles };
+  }));
+}
+
+async function readRemoteZipEntries({ fetchImpl, url, archiveSize, suffixes }) {
+  let fullArchive;
+  const readRange = async (start, end) => {
+    if (fullArchive) return fullArchive.subarray(start, end + 1);
+    const response = await fetchImpl(url, { headers: { range: `bytes=${start}-${end}` } });
+    if (response.status === 200) {
+      fullArchive = Buffer.from(await response.arrayBuffer());
+      if (fullArchive.length !== archiveSize) throw new Error("OpenViking wheel size did not match its metadata.");
+      return fullArchive.subarray(start, end + 1);
+    }
+    if (response.status !== 206) throw new Error(`Could not read OpenViking wheel (${response.status}).`);
+    const contentRange = response.headers.get("content-range");
+    if (contentRange !== `bytes ${start}-${end}/${archiveSize}`) {
+      throw new Error("OpenViking wheel returned an invalid byte range.");
+    }
+    return Buffer.from(await response.arrayBuffer());
+  };
+
+  const tailStart = Math.max(0, archiveSize - 65_557);
+  const tail = await readRange(tailStart, archiveSize - 1);
+  let endOffset = -1;
+  for (let index = tail.length - 22; index >= 0; index -= 1) {
+    if (tail.readUInt32LE(index) === 0x06054b50) {
+      endOffset = index;
+      break;
+    }
+  }
+  if (endOffset < 0) throw new Error("OpenViking wheel has no ZIP directory.");
+  const entryCount = tail.readUInt16LE(endOffset + 10);
+  const directorySize = tail.readUInt32LE(endOffset + 12);
+  const directoryOffset = tail.readUInt32LE(endOffset + 16);
+  if (entryCount === 0xffff || directorySize === 0xffffffff || directoryOffset === 0xffffffff) {
+    throw new Error("OpenViking wheel uses unsupported ZIP64 metadata.");
+  }
+  const directory = await readRange(directoryOffset, directoryOffset + directorySize - 1);
+  const candidates = [];
+  let offset = 0;
+  for (let index = 0; index < entryCount; index += 1) {
+    if (directory.readUInt32LE(offset) !== 0x02014b50) throw new Error("OpenViking wheel ZIP directory is invalid.");
+    const flags = directory.readUInt16LE(offset + 8);
+    const method = directory.readUInt16LE(offset + 10);
+    const compressedSize = directory.readUInt32LE(offset + 20);
+    const uncompressedSize = directory.readUInt32LE(offset + 24);
+    const filenameLength = directory.readUInt16LE(offset + 28);
+    const extraLength = directory.readUInt16LE(offset + 30);
+    const commentLength = directory.readUInt16LE(offset + 32);
+    const localHeaderOffset = directory.readUInt32LE(offset + 42);
+    const filename = directory.subarray(offset + 46, offset + 46 + filenameLength).toString("utf8");
+    const suffix = suffixes.find((value) => `/${filename}`.endsWith(value));
+    if (suffix) {
+      candidates.push({ suffix, filename, flags, method, compressedSize, uncompressedSize, localHeaderOffset });
+    }
+    offset += 46 + filenameLength + extraLength + commentLength;
+  }
+
+  const result = new Map();
+  for (const candidate of candidates) {
+    if (candidate.flags & 1) throw new Error(`OpenViking wheel entry ${candidate.filename} is encrypted.`);
+    const localHeader = await readRange(candidate.localHeaderOffset, candidate.localHeaderOffset + 29);
+    if (localHeader.readUInt32LE(0) !== 0x04034b50) throw new Error("OpenViking wheel local header is invalid.");
+    const filenameLength = localHeader.readUInt16LE(26);
+    const extraLength = localHeader.readUInt16LE(28);
+    const dataStart = candidate.localHeaderOffset + 30 + filenameLength + extraLength;
+    const compressed = await readRange(dataStart, dataStart + candidate.compressedSize - 1);
+    const content = candidate.method === 0
+      ? compressed
+      : candidate.method === 8
+        ? inflateRawSync(compressed)
+        : null;
+    if (!content || content.length !== candidate.uncompressedSize) {
+      throw new Error(`OpenViking wheel entry ${candidate.filename} could not be decoded.`);
+    }
+    if (result.has(candidate.suffix)) throw new Error(`OpenViking wheel contains duplicate ${candidate.suffix}.`);
+    result.set(candidate.suffix, content);
+  }
+  return result;
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  verifyOpenVikingRuntimeInputs()
+    .then((results) => {
+      for (const result of results) {
+        process.stdout.write(`Verified OpenViking ${result.platform}-${result.arch} wheel patch inputs (${result.newlineStyles.codex}/${result.newlineStyles.vlm}).\n`);
+      }
+    })
+    .catch((error) => {
+      process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+      process.exitCode = 1;
+    });
+}

--- a/apps/main-2.0/scripts/verify-openviking-runtime-inputs.test.mjs
+++ b/apps/main-2.0/scripts/verify-openviking-runtime-inputs.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { deflateRawSync } from "node:zlib";
+import { test } from "node:test";
+
+import { verifyOpenVikingRuntimeInputs } from "./verify-openviking-runtime-inputs.mjs";
+
+function createZip(files) {
+  const entryCount = Object.keys(files).length;
+  const localParts = [];
+  const directoryParts = [];
+  let localOffset = 0;
+  for (const [filename, source] of Object.entries(files)) {
+    const name = Buffer.from(filename);
+    const content = Buffer.from(source);
+    const compressed = deflateRawSync(content);
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(8, 8);
+    local.writeUInt32LE(compressed.length, 18);
+    local.writeUInt32LE(content.length, 22);
+    local.writeUInt16LE(name.length, 26);
+    localParts.push(local, name, compressed);
+
+    const directory = Buffer.alloc(46);
+    directory.writeUInt32LE(0x02014b50, 0);
+    directory.writeUInt16LE(20, 4);
+    directory.writeUInt16LE(20, 6);
+    directory.writeUInt16LE(8, 10);
+    directory.writeUInt32LE(compressed.length, 20);
+    directory.writeUInt32LE(content.length, 24);
+    directory.writeUInt16LE(name.length, 28);
+    directory.writeUInt32LE(localOffset, 42);
+    directoryParts.push(directory, name);
+    localOffset += local.length + name.length + compressed.length;
+  }
+  const directory = Buffer.concat(directoryParts);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(entryCount, 8);
+  end.writeUInt16LE(entryCount, 10);
+  end.writeUInt32LE(directory.length, 12);
+  end.writeUInt32LE(localOffset, 16);
+  return Buffer.concat([...localParts, directory, end]);
+}
+
+function fakeFetch({ archive, wheel, metadataSha256 = wheel.sha256 }) {
+  return async (input, init = {}) => {
+    if (String(input).includes("/pypi/")) {
+      return Response.json({
+        urls: [{
+          filename: wheel.filename,
+          packagetype: "bdist_wheel",
+          digests: { sha256: metadataSha256 },
+          size: archive.length,
+          url: `https://files.pythonhosted.org/packages/test/${wheel.filename}`,
+        }],
+      });
+    }
+    const match = /^bytes=(\d+)-(\d+)$/u.exec(init.headers?.range);
+    assert.ok(match, "wheel reads must use HTTP byte ranges");
+    const start = Number(match[1]);
+    const end = Number(match[2]);
+    return new Response(archive.subarray(start, end + 1), {
+      status: 206,
+      headers: { "content-range": `bytes ${start}-${end}/${archive.length}` },
+    });
+  };
+}
+
+test("preflights the actual patch surfaces from a platform wheel", async () => {
+  const newline = "\r\n";
+  const archive = createZip({
+    "openviking/llm/codex_responses_adapter.py": [
+      "        response_kwargs = {}",
+      '        tools = _convert_tools_for_responses(kwargs.get("tools"))',
+      "",
+    ].join(newline),
+    "openviking_cli/utils/config/vlm_config.py": [
+      '    thinking: bool = Field(default=False, description="Enable thinking mode")',
+      "",
+      '            "thinking": self.thinking,',
+      '            "thinking": self.thinking,',
+      "",
+    ].join(newline),
+  });
+  const wheel = {
+    platform: "win32",
+    arch: "x64",
+    filename: "openviking-test-win_amd64.whl",
+    sha256: "a".repeat(64),
+    size: archive.length,
+  };
+
+  const result = await verifyOpenVikingRuntimeInputs({
+    fetchImpl: fakeFetch({ archive, wheel }),
+    metadataUrl: "https://pypi.test/pypi/openviking/test/json",
+    wheels: [wheel],
+  });
+
+  assert.deepEqual(result, [{
+    platform: "win32",
+    arch: "x64",
+    newlineStyles: { codex: "crlf", vlm: "crlf" },
+  }]);
+});
+
+test("rejects a published wheel that no longer matches the pinned release input", async () => {
+  const archive = createZip({});
+  const wheel = {
+    platform: "win32",
+    arch: "x64",
+    filename: "openviking-test-win_amd64.whl",
+    sha256: "a".repeat(64),
+    size: archive.length,
+  };
+  await assert.rejects(
+    verifyOpenVikingRuntimeInputs({
+      fetchImpl: fakeFetch({ archive, wheel, metadataSha256: "b".repeat(64) }),
+      metadataUrl: "https://pypi.test/pypi/openviking/test/json",
+      wheels: [wheel],
+    }),
+    /wheel metadata changed/u,
+  );
+});

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "build": "npm --prefix apps/main-1.0 run build && npm --prefix apps/main-2.0 run build",
     "package:smoke": "npm --prefix apps/main-1.0 run package:smoke",
     "package:smoke:v2": "npm --prefix apps/main-2.0 run package:smoke",
-    "release:preflight": "npm run release-note:check && npm run package:smoke && npm run package:smoke:v2 && npm run release:preflight:openviking",
+    "package:smoke:all": "node scripts/run-package-smokes.mjs",
+    "release:preflight": "npm run release-note:check && npm run package:smoke:all && npm run release:preflight:openviking",
     "release:preflight:openviking": "npm --prefix apps/main-2.0 run release:preflight:openviking",
     "release-note:check": "node scripts/release-notes.mjs check-range"
   }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "build": "npm --prefix apps/main-1.0 run build && npm --prefix apps/main-2.0 run build",
     "package:smoke": "npm --prefix apps/main-1.0 run package:smoke",
     "package:smoke:v2": "npm --prefix apps/main-2.0 run package:smoke",
+    "release:preflight": "npm run release-note:check && npm run package:smoke && npm run package:smoke:v2 && npm run release:preflight:openviking",
+    "release:preflight:openviking": "npm --prefix apps/main-2.0 run release:preflight:openviking",
     "release-note:check": "node scripts/release-notes.mjs check-range"
   }
 }

--- a/scripts/monorepo-layout.test.mjs
+++ b/scripts/monorepo-layout.test.mjs
@@ -22,6 +22,14 @@ test("exposes explicit root commands for both apps", () => {
   assert.match(root.scripts.test, /test:repo/);
   assert.match(root.scripts.test, /test:v1/);
   assert.match(root.scripts.test, /test:v2/);
+  assert.match(root.scripts["package:smoke:all"], /run-package-smokes\.mjs/);
+});
+
+test("runs independent V1 and V2 package smokes concurrently", async () => {
+  const smokeRunner = await readFile("scripts/run-package-smokes.mjs", "utf8");
+  assert.match(smokeRunner, /directory:\s*"apps\/main-1\.0"/);
+  assert.match(smokeRunner, /directory:\s*"apps\/main-2\.0"/);
+  assert.match(smokeRunner, /Promise\.allSettled\(applications\.map\(runPackageSmoke\)\)/);
 });
 
 test("installs app dependencies without changing the user's Claude statusline", async () => {

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -107,6 +107,9 @@ test("workflows require branch notes and publish accumulated changes every day o
   assert.match(noteWorkflow, /release-notes\.mjs check-range/);
   assert.match(qualityWorkflow, /os:\s*\[ubuntu-latest, macos-latest, windows-latest\]/);
   assert.match(qualityWorkflow, /npm run setup/);
+  assert.match(qualityWorkflow, /ELECTRON_SKIP_BINARY_DOWNLOAD:\s*["']1["']/);
+  assert.match(qualityWorkflow, /npm_config_cache:\s*\$\{\{ github\.workspace \}\}\/\.ci-npm-cache/);
+  assert.match(qualityWorkflow, /AGENT_RECALL_TEST_NPM_CACHE:\s*\$\{\{ github\.workspace \}\}\/\.ci-npm-cache/);
   assert.match(qualityWorkflow, /- name: Test complete application suites\s+if: runner\.os == 'Linux'\s+run: npm test/);
   assert.match(qualityWorkflow, /- name: Test platform-specific scripts\s+if: runner\.os != 'Linux'\s+run: npm run test:scripts/);
   assert.doesNotMatch(qualityWorkflow, /- name: Typecheck\r?\n/u);
@@ -174,6 +177,8 @@ test("workflows require branch notes and publish accumulated changes every day o
 
 test("V2 releases publish the complete OpenViking runtime set", async () => {
   const releaseWorkflow = await readFile(".github/workflows/release.yml", "utf8");
+  const runtimeCheckWorkflow = await readFile(".github/workflows/openviking-runtime-check.yml", "utf8");
+  const runtimeInputScript = await readFile("apps/main-2.0/scripts/verify-openviking-runtime-inputs.mjs", "utf8");
   const runtimeJob = releaseWorkflow.slice(
     releaseWorkflow.indexOf("  openviking-runtime:"),
     releaseWorkflow.indexOf("  release:"),
@@ -185,6 +190,20 @@ test("V2 releases publish the complete OpenViking runtime set", async () => {
   assert.match(releaseWorkflow, /runner:\s*macos-15-intel[\s\S]*platform:\s*darwin[\s\S]*arch:\s*x64/);
   assert.match(releaseWorkflow, /runner:\s*windows-2025[\s\S]*platform:\s*win32[\s\S]*arch:\s*x64/);
   assert.match(releaseWorkflow, /apps\/main-2\.0\/scripts\/build-openviking-runtime\.mjs/);
+  assert.match(runtimeCheckWorkflow, /pull_request:[\s\S]*paths:/);
+  assert.match(runtimeCheckWorkflow, /runner:\s*macos-15[\s\S]*platform:\s*darwin[\s\S]*arch:\s*arm64/);
+  assert.match(runtimeCheckWorkflow, /runner:\s*macos-15-intel[\s\S]*platform:\s*darwin[\s\S]*arch:\s*x64/);
+  assert.match(runtimeCheckWorkflow, /runner:\s*windows-2025[\s\S]*platform:\s*win32[\s\S]*arch:\s*x64/);
+  assert.match(runtimeCheckWorkflow, /--version 0\.4\.11-r4/);
+  assert.match(runtimeCheckWorkflow, /apps\/main-2\.0\/scripts\/build-openviking-runtime\.mjs/);
+  assert.doesNotMatch(runtimeCheckWorkflow, /upload-artifact|gh release|contents:\s*write/);
+  const targetPattern = /- runner:\s*(\S+)\s+platform:\s*(\S+)\s+arch:\s*(\S+)\s+python_url:\s*(\S+)\s+python_sha256:\s*(\S+)/gu;
+  const targets = (workflow) => [...workflow.matchAll(targetPattern)].map((match) => match.slice(1));
+  assert.deepEqual(targets(runtimeCheckWorkflow), targets(runtimeJob));
+  const releaseRuntimeVersion = /--version\s+(\S+)/u.exec(runtimeJob)?.[1];
+  const checkedRuntimeVersion = /--version\s+(\S+)/u.exec(runtimeCheckWorkflow)?.[1];
+  assert.equal(checkedRuntimeVersion, releaseRuntimeVersion);
+  assert.match(runtimeInputScript, new RegExp(`OPENVIKING_VERSION = "${releaseRuntimeVersion.replace(/-r[1-9][0-9]*$/u, "")}"`, "u"));
   assert.match(runtimeJob, /name:\s*Prepare isolated Rust toolchain[\s\S]*rustup default stable/);
   assert.match(runtimeJob, /RUSTUP_HOME:\s*\$\{\{ runner\.temp \}\}\/openviking-rustup/);
   assert.match(runtimeJob, /CARGO_HOME:\s*\$\{\{ runner\.temp \}\}\/openviking-cargo/);

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -114,10 +114,8 @@ test("workflows require branch notes and publish accumulated changes every day o
   assert.match(qualityWorkflow, /- name: Test platform-specific scripts\s+if: runner\.os != 'Linux'\s+run: npm run test:scripts/);
   assert.doesNotMatch(qualityWorkflow, /- name: Typecheck\r?\n/u);
   assert.doesNotMatch(qualityWorkflow, /- name: Build\r?\n/u);
-  assert.match(qualityWorkflow, /- name: Build and smoke-test packaged V1 install/);
-  assert.match(qualityWorkflow, /- name: Build and smoke-test packaged V2 install/);
-  assert.match(qualityWorkflow, /run: npm run package:smoke\s/);
-  assert.match(qualityWorkflow, /run: npm run package:smoke:v2/);
+  assert.match(qualityWorkflow, /- name: Build and smoke-test packaged applications/);
+  assert.match(qualityWorkflow, /run: npm run package:smoke:all/);
   assert.match(releaseWorkflow, /schedule:[\s\S]*cron:\s*["']0 2 \* \* \*["']/);
   assert.match(releaseWorkflow, /workflow_dispatch:/);
   assert.doesNotMatch(releaseWorkflow, /^\s{2}push:/m);

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -107,10 +107,12 @@ test("workflows require branch notes and publish accumulated changes every day o
   assert.match(noteWorkflow, /release-notes\.mjs check-range/);
   assert.match(qualityWorkflow, /os:\s*\[ubuntu-latest, macos-latest, windows-latest\]/);
   assert.match(qualityWorkflow, /npm run setup/);
-  assert.match(qualityWorkflow, /- name: Test\s+if: runner\.os != 'Windows'\s+run: npm test/);
-  assert.match(qualityWorkflow, /- name: Test update and install scripts \(Windows\)\s+if: runner\.os == 'Windows'\s+run: npm run test:scripts/);
-  assert.match(qualityWorkflow, /- name: Typecheck\s+run: npm run typecheck/);
-  assert.match(qualityWorkflow, /- name: Build\s+run: npm run build/);
+  assert.match(qualityWorkflow, /- name: Test complete application suites\s+if: runner\.os == 'Linux'\s+run: npm test/);
+  assert.match(qualityWorkflow, /- name: Test platform-specific scripts\s+if: runner\.os != 'Linux'\s+run: npm run test:scripts/);
+  assert.doesNotMatch(qualityWorkflow, /- name: Typecheck\r?\n/u);
+  assert.doesNotMatch(qualityWorkflow, /- name: Build\r?\n/u);
+  assert.match(qualityWorkflow, /- name: Build and smoke-test packaged V1 install/);
+  assert.match(qualityWorkflow, /- name: Build and smoke-test packaged V2 install/);
   assert.match(qualityWorkflow, /run: npm run package:smoke\s/);
   assert.match(qualityWorkflow, /run: npm run package:smoke:v2/);
   assert.match(releaseWorkflow, /schedule:[\s\S]*cron:\s*["']0 2 \* \* \*["']/);
@@ -136,6 +138,7 @@ test("workflows require branch notes and publish accumulated changes every day o
   assert.match(releaseWorkflow, /release-notes\.mjs combine --target v2/);
   assert.doesNotMatch(releaseWorkflow, /release-notes\.mjs dual/);
   assert.match(releaseWorkflow, /cancel-in-progress:\s*false/);
+  assert.match(releaseWorkflow, /openviking-runtime:\s+strategy:\s+fail-fast:\s*false/);
   assert.match(releaseWorkflow, /working-directory: apps\/main-1\.0/);
   assert.match(releaseWorkflow, /working-directory: apps\/main-2\.0/);
   assert.match(releaseWorkflow, /npm test[\s\S]*npm run typecheck[\s\S]*npm run build/);

--- a/scripts/run-package-smokes.mjs
+++ b/scripts/run-package-smokes.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+
+const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+const applications = [
+  { label: "V1", directory: "apps/main-1.0" },
+  { label: "V2", directory: "apps/main-2.0" },
+];
+
+function forwardLines(stream, label, destination) {
+  let pending = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk) => {
+    const lines = `${pending}${chunk}`.split(/\r?\n/u);
+    pending = lines.pop() ?? "";
+    for (const line of lines) destination.write(`[${label}] ${line}\n`);
+  });
+  stream.on("end", () => {
+    if (pending) destination.write(`[${label}] ${pending}\n`);
+  });
+}
+
+function runPackageSmoke({ label, directory }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(npm, ["--prefix", directory, "run", "package:smoke"], {
+      cwd: process.cwd(),
+      env: process.env,
+      shell: process.platform === "win32",
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    forwardLines(child.stdout, label, process.stdout);
+    forwardLines(child.stderr, label, process.stderr);
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${label} package smoke exited with ${code ?? signal ?? "unknown status"}.`));
+    });
+  });
+}
+
+const results = await Promise.allSettled(applications.map(runPackageSmoke));
+const failures = results
+  .map((result, index) => ({ result, application: applications[index] }))
+  .filter(({ result }) => result.status === "rejected");
+if (failures.length > 0) {
+  for (const { result, application } of failures) {
+    process.stderr.write(`${application.label}: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}\n`);
+  }
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## 概要

- 完整应用测试只在 Linux 执行一次，macOS 和 Windows 保留平台脚本测试
- 三个平台继续分别完整打包并冒烟安装 V1、V2，但两套相互隔离的 smoke 并行执行
- 移除被打包构建重复覆盖的独立类型检查与构建步骤
- 三个平台共用受缓存的 npm 下载目录，并在质量检查依赖安装时跳过 Electron 二进制下载
- 修复 OpenViking Windows wheel 使用 CRLF 时无法注入 VLM reasoning_effort 配置的问题
- OpenViking 三平台运行时构建改为互不取消，单平台失败时保留其他平台结果
- 提供本地 release:preflight 与快速 OpenViking wheel 检查
- OpenViking 构建相关改动在 PR 阶段完整构建 macOS Arm、macOS Intel 和 Windows 运行时，不上传或发布产物

## 失败原因

发布任务 30758592244 下载的 Windows wheel 使用 CRLF，原补丁仅匹配 LF，因而报 Cannot patch unsupported OpenViking VLM config；同时 fail-fast 取消了尚未完成的 macOS Intel 构建。

## 验证

- npm test
- npm run release:preflight
- npm run release:preflight:openviking
- npm run release-note:check
- YAML 语法与发布/预检矩阵一致性检查
- 使用发布对应的三平台 OpenViking wheels 验证固定摘要、补丁兼容性和幂等性

未触发发布。