### PR TITLE
fix(v2): resolve npm for GUI updates

### DIFF
--- a/.release-notes/fix-v2-gui-update-npm-path.md
+++ b/.release-notes/fix-v2-gui-update-npm-path.md
@@ -1,0 +1,7 @@
+# 修复 V2 图形界面自动更新
+
+<!-- release-target: v2 -->
+
+## Bug 修复
+
+- 修复从 macOS Launchpad、Spotlight 或 Dock 打开 V2 后，自动更新可能因找不到 npm 而失败的问题。

--- a/apps/main-2.0/bin/update-client.cjs
+++ b/apps/main-2.0/bin/update-client.cjs
@@ -436,6 +436,19 @@ function formatManualUpdateFallback(version) {
 }
 
 function formatUpdateError(error, fallback = "未知错误") {
+  const missingExecutable = error && typeof error === "object" ? String(error.path || "") : "";
+  const errorMessage = error && typeof error === "object" ? String(error.message || "") : "";
+  if (
+    error
+    && typeof error === "object"
+    && error.code === "ENOENT"
+    && (
+      /(?:^|[/\\])npm(?:\.cmd)?$/i.test(missingExecutable)
+      || /\bspawn(?:Sync)?\s+npm(?:\.cmd)?\s+ENOENT\b/i.test(errorMessage)
+    )
+  ) {
+    return "应用进程找不到 npm。请在终端中手动运行更新命令。";
+  }
   const candidates = error && typeof error === "object"
     ? [error.stderr, error.stdout, error.message, error]
     : [error];
@@ -513,6 +526,33 @@ function updateProgress(version, phase, values = {}) {
   return { phase, version, ...values };
 }
 
+function resolveNpmCommand(options = {}) {
+  if (options.npmCommand) return options.npmCommand;
+  const platform = options.platform || process.platform;
+  const executableName = platform === "win32" ? "npm.cmd" : "npm";
+  if (platform === "win32") return executableName;
+  const nodePath = options.nodePath;
+  if (nodePath && path.isAbsolute(nodePath)) {
+    const adjacentNpm = path.join(path.dirname(nodePath), executableName);
+    if (fs.existsSync(adjacentNpm)) return adjacentNpm;
+  }
+  return executableName;
+}
+
+function npmSubprocessEnvironment(environment = process.env, nodePath) {
+  const result = { ...environment };
+  if (nodePath && path.isAbsolute(nodePath)) {
+    const nodeDirectory = path.dirname(nodePath);
+    const pathKey = Object.keys(result).find((key) => key.toLowerCase() === "path") || "PATH";
+    const pathEntries = String(result[pathKey] || "")
+      .split(path.delimiter)
+      .filter(Boolean);
+    result[pathKey] = [nodeDirectory, ...pathEntries.filter((entry) => entry !== nodeDirectory)].join(path.delimiter);
+  }
+  delete result.ELECTRON_RUN_AS_NODE;
+  return result;
+}
+
 async function downloadUpdatePackage(manifest, archivePath, options = {}) {
   const response = await fetchWithTimeout(
     options.fetchImpl || globalThis.fetch,
@@ -562,7 +602,7 @@ async function downloadUpdatePackage(manifest, archivePath, options = {}) {
 
 async function stageUpdate(manifest, options = {}) {
   const parsed = parseUpdateManifest(manifest);
-  const packagePath = options.packagePath || globalPackageRoot({ npmCommand: options.npmCommand });
+  const packagePath = options.packagePath || packageRoot();
   const stageRoot = options.stageRoot
     || path.join(path.dirname(packagePath), `.agent-recall-stage-${process.pid}-${randomUUID()}`);
   const archivePath = path.join(stageRoot, parsed.package.name);
@@ -581,14 +621,13 @@ async function stageUpdate(manifest, options = {}) {
     options.onProgress?.(updateProgress(parsed.version, "staging", {
       message: "正在安装到临时目录…",
     }));
-    const npmCommand = options.npmCommand || (process.platform === "win32" ? "npm.cmd" : "npm");
+    const npmCommand = resolveNpmCommand(options);
     const registry = options.registry || process.env.AGENT_RECALL_NPM_REGISTRY || DEFAULT_NPM_REGISTRY;
     const installEnvironment = {
-      ...process.env,
+      ...npmSubprocessEnvironment(process.env, options.nodePath),
       AGENT_RECALL_STAGING_INSTALL: "1",
       AGENT_RECALL_STAGE_ROOT: stageRoot,
     };
-    delete installEnvironment.ELECTRON_RUN_AS_NODE;
     try {
       await (options.execFileImpl || execFileAsync)(npmCommand, [
         "install",
@@ -1193,14 +1232,21 @@ async function waitForProcessExit(pid, timeoutMs) {
   throw new Error("The running AgentRecall process did not exit in time.");
 }
 
-function globalCommandPath() {
-  const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
-  const prefix = execFileSync(npmCommand, ["prefix", "-g"], { encoding: "utf8", shell: process.platform === "win32" }).trim();
-  return process.platform === "win32" ? path.join(prefix, "agent-recall-v2.cmd") : path.join(prefix, "bin", "agent-recall-v2");
+function globalCommandPath(options = {}) {
+  const platform = options.platform || process.platform;
+  const environment = { ...process.env, ...options.env };
+  const nodePath = options.nodePath || environment.AGENT_RECALL_NODE_PATH;
+  const npmCommand = resolveNpmCommand({ npmCommand: options.npmCommand, nodePath, platform });
+  const prefix = (options.execFileSyncImpl || execFileSync)(npmCommand, ["prefix", "-g"], {
+    encoding: "utf8",
+    shell: platform === "win32",
+    env: npmSubprocessEnvironment(environment, nodePath),
+  }).trim();
+  return platform === "win32" ? path.join(prefix, "agent-recall-v2.cmd") : path.join(prefix, "bin", "agent-recall-v2");
 }
 
 function launchInstalledApp(options = {}) {
-  const command = options.command || globalCommandPath();
+  const command = options.command || globalCommandPath(options);
   const environment = { ...process.env, ...options.env, AGENT_RECALL_NO_UPDATE_CHECK: "1" };
   delete environment.ELECTRON_RUN_AS_NODE;
   const child = (options.spawnImpl || spawn)(command, options.args || ["--no-update-check"], {

--- a/apps/main-2.0/scripts/update-client.test.mjs
+++ b/apps/main-2.0/scripts/update-client.test.mjs
@@ -6,6 +6,7 @@ import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { after, test } from "node:test";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFileCallback);
@@ -28,6 +29,21 @@ async function electronFixtureExec(command, args, options) {
   return { stdout: "v42.3.0\n", stderr: "" };
 }
 
+async function installStagedPackageFixture(stageRoot, packageName, version) {
+  const installed = path.join(stageRoot, "node_modules", packageName);
+  await mkdir(path.join(installed, "out", "main"), { recursive: true });
+  await mkdir(path.join(installed, "bin"), { recursive: true });
+  await mkdir(path.join(stageRoot, "node_modules", "electron"), { recursive: true });
+  await writeFile(path.join(installed, "package.json"), JSON.stringify({ name: packageName, version }), "utf8");
+  await writeFile(path.join(installed, "out", "main", "index.js"), "", "utf8");
+  await writeFile(path.join(installed, "bin", "agent-recall.cjs"), "", "utf8");
+  await writeFile(
+    path.join(stageRoot, "node_modules", "electron", "package.json"),
+    JSON.stringify({ version: "42.3.0" }),
+    "utf8",
+  );
+}
+
 const require = createRequire(import.meta.url);
 const mutableFsPromises = require("node:fs/promises");
 const launcherSource = await readFile(new URL("../bin/agent-recall.cjs", import.meta.url), "utf8");
@@ -45,6 +61,7 @@ const {
   formatUpdateError,
   formatManualUpdateFallback,
   formatUpdateNotice,
+  globalCommandPath,
   installUpdate,
   isElectronRuntimeReady,
   launchInstalledApp,
@@ -66,7 +83,14 @@ test("streams package bytes and reports monotonic download progress while stagin
   const directory = await temporaryDirectory("agent-recall-update-stage-");
   const stageRoot = path.join(directory, "stage");
   const packagePath = path.join(directory, "live", "agent-recall-v2");
+  const binDirectory = path.join(directory, "Program Files", "nodejs");
+  const nodePath = path.join(binDirectory, process.platform === "win32" ? "node.exe" : "node");
+  const npmPath = path.join(binDirectory, process.platform === "win32" ? "npm.cmd" : "npm");
+  await mkdir(binDirectory, { recursive: true });
+  await writeFile(nodePath, "", "utf8");
+  await writeFile(npmPath, "", "utf8");
   const progress = [];
+  let npmInvocation = null;
   const stream = new ReadableStream({
     start(controller) {
       controller.enqueue(bytes.subarray(0, 5));
@@ -82,20 +106,11 @@ test("streams package bytes and reports monotonic download progress while stagin
     }),
     stageRoot,
     packagePath,
+    nodePath,
     statusPath: path.join(directory, "status.json"),
-    execFileImpl: async (_command, _args, options) => {
-      const installed = path.join(options.env.AGENT_RECALL_STAGE_ROOT, "node_modules", "agent-recall-v2");
-      await mkdir(path.join(installed, "out", "main"), { recursive: true });
-      await mkdir(path.join(installed, "bin"), { recursive: true });
-      await mkdir(path.join(options.env.AGENT_RECALL_STAGE_ROOT, "node_modules", "electron"), { recursive: true });
-      await writeFile(path.join(installed, "package.json"), JSON.stringify({ name: "agent-recall-v2", version: value.version }), "utf8");
-      await writeFile(path.join(installed, "out", "main", "index.js"), "", "utf8");
-      await writeFile(path.join(installed, "bin", "agent-recall.cjs"), "", "utf8");
-      await writeFile(
-        path.join(options.env.AGENT_RECALL_STAGE_ROOT, "node_modules", "electron", "package.json"),
-        JSON.stringify({ version: "42.3.0" }),
-        "utf8",
-      );
+    execFileImpl: async (command, args, options) => {
+      npmInvocation = { command, args, options };
+      await installStagedPackageFixture(options.env.AGENT_RECALL_STAGE_ROOT, "agent-recall-v2", value.version);
       return { stdout: "", stderr: "" };
     },
     ensureElectronImpl: async ({ packagePath: installed, runtimeSourcePath }) => {
@@ -109,6 +124,12 @@ test("streams package bytes and reports monotonic download progress while stagin
   });
 
   assert.equal(staged.stagedPackagePath, path.join(stageRoot, "node_modules", "agent-recall-v2"));
+  assert.equal(staged.livePackagePath, packagePath);
+  assert.equal(npmInvocation.command, process.platform === "win32" ? "npm.cmd" : npmPath);
+  assert.equal(npmInvocation.options.shell, process.platform === "win32");
+  const npmPathKey = Object.keys(npmInvocation.options.env).find((key) => key.toLowerCase() === "path");
+  assert.ok(npmPathKey);
+  assert.equal(npmInvocation.options.env[npmPathKey].split(path.delimiter)[0], binDirectory);
   assert.deepEqual(
     progress.filter((event) => event.phase === "downloading").map((event) => event.percent),
     [50, 100],
@@ -116,6 +137,91 @@ test("streams package bytes and reports monotonic download progress while stagin
   assert.deepEqual(
     progress.map((event) => event.phase),
     ["downloading", "downloading", "verifying", "staging", "validating"],
+  );
+});
+
+test("resolves the live V2 package without running npm root -g", async () => {
+  const bytes = Buffer.from("synthetic update package");
+  const value = manifest();
+  value.package.sha256 = createHash("sha256").update(bytes).digest("hex");
+  const directory = await temporaryDirectory("agent-recall-update-live-root-");
+  const stageRoot = path.join(directory, "stage");
+  const packagePath = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
+  const npmCommand = path.join(directory, "missing", process.platform === "win32" ? "npm.cmd" : "npm");
+  let installInvoked = false;
+
+  const staged = await stageUpdate(value, {
+    fetchImpl: async () => new Response(bytes, {
+      status: 200,
+      headers: { "content-length": String(bytes.length) },
+    }),
+    stageRoot,
+    npmCommand,
+    statusPath: path.join(directory, "status.json"),
+    execFileImpl: async (command, _args, options) => {
+      installInvoked = true;
+      assert.equal(command, npmCommand);
+      await installStagedPackageFixture(options.env.AGENT_RECALL_STAGE_ROOT, "agent-recall-v2", value.version);
+      return { stdout: "", stderr: "" };
+    },
+    ensureElectronImpl: async ({ runtimeSourcePath }) => {
+      assert.equal(runtimeSourcePath, packagePath);
+    },
+  });
+
+  assert.equal(installInvoked, true);
+  assert.equal(staged.livePackagePath, packagePath);
+});
+
+test("formats a missing npm executable as an actionable update error", () => {
+  assert.equal(
+    formatUpdateError(Object.assign(new Error("spawn npm ENOENT"), { code: "ENOENT", path: "npm" })),
+    "应用进程找不到 npm。请在终端中手动运行更新命令。",
+  );
+});
+
+test("resolves the installed V2 launcher through npm next to the stable Node executable", async () => {
+  const directory = await temporaryDirectory("agent-recall-update-global-command-");
+  const binDirectory = path.join(directory, "Program Files", "nodejs");
+  const nodePath = path.join(binDirectory, process.platform === "win32" ? "node.exe" : "node");
+  const npmPath = path.join(binDirectory, process.platform === "win32" ? "npm.cmd" : "npm");
+  const prefix = path.join(directory, "prefix");
+  const inputPathKey = Object.keys(process.env).find((key) => key.toLowerCase() === "path") || "PATH";
+  let npmInvocation = null;
+  await mkdir(binDirectory, { recursive: true });
+  await writeFile(nodePath, "", "utf8");
+  await writeFile(npmPath, "", "utf8");
+
+  const originalPath = process.env[inputPathKey];
+  let command;
+  process.env[inputPathKey] = "";
+  try {
+    command = globalCommandPath({
+      env: {
+        [inputPathKey]: "",
+        AGENT_RECALL_NODE_PATH: nodePath,
+        ELECTRON_RUN_AS_NODE: "1",
+      },
+      execFileSyncImpl: (executable, args, options) => {
+        npmInvocation = { executable, args, options };
+        return `${prefix}\n`;
+      },
+    });
+  } finally {
+    if (originalPath === undefined) delete process.env[inputPathKey];
+    else process.env[inputPathKey] = originalPath;
+  }
+
+  assert.equal(npmInvocation.executable, process.platform === "win32" ? "npm.cmd" : npmPath);
+  assert.deepEqual(npmInvocation.args, ["prefix", "-g"]);
+  assert.equal(npmInvocation.options.shell, process.platform === "win32");
+  assert.equal(npmInvocation.options.env[inputPathKey].split(path.delimiter)[0], binDirectory);
+  assert.equal(npmInvocation.options.env.ELECTRON_RUN_AS_NODE, undefined);
+  assert.equal(
+    command,
+    process.platform === "win32"
+      ? path.join(prefix, "agent-recall-v2.cmd")
+      : path.join(prefix, "bin", "agent-recall-v2"),
   );
 });
 


### PR DESCRIPTION
## Summary

- resolve npm through the stable Node executable used to launch V2
- stage updates from the loaded V2 package instead of querying the global npm root
- use the same npm resolution when relaunching after installation
- keep Windows paths with spaces working by invoking npm.cmd through the prepared Path

## Tests

- npm --prefix apps/main-2.0 run test:scripts (123 passed)
- npm --prefix apps/main-2.0 run typecheck
- npm run test:repo (26 passed)
- npm run release-note:check

Closes #328