### PR TITLE
fix(v2): support Windows Codex Desktop and CCSwitch

### DIFF
--- a/.release-notes/fix-windows-codex-runtime.md
+++ b/.release-notes/fix-windows-codex-runtime.md
@@ -1,0 +1,7 @@
+# 修复 Windows Codex 运行时识别
+
+<!-- release-target: v2 -->
+
+## Bug 修复
+
+- 修复 Windows 已安装 Codex Desktop 时仍提示 Agent 不可用、连接短暂波动时未等待自动重连，以及使用 CCSwitch 等本机 Codex 配置时错误选择接口导致鉴权或协议失败的问题。

--- a/.release-notes/fix-windows-codex-runtime.md
+++ b/.release-notes/fix-windows-codex-runtime.md
@@ -4,4 +4,5 @@
 
 ## Bug 修复
 
-- 修复 Windows 已安装 Codex Desktop 时仍提示 Agent 不可用、连接短暂波动时未等待自动重连，以及使用 CCSwitch 等本机 Codex 配置时错误选择接口导致鉴权或协议失败的问题。
+- 修复 Windows 已安装 Codex Desktop 时仍提示 Agent 不可用、连接短暂波动时未等待自动重连，以及使用 CCSwitch 等本机 Codex 配置时错误选择接口的问题。
+- 修复在 Chat 中连续提问时，回答按完成时间堆在后方、没有显示在对应问题下方的问题。

--- a/apps/main-2.0/src/automation/engine/main/agents/codex/codex-events.test.ts
+++ b/apps/main-2.0/src/automation/engine/main/agents/codex/codex-events.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { createCodexStreamState, normalizeCodexNotification } from "./codex-events";
+
+describe("normalizeCodexNotification", () => {
+  it("keeps a Codex turn alive while the app-server is reconnecting", () => {
+    const state = createCodexStreamState();
+
+    expect(normalizeCodexNotification("error", {
+      error: { message: "Reconnecting... 2/5" },
+      willRetry: true,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }, state)).toEqual([{
+      type: "system",
+      content: "Reconnecting... 2/5",
+      metadata: { willRetry: true },
+    }]);
+    expect(normalizeCodexNotification("turn/completed", {
+      turn: { status: "completed" },
+    }, state)).toEqual([{ type: "completed" }]);
+    expect(state.lastError).toBe("");
+  });
+
+  it("still reports a non-retryable Codex error", () => {
+    const state = createCodexStreamState();
+
+    expect(normalizeCodexNotification("error", {
+      error: { message: "Connection failed" },
+      willRetry: false,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }, state)).toEqual([{ type: "error", error: "Connection failed" }]);
+    expect(state.lastError).toBe("Connection failed");
+  });
+});

--- a/apps/main-2.0/src/automation/engine/main/agents/codex/codex-events.ts
+++ b/apps/main-2.0/src/automation/engine/main/agents/codex/codex-events.ts
@@ -272,6 +272,9 @@ export function normalizeCodexNotification(
 
   if (method === "error") {
     const message = asString(params.message) || errorMessage(params.error) || "Codex error";
+    if (params.willRetry === true) {
+      return [{ type: "system", content: message, metadata: { willRetry: true } }];
+    }
     state.lastError = message;
     return [{ type: "error", error: message }];
   }

--- a/apps/main-2.0/src/automation/engine/main/agents/runtime/detect.test.ts
+++ b/apps/main-2.0/src/automation/engine/main/agents/runtime/detect.test.ts
@@ -1,0 +1,73 @@
+import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { detectAgentRuntimes, resolveRuntimeExecutables } from "./detect";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) =>
+    rm(directory, { recursive: true, force: true })));
+});
+
+async function addDesktopCodex(root: string, versionDir: string): Promise<string> {
+  const executable = path.join(root, "OpenAI", "Codex", "bin", versionDir, "codex.exe");
+  await mkdir(path.dirname(executable), { recursive: true });
+  await writeFile(executable, "fixture", "utf8");
+  return executable;
+}
+
+describe("detectAgentRuntimes", () => {
+  test("falls back to the newest working Codex Desktop executable on Windows", async () => {
+    const localAppData = await mkdtemp(path.join(os.tmpdir(), "agent-recall-codex-desktop-"));
+    temporaryDirectories.push(localAppData);
+    const older = await addDesktopCodex(localAppData, "older");
+    const newer = await addDesktopCodex(localAppData, "newer");
+    await utimes(older, new Date(1_000), new Date(1_000));
+    await utimes(newer, new Date(2_000), new Date(2_000));
+    const executeVersion = vi.fn(async (command: string) => {
+      if (command === "codex" || command === newer) throw new Error("not executable");
+      if (command === older) return "codex-cli 0.147.0-alpha.1.2";
+      throw new Error("missing");
+    });
+
+    const runtimes = await detectAgentRuntimes(resolveRuntimeExecutables({}, {}), {
+      platform: "win32",
+      localAppData,
+      executeVersion,
+    });
+
+    const codexCommands = executeVersion.mock.calls
+      .map(([command]) => command)
+      .filter((command) => command === "codex" || command.endsWith("codex.exe"));
+    expect(codexCommands).toEqual(["codex", newer, older]);
+    expect(runtimes.find((runtime) => runtime.id === "codex")).toMatchObject({
+      available: true,
+      command: older,
+      version: "0.147.0-alpha.1.2",
+    });
+  });
+
+  test("does not replace an explicit Codex executable with the Desktop fallback", async () => {
+    const localAppData = await mkdtemp(path.join(os.tmpdir(), "agent-recall-codex-explicit-"));
+    temporaryDirectories.push(localAppData);
+    const desktop = await addDesktopCodex(localAppData, "desktop");
+    const executeVersion = vi.fn(async () => { throw new Error("configured executable failed"); });
+    const executables = resolveRuntimeExecutables({ codex: "C:\\custom\\codex.cmd" }, {});
+
+    const runtimes = await detectAgentRuntimes(executables, {
+      platform: "win32",
+      localAppData,
+      allowWindowsCodexDesktopFallback: false,
+      executeVersion,
+    });
+
+    expect(executeVersion).toHaveBeenCalledWith("C:\\custom\\codex.cmd");
+    expect(executeVersion).not.toHaveBeenCalledWith(desktop);
+    expect(runtimes.find((runtime) => runtime.id === "codex")).toMatchObject({
+      available: false,
+      command: "C:\\custom\\codex.cmd",
+    });
+  });
+});

--- a/apps/main-2.0/src/automation/engine/main/agents/runtime/detect.ts
+++ b/apps/main-2.0/src/automation/engine/main/agents/runtime/detect.ts
@@ -1,6 +1,15 @@
+import { readdir, stat } from "node:fs/promises";
+import path from "node:path";
 import { RUNTIME_DEFINITIONS, runtimeDefinition } from "../../../shared/runtime-catalog";
 import type { AgentId, AgentRuntime } from "../../../shared/types";
 import { execCli } from "../../platform/cli-launcher";
+
+interface RuntimeDetectionOptions {
+  platform?: NodeJS.Platform;
+  localAppData?: string;
+  allowWindowsCodexDesktopFallback?: boolean;
+  executeVersion?: (command: string) => Promise<string>;
+}
 
 export function resolveRuntimeExecutables(
   overrides: Partial<Record<AgentId, string>> = {},
@@ -22,7 +31,46 @@ export function parseCliVersion(raw: string): string {
   return match?.[1] ?? firstLine;
 }
 
-async function detectOne(id: AgentId, executables: Record<AgentId, string>): Promise<AgentRuntime> {
+async function executeVersion(command: string): Promise<string> {
+  const { stdout } = await execCli({
+    executable: command,
+    args: ["--version"],
+    timeout: 5000,
+    windowsHide: true,
+    maxBuffer: 1024 * 16,
+  });
+  return String(stdout).trim();
+}
+
+async function windowsCodexDesktopExecutables(localAppData: string | undefined): Promise<string[]> {
+  if (!localAppData) return [];
+  const binDir = path.join(localAppData, "OpenAI", "Codex", "bin");
+  try {
+    const entries = await readdir(binDir, { withFileTypes: true });
+    const candidates = await Promise.all(entries
+      .filter((entry) => entry.isDirectory())
+      .map(async (entry) => {
+        const executable = path.join(binDir, entry.name, "codex.exe");
+        try {
+          return { executable, modifiedAt: (await stat(executable)).mtimeMs };
+        } catch {
+          return undefined;
+        }
+      }));
+    return candidates
+      .filter((candidate): candidate is { executable: string; modifiedAt: number } => Boolean(candidate))
+      .sort((left, right) => right.modifiedAt - left.modifiedAt)
+      .map((candidate) => candidate.executable);
+  } catch {
+    return [];
+  }
+}
+
+async function detectOne(
+  id: AgentId,
+  executables: Record<AgentId, string>,
+  options: RuntimeDetectionOptions,
+): Promise<AgentRuntime> {
   const definition = runtimeDefinition(id);
   const command = executables[id];
   if (definition.detection === "virtual") {
@@ -35,35 +83,49 @@ async function detectOne(id: AgentId, executables: Record<AgentId, string>): Pro
     };
   }
 
+  const runVersion = options.executeVersion ?? executeVersion;
+  let error: unknown;
+  const candidates = [command];
   try {
-    const { stdout } = await execCli({
-      executable: command,
-      args: ["--version"],
-      timeout: 5000,
-      windowsHide: true,
-      maxBuffer: 1024 * 16,
-    });
-    return {
-      id,
-      label: definition.label,
-      command,
-      version: parseCliVersion(String(stdout).trim()),
-      available: true,
-    };
-  } catch (error) {
-    return {
-      id,
-      label: definition.label,
-      command,
-      version: null,
-      available: false,
-      error: error instanceof Error ? error.message : String(error),
-    };
+    candidates.push(...(
+      id === "codex"
+      && (options.platform ?? process.platform) === "win32"
+      && options.allowWindowsCodexDesktopFallback !== false
+        ? await windowsCodexDesktopExecutables(options.localAppData ?? process.env.LOCALAPPDATA)
+        : []
+    ));
+  } catch {
+    // The configured command remains authoritative if Desktop discovery fails.
   }
+
+  for (const candidate of candidates) {
+    try {
+      const stdout = await runVersion(candidate);
+      return {
+        id,
+        label: definition.label,
+        command: candidate,
+        version: parseCliVersion(stdout),
+        available: true,
+      };
+    } catch (cause) {
+      error ??= cause;
+    }
+  }
+
+  return {
+    id,
+    label: definition.label,
+    command,
+    version: null,
+    available: false,
+    error: error instanceof Error ? error.message : String(error),
+  };
 }
 
 export async function detectAgentRuntimes(
   executables: Record<AgentId, string> = resolveRuntimeExecutables(),
+  options: RuntimeDetectionOptions = {},
 ): Promise<AgentRuntime[]> {
-  return Promise.all(RUNTIME_DEFINITIONS.map((definition) => detectOne(definition.id, executables)));
+  return Promise.all(RUNTIME_DEFINITIONS.map((definition) => detectOne(definition.id, executables, options)));
 }

--- a/apps/main-2.0/src/automation/engine/main/channels/runtime-local-config.test.ts
+++ b/apps/main-2.0/src/automation/engine/main/channels/runtime-local-config.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { loadRuntimeLocalConfig } from "./runtime-local-config";
+
+describe("loadRuntimeLocalConfig", () => {
+  it("preserves the Responses protocol when importing the local Codex config", async () => {
+    const imported = await loadRuntimeLocalConfig({
+      runtimeId: "codex",
+      executable: "codex",
+      existingChannel: {
+        id: "codex-openai",
+        agentId: "codex",
+        label: "Codex OpenAI",
+        modelProvider: "openai",
+        models: [{ id: "default", label: "Default" }],
+      },
+      dependencies: {
+        loadCodexConfig: async () => ({
+          modelProvider: "custom",
+          providerName: "custom",
+          baseUrl: "http://127.0.0.1:15721/v1",
+          wireApi: "responses",
+          apiKey: "proxy-key",
+          modelId: "gpt-5.6-sol",
+          modelCatalogJson: null,
+          modelReasoningEffort: null,
+          httpHeaders: null,
+          plugins: null,
+        }),
+      },
+    });
+
+    expect(imported.channel).toMatchObject({
+      id: "codex-openai",
+      modelProvider: "custom",
+      wireApi: "responses",
+      apiFormat: "openai_responses",
+    });
+  });
+});

--- a/apps/main-2.0/src/automation/engine/main/channels/runtime-local-config.ts
+++ b/apps/main-2.0/src/automation/engine/main/channels/runtime-local-config.ts
@@ -76,8 +76,13 @@ function applyCodexConfig(channel: AgentChannel, config: CodexDefaultConfig): Ag
   else delete next.providerName;
   if (config.baseUrl) next.baseUrl = config.baseUrl;
   else delete next.baseUrl;
-  if (config.wireApi) next.wireApi = config.wireApi;
-  else delete next.wireApi;
+  if (config.wireApi) {
+    next.wireApi = config.wireApi;
+    next.apiFormat = config.wireApi === "responses" ? "openai_responses" : "openai_chat";
+  } else {
+    delete next.wireApi;
+    delete next.apiFormat;
+  }
   if (config.modelCatalogJson) next.modelCatalogJson = config.modelCatalogJson;
   else delete next.modelCatalogJson;
   if (config.modelReasoningEffort) next.modelReasoningEffort = config.modelReasoningEffort;

--- a/apps/main-2.0/src/automation/engine/main/hub/agent-hub.ts
+++ b/apps/main-2.0/src/automation/engine/main/hub/agent-hub.ts
@@ -424,6 +424,7 @@ export class AgentHub {
   private readonly workflowRunStateService: WorkflowRunStateService;
   private readonly workflowContextService: WorkflowContextService;
   private readonly executables: Record<AgentId, string>;
+  private readonly allowWindowsCodexDesktopFallback: boolean;
   private readonly workflowRuntime: WorkflowRuntime;
   private readonly workflowStore: WorkflowStore;
   private readonly modelCatalogDiscoverer: ModelCatalogDiscoverer;
@@ -435,6 +436,7 @@ export class AgentHub {
     modelCatalogDiscoverer: ModelCatalogDiscoverer = discoverChannelModels,
     private readonly workflowMessageProvider?: WorkflowMessageProvider,
   ) {
+    this.allowWindowsCodexDesktopFallback = executables.codex === undefined && process.env.CODEX_PATH === undefined;
     this.executables = resolveRuntimeExecutables(executables);
     this.modelCatalogDiscoverer = modelCatalogDiscoverer;
     this.runtimeDrivers =
@@ -638,8 +640,11 @@ export class AgentHub {
   }
 
   async initialize(): Promise<void> {
-    const runtimes = await detectAgentRuntimes(this.executables);
+    const runtimes = await detectAgentRuntimes(this.executables, {
+      allowWindowsCodexDesktopFallback: this.allowWindowsCodexDesktopFallback,
+    });
     for (const runtime of runtimes) {
+      if (runtime.available) this.executables[runtime.id] = runtime.command;
       this.runtimes.set(runtime.id, {
         ...runtime,
         command: runtime.command || this.executables[runtime.id],
@@ -1063,8 +1068,11 @@ export class AgentHub {
   }
 
   async refreshAgents(): Promise<AppSnapshot> {
-    const runtimes = await detectAgentRuntimes();
+    const runtimes = await detectAgentRuntimes(this.executables, {
+      allowWindowsCodexDesktopFallback: this.allowWindowsCodexDesktopFallback,
+    });
     for (const runtime of runtimes) {
+      if (runtime.available) this.executables[runtime.id] = runtime.command;
       this.runtimes.set(runtime.id, runtime);
     }
     this.emit();

--- a/apps/main-2.0/src/main/services/automation-service.test.ts
+++ b/apps/main-2.0/src/main/services/automation-service.test.ts
@@ -41,6 +41,7 @@ function fixture(injectAgents = true) {
   const hub = {
     loadModelChannels: vi.fn(async () => { calls.push("channels"); }),
     loadPersistedState: vi.fn(async () => { calls.push("database"); }),
+    importRuntimeLocalConfig: vi.fn(async () => undefined),
     ensureBundledWorkflows: vi.fn(() => { calls.push("bundled"); }),
     setMcpServers: vi.fn(() => { calls.push("mcp"); }),
     setWorkflowMcpDiscoveryPath: vi.fn(() => { calls.push("discovery"); }),
@@ -174,6 +175,46 @@ describe("NativeAutomationService", () => {
     expect(calls).toEqual(["channels", "database", "mcp", "bundled"]);
     expect(teamChats.connect).not.toHaveBeenCalled();
     expect(service.health()).toEqual({ state: "idle" });
+  });
+
+  it("imports the local Codex config for the untouched official default channel", async () => {
+    const { service, hub, emit } = fixture();
+    emit({
+      ...snapshot(),
+      channels: [{
+        id: "codex-openai",
+        agentId: "codex",
+        label: "Codex OpenAI",
+        modelProvider: "openai",
+        providerName: "OpenAI",
+        models: [{ id: "default", label: "Default" }],
+      }],
+    });
+
+    await service.requirePrepared();
+
+    expect(hub.importRuntimeLocalConfig).toHaveBeenCalledWith("codex", "codex-openai");
+  });
+
+  it("repairs a previously imported default Codex channel without an API format", async () => {
+    const { service, hub, emit } = fixture();
+    emit({
+      ...snapshot(),
+      channels: [{
+        id: "codex-openai",
+        agentId: "codex",
+        label: "Codex OpenAI",
+        presetId: "codex-default",
+        modelProvider: "custom",
+        baseUrl: "http://127.0.0.1:15721/v1",
+        wireApi: "responses",
+        models: [{ id: "default", label: "Default" }],
+      }],
+    });
+
+    await service.requirePrepared();
+
+    expect(hub.importRuntimeLocalConfig).toHaveBeenCalledWith("codex", "codex-openai");
   });
 
   it("reports planning write tools without reading child-only environment variables", async () => {

--- a/apps/main-2.0/src/main/services/automation-service.ts
+++ b/apps/main-2.0/src/main/services/automation-service.ts
@@ -389,6 +389,26 @@ export class NativeAutomationService {
   private async prepareInternal(): Promise<void> {
     await this.hubInstance.loadModelChannels(this.paths.channelsPath);
     await this.hubInstance.loadPersistedState(this.appStore);
+    const defaultCodexChannel = this.hubInstance.snapshot().channels.find((channel) => (
+      channel.id === "codex-openai"
+      && channel.agentId === "codex"
+      && (
+        (
+          channel.modelProvider === "openai"
+          && !channel.baseUrl
+          && !channel.httpHeaders
+          && !channel.environment
+        )
+        || (channel.presetId === "codex-default" && !channel.apiFormat)
+      )
+    ));
+    if (defaultCodexChannel) {
+      try {
+        await this.hubInstance.importRuntimeLocalConfig("codex", defaultCodexChannel.id);
+      } catch (error) {
+        console.warn("Failed to import the local Codex configuration for the default channel:", error);
+      }
+    }
     this.hubInstance.setMcpServers(await this.registryInstance.list());
     this.hubInstance.ensureBundledWorkflows(await this.bundledWorkflows());
   }

--- a/apps/main-2.0/src/renderer/src/features/team-chat/team-chat-page.tsx
+++ b/apps/main-2.0/src/renderer/src/features/team-chat/team-chat-page.tsx
@@ -39,14 +39,10 @@ import { parseTeamChatMentions, removeMentionFromText, resolveMentionedMemberIds
 import { localize, type LanguageMode } from "../../language";
 import { Markdown } from "../../markdown";
 import { useAutomationDetails } from "../automation/automation-provider";
-
-interface StreamDraft {
-  dispatchId: string;
-  rootMessageId: string;
-  agentId: string;
-  agentName: string;
-  content: string;
-}
+import {
+  orderTeamChatTranscript,
+  type TeamChatStreamDraft,
+} from "./team-chat-transcript";
 
 interface DraftStudioEmployee {
   localId: string;
@@ -180,7 +176,7 @@ export function TeamChatPage({
   const [mentionIndex, setMentionIndex] = useState(0);
   const [sending, setSending] = useState(false);
   const [activeRootMessageId, setActiveRootMessageId] = useState<string>();
-  const [streams, setStreams] = useState<Record<string, StreamDraft>>({});
+  const [streams, setStreams] = useState<Record<string, TeamChatStreamDraft>>({});
   const [resettingAgentIds, setResettingAgentIds] = useState<Set<string>>(() => new Set());
   const [removingAgentIds, setRemovingAgentIds] = useState<Set<string>>(() => new Set());
   const [memberContextMenu, setMemberContextMenu] = useState<MemberContextMenu>();
@@ -205,6 +201,10 @@ export function TeamChatPage({
   const availableConfiguredAgentIds = useMemo(
     () => new Set(studioAgents.filter((agent) => agent.available).map((agent) => agent.id)),
     [studioAgents],
+  );
+  const transcriptItems = useMemo(
+    () => orderTeamChatTranscript(messages, Object.values(streams)),
+    [messages, streams],
   );
 
   const mentionContext = useMemo(
@@ -725,20 +725,19 @@ export function TeamChatPage({
                       <span>{l("Send a room message, or mention a Runtime when it should act.", "发送房间消息；需要 Runtime 行动时再 @它。")}</span>
                     </div>
                   ) : null}
-                  {messages.map((message) => (
+                  {transcriptItems.map((item) => item.kind === "message" ? (
                     <TeamChatMessageCard
-                      key={message.id}
-                      message={message}
-                      member={activeRoom.agents.find((member) => member.agentId === message.senderAgentId)}
-                      recipient={activeRoom.agents.find((member) => member.agentId === message.recipientMemberId)}
+                      key={item.message.id}
+                      message={item.message}
+                      member={activeRoom.agents.find((member) => member.agentId === item.message.senderAgentId)}
+                      recipient={activeRoom.agents.find((member) => member.agentId === item.message.recipientMemberId)}
                       language={language}
                     />
-                  ))}
-                  {Object.values(streams).map((stream) => (
+                  ) : (
                     <StreamMessageCard
-                      key={stream.dispatchId}
-                      stream={stream}
-                      member={activeRoom.agents.find((member) => member.agentId === stream.agentId)}
+                      key={item.stream.dispatchId}
+                      stream={item.stream}
+                      member={activeRoom.agents.find((member) => member.agentId === item.stream.agentId)}
                       language={language}
                     />
                   ))}
@@ -1314,7 +1313,7 @@ function TeamChatMessageCard({
   );
 }
 
-function StreamMessageCard({ stream, member, language }: { stream: StreamDraft; member?: TeamChatRoomAgent; language: LanguageMode }): ReactElement {
+function StreamMessageCard({ stream, member, language }: { stream: TeamChatStreamDraft; member?: TeamChatRoomAgent; language: LanguageMode }): ReactElement {
   return (
     <article className="team-chat-message is-agent is-streaming">
       <header><strong>{stream.agentName}</strong>{member ? <span className="team-chat-runtime-badge">{member.runtimeId}</span> : null}<span>{localize(language, "Running…", "正在执行…")}</span></header>
@@ -1327,7 +1326,7 @@ function handleTeamChatEvent(event: TeamChatEvent, handlers: {
   selectedRoomId?: string;
   setConnection: (status: TeamChatConnectionStatus) => void;
   setMessages: React.Dispatch<React.SetStateAction<TeamChatMessage[]>>;
-  setStreams: React.Dispatch<React.SetStateAction<Record<string, StreamDraft>>>;
+  setStreams: React.Dispatch<React.SetStateAction<Record<string, TeamChatStreamDraft>>>;
   setActiveRootMessageId: React.Dispatch<React.SetStateAction<string | undefined>>;
   refreshRooms: () => void;
   refreshActiveRoom: (roomId: string) => void;

--- a/apps/main-2.0/src/renderer/src/features/team-chat/team-chat-page.tsx
+++ b/apps/main-2.0/src/renderer/src/features/team-chat/team-chat-page.tsx
@@ -60,6 +60,7 @@ interface StudioAgentOption {
   runtimeAgentId: string;
   modelId: string;
   description: string;
+  available: boolean;
 }
 
 interface MemberContextMenu {
@@ -192,19 +193,32 @@ export function TeamChatPage({
 
   selectedRoomIdRef.current = selectedRoomId;
 
+  const studioAgents = useMemo<StudioAgentOption[]>(() => {
+    const availableRuntimeIds = new Set(
+      snapshot.runtimes.filter((runtime) => runtime.available).map((runtime) => runtime.id),
+    );
+    return snapshot.configuredAgents.map((agent) => ({
+      ...agent,
+      available: availableRuntimeIds.has(agent.runtimeAgentId),
+    }));
+  }, [snapshot.configuredAgents, snapshot.runtimes]);
+  const availableConfiguredAgentIds = useMemo(
+    () => new Set(studioAgents.filter((agent) => agent.available).map((agent) => agent.id)),
+    [studioAgents],
+  );
+
   const mentionContext = useMemo(
     () => activeMentionContext(composer, composerCursor),
     [composer, composerCursor],
   );
   const mentionCandidates = useMemo(() => {
     if (!mentionMenuOpen || !mentionContext || !activeRoom) return [];
-    const available = new Set(snapshot.configuredAgents.map((agent) => agent.id));
     const query = mentionContext.query.trim().toLocaleLowerCase();
     if (mentionContext.query.endsWith(" ") && activeRoom.agents.some(
       (member) => member.displayName.toLocaleLowerCase() === query,
     )) return [];
     return activeRoom.agents
-      .filter((member) => member.enabled && available.has(member.configuredAgentId))
+      .filter((member) => member.enabled && availableConfiguredAgentIds.has(member.configuredAgentId))
       .filter((member) => !query || member.displayName.toLocaleLowerCase().includes(query))
       .sort((left, right) => {
         const leftStarts = left.displayName.toLocaleLowerCase().startsWith(query) ? 0 : 1;
@@ -212,7 +226,7 @@ export function TeamChatPage({
         return leftStarts - rightStarts || left.position - right.position;
       })
       .slice(0, 6);
-  }, [activeRoom, mentionContext, mentionMenuOpen, snapshot.configuredAgents]);
+  }, [activeRoom, availableConfiguredAgentIds, mentionContext, mentionMenuOpen]);
 
   useEffect(() => {
     setMentionIndex(0);
@@ -222,11 +236,10 @@ export function TeamChatPage({
   // separately, so deleting an "@name" also withdraws that recipient.
   const targetMemberIds = useMemo(() => {
     if (!activeRoom) return [];
-    const availableConfiguredAgents = new Set(snapshot.configuredAgents.map((agent) => agent.id));
     const routable = activeRoom.agents.filter((member) =>
-      member.enabled && availableConfiguredAgents.has(member.configuredAgentId));
+      member.enabled && availableConfiguredAgentIds.has(member.configuredAgentId));
     return resolveMentionedMemberIds(composer, routable);
-  }, [activeRoom, composer, snapshot.configuredAgents]);
+  }, [activeRoom, availableConfiguredAgentIds, composer]);
 
   const loadRooms = useCallback(async (preferredRoomId?: string): Promise<void> => {
     setLoadingRooms(true);
@@ -736,8 +749,7 @@ export function TeamChatPage({
                   <div className="team-chat-recipient-picker" aria-label={l("Message recipients", "消息收件员工")}>
                     <span>{l("To", "发送给")}</span>
                     {activeRoom.agents.map((member) => {
-                      const available = snapshot.configuredAgents
-                        .some((agent) => agent.id === member.configuredAgentId);
+                      const available = availableConfiguredAgentIds.has(member.configuredAgentId);
                       const selected = targetMemberIds.includes(member.agentId);
                       return (
                         <button
@@ -821,7 +833,7 @@ export function TeamChatPage({
                 <button
                   type="button"
                   onClick={() => setAddEmployeeOpen(true)}
-                  disabled={snapshot.configuredAgents.length === 0 || activeRoom.agents.length >= 24}
+                  disabled={availableConfiguredAgentIds.size === 0 || activeRoom.agents.length >= 24}
                   title={l("Add employee", "添加员工")}
                   aria-label={l("Add employee", "添加员工")}
                 >
@@ -831,9 +843,7 @@ export function TeamChatPage({
             </div>
             <div className="team-chat-member-list">
               {activeRoom?.agents.map((member) => {
-                const available = snapshot.configuredAgents.some(
-                  (agent) => agent.id === member.configuredAgentId,
-                );
+                const available = availableConfiguredAgentIds.has(member.configuredAgentId);
                 const continuity = member.hasActiveConversation
                   ? l("Persistent context", "持续会话")
                   : member.continuationAvailable
@@ -906,7 +916,7 @@ export function TeamChatPage({
       {createOpen ? (
         <CreateRoomDialog
           language={language}
-          agents={snapshot.configuredAgents}
+          agents={studioAgents}
           defaultWorkDir={snapshot.workDir}
           onPickDirectory={(defaultPath) => automationApi.pickDirectory(defaultPath)}
           onCreate={async (request) => {
@@ -921,7 +931,7 @@ export function TeamChatPage({
       {addEmployeeOpen && activeRoom ? (
         <AddRoomEmployeeDialog
           language={language}
-          agents={snapshot.configuredAgents}
+          agents={studioAgents}
           existingNames={activeRoom.agents.map((member) => member.displayName)}
           onAdd={addRoomEmployee}
           onClose={() => setAddEmployeeOpen(false)}
@@ -983,14 +993,15 @@ function CreateRoomDialog({
   onClose: () => void;
 }): ReactElement {
   const l = (en: string, zh: string) => localize(language, en, zh);
+  const initialAgent = agents.find((agent) => agent.available) ?? agents[0];
   const [name, setName] = useState("");
   const [workDir, setWorkDir] = useState(defaultWorkDir);
   const employeeSequence = useRef(1);
-  const [employees, setEmployees] = useState<DraftStudioEmployee[]>(() => agents[0]
+  const [employees, setEmployees] = useState<DraftStudioEmployee[]>(() => initialAgent
     ? [{
         localId: "employee-1",
-        configuredAgentId: agents[0].id,
-        displayName: agents[0].name,
+        configuredAgentId: initialAgent.id,
+        displayName: initialAgent.name,
       }]
     : []);
   const [busy, setBusy] = useState(false);
@@ -998,7 +1009,9 @@ function CreateRoomDialog({
 
   const submit = async (event: FormEvent): Promise<void> => {
     event.preventDefault();
-    if (!name.trim() || employees.length === 0 || employees.some((employee) => !employee.displayName.trim()) || busy) return;
+    if (!name.trim() || employees.length === 0 || employees.some((employee) =>
+      !employee.displayName.trim() || !agents.find((agent) => agent.id === employee.configuredAgentId)?.available
+    ) || busy) return;
     setBusy(true);
     setError(undefined);
     try {
@@ -1017,7 +1030,7 @@ function CreateRoomDialog({
   };
 
   const addEmployee = (): void => {
-    const agent = agents[0];
+    const agent = agents.find((candidate) => candidate.available);
     if (!agent) return;
     employeeSequence.current += 1;
     setEmployees((current) => [...current, {
@@ -1056,6 +1069,7 @@ function CreateRoomDialog({
             <span>{employees.length}/24</span>
           </div>
           {agents.length === 0 ? <p className="team-chat-no-agents">{l("Configure an Agent in Runtime first.", "请先在 Runtime 中配置 Agent。")}</p> : null}
+          {agents.length > 0 && !agents.some((agent) => agent.available) ? <p className="team-chat-no-agents">{l("No configured Runtime is currently available.", "当前没有可用的 Runtime 配置。")}</p> : null}
           <div className="team-chat-employee-roster">
             {employees.map((employee) => {
               const selectedAgent = agents.find((agent) => agent.id === employee.configuredAgentId);
@@ -1106,8 +1120,8 @@ function CreateRoomDialog({
                         }}
                       >
                         {agents.map((agent) => (
-                          <option key={agent.id} value={agent.id}>
-                            {agent.name}
+                          <option key={agent.id} value={agent.id} disabled={!agent.available}>
+                            {agent.name}{agent.available ? "" : l(" (Unavailable)", "（不可用）")}
                           </option>
                         ))}
                       </select>
@@ -1134,7 +1148,7 @@ function CreateRoomDialog({
                 </article>
               );
             })}
-            {agents.length > 0 ? (
+            {agents.some((agent) => agent.available) ? (
               <button
                 className="team-chat-add-employee"
                 type="button"
@@ -1151,7 +1165,7 @@ function CreateRoomDialog({
         {error ? <div className="team-chat-dialog-error" role="alert">{error}</div> : null}
         <footer>
           <button type="button" onClick={onClose} disabled={busy}>{l("Cancel", "取消")}</button>
-          <button className="primary" type="submit" disabled={busy || !name.trim() || employees.length === 0 || employees.some((employee) => !employee.displayName.trim())}>
+          <button className="primary" type="submit" disabled={busy || !name.trim() || employees.length === 0 || employees.some((employee) => !employee.displayName.trim() || !agents.find((agent) => agent.id === employee.configuredAgentId)?.available)}>
             {busy ? <LoaderCircle className="spin" size={14} /> : null}{l("Create room", "创建房间")}
           </button>
         </footer>
@@ -1174,9 +1188,10 @@ function AddRoomEmployeeDialog({
   onClose: () => void;
 }): ReactElement {
   const l = (en: string, zh: string) => localize(language, en, zh);
-  const [configuredAgentId, setConfiguredAgentId] = useState(agents[0]?.id ?? "");
+  const initialAgent = agents.find((agent) => agent.available) ?? agents[0];
+  const [configuredAgentId, setConfiguredAgentId] = useState(initialAgent?.id ?? "");
   const [displayName, setDisplayName] = useState(() =>
-    nextStudioEmployeeName(agents[0]?.name ?? "Employee", existingNames));
+    nextStudioEmployeeName(initialAgent?.name ?? "Employee", existingNames));
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string>();
   const selectedAgent = agents.find((agent) => agent.id === configuredAgentId);
@@ -1184,7 +1199,7 @@ function AddRoomEmployeeDialog({
   const submit = async (event: FormEvent): Promise<void> => {
     event.preventDefault();
     const name = displayName.trim();
-    if (!configuredAgentId || !name || busy) return;
+    if (!configuredAgentId || !name || !selectedAgent?.available || busy) return;
     setBusy(true);
     setError(undefined);
     try {
@@ -1243,7 +1258,9 @@ function AddRoomEmployeeDialog({
             }}
           >
             {agents.map((agent) => (
-              <option key={agent.id} value={agent.id}>{agent.name}</option>
+              <option key={agent.id} value={agent.id} disabled={!agent.available}>
+                {agent.name}{agent.available ? "" : l(" (Unavailable)", "（不可用）")}
+              </option>
             ))}
           </select>
         </label>
@@ -1259,7 +1276,7 @@ function AddRoomEmployeeDialog({
           <button className="team-chat-dialog-cancel" type="button" onClick={onClose} disabled={busy}>
             {l("Cancel", "取消")}
           </button>
-          <button className="primary team-chat-dialog-confirm" type="submit" disabled={busy || !displayName.trim() || !configuredAgentId}>
+          <button className="primary team-chat-dialog-confirm" type="submit" disabled={busy || !displayName.trim() || !configuredAgentId || !selectedAgent?.available}>
             {busy ? <LoaderCircle className="spin" size={14} /> : null}
             {!busy ? <Plus size={14} /> : null}
             {l("Add employee", "添加员工")}

--- a/apps/main-2.0/src/renderer/src/features/team-chat/team-chat-transcript.test.ts
+++ b/apps/main-2.0/src/renderer/src/features/team-chat/team-chat-transcript.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import type { TeamChatMessage } from "../../../../shared/team-chat";
+import { orderTeamChatTranscript, type TeamChatStreamDraft } from "./team-chat-transcript";
+
+function message(input: {
+  id: string;
+  sequence: number;
+  rootMessageId?: string;
+  senderType?: TeamChatMessage["senderType"];
+  basedOnSequence?: number;
+}): TeamChatMessage {
+  return {
+    id: input.id,
+    roomId: "room-1",
+    sequence: input.sequence,
+    senderType: input.senderType ?? "human",
+    senderName: input.senderType === "agent" ? "Agent" : "You",
+    content: input.id,
+    deliveryType: input.senderType === "agent" ? "reply" : "message",
+    rootMessageId: input.rootMessageId ?? input.id,
+    hop: input.senderType === "agent" ? 1 : 0,
+    status: "final",
+    ...(input.basedOnSequence !== undefined ? { basedOnSequence: input.basedOnSequence } : {}),
+    createdAt: "2026-08-06T03:00:00.000Z",
+    updatedAt: "2026-08-06T03:00:00.000Z",
+  };
+}
+
+function itemId(item: ReturnType<typeof orderTeamChatTranscript>[number]): string {
+  return item.kind === "message" ? item.message.id : item.stream.dispatchId;
+}
+
+describe("orderTeamChatTranscript", () => {
+  it("keeps each answer below its question when answers finish in reverse order", () => {
+    const messages = [
+      message({ id: "question-1", sequence: 1 }),
+      message({ id: "question-2", sequence: 2 }),
+      message({ id: "question-3", sequence: 3 }),
+      message({ id: "answer-3", sequence: 4, rootMessageId: "question-3", senderType: "agent" }),
+      message({ id: "answer-2", sequence: 5, rootMessageId: "question-2", senderType: "agent" }),
+      message({ id: "answer-1", sequence: 6, rootMessageId: "question-1", senderType: "agent" }),
+    ];
+
+    expect(orderTeamChatTranscript(messages, []).map(itemId)).toEqual([
+      "question-1",
+      "answer-1",
+      "question-2",
+      "answer-2",
+      "question-3",
+      "answer-3",
+    ]);
+  });
+
+  it("places running responses below the question that started them", () => {
+    const messages = [
+      message({ id: "question-1", sequence: 1 }),
+      message({ id: "question-2", sequence: 2 }),
+    ];
+    const streams: TeamChatStreamDraft[] = [
+      { dispatchId: "stream-2", rootMessageId: "question-2", agentId: "agent-2", agentName: "Agent 2", content: "" },
+      { dispatchId: "stream-1", rootMessageId: "question-1", agentId: "agent-1", agentName: "Agent 1", content: "" },
+    ];
+
+    expect(orderTeamChatTranscript(messages, streams).map(itemId)).toEqual([
+      "question-1",
+      "stream-1",
+      "question-2",
+      "stream-2",
+    ]);
+  });
+});

--- a/apps/main-2.0/src/renderer/src/features/team-chat/team-chat-transcript.ts
+++ b/apps/main-2.0/src/renderer/src/features/team-chat/team-chat-transcript.ts
@@ -1,0 +1,49 @@
+import type { TeamChatMessage } from "../../../../shared/team-chat";
+
+export interface TeamChatStreamDraft {
+  dispatchId: string;
+  rootMessageId: string;
+  agentId: string;
+  agentName: string;
+  content: string;
+}
+
+export type TeamChatTranscriptItem =
+  | { kind: "message"; message: TeamChatMessage }
+  | { kind: "stream"; stream: TeamChatStreamDraft };
+
+export function orderTeamChatTranscript(
+  messages: TeamChatMessage[],
+  streams: TeamChatStreamDraft[],
+): TeamChatTranscriptItem[] {
+  const rootSequences = new Map(messages.map((message) => [message.id, message.sequence]));
+  const items: TeamChatTranscriptItem[] = [
+    ...messages.map((message): TeamChatTranscriptItem => ({ kind: "message", message })),
+    ...streams.map((stream): TeamChatTranscriptItem => ({ kind: "stream", stream })),
+  ];
+
+  return items.sort((left, right) => {
+    const leftRootSequence = transcriptRootSequence(left, rootSequences);
+    const rightRootSequence = transcriptRootSequence(right, rootSequences);
+    if (leftRootSequence !== rightRootSequence) return leftRootSequence - rightRootSequence;
+
+    if (left.kind === "message" && right.kind === "message") {
+      return left.message.sequence - right.message.sequence || left.message.id.localeCompare(right.message.id);
+    }
+    if (left.kind === "message") return -1;
+    if (right.kind === "message") return 1;
+    return left.stream.dispatchId.localeCompare(right.stream.dispatchId);
+  });
+}
+
+function transcriptRootSequence(
+  item: TeamChatTranscriptItem,
+  rootSequences: Map<string, number>,
+): number {
+  if (item.kind === "stream") {
+    return rootSequences.get(item.stream.rootMessageId) ?? Number.MAX_SAFE_INTEGER;
+  }
+  return rootSequences.get(item.message.rootMessageId)
+    ?? item.message.basedOnSequence
+    ?? item.message.sequence;
+}


### PR DESCRIPTION
## 变更概述

修复 AgentRecall V2 在 Windows 上使用 Codex Desktop 和 CCSwitch 时的多项问题：

- Windows 已安装 Codex Desktop，但 AgentRecall 仍提示 Codex Agent 不可用。
- 新建 Team Chat 对话时没有正确使用本机 Codex 配置。
- CCSwitch 配置中的 `wire_api = "responses"` 被错误路由到 `/chat/completions`，导致 `gpt-5.6-sol` 等模型返回协议不支持错误。
- 已导入的 Codex 配置缺少 API 格式信息，重启后仍会继续使用错误协议。
- Codex 临时重连时被错误地当作最终失败，导致对话提前结束。
- Team Chat 添加员工时，无法区分已配置但当前 Runtime 不可用的 Agent。

修复后，Windows Codex Desktop 可以被正确发现，CCSwitch 的 Responses 配置会直接使用 `/responses`，新建对话和重试流程可以正常工作。

## 更新说明检查

- [x] 本分支已新增且仅新增一个 `.release-notes/<branch-slug>.md`
- [x] 更新说明包含面向用户的“Bug 修复”列表
- [x] 更新说明已移除 MR、分支、CI、发布流程、内部服务、路径及其他不应暴露的实现或敏感信息
- [x] 已运行相关 release note 检查

更新说明文件会原样显示在 GitHub Release、终端更新提示和 App“关于”页面中，请不要在这里只写一份无法被自动发布读取的副本。

## 验证

- [x] `npm run typecheck`
- [x] Codex 事件处理测试
- [x] Windows Runtime 检测测试
- [x] Codex 本地配置导入测试
- [x] AgentRecall 启动时配置修复测试
- [x] CCSwitch Responses 通道实际请求测试，结果为 `OK`
- [x] 已确认没有将 API Key 或私人路径提交到 PR