### PR TITLE
fix(v2): 修复 V2 内置 Skill 安装时丢失附件的问题

### DIFF
--- a/.release-notes/fix-bundled-skill-assets.md
+++ b/.release-notes/fix-bundled-skill-assets.md
@@ -1,0 +1,8 @@
+# 修复内置 Skill 附件缺失
+
+## Bug 修复
+
+- 修复内置 Skill 安装到 Codex、Claude Code 或 Trae 后丢失参考资料的问题；发布版现在也会保留 Skill 依赖的本地附件。
+- 修复内置 Skill 中指向不存在参考资料和外部 Skill 的链接，相关指导可以直接在当前 Skill 中使用。
+
+<!-- release-target: v2 -->

--- a/apps/main-2.0/src/automation/engine/main/skills/skill-installer.test.ts
+++ b/apps/main-2.0/src/automation/engine/main/skills/skill-installer.test.ts
@@ -1,0 +1,24 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { installBundledSkill, uninstallBundledSkill } from "./skill-installer";
+
+describe("bundled Skill installation", () => {
+  it("materializes auxiliary files when the packaged source tree is unavailable", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "agentrecall-bundled-skill-"));
+    const homeDir = path.join(root, "home");
+    const bundledRoot = path.join(root, "bundled-skills");
+
+    try {
+      const installed = await installBundledSkill({ templateId: "brainstorming", target: "codex" }, homeDir, bundledRoot);
+      const referencePath = path.join(path.dirname(installed.sourcePath), "references", "visual-companion.md");
+      await expect(readFile(referencePath, "utf8")).resolves.toContain("visual");
+      await expect(readFile(installed.path, "utf8")).resolves.toContain("references/visual-companion.md");
+
+      await uninstallBundledSkill({ templateId: "brainstorming", target: "codex" }, homeDir, bundledRoot);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/main-2.0/src/automation/engine/main/skills/skill-installer.ts
+++ b/apps/main-2.0/src/automation/engine/main/skills/skill-installer.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { cp, lstat, mkdir, readdir, readFile, readlink, rm, symlink, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { bundledSkillAssetsFor } from "../../shared/bundled-skill-library";
 import { parseSkillMarkdown } from "../../shared/online-skills";
 import { SKILL_TEMPLATES } from "../../shared/skill-templates";
 import type {
@@ -83,6 +84,19 @@ function bundledSkillSourceDir(template: SkillTemplate): string | undefined {
 
 function pathExistsSync(filePath: string): boolean {
   return existsSync(filePath);
+}
+
+async function writeEmbeddedSkillSource(template: SkillTemplate, sourceDir: string): Promise<void> {
+  const assets = bundledSkillAssetsFor(template.id);
+  await mkdir(sourceDir, { recursive: true });
+  const skillAsset = assets.find((asset) => asset.relativePath === "SKILL.md");
+  await writeFile(path.join(sourceDir, "SKILL.md"), skillAsset?.contents ?? `${template.prompt.trim()}\n`, "utf8");
+  for (const asset of assets) {
+    if (asset.relativePath === "SKILL.md") continue;
+    const targetPath = path.join(sourceDir, asset.relativePath);
+    await mkdir(path.dirname(targetPath), { recursive: true });
+    await writeFile(targetPath, asset.contents, "utf8");
+  }
 }
 
 async function assertOwnedSymlink(linkPath: string, sourceDir: string): Promise<void> {
@@ -184,8 +198,7 @@ export async function installBundledSkill(request: InstallSkillRequest, homeDir:
     if (bundledSourceDir) {
       await cp(bundledSourceDir, sourceDir, { recursive: true });
     } else {
-      await mkdir(sourceDir, { recursive: true });
-      await writeFile(sourcePath, `${template.prompt.trim()}\n`, "utf8");
+      await writeEmbeddedSkillSource(template, sourceDir);
     }
   }
   await mkdir(path.dirname(linkPath), { recursive: true });

--- a/apps/main-2.0/src/automation/engine/shared/bundled-skill-library.test.ts
+++ b/apps/main-2.0/src/automation/engine/shared/bundled-skill-library.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { bundledSkillAssetsFor } from "./bundled-skill-library";
+
+describe("bundled Skill assets", () => {
+  it("embeds auxiliary files for Skills that reference them", () => {
+    const brainstormingAssets = bundledSkillAssetsFor("brainstorming");
+    const systematicDebuggingAssets = bundledSkillAssetsFor("systematic-debugging");
+
+    expect(brainstormingAssets.map((asset) => asset.relativePath)).toContain("references/visual-companion.md");
+    expect(systematicDebuggingAssets.map((asset) => asset.relativePath)).toEqual(expect.arrayContaining([
+      "condition-based-waiting.md",
+      "defense-in-depth.md",
+      "root-cause-tracing.md",
+    ]));
+  });
+});

--- a/apps/main-2.0/src/automation/engine/shared/bundled-skill-library.ts
+++ b/apps/main-2.0/src/automation/engine/shared/bundled-skill-library.ts
@@ -35,6 +35,21 @@ const skillMetadataFiles = import.meta.glob<string>("./bundled-skills/*/metadata
   import: "default",
   query: "?raw",
 });
+const directSkillAssetFiles = import.meta.glob<string>("./bundled-skills/*/*", {
+  eager: true,
+  import: "default",
+  query: "?raw",
+});
+const nestedSkillAssetFiles = import.meta.glob<string>("./bundled-skills/*/**/*", {
+  eager: true,
+  import: "default",
+  query: "?raw",
+});
+
+export interface BundledSkillAsset {
+  relativePath: string;
+  contents: string;
+}
 
 function skillIdFromPath(filePath: string): string {
   const match = filePath.match(/\.\/bundled-skills\/([^/]+)\/[^/]+$/);
@@ -44,6 +59,18 @@ function skillIdFromPath(filePath: string): string {
 
 function sourcePathFor(filePath: string): string {
   return `src/shared/${filePath.replace(/^\.\//, "")}`;
+}
+
+export function bundledSkillAssetsFor(skillId: string): BundledSkillAsset[] {
+  const prefix = `./bundled-skills/${skillId}/`;
+  const assets = new Map<string, string>();
+  for (const [filePath, contents] of Object.entries({ ...directSkillAssetFiles, ...nestedSkillAssetFiles })) {
+    if (!filePath.startsWith(prefix)) continue;
+    assets.set(filePath.slice(prefix.length), contents);
+  }
+  return [...assets.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([relativePath, contents]) => ({ relativePath, contents }));
 }
 
 function normalizeNewlines(markdown: string): string {

--- a/apps/main-2.0/src/automation/engine/shared/bundled-skills/brainstorming/SKILL.md
+++ b/apps/main-2.0/src/automation/engine/shared/bundled-skills/brainstorming/SKILL.md
@@ -156,4 +156,4 @@ A browser-based companion for showing mockups, diagrams, and visual options duri
 A question about a UI topic is not automatically a visual question. "What does personality mean in this context?" is a conceptual question — use the terminal. "Which wizard layout works better?" is a visual question — use the browser.
 
 If they agree to the companion, read the detailed guide before proceeding:
-`skills/brainstorming/visual-companion.md`
+`references/visual-companion.md`

--- a/apps/main-2.0/src/automation/engine/shared/bundled-skills/resume-optimization/SKILL.md
+++ b/apps/main-2.0/src/automation/engine/shared/bundled-skills/resume-optimization/SKILL.md
@@ -161,18 +161,9 @@ When tailoring for a job description:
 
 ## References
 
-For detailed guidance on specific topics:
-
-- [Resume Structure Guide](references/resume-structure.md) - Section order, formatting, length
-- [Achievement Formula Guide](references/achievement-formula.md) - Transforming experience into impact
-- [ATS Keywords Guide](references/ats-keywords.md) - Keyword extraction and optimization
-- [Tailoring Guide](references/tailoring-guide.md) - Matching resume to job description
-
-## Related Resources
-
-- `achievement-bullet` output style - Format for achievement bullets
-- `/soft-skills:track-win` skill - Transform descriptions into achievement bullets
-- `resume-coach` agent - Interactive resume improvement
+The guidance in this Skill is self-contained. Use the section headings above to
+jump directly to resume structure, achievement bullets, ATS optimization, or
+job tailoring without relying on other Skills or agents.
 
 ## User-Facing Interface
 


### PR DESCRIPTION
## 背景

V2 发布包不包含完整的 `src` Skill 源目录。安装内置 Skill 时，如果找不到源目录，安装器此前只会写入 `SKILL.md`，导致 Skill 依赖的 `references/` 等附件丢失，安装后的 Skill 无法正常使用相关指南。

同时，部分内置 Skill 存在失效的本地文件引用。

## 改动内容

- 在构建阶段嵌入内置 Skill 的所有辅助文件，包括嵌套目录中的附件。
- 安装时在源目录不可用的情况下，恢复完整的 Skill 文件结构。
- 修复 brainstorming 对 `visual-companion.md` 的错误路径引用。
- 清理 resume-optimization 中不存在的参考文件和外部 Skill 引用。
- 增加资源嵌入和安装行为测试。
- 添加 V2 发布说明。

## 验证

- 定向 Vitest 测试通过：2 个测试文件，2 个测试用例。
- 发布说明范围校验通过：`upstream/main...HEAD`。
- TypeScript 全量检查仍受仓库现有缺失依赖影响，未发现与本次改动直接相关的新错误。

<!-- release-target: v2 -->