### PR TITLE
fix(v2): avoid overwriting existing MCP reference keys when adding

### DIFF
--- a/.release-notes/fix-mcp-reference-add-collision.md
+++ b/.release-notes/fix-mcp-reference-add-collision.md
@@ -1,0 +1,5 @@
+# MCP 引用编辑不再覆盖已填内容
+
+## Bug 修复
+
+- MCP Server 详情页里，重复点击「+ Header」不会再把已经填好的 `Authorization` 请求头引用清空：新增条目会自动使用未占用的名称（如 `New-Header`、`New-Header-2`）。「+ Variable」新增环境变量引用同样不再覆盖同名条目。

--- a/apps/main-2.0/src/automation/engine/renderer/src/pages/mcp/McpPage.tsx
+++ b/apps/main-2.0/src/automation/engine/renderer/src/pages/mcp/McpPage.tsx
@@ -381,12 +381,17 @@ export function McpPage({
                     <button
                       type="button"
                       className="control-btn compact secondary"
-                      onClick={() =>
-                        setReferences({
-                          ...references,
-                          [isHttp ? "Authorization" : "NEW_VARIABLE"]: "",
-                        })
-                      }
+                      onClick={() => {
+                        // Never reuse an existing key: overwriting would wipe a
+                        // reference the user already filled in.
+                        const candidates = isHttp ? ["Authorization", "New-Header"] : ["NEW_VARIABLE"];
+                        let key = candidates.find((name) => !(name in references));
+                        for (let index = 2; !key; index += 1) {
+                          const candidate = `${isHttp ? "New-Header-" : "NEW_VARIABLE_"}${index}`;
+                          if (!(candidate in references)) key = candidate;
+                        }
+                        setReferences({ ...references, [key]: "" });
+                      }}
                     >
                       {isHttp ? "+ Header" : "+ Variable"}
                     </button>


### PR DESCRIPTION
# 问题

MCP Server 详情页的引用编辑区里，「+ Header」按钮固定用 Authorization 作为新条目的键名（「+ Variable」固定用 NEW_VARIABLE）。如果用户已经添加并填好了 Authorization 的宿主环境变量引用，再点一次「+ Header」想加第二个请求头时，会用空值覆盖掉已填的引用，造成配置静默丢失。

# 改动

- 新增引用条目时改为选取第一个未被占用的键名：HTTP 传输依次尝试 Authorization、New-Header、New-Header-2…；STDIO 依次 NEW_VARIABLE、NEW_VARIABLE_2…。已有条目永远不会被覆盖。
- 仅点击处理逻辑变化，不涉及数据结构和保存链路。

# 测试

- tsc --noEmit 通过；MCP 相关 12 个测试文件 83 个用例全部通过。
- 手工路径：HTTP Server 上连点两次「+ Header」→ 得到 Authorization 与 New-Header 两条，已填的引用保持不变；STDIO 上连点「+ Variable」同理。