### PR TITLE
fix(v2): support custom OpenAI responses memory

### DIFF
--- a/.release-notes/openviking-custom-openai-responses.md
+++ b/.release-notes/openviking-custom-openai-responses.md
@@ -5,3 +5,4 @@
 - 使用自定义 OpenAI Responses 接口作为摘要 Provider 时，现在可以正常创建并运行目录 Memory。
 - 保存专用的 AI 摘要与搜索配置后，即使 Codex 同时使用自定义 Provider，也会正确显示已经保存的接口地址、模型和 API Key。
 - 自定义 AI 摘要与搜索 Provider 现在可以明确选择 OpenAI Chat Completions 或 OpenAI Responses API，避免接口协议判断错误。
+- 升级后会自动补齐目录 Memory 所需的数据结构，避免搜索、诊断或批量删除时提示数据不存在。

--- a/.release-notes/openviking-custom-openai-responses.md
+++ b/.release-notes/openviking-custom-openai-responses.md
@@ -1,0 +1,6 @@
+# OpenViking 支持自定义 OpenAI Responses Provider
+
+## Bug 修复
+
+- 使用自定义 OpenAI Responses 接口作为摘要 Provider 时，现在可以正常创建并运行目录 Memory。
+- 保存专用的 AI 摘要与搜索配置后，即使 Codex 同时使用自定义 Provider，也会正确显示已经保存的接口地址、模型和 API Key。

--- a/.release-notes/openviking-custom-openai-responses.md
+++ b/.release-notes/openviking-custom-openai-responses.md
@@ -4,3 +4,4 @@
 
 - 使用自定义 OpenAI Responses 接口作为摘要 Provider 时，现在可以正常创建并运行目录 Memory。
 - 保存专用的 AI 摘要与搜索配置后，即使 Codex 同时使用自定义 Provider，也会正确显示已经保存的接口地址、模型和 API Key。
+- 自定义 AI 摘要与搜索 Provider 现在可以明确选择 OpenAI Chat Completions 或 OpenAI Responses API，避免接口协议判断错误。

--- a/apps/main-2.0/src/core/postgres/schema.test.ts
+++ b/apps/main-2.0/src/core/postgres/schema.test.ts
@@ -304,6 +304,56 @@ describe("AgentRecall PostgreSQL schema", () => {
     await upgradedDatabase.close();
   });
 
+  it("repairs directory memory tables when version 28 was already used by another migration", async () => {
+    const pool = new PGliteTestPool();
+    const branchDatabase = new PostgresDatabase(pool, {
+      migrationLock: false,
+      migrations: POSTGRES_MIGRATIONS.filter((migration) => migration.version <= 27),
+    });
+    await branchDatabase.initialize();
+    await branchDatabase.query(`
+      INSERT INTO agent_recall.schema_migrations (version, name)
+      VALUES (28, 'persist Workflow review history and full-rerun lineage');
+    `);
+
+    const upgradedDatabase = new PostgresDatabase(pool, {
+      migrationLock: false,
+      migrations: POSTGRES_MIGRATIONS,
+    });
+    await upgradedDatabase.initialize();
+
+    const tables = await upgradedDatabase.query<{ table_name: string }>(`
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_schema = 'agent_recall'
+        AND table_name IN (
+          'openviking_memories',
+          'openviking_memory_evidence',
+          'openviking_memory_feedback',
+          'openviking_commit_runs',
+          'openviking_operation_events',
+          'openviking_recall_traces'
+        )
+      ORDER BY table_name
+    `);
+    expect(tables.rows.map((row) => row.table_name)).toEqual([
+      "openviking_commit_runs",
+      "openviking_memories",
+      "openviking_memory_evidence",
+      "openviking_memory_feedback",
+      "openviking_operation_events",
+      "openviking_recall_traces",
+    ]);
+
+    const repairMigration = await upgradedDatabase.query<{ name: string }>(`
+      SELECT name FROM agent_recall.schema_migrations WHERE version = 32
+    `);
+    expect(repairMigration.rows).toEqual([{
+      name: "repair directory memory control plane after migration version collision",
+    }]);
+    await upgradedDatabase.close();
+  });
+
   it("stores Turn search and trace hierarchy as first-class PostgreSQL structures", async () => {
     const database = new PostgresDatabase(new PGliteTestPool(), {
       migrationLock: false,

--- a/apps/main-2.0/src/core/postgres/schema.ts
+++ b/apps/main-2.0/src/core/postgres/schema.ts
@@ -1488,4 +1488,130 @@ export const POSTGRES_MIGRATIONS: readonly PostgresMigration[] = [{
         ADD COLUMN IF NOT EXISTS read_only boolean NOT NULL DEFAULT false;
     `,
   ],
+}, {
+  version: 32,
+  name: "repair directory memory control plane after migration version collision",
+  statements: [
+    `
+      CREATE TABLE IF NOT EXISTS agent_recall.openviking_memories (
+        workspace_id text NOT NULL
+          REFERENCES agent_recall.openviking_workspaces(id) ON DELETE CASCADE,
+        uri text NOT NULL,
+        memory_type text NOT NULL,
+        authority text NOT NULL DEFAULT 'model'
+          CHECK (authority IN ('model', 'user')),
+        lifecycle text NOT NULL DEFAULT 'active'
+          CHECK (lifecycle IN ('active', 'disputed', 'superseded', 'invalidated', 'deleted')),
+        locked boolean NOT NULL DEFAULT false,
+        evidence_status text NOT NULL DEFAULT 'legacy'
+          CHECK (evidence_status IN ('verified', 'legacy', 'invalid')),
+        source text NOT NULL DEFAULT 'legacy'
+          CHECK (source IN ('openviking', 'manual', 'user-edit', 'legacy')),
+        title text,
+        locked_content text,
+        created_at timestamptz NOT NULL,
+        updated_at timestamptz NOT NULL,
+        PRIMARY KEY (workspace_id, uri)
+      );
+
+      CREATE TABLE IF NOT EXISTS agent_recall.openviking_memory_evidence (
+        id text PRIMARY KEY,
+        workspace_id text NOT NULL,
+        memory_uri text NOT NULL,
+        source_session_id text,
+        source_agent text,
+        source_turn_ids jsonb NOT NULL DEFAULT '[]'::jsonb,
+        archive_uri text,
+        memory_diff_uri text,
+        remote_task_id text,
+        model_snapshot jsonb,
+        policy_snapshot jsonb,
+        state text NOT NULL DEFAULT 'active'
+          CHECK (state IN ('active', 'invalidated')),
+        created_at timestamptz NOT NULL,
+        updated_at timestamptz NOT NULL,
+        FOREIGN KEY (workspace_id, memory_uri)
+          REFERENCES agent_recall.openviking_memories(workspace_id, uri) ON DELETE CASCADE
+      );
+
+      CREATE TABLE IF NOT EXISTS agent_recall.openviking_memory_feedback (
+        id text PRIMARY KEY,
+        workspace_id text NOT NULL,
+        memory_uri text NOT NULL,
+        feedback text NOT NULL CHECK (feedback IN ('helpful', 'wrong', 'outdated')),
+        actor text NOT NULL,
+        note text,
+        created_at timestamptz NOT NULL,
+        FOREIGN KEY (workspace_id, memory_uri)
+          REFERENCES agent_recall.openviking_memories(workspace_id, uri) ON DELETE CASCADE
+      );
+
+      CREATE TABLE IF NOT EXISTS agent_recall.openviking_commit_runs (
+        task_id text PRIMARY KEY,
+        workspace_id text NOT NULL
+          REFERENCES agent_recall.openviking_workspaces(id) ON DELETE CASCADE,
+        session_id text NOT NULL,
+        agent text,
+        trigger text NOT NULL,
+        state text NOT NULL CHECK (state IN ('running', 'completed', 'failed')),
+        source_turn_ids jsonb NOT NULL DEFAULT '[]'::jsonb,
+        token_estimate integer NOT NULL DEFAULT 0 CHECK (token_estimate >= 0),
+        archive_uri text,
+        memory_diff_uri text,
+        memories_extracted jsonb,
+        token_usage jsonb,
+        error text,
+        started_at timestamptz NOT NULL,
+        completed_at timestamptz,
+        updated_at timestamptz NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS agent_recall.openviking_operation_events (
+        id text PRIMARY KEY,
+        workspace_id text NOT NULL
+          REFERENCES agent_recall.openviking_workspaces(id) ON DELETE CASCADE,
+        phase text NOT NULL,
+        status text NOT NULL
+          CHECK (status IN ('started', 'completed', 'failed', 'degraded', 'skipped')),
+        session_id text,
+        task_id text,
+        started_at timestamptz NOT NULL,
+        completed_at timestamptz,
+        duration_ms integer CHECK (duration_ms IS NULL OR duration_ms >= 0),
+        details jsonb
+      );
+
+      CREATE TABLE IF NOT EXISTS agent_recall.openviking_recall_traces (
+        id text PRIMARY KEY,
+        workspace_id text NOT NULL
+          REFERENCES agent_recall.openviking_workspaces(id) ON DELETE CASCADE,
+        agent text NOT NULL,
+        query text NOT NULL,
+        contextual_query text NOT NULL,
+        searched_scopes jsonb NOT NULL DEFAULT '[]'::jsonb,
+        searched_types jsonb NOT NULL DEFAULT '[]'::jsonb,
+        candidates jsonb NOT NULL DEFAULT '[]'::jsonb,
+        injected_uris jsonb NOT NULL DEFAULT '[]'::jsonb,
+        injected_token_count integer NOT NULL DEFAULT 0 CHECK (injected_token_count >= 0),
+        duration_ms integer NOT NULL DEFAULT 0 CHECK (duration_ms >= 0),
+        degraded_reason text,
+        created_at timestamptz NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS openviking_memories_recall_idx
+        ON agent_recall.openviking_memories (
+          workspace_id, lifecycle, evidence_status, locked, updated_at DESC
+        );
+      CREATE INDEX IF NOT EXISTS openviking_memory_evidence_uri_idx
+        ON agent_recall.openviking_memory_evidence (workspace_id, memory_uri, created_at DESC);
+      CREATE INDEX IF NOT EXISTS openviking_memory_feedback_uri_idx
+        ON agent_recall.openviking_memory_feedback (workspace_id, memory_uri, created_at DESC);
+      CREATE INDEX IF NOT EXISTS openviking_commit_runs_workspace_idx
+        ON agent_recall.openviking_commit_runs (workspace_id, updated_at DESC);
+      CREATE INDEX IF NOT EXISTS openviking_operation_events_workspace_idx
+        ON agent_recall.openviking_operation_events (workspace_id, started_at DESC);
+      CREATE INDEX IF NOT EXISTS openviking_recall_traces_workspace_idx
+        ON agent_recall.openviking_recall_traces (workspace_id, created_at DESC);
+    `,
+  ],
 }];

--- a/apps/main-2.0/src/main/services/openviking-extraction-config.test.ts
+++ b/apps/main-2.0/src/main/services/openviking-extraction-config.test.ts
@@ -131,17 +131,26 @@ describe("resolveOpenVikingExtractionConfig", () => {
     })).toThrow("Claude CLI cannot be used");
   });
 
-  it("rejects custom OpenAI Responses Providers", () => {
-    expect(() => resolveOpenVikingExtractionConfig({
+  it("maps a custom OpenAI Responses Provider", () => {
+    expect(resolveOpenVikingExtractionConfig({
       settings: {
         ...defaultSettings,
         summarySource: "custom",
         summaryApiConfig: {
           ...defaultSettings.summaryApiConfig,
           customApiFormat: "openai_responses",
+          customBaseUrl: "https://example.com/v1",
+          customApiKey: "secret",
+          customModel: "responses-model",
         },
       },
       codex: { activeModel: "" },
-    })).toThrow("custom OpenAI Chat providers only");
+    })).toEqual({
+      provider: "openai-codex",
+      model: "responses-model",
+      api_base: "https://example.com/v1",
+      api_key: "secret",
+      reasoning_effort: "medium",
+    });
   });
 });

--- a/apps/main-2.0/src/main/services/openviking-extraction-config.ts
+++ b/apps/main-2.0/src/main/services/openviking-extraction-config.ts
@@ -52,9 +52,6 @@ export function resolveOpenVikingExtractionConfig(input: {
   }
 
   const config = input.settings.summaryApiConfig;
-  if (config.customApiFormat !== "openai_chat") {
-    throw new Error("OpenViking currently supports custom OpenAI Chat providers only.");
-  }
   const model = config.customModel.trim();
   const apiBase = config.customBaseUrl.trim();
   const apiKey = config.customApiKey.trim();
@@ -62,7 +59,7 @@ export function resolveOpenVikingExtractionConfig(input: {
     throw new Error("Complete the summary Provider URL, API key, and model before starting Memory.");
   }
   return {
-    provider: "openai",
+    provider: config.customApiFormat === "openai_responses" ? "openai-codex" : "openai",
     model,
     api_base: apiBase,
     api_key: apiKey,

--- a/apps/main-2.0/src/renderer/src/features/providers/provider-page.test.tsx
+++ b/apps/main-2.0/src/renderer/src/features/providers/provider-page.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { defaultSettings } from "../../../../core/platform";
+import { ProviderPage } from "./provider-page";
+
+describe("ProviderPage summary settings", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+    Object.defineProperty(window, "sessionSearch", {
+      configurable: true,
+      value: {
+        getCodexConfig: vi.fn(async () => ({
+          exists: false,
+          configPath: "C:\\tmp\\codex\\config.toml",
+          activeProviderId: "openai",
+          activeModel: "",
+          availableModels: [],
+          providers: [],
+        })),
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps a saved summary API key when Codex also uses a custom provider", async () => {
+    const settings = {
+      ...defaultSettings,
+      summarySource: "custom" as const,
+      apiConfig: {
+        ...defaultSettings.apiConfig,
+        activeProvider: "custom" as const,
+        customProviderId: "custom" as const,
+        customBaseUrl: "https://codex.example/v1",
+        customApiKey: "codex-key",
+        customModel: "codex-model",
+      },
+      summaryApiConfig: {
+        ...defaultSettings.summaryApiConfig,
+        activeProvider: "custom" as const,
+        customProviderId: "custom" as const,
+        customBaseUrl: "https://summary.example/v1",
+        customApiKey: "summary-key",
+        customModel: "summary-model",
+      },
+    };
+
+    await act(async () => root.render(
+      <ProviderPage
+        settings={settings}
+        language="en"
+        feedback={null}
+        onSettingsChange={vi.fn()}
+        onApplyToCodex={vi.fn()}
+        onApplyToClaude={vi.fn()}
+      />,
+    ));
+    const summaryTab = [...container.querySelectorAll("button")]
+      .find((button) => button.textContent?.includes("AI Summary & Search"));
+    expect(summaryTab).toBeDefined();
+    await act(async () => summaryTab!.click());
+
+    const keyInput = container.querySelector<HTMLInputElement>('input[type="password"]');
+    expect(keyInput?.value).toBe("summary-key");
+    expect(container.querySelector<HTMLInputElement>('input[placeholder="https://api.deepseek.com"]')?.value)
+      .toBe("https://summary.example/v1");
+    expect(container.querySelector<HTMLInputElement>('input[placeholder="deepseek-v4-flash"]')?.value)
+      .toBe("summary-model");
+  });
+});

--- a/apps/main-2.0/src/renderer/src/features/providers/provider-page.test.tsx
+++ b/apps/main-2.0/src/renderer/src/features/providers/provider-page.test.tsx
@@ -38,6 +38,7 @@ describe("ProviderPage summary settings", () => {
   });
 
   it("keeps a saved summary API key when Codex also uses a custom provider", async () => {
+    const onSettingsChange = vi.fn();
     const settings = {
       ...defaultSettings,
       summarySource: "custom" as const,
@@ -64,7 +65,7 @@ describe("ProviderPage summary settings", () => {
         settings={settings}
         language="en"
         feedback={null}
-        onSettingsChange={vi.fn()}
+        onSettingsChange={onSettingsChange}
         onApplyToCodex={vi.fn()}
         onApplyToClaude={vi.fn()}
       />,
@@ -80,5 +81,19 @@ describe("ProviderPage summary settings", () => {
       .toBe("https://summary.example/v1");
     expect(container.querySelector<HTMLInputElement>('input[placeholder="deepseek-v4-flash"]')?.value)
       .toBe("summary-model");
+
+    const formatSelect = container.querySelector<HTMLSelectElement>('select[aria-label="Summary API format"]');
+    expect(formatSelect?.value).toBe("openai_responses");
+    await act(async () => {
+      formatSelect!.value = "openai_chat";
+      formatSelect!.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    const saveButton = [...container.querySelectorAll("button")]
+      .find((button) => button.textContent?.includes("Save summary settings"));
+    expect(saveButton).toBeDefined();
+    await act(async () => saveButton!.click());
+    expect(onSettingsChange).toHaveBeenCalledWith(expect.objectContaining({
+      summaryApiConfig: expect.objectContaining({ customApiFormat: "openai_chat" }),
+    }));
   });
 });

--- a/apps/main-2.0/src/renderer/src/features/providers/provider-page.tsx
+++ b/apps/main-2.0/src/renderer/src/features/providers/provider-page.tsx
@@ -1019,6 +1019,25 @@ export function ProviderPage({
                       onChange={(event) => updateDraftSummaryApiConfig({ customBaseUrl: event.currentTarget.value })}
                     />
                   </label>
+                  <label className="settings-field">
+                    <div className="settings-field-text">
+                      <span className="settings-field-title">{l("API format", "API 格式")}</span>
+                      <span className="settings-field-sub">
+                        {l("Choose the request protocol supported by this endpoint.", "选择该接口实际支持的请求协议。")}
+                      </span>
+                    </div>
+                    <select
+                      aria-label={l("Summary API format", "摘要 API 格式")}
+                      value={draftSummaryApiConfig.customApiFormat}
+                      disabled={!settings || saving}
+                      onChange={(event) => updateDraftSummaryApiConfig({
+                        customApiFormat: event.currentTarget.value as ApiConfig["customApiFormat"],
+                      })}
+                    >
+                      <option value="openai_chat">OpenAI Chat Completions</option>
+                      <option value="openai_responses">OpenAI Responses API</option>
+                    </select>
+                  </label>
                   <div className="settings-field">
                     <div className="settings-field-text">
                       <span className="settings-field-title">{l("Model", "模型")}</span>

--- a/apps/main-2.0/src/renderer/src/features/providers/provider-page.tsx
+++ b/apps/main-2.0/src/renderer/src/features/providers/provider-page.tsx
@@ -58,6 +58,12 @@ function summaryFromCustomClaude(config: ClaudeApiConfig | undefined, base: ApiC
 
 function buildSummaryDraftFromSettings(settings: AppSettings | null): ApiConfig {
   const base = settings?.summaryApiConfig ?? { ...defaultApiConfig };
+  if (
+    settings?.summarySource === "custom"
+    && (base.customBaseUrl.trim() || base.customModel.trim() || base.customApiKey.trim())
+  ) {
+    return base;
+  }
   const codex = summaryFromCustomCodex(settings?.apiConfig, base);
   if (codex) {
     return {


### PR DESCRIPTION
## 概述

  修复 V2 中 OpenViking 目录 Memory 使用自定义 OpenAI Provider 时的配置、协议识别和数据库升级问题。

  ## 主要改动

  - 支持将自定义 OpenAI Responses API 作为 OpenViking 提取模型。
  - 根据用户选择，将自定义 Provider 映射为：
    - Chat Completions → `openai`
    - Responses API → `openai-codex`
  - 在“AI 摘要与搜索”自定义配置中增加 API 格式选择。
  - 修复自定义摘要配置保存后，API 地址、模型和 API Key 不正确回显的问题。
  - 新增迁移 `32`，为受迁移版本冲突影响的数据库自动补齐 OpenViking Memory 数据结构。
  - 覆盖 `search`、`diagnostics` 和 `bulk-delete` 所依赖的 Memory、Evidence 和 Operation Events 等表。

  已有数据库曾将迁移版本 `28` 用于 Workflow 数据结构，而当前目录 Memory 迁移也使用了版本 `28`。

  迁移器只根据版本号判断是否执行，导致目录 Memory 建表语句被跳过，继而出现：

  - `openviking_memories does not exist`
  - `openviking_memory_evidence does not exist`
  - `openviking_operation_events does not exist`

  ## 验证

  - [x] OpenViking 提取配置与 Provider 页面定向测试通过
  - [x] PostgreSQL Schema 测试通过（11 tests）
  - [x] V2 TypeScript 类型检查通过
  - [x] `git diff --check` 通过
  - [x] `npm run release-note:check` 通过

  ## 影响范围

  仅影响 `apps/main-2.0`。

  升级后应用会自动执行修复迁移；如 MCP 客户端仍保留旧连接，重新连接后即可正常使用目录 Memory。