### PR TITLE
fix(sessions): keep migrated Codex history stateless

### DIFF
--- a/.release-notes/fix-migrated-codex-upstream-400.md
+++ b/.release-notes/fix-migrated-codex-upstream-400.md
@@ -1,0 +1,5 @@
+# 修复迁移到 Codex 后无法继续对话
+
+## Bug 修复
+
+- 修复部分迁移到 Codex 的会话在桌面端发送消息时提示“Upstream request failed”的问题，同时保留子 Agent 会话的查看与跳转能力。

--- a/.release-notes/fix-migrated-codex-upstream-400.md
+++ b/.release-notes/fix-migrated-codex-upstream-400.md
@@ -1,5 +1,7 @@
 # 修复迁移到 Codex 后无法继续对话
 
+<!-- release-target: both -->
+
 ## Bug 修复
 
-- 修复部分迁移到 Codex 的会话在桌面端发送消息时提示“Upstream request failed”的问题，同时保留子 Agent 会话的查看与跳转能力。
+- 修复已有及新迁移到 Codex 的会话在桌面端发送消息时提示“Upstream request failed”的问题，同时保留子 Agent 会话的查看与跳转能力。

--- a/apps/main-1.0/src/core/codex-migration-repair.test.ts
+++ b/apps/main-1.0/src/core/codex-migration-repair.test.ts
@@ -16,6 +16,14 @@ describe("repairLegacyAgentRecallCodexRollouts", () => {
       const tcodexPath = writeLegacyRollout(homeDir, ".tcodex", "tcodex", "agent-recall-v2", false, "legacy-nondeterministic");
       const partialPath = writeLegacyRollout(homeDir, ".codex", "partial", "agent-recall", true, "repaired");
       const missingMessageIdPath = writeLegacyRollout(homeDir, ".codex", "missing-id", "agent-recall", true, "missing");
+      const legacySingleTurnPath = writeLegacyRollout(
+        homeDir,
+        ".codex",
+        "legacy-single-turn",
+        "agent-recall",
+        true,
+        "missing-legacy-turn",
+      );
       const currentWriterPath = writeLegacyRollout(homeDir, ".codex", "current", "agent-recall", true, "current");
       const nativePath = path.join(homeDir, ".codex", "sessions", "native.jsonl");
       const nativeContent = `${JSON.stringify({
@@ -25,33 +33,45 @@ describe("repairLegacyAgentRecallCodexRollouts", () => {
       fs.writeFileSync(nativePath, nativeContent);
       const originalSize = fs.statSync(v1Path).size;
       const originalMissingMessageIdSize = fs.statSync(missingMessageIdPath).size;
+      const nativeSuffix = `${JSON.stringify({ type: "event_msg", payload: { type: "task_started", turn_id: "native-turn" } })}\n${JSON.stringify({
+        type: "response_item",
+        timestamp: "2026-08-10T06:24:27.000Z",
+        payload: { type: "message", id: `msg_${"f".repeat(8)}-ffff-4fff-8fff-${"f".repeat(12)}`, role: "user", content: [] },
+      })}\n`;
+      expect(fs.readFileSync(missingMessageIdPath, "utf8")).toContain(nativeSuffix);
 
       const result = await repairLegacyAgentRecallCodexRollouts(homeDir);
 
-      expect(result).toEqual({ scannedFiles: 7, repairedFiles: 5, repairedItemIds: 13, failedFiles: 0 });
+      expect(result).toEqual({ scannedFiles: 8, repairedFiles: 5, repairedItemIds: 12, failedFiles: 0 });
       for (const filePath of [v1Path, v2Path, partialPath]) {
         const repaired = fs.readFileSync(filePath, "utf8");
         expect(repaired).toContain(`"id":"msg-${legacyMessageUuid()}"`);
       }
-      for (const filePath of [v1Path, v2Path, partialPath, missingMessageIdPath]) {
+      for (const filePath of [v1Path, v2Path, partialPath]) {
         const repaired = fs.readFileSync(filePath, "utf8");
         expect(repaired).toContain(`"id":"fc-${"a".repeat(64)}"`);
         expect(repaired).toContain(`"id":"fco-${"b".repeat(64)}"`);
         expect(repaired).toContain(`"id":"msg_${"f".repeat(8)}-ffff-4fff-8fff-${"f".repeat(12)}"`);
         expect(repaired).toContain("content keeps msg_ text unchanged");
-        expect(repaired).toContain('"cli_version":"repair-v1"');
+        expect(repaired).toContain('"cli_version":"migrati0n"');
       }
       const repairedMissingMessageId = fs.readFileSync(missingMessageIdPath, "utf8");
-      expect(repairedMissingMessageId).toContain('"timestamp":"2026-08-10","payload":{"type":"message","id":"0"');
-      expect(() => repairedMissingMessageId.trim().split("\n").forEach((line) => JSON.parse(line))).not.toThrow();
+      expect(repairedMissingMessageId).toContain('"timestamp":"2026-08-10T06:22:27.000Z","payload":{"type":"message","role":"user"');
+      expect(repairedMissingMessageId).toContain(`"id":"fc-${"a".repeat(64)}"`);
+      expect(repairedMissingMessageId).toContain(`"id":"fco-${"b".repeat(64)}"`);
+      expect(repairedMissingMessageId).toContain('"cli_version":"migrati0n"');
+      expect(repairedMissingMessageId).toContain(nativeSuffix);
+      const legacySingleTurn = fs.readFileSync(legacySingleTurnPath, "utf8");
+      expect(legacySingleTurn).toContain('"cli_version":"migrati0n"');
+      expect(legacySingleTurn).toContain('"timestamp":"2026-08-10T06:22:27.000Z","payload":{"type":"message","role":"user"');
       const repairedTcodex = fs.readFileSync(tcodexPath, "utf8");
       expect(repairedTcodex).toContain(`"id":"msg-${legacyMessageUuid()}"`);
       expect(repairedTcodex).toContain(`"id":"msg-${deterministicUuid(`${SESSION_ID}:turn:0:message:1`)}"`);
       expect(repairedTcodex).toContain(`"id":"msg_${"f".repeat(8)}-ffff-4fff-8fff-${"f".repeat(12)}"`);
-      expect(repairedTcodex).toContain('"cli_version":"repair-v1"');
+      expect(repairedTcodex).toContain('"cli_version":"migrati0n"');
       const currentWriter = fs.readFileSync(currentWriterPath, "utf8");
       expect(currentWriter).toContain(`"id":"${currentMessageUuid()}"`);
-      expect(currentWriter).toContain('"cli_version":"repair-v1"');
+      expect(currentWriter).toContain('"cli_version":"migrati0n"');
       expect(fs.statSync(v1Path).size).toBe(originalSize);
       expect(fs.statSync(missingMessageIdPath).size).toBe(originalMissingMessageIdSize);
       expect(fs.readFileSync(nativePath, "utf8")).toBe(nativeContent);
@@ -68,7 +88,7 @@ function writeLegacyRollout(
   name: string,
   originator: string,
   includeVsCodeEvents: boolean,
-  messageId: "legacy" | "legacy-nondeterministic" | "repaired" | "missing" | "current" = "legacy",
+  messageId: "legacy" | "legacy-nondeterministic" | "repaired" | "missing" | "missing-legacy-turn" | "current" = "legacy",
 ): string {
   const filePath = path.join(homeDir, root, "sessions", `${name}.jsonl`);
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -76,14 +96,20 @@ function writeLegacyRollout(
   const rows = [
     { type: "session_meta", payload: { id: SESSION_ID, originator, cli_version: "migration", ...(includeVsCodeEvents ? { source: "vscode" } : {}) } },
     ...(includeVsCodeEvents
-      ? [{ type: "event_msg", payload: { type: "task_started", turn_id: deterministicUuid(`${SESSION_ID}:turn:0`) } }]
+      ? [{
+          type: "event_msg",
+          payload: {
+            type: "task_started",
+            turn_id: messageId === "missing-legacy-turn" ? SESSION_ID : deterministicUuid(`${SESSION_ID}:turn:0`),
+          },
+        }]
       : []),
     {
       type: "response_item",
       timestamp: "2026-08-10T06:22:27.000Z",
       payload: {
         type: "message",
-        ...(messageId === "missing"
+        ...(messageId === "missing" || messageId === "missing-legacy-turn"
           ? {}
           : {
               id: messageId === "current"
@@ -106,7 +132,7 @@ function writeLegacyRollout(
           },
         }]
       : []),
-    ...(includeVsCodeEvents && messageId !== "current"
+    ...(includeVsCodeEvents && messageId !== "current" && messageId !== "missing-legacy-turn"
       ? [
           { type: "response_item", payload: { type: "function_call", id: `fc_${"a".repeat(64)}`, name: "spawn_agent", namespace: "collaboration", call_id: callId } },
           { type: "event_msg", payload: { type: "sub_agent_activity", event_id: callId, agent_thread_id: "20000000-0000-4000-8000-000000000002" } },
@@ -114,7 +140,11 @@ function writeLegacyRollout(
           { type: "event_msg", payload: { type: "task_started", turn_id: "native-turn" } },
         ]
       : []),
-    { type: "response_item", payload: { type: "message", id: `msg_${"f".repeat(8)}-ffff-4fff-8fff-${"f".repeat(12)}`, role: "user", content: [] } },
+    {
+      type: "response_item",
+      timestamp: "2026-08-10T06:24:27.000Z",
+      payload: { type: "message", id: `msg_${"f".repeat(8)}-ffff-4fff-8fff-${"f".repeat(12)}`, role: "user", content: [] },
+    },
   ];
   fs.writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
   return filePath;

--- a/apps/main-1.0/src/core/codex-migration-repair.test.ts
+++ b/apps/main-1.0/src/core/codex-migration-repair.test.ts
@@ -1,0 +1,82 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { repairLegacyAgentRecallCodexRollouts } from "./codex-migration-repair";
+
+const SESSION_ID = "10000000-0000-4000-8000-000000000001";
+
+describe("repairLegacyAgentRecallCodexRollouts", () => {
+  it("repairs only the deterministic legacy item ids in AgentRecall migration rollouts", async () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-migration-repair-"));
+    try {
+      const v1Path = writeLegacyRollout(homeDir, ".codex", "v1", "agent-recall", true);
+      const v2Path = writeLegacyRollout(homeDir, ".codex", "v2", "agent-recall-v2", true);
+      const tcodexPath = writeLegacyRollout(homeDir, ".tcodex", "tcodex", "agent-recall-v2", false);
+      const nativePath = path.join(homeDir, ".codex", "sessions", "native.jsonl");
+      const nativeContent = `${JSON.stringify({
+        type: "session_meta",
+        payload: { id: "native", originator: "codex", cli_version: "0.147.0" },
+      })}\n${JSON.stringify({ type: "response_item", payload: { type: "message", id: "msg_native" } })}\n`;
+      fs.writeFileSync(nativePath, nativeContent);
+      const originalSize = fs.statSync(v1Path).size;
+
+      const result = await repairLegacyAgentRecallCodexRollouts(homeDir);
+
+      expect(result).toEqual({ scannedFiles: 4, repairedFiles: 3, repairedItemIds: 7, failedFiles: 0 });
+      for (const filePath of [v1Path, v2Path]) {
+        const repaired = fs.readFileSync(filePath, "utf8");
+        expect(repaired).toContain(`"id":"msg-${legacyMessageUuid()}"`);
+        expect(repaired).toContain(`"id":"fc-${"a".repeat(64)}"`);
+        expect(repaired).toContain(`"id":"fco-${"b".repeat(64)}"`);
+        expect(repaired).toContain(`"id":"msg_${"f".repeat(8)}-ffff-4fff-8fff-${"f".repeat(12)}"`);
+        expect(repaired).toContain("content keeps msg_ text unchanged");
+      }
+      const repairedTcodex = fs.readFileSync(tcodexPath, "utf8");
+      expect(repairedTcodex).toContain(`"id":"msg-${legacyMessageUuid()}"`);
+      expect(repairedTcodex).toContain(`"id":"msg_${"f".repeat(8)}-ffff-4fff-8fff-${"f".repeat(12)}"`);
+      expect(fs.statSync(v1Path).size).toBe(originalSize);
+      expect(fs.readFileSync(nativePath, "utf8")).toBe(nativeContent);
+      expect(await repairLegacyAgentRecallCodexRollouts(homeDir)).toMatchObject({ repairedFiles: 0, repairedItemIds: 0 });
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+});
+
+function writeLegacyRollout(homeDir: string, root: string, name: string, originator: string, includeVsCodeEvents: boolean): string {
+  const filePath = path.join(homeDir, root, "sessions", `${name}.jsonl`);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const callId = `call_migrated_${"c".repeat(24)}`;
+  const rows = [
+    { type: "session_meta", payload: { id: SESSION_ID, originator, cli_version: "migration", ...(includeVsCodeEvents ? { source: "vscode" } : {}) } },
+    ...(includeVsCodeEvents
+      ? [{ type: "event_msg", payload: { type: "task_started", turn_id: deterministicUuid(`${SESSION_ID}:turn:0`) } }]
+      : []),
+    { type: "response_item", payload: { type: "message", id: `msg_${legacyMessageUuid()}`, role: "user", content: [{ type: "input_text", text: "content keeps msg_ text unchanged" }] } },
+    ...(includeVsCodeEvents
+      ? [
+          { type: "response_item", payload: { type: "function_call", id: `fc_${"a".repeat(64)}`, name: "spawn_agent", namespace: "collaboration", call_id: callId } },
+          { type: "event_msg", payload: { type: "sub_agent_activity", event_id: callId, agent_thread_id: "20000000-0000-4000-8000-000000000002" } },
+          { type: "response_item", payload: { type: "function_call_output", id: `fco_${"b".repeat(64)}`, call_id: callId } },
+          { type: "event_msg", payload: { type: "task_started", turn_id: "native-turn" } },
+        ]
+      : []),
+    { type: "response_item", payload: { type: "message", id: `msg_${"f".repeat(8)}-ffff-4fff-8fff-${"f".repeat(12)}`, role: "user", content: [] } },
+  ];
+  fs.writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+  return filePath;
+}
+
+function legacyMessageUuid(): string {
+  return deterministicUuid(`${SESSION_ID}:turn:0:message:0`);
+}
+
+function deterministicUuid(seed: string): string {
+  const bytes = Buffer.from(crypto.createHash("sha256").update(seed).digest().subarray(0, 16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/apps/main-1.0/src/core/codex-migration-repair.test.ts
+++ b/apps/main-1.0/src/core/codex-migration-repair.test.ts
@@ -13,7 +13,10 @@ describe("repairLegacyAgentRecallCodexRollouts", () => {
     try {
       const v1Path = writeLegacyRollout(homeDir, ".codex", "v1", "agent-recall", true);
       const v2Path = writeLegacyRollout(homeDir, ".codex", "v2", "agent-recall-v2", true);
-      const tcodexPath = writeLegacyRollout(homeDir, ".tcodex", "tcodex", "agent-recall-v2", false);
+      const tcodexPath = writeLegacyRollout(homeDir, ".tcodex", "tcodex", "agent-recall-v2", false, "legacy-nondeterministic");
+      const partialPath = writeLegacyRollout(homeDir, ".codex", "partial", "agent-recall", true, "repaired");
+      const missingMessageIdPath = writeLegacyRollout(homeDir, ".codex", "missing-id", "agent-recall", true, "missing");
+      const currentWriterPath = writeLegacyRollout(homeDir, ".codex", "current", "agent-recall", true, "current");
       const nativePath = path.join(homeDir, ".codex", "sessions", "native.jsonl");
       const nativeContent = `${JSON.stringify({
         type: "session_meta",
@@ -21,22 +24,36 @@ describe("repairLegacyAgentRecallCodexRollouts", () => {
       })}\n${JSON.stringify({ type: "response_item", payload: { type: "message", id: "msg_native" } })}\n`;
       fs.writeFileSync(nativePath, nativeContent);
       const originalSize = fs.statSync(v1Path).size;
+      const originalMissingMessageIdSize = fs.statSync(missingMessageIdPath).size;
 
       const result = await repairLegacyAgentRecallCodexRollouts(homeDir);
 
-      expect(result).toEqual({ scannedFiles: 4, repairedFiles: 3, repairedItemIds: 7, failedFiles: 0 });
-      for (const filePath of [v1Path, v2Path]) {
+      expect(result).toEqual({ scannedFiles: 7, repairedFiles: 5, repairedItemIds: 13, failedFiles: 0 });
+      for (const filePath of [v1Path, v2Path, partialPath]) {
         const repaired = fs.readFileSync(filePath, "utf8");
         expect(repaired).toContain(`"id":"msg-${legacyMessageUuid()}"`);
+      }
+      for (const filePath of [v1Path, v2Path, partialPath, missingMessageIdPath]) {
+        const repaired = fs.readFileSync(filePath, "utf8");
         expect(repaired).toContain(`"id":"fc-${"a".repeat(64)}"`);
         expect(repaired).toContain(`"id":"fco-${"b".repeat(64)}"`);
         expect(repaired).toContain(`"id":"msg_${"f".repeat(8)}-ffff-4fff-8fff-${"f".repeat(12)}"`);
         expect(repaired).toContain("content keeps msg_ text unchanged");
+        expect(repaired).toContain('"cli_version":"repair-v1"');
       }
+      const repairedMissingMessageId = fs.readFileSync(missingMessageIdPath, "utf8");
+      expect(repairedMissingMessageId).toContain('"timestamp":"2026-08-10","payload":{"type":"message","id":"0"');
+      expect(() => repairedMissingMessageId.trim().split("\n").forEach((line) => JSON.parse(line))).not.toThrow();
       const repairedTcodex = fs.readFileSync(tcodexPath, "utf8");
       expect(repairedTcodex).toContain(`"id":"msg-${legacyMessageUuid()}"`);
+      expect(repairedTcodex).toContain(`"id":"msg-${deterministicUuid(`${SESSION_ID}:turn:0:message:1`)}"`);
       expect(repairedTcodex).toContain(`"id":"msg_${"f".repeat(8)}-ffff-4fff-8fff-${"f".repeat(12)}"`);
+      expect(repairedTcodex).toContain('"cli_version":"repair-v1"');
+      const currentWriter = fs.readFileSync(currentWriterPath, "utf8");
+      expect(currentWriter).toContain(`"id":"${currentMessageUuid()}"`);
+      expect(currentWriter).toContain('"cli_version":"repair-v1"');
       expect(fs.statSync(v1Path).size).toBe(originalSize);
+      expect(fs.statSync(missingMessageIdPath).size).toBe(originalMissingMessageIdSize);
       expect(fs.readFileSync(nativePath, "utf8")).toBe(nativeContent);
       expect(await repairLegacyAgentRecallCodexRollouts(homeDir)).toMatchObject({ repairedFiles: 0, repairedItemIds: 0 });
     } finally {
@@ -45,7 +62,14 @@ describe("repairLegacyAgentRecallCodexRollouts", () => {
   });
 });
 
-function writeLegacyRollout(homeDir: string, root: string, name: string, originator: string, includeVsCodeEvents: boolean): string {
+function writeLegacyRollout(
+  homeDir: string,
+  root: string,
+  name: string,
+  originator: string,
+  includeVsCodeEvents: boolean,
+  messageId: "legacy" | "legacy-nondeterministic" | "repaired" | "missing" | "current" = "legacy",
+): string {
   const filePath = path.join(homeDir, root, "sessions", `${name}.jsonl`);
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   const callId = `call_migrated_${"c".repeat(24)}`;
@@ -54,8 +78,35 @@ function writeLegacyRollout(homeDir: string, root: string, name: string, origina
     ...(includeVsCodeEvents
       ? [{ type: "event_msg", payload: { type: "task_started", turn_id: deterministicUuid(`${SESSION_ID}:turn:0`) } }]
       : []),
-    { type: "response_item", payload: { type: "message", id: `msg_${legacyMessageUuid()}`, role: "user", content: [{ type: "input_text", text: "content keeps msg_ text unchanged" }] } },
-    ...(includeVsCodeEvents
+    {
+      type: "response_item",
+      timestamp: "2026-08-10T06:22:27.000Z",
+      payload: {
+        type: "message",
+        ...(messageId === "missing"
+          ? {}
+          : {
+              id: messageId === "current"
+                ? currentMessageUuid()
+                : `${messageId === "repaired" ? "msg-" : "msg_"}${legacyMessageUuid()}`,
+            }),
+        role: "user",
+        content: [{ type: "input_text", text: "content keeps msg_ text unchanged" }],
+      },
+    },
+    ...(messageId === "legacy-nondeterministic"
+      ? [{
+          type: "response_item",
+          timestamp: "2026-08-10T06:23:27.000Z",
+          payload: {
+            type: "message",
+            id: `msg_${deterministicUuid(`${SESSION_ID}:turn:0:message:1`)}`,
+            role: "user",
+            content: [{ type: "input_text", text: "same turn second user message" }],
+          },
+        }]
+      : []),
+    ...(includeVsCodeEvents && messageId !== "current"
       ? [
           { type: "response_item", payload: { type: "function_call", id: `fc_${"a".repeat(64)}`, name: "spawn_agent", namespace: "collaboration", call_id: callId } },
           { type: "event_msg", payload: { type: "sub_agent_activity", event_id: callId, agent_thread_id: "20000000-0000-4000-8000-000000000002" } },
@@ -71,6 +122,10 @@ function writeLegacyRollout(homeDir: string, root: string, name: string, origina
 
 function legacyMessageUuid(): string {
   return deterministicUuid(`${SESSION_ID}:turn:0:message:0`);
+}
+
+function currentMessageUuid(): string {
+  return deterministicUuid(`response-item:${SESSION_ID}:turn:0:message:0`);
 }
 
 function deterministicUuid(seed: string): string {

--- a/apps/main-1.0/src/core/codex-migration-repair.ts
+++ b/apps/main-1.0/src/core/codex-migration-repair.ts
@@ -1,0 +1,224 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const AGENT_RECALL_ORIGINATORS = new Set(["agent-recall", "agent-recall-v2"]);
+const FIRST_LINE_LIMIT = 256 * 1024;
+const FIRST_LINE_CHUNK_SIZE = 16 * 1024;
+const LEGACY_MESSAGE_ID = /^msg_[0-9a-f-]{36}$/i;
+const LEGACY_FUNCTION_CALL_ID = /^fc_[0-9a-f]{64}$/i;
+const LEGACY_FUNCTION_OUTPUT_ID = /^fco_[0-9a-f]{64}$/i;
+const MIGRATED_CALL_ID = /^call_migrated_[0-9a-f]{24}$/i;
+
+export interface CodexMigrationRepairResult {
+  scannedFiles: number;
+  repairedFiles: number;
+  repairedItemIds: number;
+  failedFiles: number;
+}
+
+export async function repairLegacyAgentRecallCodexRollouts(
+  homeDir = os.homedir(),
+): Promise<CodexMigrationRepairResult> {
+  const result: CodexMigrationRepairResult = {
+    scannedFiles: 0,
+    repairedFiles: 0,
+    repairedItemIds: 0,
+    failedFiles: 0,
+  };
+
+  for (const relativeRoot of [path.join(".codex", "sessions"), path.join(".tcodex", "sessions")]) {
+    for (const filePath of await listJsonlFiles(path.join(homeDir, relativeRoot))) {
+      result.scannedFiles += 1;
+      try {
+        const repairedItemIds = await repairLegacyRolloutFile(filePath);
+        if (repairedItemIds > 0) {
+          result.repairedFiles += 1;
+          result.repairedItemIds += repairedItemIds;
+        }
+      } catch {
+        // A locked or concurrently removed file is retried on the next startup.
+        result.failedFiles += 1;
+      }
+    }
+  }
+
+  return result;
+}
+
+async function listJsonlFiles(root: string): Promise<string[]> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const files: string[] = [];
+  for (const entry of entries) {
+    const filePath = path.join(root, entry.name);
+    if (entry.isDirectory()) files.push(...await listJsonlFiles(filePath));
+    else if (entry.isFile() && entry.name.endsWith(".jsonl")) files.push(filePath);
+  }
+  return files;
+}
+
+async function repairLegacyRolloutFile(filePath: string): Promise<number> {
+  const firstRow = await readFirstJsonlRow(filePath);
+  const firstPayload = record(firstRow?.payload);
+  if (
+    firstRow?.type !== "session_meta"
+    || !AGENT_RECALL_ORIGINATORS.has(stringField(firstPayload, "originator"))
+    || stringField(firstPayload, "cli_version") !== "migration"
+  ) {
+    return 0;
+  }
+
+  const sessionId = stringField(firstPayload, "id");
+  if (!sessionId) return 0;
+
+  const content = await fs.promises.readFile(filePath);
+  const offsets = legacyItemIdUnderscoreOffsets(content, sessionId, Boolean(firstPayload?.source));
+  if (offsets.length === 0) return 0;
+
+  const handle = await fs.promises.open(filePath, "r+");
+  let repaired = 0;
+  try {
+    // Keep every edit byte-for-byte the same length. Codex may already have the
+    // rollout open for append, so replacing the file or shifting offsets could
+    // detach subsequent turns from the path that the App resumes.
+    const current = Buffer.allocUnsafe(1);
+    const replacement = Buffer.from("-");
+    for (const offset of offsets) {
+      const read = await handle.read(current, 0, 1, offset);
+      if (read.bytesRead !== 1 || current[0] !== 0x5f) continue;
+      await handle.write(replacement, 0, 1, offset);
+      repaired += 1;
+    }
+    if (repaired > 0) await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  return repaired;
+}
+
+async function readFirstJsonlRow(filePath: string): Promise<Record<string, unknown> | null> {
+  const handle = await fs.promises.open(filePath, "r");
+  try {
+    const chunks: Buffer[] = [];
+    let position = 0;
+    while (position < FIRST_LINE_LIMIT) {
+      const buffer = Buffer.allocUnsafe(Math.min(FIRST_LINE_CHUNK_SIZE, FIRST_LINE_LIMIT - position));
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, position);
+      if (bytesRead === 0) return null;
+      const chunk = buffer.subarray(0, bytesRead);
+      const newline = chunk.indexOf(0x0a);
+      chunks.push(newline < 0 ? chunk : chunk.subarray(0, newline));
+      if (newline >= 0) {
+        return record(JSON.parse(Buffer.concat(chunks).toString("utf8").trim()));
+      }
+      position += bytesRead;
+    }
+    return null;
+  } catch {
+    return null;
+  } finally {
+    await handle.close();
+  }
+}
+
+function legacyItemIdUnderscoreOffsets(content: Buffer, sessionId: string, hasVsCodeEvents: boolean): number[] {
+  const offsets: number[] = [];
+  let lineStart = 0;
+  let migrationEnded = false;
+  let turnIndex = hasVsCodeEvents ? -1 : 0;
+  let messageIndex = 0;
+
+  while (lineStart < content.length) {
+    const newline = content.indexOf(0x0a, lineStart);
+    const lineEnd = newline < 0 ? content.length : newline;
+    const line = content.subarray(lineStart, lineEnd);
+    let row: Record<string, unknown> | null = null;
+    try {
+      row = record(JSON.parse(line.toString("utf8")));
+    } catch {
+      migrationEnded = true;
+    }
+
+    const payload = record(row?.payload);
+    if (!migrationEnded && row?.type === "event_msg" && payload?.type === "task_started") {
+      const nextTurnIndex = turnIndex + 1;
+      if (stringField(payload, "turn_id") === deterministicCodexUuid(`${sessionId}:turn:${nextTurnIndex}`)) {
+        turnIndex = nextTurnIndex;
+      } else if (turnIndex >= 0) {
+        migrationEnded = true;
+      }
+    }
+
+    if (!migrationEnded && row?.type === "response_item" && payload?.type === "message") {
+      if (!hasVsCodeEvents && messageIndex > 0 && payload.role === "user") turnIndex += 1;
+      const id = stringField(payload, "id");
+      const expectedId = `msg_${deterministicCodexUuid(`${sessionId}:turn:${Math.max(0, turnIndex)}:message:${messageIndex}`)}`;
+      if (id === expectedId && LEGACY_MESSAGE_ID.test(id)) {
+        const offset = idUnderscoreOffset(line, lineStart, id);
+        if (offset !== null) offsets.push(offset);
+        messageIndex += 1;
+      } else {
+        migrationEnded = true;
+      }
+    }
+
+    if (!migrationEnded && row?.type === "response_item" && payload?.type === "function_call") {
+      const id = stringField(payload, "id");
+      if (
+        payload.name === "spawn_agent"
+        && payload.namespace === "collaboration"
+        && LEGACY_FUNCTION_CALL_ID.test(id)
+        && MIGRATED_CALL_ID.test(stringField(payload, "call_id"))
+      ) {
+        const offset = idUnderscoreOffset(line, lineStart, id);
+        if (offset !== null) offsets.push(offset);
+      }
+    }
+
+    if (!migrationEnded && row?.type === "response_item" && payload?.type === "function_call_output") {
+      const id = stringField(payload, "id");
+      if (LEGACY_FUNCTION_OUTPUT_ID.test(id) && MIGRATED_CALL_ID.test(stringField(payload, "call_id"))) {
+        const offset = idUnderscoreOffset(line, lineStart, id);
+        if (offset !== null) offsets.push(offset);
+      }
+    }
+
+    if (newline < 0) break;
+    lineStart = newline + 1;
+  }
+
+  return offsets;
+}
+
+function idUnderscoreOffset(line: Buffer, lineStart: number, id: string): number | null {
+  const token = Buffer.from(`"id":${JSON.stringify(id)}`);
+  const tokenOffset = line.indexOf(token);
+  const underscoreOffset = token.indexOf(0x5f);
+  if (tokenOffset < 0 || underscoreOffset < 0) return null;
+  return lineStart + tokenOffset + underscoreOffset;
+}
+
+function deterministicCodexUuid(seed: string): string {
+  const bytes = Buffer.from(crypto.createHash("sha256").update(seed).digest().subarray(0, 16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function stringField(value: Record<string, unknown> | null, key: string): string {
+  return typeof value?.[key] === "string" ? value[key] : "";
+}

--- a/apps/main-1.0/src/core/codex-migration-repair.ts
+++ b/apps/main-1.0/src/core/codex-migration-repair.ts
@@ -6,9 +6,15 @@ import * as path from "node:path";
 const AGENT_RECALL_ORIGINATORS = new Set(["agent-recall", "agent-recall-v2"]);
 const FIRST_LINE_LIMIT = 256 * 1024;
 const FIRST_LINE_CHUNK_SIZE = 16 * 1024;
+const FILE_SCAN_CHUNK_SIZE = 64 * 1024;
+const CURRENT_WRITER_PROBE_LIMIT = FIRST_LINE_LIMIT + FIRST_LINE_CHUNK_SIZE;
+const REPAIRED_CLI_VERSION = "repair-v1";
 const LEGACY_MESSAGE_ID = /^msg_[0-9a-f-]{36}$/i;
+const REPAIRED_MESSAGE_ID = /^msg-[0-9a-f-]{36}$/i;
 const LEGACY_FUNCTION_CALL_ID = /^fc_[0-9a-f]{64}$/i;
 const LEGACY_FUNCTION_OUTPUT_ID = /^fco_[0-9a-f]{64}$/i;
+const REPAIRED_FUNCTION_CALL_ID = /^fc-[0-9a-f]{64}$/i;
+const REPAIRED_FUNCTION_OUTPUT_ID = /^fco-[0-9a-f]{64}$/i;
 const MIGRATED_CALL_ID = /^call_migrated_[0-9a-f]{24}$/i;
 
 export interface CodexMigrationRepairResult {
@@ -78,29 +84,126 @@ async function repairLegacyRolloutFile(filePath: string): Promise<number> {
   const sessionId = stringField(firstPayload, "id");
   if (!sessionId) return 0;
 
-  const content = await fs.promises.readFile(filePath);
-  const offsets = legacyItemIdUnderscoreOffsets(content, sessionId, Boolean(firstPayload?.source));
-  if (offsets.length === 0) return 0;
-
   const handle = await fs.promises.open(filePath, "r+");
   let repaired = 0;
   try {
+    const probe = await readFilePrefix(handle, CURRENT_WRITER_PROBE_LIMIT);
+    const currentFirstRow = firstJsonlRow(probe);
+    const currentFirstPayload = record(currentFirstRow?.payload);
+    if (
+      currentFirstRow?.type !== "session_meta"
+      || !AGENT_RECALL_ORIGINATORS.has(stringField(currentFirstPayload, "originator"))
+      || stringField(currentFirstPayload, "cli_version") !== "migration"
+      || stringField(currentFirstPayload, "id") !== sessionId
+    ) {
+      return 0;
+    }
+    const probeMarkerOffset = cliVersionValueOffset(probe, 0);
+    if (probeMarkerOffset === null) return 0;
+
+    // The current writer never emits the legacy synthetic function rows. Its
+    // deterministic first message ID is enough to mark the whole atomic file
+    // without reading a potentially huge first message or the remaining turns.
+    const currentFirstMessageId = deterministicCodexUuid(`response-item:${sessionId}:turn:0:message:0`);
+    if (probe.includes(Buffer.from(`"id":${JSON.stringify(currentFirstMessageId)}`))) {
+      await writeRepairMarker(handle, probeMarkerOffset);
+      await handle.sync();
+      return 0;
+    }
+
+    // Scan from the same file descriptor used for the edits. A rollout can be
+    // replaced between discovery and repair; keeping discovery and positional
+    // writes on one descriptor prevents patching an unrelated file.
+    const scan = await scanLegacyItemIds(handle, sessionId);
+    if (!scan) return 0;
+
     // Keep every edit byte-for-byte the same length. Codex may already have the
     // rollout open for append, so replacing the file or shifting offsets could
     // detach subsequent turns from the path that the App resumes.
-    const current = Buffer.allocUnsafe(1);
-    const replacement = Buffer.from("-");
-    for (const offset of offsets) {
-      const read = await handle.read(current, 0, 1, offset);
-      if (read.bytesRead !== 1 || current[0] !== 0x5f) continue;
-      await handle.write(replacement, 0, 1, offset);
+    for (const rewrite of scan.messageRewrites) {
+      const currentPrefix = await readBufferAt(handle, rewrite.original.length, rewrite.offset);
+      if (currentPrefix.equals(rewrite.replacement)) continue;
+      if (!currentPrefix.equals(rewrite.original)) {
+        throw new Error("Legacy Codex rollout changed during repair.");
+      }
+      await writeBufferAt(handle, rewrite.replacement, rewrite.offset);
       repaired += 1;
     }
+    const current = Buffer.allocUnsafe(1);
+    const replacement = Buffer.from("-");
+    for (const offset of scan.offsets) {
+      const read = await handle.read(current, 0, 1, offset);
+      if (read.bytesRead !== 1) throw new Error("Legacy Codex rollout changed during repair.");
+      if (current[0] === 0x5f) {
+        await handle.write(replacement, 0, 1, offset);
+        repaired += 1;
+      } else if (current[0] !== 0x2d) {
+        throw new Error("Legacy Codex rollout changed during repair.");
+      }
+    }
     if (repaired > 0) await handle.sync();
+    if (scan.complete) {
+      await writeRepairMarker(handle, scan.cliVersionOffset);
+      await handle.sync();
+    }
   } finally {
     await handle.close();
   }
   return repaired;
+}
+
+async function readFilePrefix(handle: fs.promises.FileHandle, limit: number): Promise<Buffer> {
+  const buffer = Buffer.allocUnsafe(limit);
+  let bytesRead = 0;
+  while (bytesRead < buffer.length) {
+    const read = await handle.read(
+      buffer,
+      bytesRead,
+      Math.min(FIRST_LINE_CHUNK_SIZE, buffer.length - bytesRead),
+      bytesRead,
+    );
+    if (read.bytesRead === 0) break;
+    bytesRead += read.bytesRead;
+  }
+  return buffer.subarray(0, bytesRead);
+}
+
+function firstJsonlRow(content: Buffer): Record<string, unknown> | null {
+  const newline = content.indexOf(0x0a);
+  if (newline < 0 || newline > FIRST_LINE_LIMIT) return null;
+  try {
+    return record(JSON.parse(content.subarray(0, newline).toString("utf8").trim()));
+  } catch {
+    return null;
+  }
+}
+
+async function writeRepairMarker(handle: fs.promises.FileHandle, offset: number): Promise<void> {
+  const current = await readBufferAt(handle, REPAIRED_CLI_VERSION.length, offset);
+  const value = current.toString("utf8");
+  if (value === REPAIRED_CLI_VERSION) return;
+  if (value !== "migration") throw new Error("Legacy Codex rollout changed during repair.");
+  await writeBufferAt(handle, Buffer.from(REPAIRED_CLI_VERSION), offset);
+}
+
+async function readBufferAt(handle: fs.promises.FileHandle, length: number, offset: number): Promise<Buffer> {
+  const buffer = Buffer.allocUnsafe(length);
+  let readBytes = 0;
+  while (readBytes < buffer.length) {
+    const read = await handle.read(buffer, readBytes, buffer.length - readBytes, offset + readBytes);
+    if (read.bytesRead === 0) throw new Error("Legacy Codex rollout changed during repair.");
+    readBytes += read.bytesRead;
+  }
+  return buffer;
+}
+
+async function writeBufferAt(handle: fs.promises.FileHandle, buffer: Buffer, offset: number): Promise<void> {
+  let writtenBytes = 0;
+  while (writtenBytes < buffer.length) {
+    const write = await handle.write(buffer, writtenBytes, buffer.length - writtenBytes, offset + writtenBytes);
+    if (write.bytesWritten === 0) throw new Error("Legacy Codex rollout could not be repaired.");
+    writtenBytes += write.bytesWritten;
+  }
 }
 
 async function readFirstJsonlRow(filePath: string): Promise<Record<string, unknown> | null> {
@@ -128,73 +231,218 @@ async function readFirstJsonlRow(filePath: string): Promise<Record<string, unkno
   }
 }
 
-function legacyItemIdUnderscoreOffsets(content: Buffer, sessionId: string, hasVsCodeEvents: boolean): number[] {
+interface LegacyItemIdScan {
+  offsets: number[];
+  messageRewrites: MessagePrefixRewrite[];
+  cliVersionOffset: number;
+  complete: boolean;
+}
+
+interface MessagePrefixRewrite {
+  offset: number;
+  original: Buffer;
+  replacement: Buffer;
+}
+
+async function scanLegacyItemIds(
+  handle: fs.promises.FileHandle,
+  sessionId: string,
+): Promise<LegacyItemIdScan | null> {
   const offsets: number[] = [];
-  let lineStart = 0;
-  let migrationEnded = false;
-  let turnIndex = hasVsCodeEvents ? -1 : 0;
+  const messageRewrites: MessagePrefixRewrite[] = [];
+  let cliVersionOffset: number | null = null;
+  let complete = true;
+  let firstLine = true;
+  let hasVsCodeEvents = false;
+  let turnIndex = 0;
   let messageIndex = 0;
 
-  while (lineStart < content.length) {
-    const newline = content.indexOf(0x0a, lineStart);
-    const lineEnd = newline < 0 ? content.length : newline;
-    const line = content.subarray(lineStart, lineEnd);
+  await visitJsonlLines(handle, (line, lineStart) => {
     let row: Record<string, unknown> | null = null;
     try {
       row = record(JSON.parse(line.toString("utf8")));
     } catch {
-      migrationEnded = true;
+      complete = false;
+      return true;
     }
 
     const payload = record(row?.payload);
-    if (!migrationEnded && row?.type === "event_msg" && payload?.type === "task_started") {
+    if (firstLine) {
+      firstLine = false;
+      if (
+        row?.type !== "session_meta"
+        || !AGENT_RECALL_ORIGINATORS.has(stringField(payload, "originator"))
+        || stringField(payload, "cli_version") !== "migration"
+        || stringField(payload, "id") !== sessionId
+      ) {
+        complete = false;
+        return true;
+      }
+      cliVersionOffset = cliVersionValueOffset(line, lineStart);
+      if (cliVersionOffset === null) {
+        complete = false;
+        return true;
+      }
+      hasVsCodeEvents = Boolean(payload?.source);
+      turnIndex = hasVsCodeEvents ? -1 : 0;
+      return false;
+    }
+
+    if (row?.type === "event_msg" && payload?.type === "task_started") {
       const nextTurnIndex = turnIndex + 1;
-      if (stringField(payload, "turn_id") === deterministicCodexUuid(`${sessionId}:turn:${nextTurnIndex}`)) {
+      if (hasVsCodeEvents && stringField(payload, "turn_id") === deterministicCodexUuid(`${sessionId}:turn:${nextTurnIndex}`)) {
         turnIndex = nextTurnIndex;
-      } else if (turnIndex >= 0) {
-        migrationEnded = true;
-      }
-    }
-
-    if (!migrationEnded && row?.type === "response_item" && payload?.type === "message") {
-      if (!hasVsCodeEvents && messageIndex > 0 && payload.role === "user") turnIndex += 1;
-      const id = stringField(payload, "id");
-      const expectedId = `msg_${deterministicCodexUuid(`${sessionId}:turn:${Math.max(0, turnIndex)}:message:${messageIndex}`)}`;
-      if (id === expectedId && LEGACY_MESSAGE_ID.test(id)) {
-        const offset = idUnderscoreOffset(line, lineStart, id);
-        if (offset !== null) offsets.push(offset);
-        messageIndex += 1;
       } else {
-        migrationEnded = true;
+        return true;
       }
+      return false;
     }
 
-    if (!migrationEnded && row?.type === "response_item" && payload?.type === "function_call") {
+    if (row?.type === "event_msg") return false;
+    if (row?.type !== "response_item") return true;
+
+    if (payload?.type === "message") {
+      const id = stringField(payload, "id");
+      if (LEGACY_MESSAGE_ID.test(id) || REPAIRED_MESSAGE_ID.test(id)) {
+        // Terminal Codex rollouts have no task_started rows. Recover the
+        // monotonic turn index from the writer's deterministic IDs instead of
+        // assuming every user message starts a turn.
+        const firstCandidate = Math.max(0, turnIndex);
+        const lastCandidate = hasVsCodeEvents ? firstCandidate : messageIndex;
+        let matchedTurnIndex = -1;
+        for (let candidate = firstCandidate; candidate <= lastCandidate; candidate += 1) {
+          const migratedUuid = deterministicCodexUuid(`${sessionId}:turn:${candidate}:message:${messageIndex}`);
+          if (id === `msg_${migratedUuid}` || id === `msg-${migratedUuid}`) {
+            matchedTurnIndex = candidate;
+            break;
+          }
+        }
+        if (matchedTurnIndex < 0) return true;
+        turnIndex = matchedTurnIndex;
+        if (LEGACY_MESSAGE_ID.test(id)) {
+          const offset = idUnderscoreOffset(line, lineStart, id);
+          if (offset !== null) offsets.push(offset);
+        }
+      } else if (!id) {
+        const rewrite = missingMessageIdRewrite(line, lineStart, stringField(row, "timestamp"), messageIndex);
+        if (!rewrite) throw new Error("Unsupported legacy Codex message layout.");
+        messageRewrites.push(rewrite);
+      } else if (id !== repairedMessageId(messageIndex)) {
+        return true;
+      }
+      messageIndex += 1;
+      return false;
+    }
+
+    if (payload?.type === "function_call") {
       const id = stringField(payload, "id");
       if (
-        payload.name === "spawn_agent"
-        && payload.namespace === "collaboration"
-        && LEGACY_FUNCTION_CALL_ID.test(id)
-        && MIGRATED_CALL_ID.test(stringField(payload, "call_id"))
-      ) {
+        payload.name !== "spawn_agent"
+        || payload.namespace !== "collaboration"
+        || !MIGRATED_CALL_ID.test(stringField(payload, "call_id"))
+      ) return true;
+      if (LEGACY_FUNCTION_CALL_ID.test(id)) {
         const offset = idUnderscoreOffset(line, lineStart, id);
         if (offset !== null) offsets.push(offset);
-      }
+      } else if (id && !REPAIRED_FUNCTION_CALL_ID.test(id)) return true;
+      return false;
     }
 
-    if (!migrationEnded && row?.type === "response_item" && payload?.type === "function_call_output") {
+    if (payload?.type === "function_call_output") {
       const id = stringField(payload, "id");
-      if (LEGACY_FUNCTION_OUTPUT_ID.test(id) && MIGRATED_CALL_ID.test(stringField(payload, "call_id"))) {
+      if (!MIGRATED_CALL_ID.test(stringField(payload, "call_id"))) return true;
+      if (LEGACY_FUNCTION_OUTPUT_ID.test(id)) {
         const offset = idUnderscoreOffset(line, lineStart, id);
         if (offset !== null) offsets.push(offset);
-      }
+      } else if (id && !REPAIRED_FUNCTION_OUTPUT_ID.test(id)) return true;
+      return false;
     }
 
-    if (newline < 0) break;
-    lineStart = newline + 1;
+    return true;
+  });
+
+  if (firstLine || cliVersionOffset === null) return null;
+  return { offsets, messageRewrites, cliVersionOffset, complete };
+}
+
+function missingMessageIdRewrite(
+  line: Buffer,
+  lineStart: number,
+  timestamp: string,
+  messageIndex: number,
+): MessagePrefixRewrite | null {
+  const payloadPrefix = Buffer.from('"payload":{"type":"message",');
+  const payloadOffset = line.indexOf(payloadPrefix);
+  if (payloadOffset < 0 || !line.subarray(0, payloadOffset).includes(Buffer.from('"timestamp":'))) return null;
+  const original = Buffer.from(line.subarray(0, payloadOffset + payloadPrefix.length));
+  const itemId = repairedMessageId(messageIndex);
+  // These older rows have no spare field for an ID. Keep the required
+  // timestamp string (normally retaining its date), use the freed precision
+  // for a short per-file ID, and pad the prefix so every later byte stays put.
+  const availableTimestampLength = Buffer.byteLength(timestamp) - Buffer.byteLength(itemId) - 8;
+  if (availableTimestampLength < 0) return null;
+  const retainedTimestamp = availableTimestampLength >= 10 && /^\d{4}-\d{2}-\d{2}/.test(timestamp)
+    ? timestamp.slice(0, 10)
+    : availableTimestampLength >= 4 && /^\d{4}/.test(timestamp)
+      ? timestamp.slice(0, 4)
+      : "";
+  const replacementText = Buffer.from(
+    `{"type":"response_item","timestamp":${JSON.stringify(retainedTimestamp)},"payload":{"type":"message","id":"${itemId}",`,
+  );
+  if (replacementText.length > original.length) return null;
+  const replacement = Buffer.alloc(original.length, 0x20);
+  replacementText.copy(replacement);
+  return { offset: lineStart, original, replacement };
+}
+
+function repairedMessageId(messageIndex: number): string {
+  return messageIndex.toString(36);
+}
+
+async function visitJsonlLines(
+  handle: fs.promises.FileHandle,
+  visit: (line: Buffer, lineStart: number) => boolean,
+): Promise<void> {
+  const size = (await handle.stat()).size;
+  let position = 0;
+  let lineStart = 0;
+  let fragments: Buffer[] = [];
+
+  while (position < size) {
+    const buffer = Buffer.allocUnsafe(Math.min(FILE_SCAN_CHUNK_SIZE, size - position));
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, position);
+    if (bytesRead === 0) break;
+    const chunk = buffer.subarray(0, bytesRead);
+    let cursor = 0;
+    while (cursor < chunk.length) {
+      const newline = chunk.indexOf(0x0a, cursor);
+      if (newline < 0) {
+        fragments.push(chunk.subarray(cursor));
+        break;
+      }
+      fragments.push(chunk.subarray(cursor, newline));
+      const line = fragments.length === 1 ? fragments[0] : Buffer.concat(fragments);
+      if (visit(line, lineStart)) return;
+      fragments = [];
+      cursor = newline + 1;
+      lineStart = position + cursor;
+    }
+    position += bytesRead;
   }
 
-  return offsets;
+  if (fragments.length > 0) {
+    const line = fragments.length === 1 ? fragments[0] : Buffer.concat(fragments);
+    visit(line, lineStart);
+  }
+}
+
+function cliVersionValueOffset(lineOrPrefix: Buffer, lineStart: number): number | null {
+  const newline = lineOrPrefix.indexOf(0x0a);
+  const firstLine = newline < 0 ? lineOrPrefix : lineOrPrefix.subarray(0, newline);
+  const prefix = Buffer.from('"cli_version":"');
+  const token = Buffer.from('"cli_version":"migration"');
+  const tokenOffset = firstLine.indexOf(token);
+  return tokenOffset < 0 ? null : lineStart + tokenOffset + prefix.length;
 }
 
 function idUnderscoreOffset(line: Buffer, lineStart: number, id: string): number | null {

--- a/apps/main-1.0/src/core/codex-migration-repair.ts
+++ b/apps/main-1.0/src/core/codex-migration-repair.ts
@@ -8,7 +8,8 @@ const FIRST_LINE_LIMIT = 256 * 1024;
 const FIRST_LINE_CHUNK_SIZE = 16 * 1024;
 const FILE_SCAN_CHUNK_SIZE = 64 * 1024;
 const CURRENT_WRITER_PROBE_LIMIT = FIRST_LINE_LIMIT + FIRST_LINE_CHUNK_SIZE;
-const REPAIRED_CLI_VERSION = "repair-v1";
+const REPAIRED_CLI_VERSION = "migrati0n";
+const REPAIR_MARKER_INDEX = 7;
 const LEGACY_MESSAGE_ID = /^msg_[0-9a-f-]{36}$/i;
 const REPAIRED_MESSAGE_ID = /^msg-[0-9a-f-]{36}$/i;
 const LEGACY_FUNCTION_CALL_ID = /^fc_[0-9a-f]{64}$/i;
@@ -120,15 +121,6 @@ async function repairLegacyRolloutFile(filePath: string): Promise<number> {
     // Keep every edit byte-for-byte the same length. Codex may already have the
     // rollout open for append, so replacing the file or shifting offsets could
     // detach subsequent turns from the path that the App resumes.
-    for (const rewrite of scan.messageRewrites) {
-      const currentPrefix = await readBufferAt(handle, rewrite.original.length, rewrite.offset);
-      if (currentPrefix.equals(rewrite.replacement)) continue;
-      if (!currentPrefix.equals(rewrite.original)) {
-        throw new Error("Legacy Codex rollout changed during repair.");
-      }
-      await writeBufferAt(handle, rewrite.replacement, rewrite.offset);
-      repaired += 1;
-    }
     const current = Buffer.allocUnsafe(1);
     const replacement = Buffer.from("-");
     for (const offset of scan.offsets) {
@@ -179,11 +171,13 @@ function firstJsonlRow(content: Buffer): Record<string, unknown> | null {
 }
 
 async function writeRepairMarker(handle: fs.promises.FileHandle, offset: number): Promise<void> {
-  const current = await readBufferAt(handle, REPAIRED_CLI_VERSION.length, offset);
+  const current = await readBufferAt(handle, "migration".length, offset);
   const value = current.toString("utf8");
   if (value === REPAIRED_CLI_VERSION) return;
   if (value !== "migration") throw new Error("Legacy Codex rollout changed during repair.");
-  await writeBufferAt(handle, Buffer.from(REPAIRED_CLI_VERSION), offset);
+  // A one-byte marker stays valid JSON even if V1 and V2 start together, and
+  // cannot leave a partially rewritten cli_version if the process exits.
+  await writeBufferAt(handle, Buffer.from("0"), offset + REPAIR_MARKER_INDEX);
 }
 
 async function readBufferAt(handle: fs.promises.FileHandle, length: number, offset: number): Promise<Buffer> {
@@ -233,15 +227,8 @@ async function readFirstJsonlRow(filePath: string): Promise<Record<string, unkno
 
 interface LegacyItemIdScan {
   offsets: number[];
-  messageRewrites: MessagePrefixRewrite[];
   cliVersionOffset: number;
   complete: boolean;
-}
-
-interface MessagePrefixRewrite {
-  offset: number;
-  original: Buffer;
-  replacement: Buffer;
 }
 
 async function scanLegacyItemIds(
@@ -249,7 +236,6 @@ async function scanLegacyItemIds(
   sessionId: string,
 ): Promise<LegacyItemIdScan | null> {
   const offsets: number[] = [];
-  const messageRewrites: MessagePrefixRewrite[] = [];
   let cliVersionOffset: number | null = null;
   let complete = true;
   let firstLine = true;
@@ -292,6 +278,11 @@ async function scanLegacyItemIds(
       const nextTurnIndex = turnIndex + 1;
       if (hasVsCodeEvents && stringField(payload, "turn_id") === deterministicCodexUuid(`${sessionId}:turn:${nextTurnIndex}`)) {
         turnIndex = nextTurnIndex;
+      } else if (hasVsCodeEvents && turnIndex < 0 && stringField(payload, "turn_id") === sessionId) {
+        // The first App migration writer represented its whole snapshot as one
+        // turn. Keep scanning its known migration prefix so later synthetic
+        // tool rows can still be repaired.
+        turnIndex = 0;
       } else {
         return true;
       }
@@ -324,10 +315,17 @@ async function scanLegacyItemIds(
           if (offset !== null) offsets.push(offset);
         }
       } else if (!id) {
-        const rewrite = missingMessageIdRewrite(line, lineStart, stringField(row, "timestamp"), messageIndex);
-        if (!rewrite) throw new Error("Unsupported legacy Codex message layout.");
-        messageRewrites.push(rewrite);
-      } else if (id !== repairedMessageId(messageIndex)) {
+        // Older AgentRecall snapshots intentionally left local IDs absent.
+        // Keep those messages byte-identical: current Codex resumes them
+        // without sending a server-backed item reference. Continue scanning,
+        // because a later AgentRecall subagent row can still carry a bad ID.
+        // Once that known migration prefix is fully inspected, the one-byte
+        // marker avoids rescanning the same large, already-safe history.
+      } else {
+        // A short unprefixed ID comes from a partially completed repair built
+        // before full RFC3339 timestamps were enforced. Keep the marker as
+        // `migration` so it is never mistaken for a fully repaired rollout.
+        complete = false;
         return true;
       }
       messageIndex += 1;
@@ -362,41 +360,7 @@ async function scanLegacyItemIds(
   });
 
   if (firstLine || cliVersionOffset === null) return null;
-  return { offsets, messageRewrites, cliVersionOffset, complete };
-}
-
-function missingMessageIdRewrite(
-  line: Buffer,
-  lineStart: number,
-  timestamp: string,
-  messageIndex: number,
-): MessagePrefixRewrite | null {
-  const payloadPrefix = Buffer.from('"payload":{"type":"message",');
-  const payloadOffset = line.indexOf(payloadPrefix);
-  if (payloadOffset < 0 || !line.subarray(0, payloadOffset).includes(Buffer.from('"timestamp":'))) return null;
-  const original = Buffer.from(line.subarray(0, payloadOffset + payloadPrefix.length));
-  const itemId = repairedMessageId(messageIndex);
-  // These older rows have no spare field for an ID. Keep the required
-  // timestamp string (normally retaining its date), use the freed precision
-  // for a short per-file ID, and pad the prefix so every later byte stays put.
-  const availableTimestampLength = Buffer.byteLength(timestamp) - Buffer.byteLength(itemId) - 8;
-  if (availableTimestampLength < 0) return null;
-  const retainedTimestamp = availableTimestampLength >= 10 && /^\d{4}-\d{2}-\d{2}/.test(timestamp)
-    ? timestamp.slice(0, 10)
-    : availableTimestampLength >= 4 && /^\d{4}/.test(timestamp)
-      ? timestamp.slice(0, 4)
-      : "";
-  const replacementText = Buffer.from(
-    `{"type":"response_item","timestamp":${JSON.stringify(retainedTimestamp)},"payload":{"type":"message","id":"${itemId}",`,
-  );
-  if (replacementText.length > original.length) return null;
-  const replacement = Buffer.alloc(original.length, 0x20);
-  replacementText.copy(replacement);
-  return { offset: lineStart, original, replacement };
-}
-
-function repairedMessageId(messageIndex: number): string {
-  return messageIndex.toString(36);
+  return { offsets, cliVersionOffset, complete };
 }
 
 async function visitJsonlLines(

--- a/apps/main-1.0/src/core/session-migration-writers.test.ts
+++ b/apps/main-1.0/src/core/session-migration-writers.test.ts
@@ -158,11 +158,16 @@ describe("writeMigratedSession", () => {
       });
       const rows = readRows(result.filePath);
       const spawn = rows.find((row) => row.type === "response_item" && row.payload?.name === "spawn_agent");
+      const spawnOutput = rows.find((row) => row.type === "response_item" && row.payload?.type === "function_call_output");
       const activity = rows.find((row) => row.type === "event_msg" && row.payload?.type === "sub_agent_activity");
 
       expect(result.sessionId).toBe(SESSION_ID);
       expect(JSON.parse(spawn?.payload.arguments)).toMatchObject({ task_name: "child", message: "Research child" });
+      expect(spawn?.payload.id).toBeUndefined();
+      expect(spawnOutput?.payload.id).toBeUndefined();
+      expect(spawnOutput?.payload.call_id).toBe(spawn?.payload.call_id);
       expect(activity?.payload).toMatchObject({
+        event_id: spawn?.payload.call_id,
         agent_thread_id: CHILD_SESSION_ID,
         agent_path: "/root/migrated_child",
         kind: "started",
@@ -226,7 +231,7 @@ describe("writeMigratedSession", () => {
       expect(messageRows.map((row) => row.payload.role)).toEqual(["user", "assistant", "user", "assistant"]);
       expect(messageRows[1].payload.content[0].text).toContain("过程更新 1\n\n过程更新 2");
       expect(messageRows[1].payload.content[0].text).toContain("过程更新 260");
-      expect(messageRows.every((row) => /^msg_[0-9a-f-]{36}$/.test(row.payload.id))).toBe(true);
+      expect(messageRows.every((row) => row.payload.id === undefined)).toBe(true);
       expect(messageRows.filter((row) => row.payload.role === "assistant").every((row) => row.payload.phase === "final_answer")).toBe(true);
       expect(rows.filter((row) => row.payload?.type === "task_started")).toHaveLength(2);
     } finally {

--- a/apps/main-1.0/src/core/session-migration-writers.test.ts
+++ b/apps/main-1.0/src/core/session-migration-writers.test.ts
@@ -130,7 +130,7 @@ function loadWrittenSession(
 }
 
 describe("writeMigratedSession", () => {
-  it("emits native Codex subagent activity linked to a reserved child thread", async () => {
+  it("emits native Codex subagent activity without model-visible synthetic tool history", async () => {
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "migration-writer-subagent-activity-"));
     try {
       const session = {
@@ -157,21 +157,18 @@ describe("writeMigratedSession", () => {
         now: NOW,
       });
       const rows = readRows(result.filePath);
-      const spawn = rows.find((row) => row.type === "response_item" && row.payload?.name === "spawn_agent");
-      const spawnOutput = rows.find((row) => row.type === "response_item" && row.payload?.type === "function_call_output");
       const activity = rows.find((row) => row.type === "event_msg" && row.payload?.type === "sub_agent_activity");
+      const syntheticToolRows = rows.filter((row) => row.type === "response_item"
+        && (row.payload?.type === "function_call" || row.payload?.type === "function_call_output"));
 
       expect(result.sessionId).toBe(SESSION_ID);
-      expect(JSON.parse(spawn?.payload.arguments)).toMatchObject({ task_name: "child", message: "Research child" });
-      expect(spawn?.payload.id).toBeUndefined();
-      expect(spawnOutput?.payload.id).toBeUndefined();
-      expect(spawnOutput?.payload.call_id).toBe(spawn?.payload.call_id);
+      expect(syntheticToolRows).toHaveLength(0);
       expect(activity?.payload).toMatchObject({
-        event_id: spawn?.payload.call_id,
         agent_thread_id: CHILD_SESSION_ID,
         agent_path: "/root/migrated_child",
         kind: "started",
       });
+      expect(activity?.payload.event_id).toMatch(/^[0-9a-f-]{36}$/);
     } finally {
       fs.rmSync(homeDir, { recursive: true, force: true });
     }
@@ -231,7 +228,8 @@ describe("writeMigratedSession", () => {
       expect(messageRows.map((row) => row.payload.role)).toEqual(["user", "assistant", "user", "assistant"]);
       expect(messageRows[1].payload.content[0].text).toContain("过程更新 1\n\n过程更新 2");
       expect(messageRows[1].payload.content[0].text).toContain("过程更新 260");
-      expect(messageRows.every((row) => row.payload.id === undefined)).toBe(true);
+      expect(messageRows.every((row) => /^[0-9a-f-]{36}$/.test(row.payload.id) && !row.payload.id.includes("_"))).toBe(true);
+      expect(new Set(messageRows.map((row) => row.payload.id)).size).toBe(messageRows.length);
       expect(messageRows.filter((row) => row.payload.role === "assistant").every((row) => row.payload.phase === "final_answer")).toBe(true);
       expect(rows.filter((row) => row.payload?.type === "task_started")).toHaveLength(2);
     } finally {

--- a/apps/main-1.0/src/core/session-migration-writers.ts
+++ b/apps/main-1.0/src/core/session-migration-writers.ts
@@ -205,13 +205,11 @@ function serializeCodex(
     }
 
     for (const message of messages) {
-      const messageId = codexMessageId(sessionId, turnIndex, message.index);
       rows.push({
         type: "response_item",
         timestamp: message.timestamp,
         payload: {
           type: "message",
-          id: messageId,
           role: message.role,
           content: [{
             type: message.role === "user" ? "input_text" : "output_text",
@@ -290,7 +288,6 @@ function codexSubagentActivityRows(
         timestamp: subagent.startedAt,
         payload: {
           type: "function_call",
-          id: `fc_${digest}`,
           name: "spawn_agent",
           namespace: "collaboration",
           arguments: JSON.stringify({
@@ -317,7 +314,6 @@ function codexSubagentActivityRows(
         timestamp: subagent.startedAt,
         payload: {
           type: "function_call_output",
-          id: `fco_${digest}`,
           call_id: callId,
           output: JSON.stringify({ task_name: agentPath }),
           internal_chat_message_metadata_passthrough: { turn_id: turnId },
@@ -347,10 +343,6 @@ function codexTurnBoundaries(session: PortableSession): number[] {
 
 function codexTurnId(sessionId: string, turnIndex: number): string {
   return deterministicCodexUuid(`${sessionId}:turn:${turnIndex}`);
-}
-
-function codexMessageId(sessionId: string, turnIndex: number, messageIndex: number): string {
-  return `msg_${deterministicCodexUuid(`${sessionId}:turn:${turnIndex}:message:${messageIndex}`)}`;
 }
 
 function deterministicCodexUuid(seed: string): string {
@@ -1089,7 +1081,7 @@ function validateCodexStructure(
         row?.type !== "response_item"
         || row.timestamp !== message.timestamp
         || messagePayload?.type !== "message"
-        || messagePayload.id !== codexMessageId(sessionId, turnIndex, message.index)
+        || messagePayload.id !== undefined
         || messagePayload.role !== message.role
         || (message.role === "assistant" && messagePayload.phase !== "final_answer")
         || (message.role === "user" && messagePayload.phase !== undefined)

--- a/apps/main-1.0/src/core/session-migration-writers.ts
+++ b/apps/main-1.0/src/core/session-migration-writers.ts
@@ -210,6 +210,7 @@ function serializeCodex(
         timestamp: message.timestamp,
         payload: {
           type: "message",
+          id: codexStatelessItemId(`${sessionId}:turn:${turnIndex}:message:${message.index}`),
           role: message.role,
           content: [{
             type: message.role === "user" ? "input_text" : "output_text",
@@ -233,7 +234,7 @@ function serializeCodex(
     }
 
     if (includeVsCodeEvents) {
-      rows.push(...codexSubagentActivityRows(session, sessionId, turnIndex, turnId));
+      rows.push(...codexSubagentActivityRows(session, sessionId, turnIndex));
     }
 
     if (includeVsCodeEvents) {
@@ -261,7 +262,6 @@ function codexSubagentActivityRows(
   session: PortableSession,
   sessionId: string,
   turnIndex: number,
-  turnId: string,
 ): unknown[] {
   const boundaries = codexTurnBoundaries(session);
   const turnStartTimes = boundaries.map((boundary) => timestampMs(session.messages[boundary]?.timestamp ?? session.startedAt));
@@ -277,54 +277,22 @@ function codexSubagentActivityRows(
       return assignedTurn === turnIndex;
     })
     .sort((left, right) => timestampMs(left.startedAt) - timestampMs(right.startedAt))
-    .flatMap((subagent) => {
+    .map((subagent) => {
       const childSessionId = subagent.sourceSessionId!;
-      const digest = crypto.createHash("sha256").update(`${sessionId}:subagent:${childSessionId}`).digest("hex");
-      const callId = `call_migrated_${digest.slice(0, 24)}`;
-      const taskName = codexSubagentTaskName(subagent);
       const agentPath = codexSubagentPath(subagent);
-      return [{
-        type: "response_item",
-        timestamp: subagent.startedAt,
-        payload: {
-          type: "function_call",
-          name: "spawn_agent",
-          namespace: "collaboration",
-          arguments: JSON.stringify({
-            task_name: taskName,
-            fork_turns: "all",
-            message: subagent.title || taskName,
-          }),
-          call_id: callId,
-          internal_chat_message_metadata_passthrough: { turn_id: turnId },
-        },
-      }, {
+      return {
         type: "event_msg",
         timestamp: subagent.startedAt,
         payload: {
           type: "sub_agent_activity",
-          event_id: callId,
+          event_id: codexStatelessItemId(`${sessionId}:subagent:${childSessionId}:activity`),
           occurred_at_ms: timestampMs(subagent.startedAt),
           agent_thread_id: childSessionId,
           agent_path: agentPath,
           kind: "started",
         },
-      }, {
-        type: "response_item",
-        timestamp: subagent.startedAt,
-        payload: {
-          type: "function_call_output",
-          call_id: callId,
-          output: JSON.stringify({ task_name: agentPath }),
-          internal_chat_message_metadata_passthrough: { turn_id: turnId },
-        },
-      }];
+      };
     });
-}
-
-function codexSubagentTaskName(session: PortableSession): string {
-  const sourceId = session.sourceSessionKey.split(":").at(-1) || session.title || "subagent";
-  return sourceId.replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^_+|_+$/g, "").slice(0, 64) || "subagent";
 }
 
 function codexTurnBoundaries(session: PortableSession): number[] {
@@ -343,6 +311,12 @@ function codexTurnBoundaries(session: PortableSession): number[] {
 
 function codexTurnId(sessionId: string, turnIndex: number): string {
   return deterministicCodexUuid(`${sessionId}:turn:${turnIndex}`);
+}
+
+function codexStatelessItemId(seed: string): string {
+  // Codex keeps a non-empty local item id while rebuilding resumed history, then
+  // strips legacy ids without an underscore before a stateless Responses request.
+  return deterministicCodexUuid(`response-item:${seed}`);
 }
 
 function deterministicCodexUuid(seed: string): string {
@@ -1020,7 +994,6 @@ function validateCodexStructure(
         session,
         sessionId,
         turnIndex,
-        codexTurnId(sessionId, turnIndex),
       ))
     : [];
   const expectedRows = 1
@@ -1081,7 +1054,7 @@ function validateCodexStructure(
         row?.type !== "response_item"
         || row.timestamp !== message.timestamp
         || messagePayload?.type !== "message"
-        || messagePayload.id !== undefined
+        || messagePayload.id !== codexStatelessItemId(`${sessionId}:turn:${turnIndex}:message:${message.index}`)
         || messagePayload.role !== message.role
         || (message.role === "assistant" && messagePayload.phase !== "final_answer")
         || (message.role === "user" && messagePayload.phase !== undefined)
@@ -1107,7 +1080,7 @@ function validateCodexStructure(
     }
 
     if (includeVsCodeEvents) {
-      const expectedActivities = codexSubagentActivityRows(session, sessionId, turnIndex, turnId);
+      const expectedActivities = codexSubagentActivityRows(session, sessionId, turnIndex);
       const actualActivities = rows.slice(rowIndex, rowIndex + expectedActivities.length);
       if (JSON.stringify(actualActivities) !== JSON.stringify(expectedActivities)) {
         failValidation("codex", "has invalid subagent activity metadata");

--- a/apps/main-1.0/src/main/index.ts
+++ b/apps/main-1.0/src/main/index.ts
@@ -57,6 +57,7 @@ import {
   revealInFileManager,
 } from "../core/platform";
 import { loadUsageQuotaSnapshot } from "../core/quota";
+import { repairLegacyAgentRecallCodexRollouts } from "../core/codex-migration-repair";
 import { focusLiveSessionTerminal, setLiveSessionTerminalTitle } from "../core/session-focus";
 import { setSessionCustomTitleAndSyncTerminal } from "../core/session-title-sync";
 import { createCachedLiveSessionSnapshotLoader } from "../core/session-activity";
@@ -2458,7 +2459,17 @@ const applicationReady = hasSingleInstanceLock
       }
       const initialIndexSettled = new Promise<void>((resolve) => {
         startupTasks.schedule(INITIAL_INDEX_DELAY_MS, () => {
-          void runIndexSync().then(() => resolve(), () => resolve());
+          void (async () => {
+            try {
+              const repair = await repairLegacyAgentRecallCodexRollouts(homedir());
+              if (repair.failedFiles > 0) {
+                console.warn(`[session-migration] ${repair.failedFiles} legacy Codex rollout(s) could not be repaired; they will be retried on the next startup.`);
+              }
+            } catch (error) {
+              console.warn("[session-migration] Legacy Codex rollout repair failed; startup indexing will continue.", error);
+            }
+            await runIndexSync();
+          })().then(() => resolve(), () => resolve());
         });
       });
       startAutoIndexRefresh();

--- a/apps/main-2.0/src/core/codex-migration-repair.test.ts
+++ b/apps/main-2.0/src/core/codex-migration-repair.test.ts
@@ -16,6 +16,14 @@ describe("repairLegacyAgentRecallCodexRollouts", () => {
       const tcodexPath = writeLegacyRollout(homeDir, ".tcodex", "tcodex", "agent-recall-v2", false, "legacy-nondeterministic");
       const partialPath = writeLegacyRollout(homeDir, ".codex", "partial", "agent-recall", true, "repaired");
       const missingMessageIdPath = writeLegacyRollout(homeDir, ".codex", "missing-id", "agent-recall", true, "missing");
+      const legacySingleTurnPath = writeLegacyRollout(
+        homeDir,
+        ".codex",
+        "legacy-single-turn",
+        "agent-recall",
+        true,
+        "missing-legacy-turn",
+      );
       const currentWriterPath = writeLegacyRollout(homeDir, ".codex", "current", "agent-recall", true, "current");
       const nativePath = path.join(homeDir, ".codex", "sessions", "native.jsonl");
       const nativeContent = `${JSON.stringify({
@@ -25,33 +33,45 @@ describe("repairLegacyAgentRecallCodexRollouts", () => {
       fs.writeFileSync(nativePath, nativeContent);
       const originalSize = fs.statSync(v1Path).size;
       const originalMissingMessageIdSize = fs.statSync(missingMessageIdPath).size;
+      const nativeSuffix = `${JSON.stringify({ type: "event_msg", payload: { type: "task_started", turn_id: "native-turn" } })}\n${JSON.stringify({
+        type: "response_item",
+        timestamp: "2026-08-10T06:24:27.000Z",
+        payload: { type: "message", id: `msg_${"f".repeat(8)}-ffff-4fff-8fff-${"f".repeat(12)}`, role: "user", content: [] },
+      })}\n`;
+      expect(fs.readFileSync(missingMessageIdPath, "utf8")).toContain(nativeSuffix);
 
       const result = await repairLegacyAgentRecallCodexRollouts(homeDir);
 
-      expect(result).toEqual({ scannedFiles: 7, repairedFiles: 5, repairedItemIds: 13, failedFiles: 0 });
+      expect(result).toEqual({ scannedFiles: 8, repairedFiles: 5, repairedItemIds: 12, failedFiles: 0 });
       for (const filePath of [v1Path, v2Path, partialPath]) {
         const repaired = fs.readFileSync(filePath, "utf8");
         expect(repaired).toContain(`"id":"msg-${legacyMessageUuid()}"`);
       }
-      for (const filePath of [v1Path, v2Path, partialPath, missingMessageIdPath]) {
+      for (const filePath of [v1Path, v2Path, partialPath]) {
         const repaired = fs.readFileSync(filePath, "utf8");
         expect(repaired).toContain(`"id":"fc-${"a".repeat(64)}"`);
         expect(repaired).toContain(`"id":"fco-${"b".repeat(64)}"`);
         expect(repaired).toContain(`"id":"msg_${"f".repeat(8)}-ffff-4fff-8fff-${"f".repeat(12)}"`);
         expect(repaired).toContain("content keeps msg_ text unchanged");
-        expect(repaired).toContain('"cli_version":"repair-v1"');
+        expect(repaired).toContain('"cli_version":"migrati0n"');
       }
       const repairedMissingMessageId = fs.readFileSync(missingMessageIdPath, "utf8");
-      expect(repairedMissingMessageId).toContain('"timestamp":"2026-08-10","payload":{"type":"message","id":"0"');
-      expect(() => repairedMissingMessageId.trim().split("\n").forEach((line) => JSON.parse(line))).not.toThrow();
+      expect(repairedMissingMessageId).toContain('"timestamp":"2026-08-10T06:22:27.000Z","payload":{"type":"message","role":"user"');
+      expect(repairedMissingMessageId).toContain(`"id":"fc-${"a".repeat(64)}"`);
+      expect(repairedMissingMessageId).toContain(`"id":"fco-${"b".repeat(64)}"`);
+      expect(repairedMissingMessageId).toContain('"cli_version":"migrati0n"');
+      expect(repairedMissingMessageId).toContain(nativeSuffix);
+      const legacySingleTurn = fs.readFileSync(legacySingleTurnPath, "utf8");
+      expect(legacySingleTurn).toContain('"cli_version":"migrati0n"');
+      expect(legacySingleTurn).toContain('"timestamp":"2026-08-10T06:22:27.000Z","payload":{"type":"message","role":"user"');
       const repairedTcodex = fs.readFileSync(tcodexPath, "utf8");
       expect(repairedTcodex).toContain(`"id":"msg-${legacyMessageUuid()}"`);
       expect(repairedTcodex).toContain(`"id":"msg-${deterministicUuid(`${SESSION_ID}:turn:0:message:1`)}"`);
       expect(repairedTcodex).toContain(`"id":"msg_${"f".repeat(8)}-ffff-4fff-8fff-${"f".repeat(12)}"`);
-      expect(repairedTcodex).toContain('"cli_version":"repair-v1"');
+      expect(repairedTcodex).toContain('"cli_version":"migrati0n"');
       const currentWriter = fs.readFileSync(currentWriterPath, "utf8");
       expect(currentWriter).toContain(`"id":"${currentMessageUuid()}"`);
-      expect(currentWriter).toContain('"cli_version":"repair-v1"');
+      expect(currentWriter).toContain('"cli_version":"migrati0n"');
       expect(fs.statSync(v1Path).size).toBe(originalSize);
       expect(fs.statSync(missingMessageIdPath).size).toBe(originalMissingMessageIdSize);
       expect(fs.readFileSync(nativePath, "utf8")).toBe(nativeContent);
@@ -68,7 +88,7 @@ function writeLegacyRollout(
   name: string,
   originator: string,
   includeVsCodeEvents: boolean,
-  messageId: "legacy" | "legacy-nondeterministic" | "repaired" | "missing" | "current" = "legacy",
+  messageId: "legacy" | "legacy-nondeterministic" | "repaired" | "missing" | "missing-legacy-turn" | "current" = "legacy",
 ): string {
   const filePath = path.join(homeDir, root, "sessions", `${name}.jsonl`);
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -76,14 +96,20 @@ function writeLegacyRollout(
   const rows = [
     { type: "session_meta", payload: { id: SESSION_ID, originator, cli_version: "migration", ...(includeVsCodeEvents ? { source: "vscode" } : {}) } },
     ...(includeVsCodeEvents
-      ? [{ type: "event_msg", payload: { type: "task_started", turn_id: deterministicUuid(`${SESSION_ID}:turn:0`) } }]
+      ? [{
+          type: "event_msg",
+          payload: {
+            type: "task_started",
+            turn_id: messageId === "missing-legacy-turn" ? SESSION_ID : deterministicUuid(`${SESSION_ID}:turn:0`),
+          },
+        }]
       : []),
     {
       type: "response_item",
       timestamp: "2026-08-10T06:22:27.000Z",
       payload: {
         type: "message",
-        ...(messageId === "missing"
+        ...(messageId === "missing" || messageId === "missing-legacy-turn"
           ? {}
           : {
               id: messageId === "current"
@@ -106,7 +132,7 @@ function writeLegacyRollout(
           },
         }]
       : []),
-    ...(includeVsCodeEvents && messageId !== "current"
+    ...(includeVsCodeEvents && messageId !== "current" && messageId !== "missing-legacy-turn"
       ? [
           { type: "response_item", payload: { type: "function_call", id: `fc_${"a".repeat(64)}`, name: "spawn_agent", namespace: "collaboration", call_id: callId } },
           { type: "event_msg", payload: { type: "sub_agent_activity", event_id: callId, agent_thread_id: "20000000-0000-4000-8000-000000000002" } },
@@ -114,7 +140,11 @@ function writeLegacyRollout(
           { type: "event_msg", payload: { type: "task_started", turn_id: "native-turn" } },
         ]
       : []),
-    { type: "response_item", payload: { type: "message", id: `msg_${"f".repeat(8)}-ffff-4fff-8fff-${"f".repeat(12)}`, role: "user", content: [] } },
+    {
+      type: "response_item",
+      timestamp: "2026-08-10T06:24:27.000Z",
+      payload: { type: "message", id: `msg_${"f".repeat(8)}-ffff-4fff-8fff-${"f".repeat(12)}`, role: "user", content: [] },
+    },
   ];
   fs.writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
   return filePath;

--- a/apps/main-2.0/src/core/codex-migration-repair.test.ts
+++ b/apps/main-2.0/src/core/codex-migration-repair.test.ts
@@ -1,0 +1,82 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { repairLegacyAgentRecallCodexRollouts } from "./codex-migration-repair";
+
+const SESSION_ID = "10000000-0000-4000-8000-000000000001";
+
+describe("repairLegacyAgentRecallCodexRollouts", () => {
+  it("repairs only the deterministic legacy item ids in AgentRecall migration rollouts", async () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-migration-repair-"));
+    try {
+      const v1Path = writeLegacyRollout(homeDir, ".codex", "v1", "agent-recall", true);
+      const v2Path = writeLegacyRollout(homeDir, ".codex", "v2", "agent-recall-v2", true);
+      const tcodexPath = writeLegacyRollout(homeDir, ".tcodex", "tcodex", "agent-recall-v2", false);
+      const nativePath = path.join(homeDir, ".codex", "sessions", "native.jsonl");
+      const nativeContent = `${JSON.stringify({
+        type: "session_meta",
+        payload: { id: "native", originator: "codex", cli_version: "0.147.0" },
+      })}\n${JSON.stringify({ type: "response_item", payload: { type: "message", id: "msg_native" } })}\n`;
+      fs.writeFileSync(nativePath, nativeContent);
+      const originalSize = fs.statSync(v1Path).size;
+
+      const result = await repairLegacyAgentRecallCodexRollouts(homeDir);
+
+      expect(result).toEqual({ scannedFiles: 4, repairedFiles: 3, repairedItemIds: 7, failedFiles: 0 });
+      for (const filePath of [v1Path, v2Path]) {
+        const repaired = fs.readFileSync(filePath, "utf8");
+        expect(repaired).toContain(`"id":"msg-${legacyMessageUuid()}"`);
+        expect(repaired).toContain(`"id":"fc-${"a".repeat(64)}"`);
+        expect(repaired).toContain(`"id":"fco-${"b".repeat(64)}"`);
+        expect(repaired).toContain(`"id":"msg_${"f".repeat(8)}-ffff-4fff-8fff-${"f".repeat(12)}"`);
+        expect(repaired).toContain("content keeps msg_ text unchanged");
+      }
+      const repairedTcodex = fs.readFileSync(tcodexPath, "utf8");
+      expect(repairedTcodex).toContain(`"id":"msg-${legacyMessageUuid()}"`);
+      expect(repairedTcodex).toContain(`"id":"msg_${"f".repeat(8)}-ffff-4fff-8fff-${"f".repeat(12)}"`);
+      expect(fs.statSync(v1Path).size).toBe(originalSize);
+      expect(fs.readFileSync(nativePath, "utf8")).toBe(nativeContent);
+      expect(await repairLegacyAgentRecallCodexRollouts(homeDir)).toMatchObject({ repairedFiles: 0, repairedItemIds: 0 });
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+});
+
+function writeLegacyRollout(homeDir: string, root: string, name: string, originator: string, includeVsCodeEvents: boolean): string {
+  const filePath = path.join(homeDir, root, "sessions", `${name}.jsonl`);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const callId = `call_migrated_${"c".repeat(24)}`;
+  const rows = [
+    { type: "session_meta", payload: { id: SESSION_ID, originator, cli_version: "migration", ...(includeVsCodeEvents ? { source: "vscode" } : {}) } },
+    ...(includeVsCodeEvents
+      ? [{ type: "event_msg", payload: { type: "task_started", turn_id: deterministicUuid(`${SESSION_ID}:turn:0`) } }]
+      : []),
+    { type: "response_item", payload: { type: "message", id: `msg_${legacyMessageUuid()}`, role: "user", content: [{ type: "input_text", text: "content keeps msg_ text unchanged" }] } },
+    ...(includeVsCodeEvents
+      ? [
+          { type: "response_item", payload: { type: "function_call", id: `fc_${"a".repeat(64)}`, name: "spawn_agent", namespace: "collaboration", call_id: callId } },
+          { type: "event_msg", payload: { type: "sub_agent_activity", event_id: callId, agent_thread_id: "20000000-0000-4000-8000-000000000002" } },
+          { type: "response_item", payload: { type: "function_call_output", id: `fco_${"b".repeat(64)}`, call_id: callId } },
+          { type: "event_msg", payload: { type: "task_started", turn_id: "native-turn" } },
+        ]
+      : []),
+    { type: "response_item", payload: { type: "message", id: `msg_${"f".repeat(8)}-ffff-4fff-8fff-${"f".repeat(12)}`, role: "user", content: [] } },
+  ];
+  fs.writeFileSync(filePath, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+  return filePath;
+}
+
+function legacyMessageUuid(): string {
+  return deterministicUuid(`${SESSION_ID}:turn:0:message:0`);
+}
+
+function deterministicUuid(seed: string): string {
+  const bytes = Buffer.from(crypto.createHash("sha256").update(seed).digest().subarray(0, 16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/apps/main-2.0/src/core/codex-migration-repair.test.ts
+++ b/apps/main-2.0/src/core/codex-migration-repair.test.ts
@@ -13,7 +13,10 @@ describe("repairLegacyAgentRecallCodexRollouts", () => {
     try {
       const v1Path = writeLegacyRollout(homeDir, ".codex", "v1", "agent-recall", true);
       const v2Path = writeLegacyRollout(homeDir, ".codex", "v2", "agent-recall-v2", true);
-      const tcodexPath = writeLegacyRollout(homeDir, ".tcodex", "tcodex", "agent-recall-v2", false);
+      const tcodexPath = writeLegacyRollout(homeDir, ".tcodex", "tcodex", "agent-recall-v2", false, "legacy-nondeterministic");
+      const partialPath = writeLegacyRollout(homeDir, ".codex", "partial", "agent-recall", true, "repaired");
+      const missingMessageIdPath = writeLegacyRollout(homeDir, ".codex", "missing-id", "agent-recall", true, "missing");
+      const currentWriterPath = writeLegacyRollout(homeDir, ".codex", "current", "agent-recall", true, "current");
       const nativePath = path.join(homeDir, ".codex", "sessions", "native.jsonl");
       const nativeContent = `${JSON.stringify({
         type: "session_meta",
@@ -21,22 +24,36 @@ describe("repairLegacyAgentRecallCodexRollouts", () => {
       })}\n${JSON.stringify({ type: "response_item", payload: { type: "message", id: "msg_native" } })}\n`;
       fs.writeFileSync(nativePath, nativeContent);
       const originalSize = fs.statSync(v1Path).size;
+      const originalMissingMessageIdSize = fs.statSync(missingMessageIdPath).size;
 
       const result = await repairLegacyAgentRecallCodexRollouts(homeDir);
 
-      expect(result).toEqual({ scannedFiles: 4, repairedFiles: 3, repairedItemIds: 7, failedFiles: 0 });
-      for (const filePath of [v1Path, v2Path]) {
+      expect(result).toEqual({ scannedFiles: 7, repairedFiles: 5, repairedItemIds: 13, failedFiles: 0 });
+      for (const filePath of [v1Path, v2Path, partialPath]) {
         const repaired = fs.readFileSync(filePath, "utf8");
         expect(repaired).toContain(`"id":"msg-${legacyMessageUuid()}"`);
+      }
+      for (const filePath of [v1Path, v2Path, partialPath, missingMessageIdPath]) {
+        const repaired = fs.readFileSync(filePath, "utf8");
         expect(repaired).toContain(`"id":"fc-${"a".repeat(64)}"`);
         expect(repaired).toContain(`"id":"fco-${"b".repeat(64)}"`);
         expect(repaired).toContain(`"id":"msg_${"f".repeat(8)}-ffff-4fff-8fff-${"f".repeat(12)}"`);
         expect(repaired).toContain("content keeps msg_ text unchanged");
+        expect(repaired).toContain('"cli_version":"repair-v1"');
       }
+      const repairedMissingMessageId = fs.readFileSync(missingMessageIdPath, "utf8");
+      expect(repairedMissingMessageId).toContain('"timestamp":"2026-08-10","payload":{"type":"message","id":"0"');
+      expect(() => repairedMissingMessageId.trim().split("\n").forEach((line) => JSON.parse(line))).not.toThrow();
       const repairedTcodex = fs.readFileSync(tcodexPath, "utf8");
       expect(repairedTcodex).toContain(`"id":"msg-${legacyMessageUuid()}"`);
+      expect(repairedTcodex).toContain(`"id":"msg-${deterministicUuid(`${SESSION_ID}:turn:0:message:1`)}"`);
       expect(repairedTcodex).toContain(`"id":"msg_${"f".repeat(8)}-ffff-4fff-8fff-${"f".repeat(12)}"`);
+      expect(repairedTcodex).toContain('"cli_version":"repair-v1"');
+      const currentWriter = fs.readFileSync(currentWriterPath, "utf8");
+      expect(currentWriter).toContain(`"id":"${currentMessageUuid()}"`);
+      expect(currentWriter).toContain('"cli_version":"repair-v1"');
       expect(fs.statSync(v1Path).size).toBe(originalSize);
+      expect(fs.statSync(missingMessageIdPath).size).toBe(originalMissingMessageIdSize);
       expect(fs.readFileSync(nativePath, "utf8")).toBe(nativeContent);
       expect(await repairLegacyAgentRecallCodexRollouts(homeDir)).toMatchObject({ repairedFiles: 0, repairedItemIds: 0 });
     } finally {
@@ -45,7 +62,14 @@ describe("repairLegacyAgentRecallCodexRollouts", () => {
   });
 });
 
-function writeLegacyRollout(homeDir: string, root: string, name: string, originator: string, includeVsCodeEvents: boolean): string {
+function writeLegacyRollout(
+  homeDir: string,
+  root: string,
+  name: string,
+  originator: string,
+  includeVsCodeEvents: boolean,
+  messageId: "legacy" | "legacy-nondeterministic" | "repaired" | "missing" | "current" = "legacy",
+): string {
   const filePath = path.join(homeDir, root, "sessions", `${name}.jsonl`);
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   const callId = `call_migrated_${"c".repeat(24)}`;
@@ -54,8 +78,35 @@ function writeLegacyRollout(homeDir: string, root: string, name: string, origina
     ...(includeVsCodeEvents
       ? [{ type: "event_msg", payload: { type: "task_started", turn_id: deterministicUuid(`${SESSION_ID}:turn:0`) } }]
       : []),
-    { type: "response_item", payload: { type: "message", id: `msg_${legacyMessageUuid()}`, role: "user", content: [{ type: "input_text", text: "content keeps msg_ text unchanged" }] } },
-    ...(includeVsCodeEvents
+    {
+      type: "response_item",
+      timestamp: "2026-08-10T06:22:27.000Z",
+      payload: {
+        type: "message",
+        ...(messageId === "missing"
+          ? {}
+          : {
+              id: messageId === "current"
+                ? currentMessageUuid()
+                : `${messageId === "repaired" ? "msg-" : "msg_"}${legacyMessageUuid()}`,
+            }),
+        role: "user",
+        content: [{ type: "input_text", text: "content keeps msg_ text unchanged" }],
+      },
+    },
+    ...(messageId === "legacy-nondeterministic"
+      ? [{
+          type: "response_item",
+          timestamp: "2026-08-10T06:23:27.000Z",
+          payload: {
+            type: "message",
+            id: `msg_${deterministicUuid(`${SESSION_ID}:turn:0:message:1`)}`,
+            role: "user",
+            content: [{ type: "input_text", text: "same turn second user message" }],
+          },
+        }]
+      : []),
+    ...(includeVsCodeEvents && messageId !== "current"
       ? [
           { type: "response_item", payload: { type: "function_call", id: `fc_${"a".repeat(64)}`, name: "spawn_agent", namespace: "collaboration", call_id: callId } },
           { type: "event_msg", payload: { type: "sub_agent_activity", event_id: callId, agent_thread_id: "20000000-0000-4000-8000-000000000002" } },
@@ -71,6 +122,10 @@ function writeLegacyRollout(homeDir: string, root: string, name: string, origina
 
 function legacyMessageUuid(): string {
   return deterministicUuid(`${SESSION_ID}:turn:0:message:0`);
+}
+
+function currentMessageUuid(): string {
+  return deterministicUuid(`response-item:${SESSION_ID}:turn:0:message:0`);
 }
 
 function deterministicUuid(seed: string): string {

--- a/apps/main-2.0/src/core/codex-migration-repair.ts
+++ b/apps/main-2.0/src/core/codex-migration-repair.ts
@@ -1,0 +1,224 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const AGENT_RECALL_ORIGINATORS = new Set(["agent-recall", "agent-recall-v2"]);
+const FIRST_LINE_LIMIT = 256 * 1024;
+const FIRST_LINE_CHUNK_SIZE = 16 * 1024;
+const LEGACY_MESSAGE_ID = /^msg_[0-9a-f-]{36}$/i;
+const LEGACY_FUNCTION_CALL_ID = /^fc_[0-9a-f]{64}$/i;
+const LEGACY_FUNCTION_OUTPUT_ID = /^fco_[0-9a-f]{64}$/i;
+const MIGRATED_CALL_ID = /^call_migrated_[0-9a-f]{24}$/i;
+
+export interface CodexMigrationRepairResult {
+  scannedFiles: number;
+  repairedFiles: number;
+  repairedItemIds: number;
+  failedFiles: number;
+}
+
+export async function repairLegacyAgentRecallCodexRollouts(
+  homeDir = os.homedir(),
+): Promise<CodexMigrationRepairResult> {
+  const result: CodexMigrationRepairResult = {
+    scannedFiles: 0,
+    repairedFiles: 0,
+    repairedItemIds: 0,
+    failedFiles: 0,
+  };
+
+  for (const relativeRoot of [path.join(".codex", "sessions"), path.join(".tcodex", "sessions")]) {
+    for (const filePath of await listJsonlFiles(path.join(homeDir, relativeRoot))) {
+      result.scannedFiles += 1;
+      try {
+        const repairedItemIds = await repairLegacyRolloutFile(filePath);
+        if (repairedItemIds > 0) {
+          result.repairedFiles += 1;
+          result.repairedItemIds += repairedItemIds;
+        }
+      } catch {
+        // A locked or concurrently removed file is retried on the next startup.
+        result.failedFiles += 1;
+      }
+    }
+  }
+
+  return result;
+}
+
+async function listJsonlFiles(root: string): Promise<string[]> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const files: string[] = [];
+  for (const entry of entries) {
+    const filePath = path.join(root, entry.name);
+    if (entry.isDirectory()) files.push(...await listJsonlFiles(filePath));
+    else if (entry.isFile() && entry.name.endsWith(".jsonl")) files.push(filePath);
+  }
+  return files;
+}
+
+async function repairLegacyRolloutFile(filePath: string): Promise<number> {
+  const firstRow = await readFirstJsonlRow(filePath);
+  const firstPayload = record(firstRow?.payload);
+  if (
+    firstRow?.type !== "session_meta"
+    || !AGENT_RECALL_ORIGINATORS.has(stringField(firstPayload, "originator"))
+    || stringField(firstPayload, "cli_version") !== "migration"
+  ) {
+    return 0;
+  }
+
+  const sessionId = stringField(firstPayload, "id");
+  if (!sessionId) return 0;
+
+  const content = await fs.promises.readFile(filePath);
+  const offsets = legacyItemIdUnderscoreOffsets(content, sessionId, Boolean(firstPayload?.source));
+  if (offsets.length === 0) return 0;
+
+  const handle = await fs.promises.open(filePath, "r+");
+  let repaired = 0;
+  try {
+    // Keep every edit byte-for-byte the same length. Codex may already have the
+    // rollout open for append, so replacing the file or shifting offsets could
+    // detach subsequent turns from the path that the App resumes.
+    const current = Buffer.allocUnsafe(1);
+    const replacement = Buffer.from("-");
+    for (const offset of offsets) {
+      const read = await handle.read(current, 0, 1, offset);
+      if (read.bytesRead !== 1 || current[0] !== 0x5f) continue;
+      await handle.write(replacement, 0, 1, offset);
+      repaired += 1;
+    }
+    if (repaired > 0) await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  return repaired;
+}
+
+async function readFirstJsonlRow(filePath: string): Promise<Record<string, unknown> | null> {
+  const handle = await fs.promises.open(filePath, "r");
+  try {
+    const chunks: Buffer[] = [];
+    let position = 0;
+    while (position < FIRST_LINE_LIMIT) {
+      const buffer = Buffer.allocUnsafe(Math.min(FIRST_LINE_CHUNK_SIZE, FIRST_LINE_LIMIT - position));
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, position);
+      if (bytesRead === 0) return null;
+      const chunk = buffer.subarray(0, bytesRead);
+      const newline = chunk.indexOf(0x0a);
+      chunks.push(newline < 0 ? chunk : chunk.subarray(0, newline));
+      if (newline >= 0) {
+        return record(JSON.parse(Buffer.concat(chunks).toString("utf8").trim()));
+      }
+      position += bytesRead;
+    }
+    return null;
+  } catch {
+    return null;
+  } finally {
+    await handle.close();
+  }
+}
+
+function legacyItemIdUnderscoreOffsets(content: Buffer, sessionId: string, hasVsCodeEvents: boolean): number[] {
+  const offsets: number[] = [];
+  let lineStart = 0;
+  let migrationEnded = false;
+  let turnIndex = hasVsCodeEvents ? -1 : 0;
+  let messageIndex = 0;
+
+  while (lineStart < content.length) {
+    const newline = content.indexOf(0x0a, lineStart);
+    const lineEnd = newline < 0 ? content.length : newline;
+    const line = content.subarray(lineStart, lineEnd);
+    let row: Record<string, unknown> | null = null;
+    try {
+      row = record(JSON.parse(line.toString("utf8")));
+    } catch {
+      migrationEnded = true;
+    }
+
+    const payload = record(row?.payload);
+    if (!migrationEnded && row?.type === "event_msg" && payload?.type === "task_started") {
+      const nextTurnIndex = turnIndex + 1;
+      if (stringField(payload, "turn_id") === deterministicCodexUuid(`${sessionId}:turn:${nextTurnIndex}`)) {
+        turnIndex = nextTurnIndex;
+      } else if (turnIndex >= 0) {
+        migrationEnded = true;
+      }
+    }
+
+    if (!migrationEnded && row?.type === "response_item" && payload?.type === "message") {
+      if (!hasVsCodeEvents && messageIndex > 0 && payload.role === "user") turnIndex += 1;
+      const id = stringField(payload, "id");
+      const expectedId = `msg_${deterministicCodexUuid(`${sessionId}:turn:${Math.max(0, turnIndex)}:message:${messageIndex}`)}`;
+      if (id === expectedId && LEGACY_MESSAGE_ID.test(id)) {
+        const offset = idUnderscoreOffset(line, lineStart, id);
+        if (offset !== null) offsets.push(offset);
+        messageIndex += 1;
+      } else {
+        migrationEnded = true;
+      }
+    }
+
+    if (!migrationEnded && row?.type === "response_item" && payload?.type === "function_call") {
+      const id = stringField(payload, "id");
+      if (
+        payload.name === "spawn_agent"
+        && payload.namespace === "collaboration"
+        && LEGACY_FUNCTION_CALL_ID.test(id)
+        && MIGRATED_CALL_ID.test(stringField(payload, "call_id"))
+      ) {
+        const offset = idUnderscoreOffset(line, lineStart, id);
+        if (offset !== null) offsets.push(offset);
+      }
+    }
+
+    if (!migrationEnded && row?.type === "response_item" && payload?.type === "function_call_output") {
+      const id = stringField(payload, "id");
+      if (LEGACY_FUNCTION_OUTPUT_ID.test(id) && MIGRATED_CALL_ID.test(stringField(payload, "call_id"))) {
+        const offset = idUnderscoreOffset(line, lineStart, id);
+        if (offset !== null) offsets.push(offset);
+      }
+    }
+
+    if (newline < 0) break;
+    lineStart = newline + 1;
+  }
+
+  return offsets;
+}
+
+function idUnderscoreOffset(line: Buffer, lineStart: number, id: string): number | null {
+  const token = Buffer.from(`"id":${JSON.stringify(id)}`);
+  const tokenOffset = line.indexOf(token);
+  const underscoreOffset = token.indexOf(0x5f);
+  if (tokenOffset < 0 || underscoreOffset < 0) return null;
+  return lineStart + tokenOffset + underscoreOffset;
+}
+
+function deterministicCodexUuid(seed: string): string {
+  const bytes = Buffer.from(crypto.createHash("sha256").update(seed).digest().subarray(0, 16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function stringField(value: Record<string, unknown> | null, key: string): string {
+  return typeof value?.[key] === "string" ? value[key] : "";
+}

--- a/apps/main-2.0/src/core/codex-migration-repair.ts
+++ b/apps/main-2.0/src/core/codex-migration-repair.ts
@@ -6,9 +6,15 @@ import * as path from "node:path";
 const AGENT_RECALL_ORIGINATORS = new Set(["agent-recall", "agent-recall-v2"]);
 const FIRST_LINE_LIMIT = 256 * 1024;
 const FIRST_LINE_CHUNK_SIZE = 16 * 1024;
+const FILE_SCAN_CHUNK_SIZE = 64 * 1024;
+const CURRENT_WRITER_PROBE_LIMIT = FIRST_LINE_LIMIT + FIRST_LINE_CHUNK_SIZE;
+const REPAIRED_CLI_VERSION = "repair-v1";
 const LEGACY_MESSAGE_ID = /^msg_[0-9a-f-]{36}$/i;
+const REPAIRED_MESSAGE_ID = /^msg-[0-9a-f-]{36}$/i;
 const LEGACY_FUNCTION_CALL_ID = /^fc_[0-9a-f]{64}$/i;
 const LEGACY_FUNCTION_OUTPUT_ID = /^fco_[0-9a-f]{64}$/i;
+const REPAIRED_FUNCTION_CALL_ID = /^fc-[0-9a-f]{64}$/i;
+const REPAIRED_FUNCTION_OUTPUT_ID = /^fco-[0-9a-f]{64}$/i;
 const MIGRATED_CALL_ID = /^call_migrated_[0-9a-f]{24}$/i;
 
 export interface CodexMigrationRepairResult {
@@ -78,29 +84,126 @@ async function repairLegacyRolloutFile(filePath: string): Promise<number> {
   const sessionId = stringField(firstPayload, "id");
   if (!sessionId) return 0;
 
-  const content = await fs.promises.readFile(filePath);
-  const offsets = legacyItemIdUnderscoreOffsets(content, sessionId, Boolean(firstPayload?.source));
-  if (offsets.length === 0) return 0;
-
   const handle = await fs.promises.open(filePath, "r+");
   let repaired = 0;
   try {
+    const probe = await readFilePrefix(handle, CURRENT_WRITER_PROBE_LIMIT);
+    const currentFirstRow = firstJsonlRow(probe);
+    const currentFirstPayload = record(currentFirstRow?.payload);
+    if (
+      currentFirstRow?.type !== "session_meta"
+      || !AGENT_RECALL_ORIGINATORS.has(stringField(currentFirstPayload, "originator"))
+      || stringField(currentFirstPayload, "cli_version") !== "migration"
+      || stringField(currentFirstPayload, "id") !== sessionId
+    ) {
+      return 0;
+    }
+    const probeMarkerOffset = cliVersionValueOffset(probe, 0);
+    if (probeMarkerOffset === null) return 0;
+
+    // The current writer never emits the legacy synthetic function rows. Its
+    // deterministic first message ID is enough to mark the whole atomic file
+    // without reading a potentially huge first message or the remaining turns.
+    const currentFirstMessageId = deterministicCodexUuid(`response-item:${sessionId}:turn:0:message:0`);
+    if (probe.includes(Buffer.from(`"id":${JSON.stringify(currentFirstMessageId)}`))) {
+      await writeRepairMarker(handle, probeMarkerOffset);
+      await handle.sync();
+      return 0;
+    }
+
+    // Scan from the same file descriptor used for the edits. A rollout can be
+    // replaced between discovery and repair; keeping discovery and positional
+    // writes on one descriptor prevents patching an unrelated file.
+    const scan = await scanLegacyItemIds(handle, sessionId);
+    if (!scan) return 0;
+
     // Keep every edit byte-for-byte the same length. Codex may already have the
     // rollout open for append, so replacing the file or shifting offsets could
     // detach subsequent turns from the path that the App resumes.
-    const current = Buffer.allocUnsafe(1);
-    const replacement = Buffer.from("-");
-    for (const offset of offsets) {
-      const read = await handle.read(current, 0, 1, offset);
-      if (read.bytesRead !== 1 || current[0] !== 0x5f) continue;
-      await handle.write(replacement, 0, 1, offset);
+    for (const rewrite of scan.messageRewrites) {
+      const currentPrefix = await readBufferAt(handle, rewrite.original.length, rewrite.offset);
+      if (currentPrefix.equals(rewrite.replacement)) continue;
+      if (!currentPrefix.equals(rewrite.original)) {
+        throw new Error("Legacy Codex rollout changed during repair.");
+      }
+      await writeBufferAt(handle, rewrite.replacement, rewrite.offset);
       repaired += 1;
     }
+    const current = Buffer.allocUnsafe(1);
+    const replacement = Buffer.from("-");
+    for (const offset of scan.offsets) {
+      const read = await handle.read(current, 0, 1, offset);
+      if (read.bytesRead !== 1) throw new Error("Legacy Codex rollout changed during repair.");
+      if (current[0] === 0x5f) {
+        await handle.write(replacement, 0, 1, offset);
+        repaired += 1;
+      } else if (current[0] !== 0x2d) {
+        throw new Error("Legacy Codex rollout changed during repair.");
+      }
+    }
     if (repaired > 0) await handle.sync();
+    if (scan.complete) {
+      await writeRepairMarker(handle, scan.cliVersionOffset);
+      await handle.sync();
+    }
   } finally {
     await handle.close();
   }
   return repaired;
+}
+
+async function readFilePrefix(handle: fs.promises.FileHandle, limit: number): Promise<Buffer> {
+  const buffer = Buffer.allocUnsafe(limit);
+  let bytesRead = 0;
+  while (bytesRead < buffer.length) {
+    const read = await handle.read(
+      buffer,
+      bytesRead,
+      Math.min(FIRST_LINE_CHUNK_SIZE, buffer.length - bytesRead),
+      bytesRead,
+    );
+    if (read.bytesRead === 0) break;
+    bytesRead += read.bytesRead;
+  }
+  return buffer.subarray(0, bytesRead);
+}
+
+function firstJsonlRow(content: Buffer): Record<string, unknown> | null {
+  const newline = content.indexOf(0x0a);
+  if (newline < 0 || newline > FIRST_LINE_LIMIT) return null;
+  try {
+    return record(JSON.parse(content.subarray(0, newline).toString("utf8").trim()));
+  } catch {
+    return null;
+  }
+}
+
+async function writeRepairMarker(handle: fs.promises.FileHandle, offset: number): Promise<void> {
+  const current = await readBufferAt(handle, REPAIRED_CLI_VERSION.length, offset);
+  const value = current.toString("utf8");
+  if (value === REPAIRED_CLI_VERSION) return;
+  if (value !== "migration") throw new Error("Legacy Codex rollout changed during repair.");
+  await writeBufferAt(handle, Buffer.from(REPAIRED_CLI_VERSION), offset);
+}
+
+async function readBufferAt(handle: fs.promises.FileHandle, length: number, offset: number): Promise<Buffer> {
+  const buffer = Buffer.allocUnsafe(length);
+  let readBytes = 0;
+  while (readBytes < buffer.length) {
+    const read = await handle.read(buffer, readBytes, buffer.length - readBytes, offset + readBytes);
+    if (read.bytesRead === 0) throw new Error("Legacy Codex rollout changed during repair.");
+    readBytes += read.bytesRead;
+  }
+  return buffer;
+}
+
+async function writeBufferAt(handle: fs.promises.FileHandle, buffer: Buffer, offset: number): Promise<void> {
+  let writtenBytes = 0;
+  while (writtenBytes < buffer.length) {
+    const write = await handle.write(buffer, writtenBytes, buffer.length - writtenBytes, offset + writtenBytes);
+    if (write.bytesWritten === 0) throw new Error("Legacy Codex rollout could not be repaired.");
+    writtenBytes += write.bytesWritten;
+  }
 }
 
 async function readFirstJsonlRow(filePath: string): Promise<Record<string, unknown> | null> {
@@ -128,73 +231,218 @@ async function readFirstJsonlRow(filePath: string): Promise<Record<string, unkno
   }
 }
 
-function legacyItemIdUnderscoreOffsets(content: Buffer, sessionId: string, hasVsCodeEvents: boolean): number[] {
+interface LegacyItemIdScan {
+  offsets: number[];
+  messageRewrites: MessagePrefixRewrite[];
+  cliVersionOffset: number;
+  complete: boolean;
+}
+
+interface MessagePrefixRewrite {
+  offset: number;
+  original: Buffer;
+  replacement: Buffer;
+}
+
+async function scanLegacyItemIds(
+  handle: fs.promises.FileHandle,
+  sessionId: string,
+): Promise<LegacyItemIdScan | null> {
   const offsets: number[] = [];
-  let lineStart = 0;
-  let migrationEnded = false;
-  let turnIndex = hasVsCodeEvents ? -1 : 0;
+  const messageRewrites: MessagePrefixRewrite[] = [];
+  let cliVersionOffset: number | null = null;
+  let complete = true;
+  let firstLine = true;
+  let hasVsCodeEvents = false;
+  let turnIndex = 0;
   let messageIndex = 0;
 
-  while (lineStart < content.length) {
-    const newline = content.indexOf(0x0a, lineStart);
-    const lineEnd = newline < 0 ? content.length : newline;
-    const line = content.subarray(lineStart, lineEnd);
+  await visitJsonlLines(handle, (line, lineStart) => {
     let row: Record<string, unknown> | null = null;
     try {
       row = record(JSON.parse(line.toString("utf8")));
     } catch {
-      migrationEnded = true;
+      complete = false;
+      return true;
     }
 
     const payload = record(row?.payload);
-    if (!migrationEnded && row?.type === "event_msg" && payload?.type === "task_started") {
+    if (firstLine) {
+      firstLine = false;
+      if (
+        row?.type !== "session_meta"
+        || !AGENT_RECALL_ORIGINATORS.has(stringField(payload, "originator"))
+        || stringField(payload, "cli_version") !== "migration"
+        || stringField(payload, "id") !== sessionId
+      ) {
+        complete = false;
+        return true;
+      }
+      cliVersionOffset = cliVersionValueOffset(line, lineStart);
+      if (cliVersionOffset === null) {
+        complete = false;
+        return true;
+      }
+      hasVsCodeEvents = Boolean(payload?.source);
+      turnIndex = hasVsCodeEvents ? -1 : 0;
+      return false;
+    }
+
+    if (row?.type === "event_msg" && payload?.type === "task_started") {
       const nextTurnIndex = turnIndex + 1;
-      if (stringField(payload, "turn_id") === deterministicCodexUuid(`${sessionId}:turn:${nextTurnIndex}`)) {
+      if (hasVsCodeEvents && stringField(payload, "turn_id") === deterministicCodexUuid(`${sessionId}:turn:${nextTurnIndex}`)) {
         turnIndex = nextTurnIndex;
-      } else if (turnIndex >= 0) {
-        migrationEnded = true;
-      }
-    }
-
-    if (!migrationEnded && row?.type === "response_item" && payload?.type === "message") {
-      if (!hasVsCodeEvents && messageIndex > 0 && payload.role === "user") turnIndex += 1;
-      const id = stringField(payload, "id");
-      const expectedId = `msg_${deterministicCodexUuid(`${sessionId}:turn:${Math.max(0, turnIndex)}:message:${messageIndex}`)}`;
-      if (id === expectedId && LEGACY_MESSAGE_ID.test(id)) {
-        const offset = idUnderscoreOffset(line, lineStart, id);
-        if (offset !== null) offsets.push(offset);
-        messageIndex += 1;
       } else {
-        migrationEnded = true;
+        return true;
       }
+      return false;
     }
 
-    if (!migrationEnded && row?.type === "response_item" && payload?.type === "function_call") {
+    if (row?.type === "event_msg") return false;
+    if (row?.type !== "response_item") return true;
+
+    if (payload?.type === "message") {
+      const id = stringField(payload, "id");
+      if (LEGACY_MESSAGE_ID.test(id) || REPAIRED_MESSAGE_ID.test(id)) {
+        // Terminal Codex rollouts have no task_started rows. Recover the
+        // monotonic turn index from the writer's deterministic IDs instead of
+        // assuming every user message starts a turn.
+        const firstCandidate = Math.max(0, turnIndex);
+        const lastCandidate = hasVsCodeEvents ? firstCandidate : messageIndex;
+        let matchedTurnIndex = -1;
+        for (let candidate = firstCandidate; candidate <= lastCandidate; candidate += 1) {
+          const migratedUuid = deterministicCodexUuid(`${sessionId}:turn:${candidate}:message:${messageIndex}`);
+          if (id === `msg_${migratedUuid}` || id === `msg-${migratedUuid}`) {
+            matchedTurnIndex = candidate;
+            break;
+          }
+        }
+        if (matchedTurnIndex < 0) return true;
+        turnIndex = matchedTurnIndex;
+        if (LEGACY_MESSAGE_ID.test(id)) {
+          const offset = idUnderscoreOffset(line, lineStart, id);
+          if (offset !== null) offsets.push(offset);
+        }
+      } else if (!id) {
+        const rewrite = missingMessageIdRewrite(line, lineStart, stringField(row, "timestamp"), messageIndex);
+        if (!rewrite) throw new Error("Unsupported legacy Codex message layout.");
+        messageRewrites.push(rewrite);
+      } else if (id !== repairedMessageId(messageIndex)) {
+        return true;
+      }
+      messageIndex += 1;
+      return false;
+    }
+
+    if (payload?.type === "function_call") {
       const id = stringField(payload, "id");
       if (
-        payload.name === "spawn_agent"
-        && payload.namespace === "collaboration"
-        && LEGACY_FUNCTION_CALL_ID.test(id)
-        && MIGRATED_CALL_ID.test(stringField(payload, "call_id"))
-      ) {
+        payload.name !== "spawn_agent"
+        || payload.namespace !== "collaboration"
+        || !MIGRATED_CALL_ID.test(stringField(payload, "call_id"))
+      ) return true;
+      if (LEGACY_FUNCTION_CALL_ID.test(id)) {
         const offset = idUnderscoreOffset(line, lineStart, id);
         if (offset !== null) offsets.push(offset);
-      }
+      } else if (id && !REPAIRED_FUNCTION_CALL_ID.test(id)) return true;
+      return false;
     }
 
-    if (!migrationEnded && row?.type === "response_item" && payload?.type === "function_call_output") {
+    if (payload?.type === "function_call_output") {
       const id = stringField(payload, "id");
-      if (LEGACY_FUNCTION_OUTPUT_ID.test(id) && MIGRATED_CALL_ID.test(stringField(payload, "call_id"))) {
+      if (!MIGRATED_CALL_ID.test(stringField(payload, "call_id"))) return true;
+      if (LEGACY_FUNCTION_OUTPUT_ID.test(id)) {
         const offset = idUnderscoreOffset(line, lineStart, id);
         if (offset !== null) offsets.push(offset);
-      }
+      } else if (id && !REPAIRED_FUNCTION_OUTPUT_ID.test(id)) return true;
+      return false;
     }
 
-    if (newline < 0) break;
-    lineStart = newline + 1;
+    return true;
+  });
+
+  if (firstLine || cliVersionOffset === null) return null;
+  return { offsets, messageRewrites, cliVersionOffset, complete };
+}
+
+function missingMessageIdRewrite(
+  line: Buffer,
+  lineStart: number,
+  timestamp: string,
+  messageIndex: number,
+): MessagePrefixRewrite | null {
+  const payloadPrefix = Buffer.from('"payload":{"type":"message",');
+  const payloadOffset = line.indexOf(payloadPrefix);
+  if (payloadOffset < 0 || !line.subarray(0, payloadOffset).includes(Buffer.from('"timestamp":'))) return null;
+  const original = Buffer.from(line.subarray(0, payloadOffset + payloadPrefix.length));
+  const itemId = repairedMessageId(messageIndex);
+  // These older rows have no spare field for an ID. Keep the required
+  // timestamp string (normally retaining its date), use the freed precision
+  // for a short per-file ID, and pad the prefix so every later byte stays put.
+  const availableTimestampLength = Buffer.byteLength(timestamp) - Buffer.byteLength(itemId) - 8;
+  if (availableTimestampLength < 0) return null;
+  const retainedTimestamp = availableTimestampLength >= 10 && /^\d{4}-\d{2}-\d{2}/.test(timestamp)
+    ? timestamp.slice(0, 10)
+    : availableTimestampLength >= 4 && /^\d{4}/.test(timestamp)
+      ? timestamp.slice(0, 4)
+      : "";
+  const replacementText = Buffer.from(
+    `{"type":"response_item","timestamp":${JSON.stringify(retainedTimestamp)},"payload":{"type":"message","id":"${itemId}",`,
+  );
+  if (replacementText.length > original.length) return null;
+  const replacement = Buffer.alloc(original.length, 0x20);
+  replacementText.copy(replacement);
+  return { offset: lineStart, original, replacement };
+}
+
+function repairedMessageId(messageIndex: number): string {
+  return messageIndex.toString(36);
+}
+
+async function visitJsonlLines(
+  handle: fs.promises.FileHandle,
+  visit: (line: Buffer, lineStart: number) => boolean,
+): Promise<void> {
+  const size = (await handle.stat()).size;
+  let position = 0;
+  let lineStart = 0;
+  let fragments: Buffer[] = [];
+
+  while (position < size) {
+    const buffer = Buffer.allocUnsafe(Math.min(FILE_SCAN_CHUNK_SIZE, size - position));
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, position);
+    if (bytesRead === 0) break;
+    const chunk = buffer.subarray(0, bytesRead);
+    let cursor = 0;
+    while (cursor < chunk.length) {
+      const newline = chunk.indexOf(0x0a, cursor);
+      if (newline < 0) {
+        fragments.push(chunk.subarray(cursor));
+        break;
+      }
+      fragments.push(chunk.subarray(cursor, newline));
+      const line = fragments.length === 1 ? fragments[0] : Buffer.concat(fragments);
+      if (visit(line, lineStart)) return;
+      fragments = [];
+      cursor = newline + 1;
+      lineStart = position + cursor;
+    }
+    position += bytesRead;
   }
 
-  return offsets;
+  if (fragments.length > 0) {
+    const line = fragments.length === 1 ? fragments[0] : Buffer.concat(fragments);
+    visit(line, lineStart);
+  }
+}
+
+function cliVersionValueOffset(lineOrPrefix: Buffer, lineStart: number): number | null {
+  const newline = lineOrPrefix.indexOf(0x0a);
+  const firstLine = newline < 0 ? lineOrPrefix : lineOrPrefix.subarray(0, newline);
+  const prefix = Buffer.from('"cli_version":"');
+  const token = Buffer.from('"cli_version":"migration"');
+  const tokenOffset = firstLine.indexOf(token);
+  return tokenOffset < 0 ? null : lineStart + tokenOffset + prefix.length;
 }
 
 function idUnderscoreOffset(line: Buffer, lineStart: number, id: string): number | null {

--- a/apps/main-2.0/src/core/codex-migration-repair.ts
+++ b/apps/main-2.0/src/core/codex-migration-repair.ts
@@ -8,7 +8,8 @@ const FIRST_LINE_LIMIT = 256 * 1024;
 const FIRST_LINE_CHUNK_SIZE = 16 * 1024;
 const FILE_SCAN_CHUNK_SIZE = 64 * 1024;
 const CURRENT_WRITER_PROBE_LIMIT = FIRST_LINE_LIMIT + FIRST_LINE_CHUNK_SIZE;
-const REPAIRED_CLI_VERSION = "repair-v1";
+const REPAIRED_CLI_VERSION = "migrati0n";
+const REPAIR_MARKER_INDEX = 7;
 const LEGACY_MESSAGE_ID = /^msg_[0-9a-f-]{36}$/i;
 const REPAIRED_MESSAGE_ID = /^msg-[0-9a-f-]{36}$/i;
 const LEGACY_FUNCTION_CALL_ID = /^fc_[0-9a-f]{64}$/i;
@@ -120,15 +121,6 @@ async function repairLegacyRolloutFile(filePath: string): Promise<number> {
     // Keep every edit byte-for-byte the same length. Codex may already have the
     // rollout open for append, so replacing the file or shifting offsets could
     // detach subsequent turns from the path that the App resumes.
-    for (const rewrite of scan.messageRewrites) {
-      const currentPrefix = await readBufferAt(handle, rewrite.original.length, rewrite.offset);
-      if (currentPrefix.equals(rewrite.replacement)) continue;
-      if (!currentPrefix.equals(rewrite.original)) {
-        throw new Error("Legacy Codex rollout changed during repair.");
-      }
-      await writeBufferAt(handle, rewrite.replacement, rewrite.offset);
-      repaired += 1;
-    }
     const current = Buffer.allocUnsafe(1);
     const replacement = Buffer.from("-");
     for (const offset of scan.offsets) {
@@ -179,11 +171,13 @@ function firstJsonlRow(content: Buffer): Record<string, unknown> | null {
 }
 
 async function writeRepairMarker(handle: fs.promises.FileHandle, offset: number): Promise<void> {
-  const current = await readBufferAt(handle, REPAIRED_CLI_VERSION.length, offset);
+  const current = await readBufferAt(handle, "migration".length, offset);
   const value = current.toString("utf8");
   if (value === REPAIRED_CLI_VERSION) return;
   if (value !== "migration") throw new Error("Legacy Codex rollout changed during repair.");
-  await writeBufferAt(handle, Buffer.from(REPAIRED_CLI_VERSION), offset);
+  // A one-byte marker stays valid JSON even if V1 and V2 start together, and
+  // cannot leave a partially rewritten cli_version if the process exits.
+  await writeBufferAt(handle, Buffer.from("0"), offset + REPAIR_MARKER_INDEX);
 }
 
 async function readBufferAt(handle: fs.promises.FileHandle, length: number, offset: number): Promise<Buffer> {
@@ -233,15 +227,8 @@ async function readFirstJsonlRow(filePath: string): Promise<Record<string, unkno
 
 interface LegacyItemIdScan {
   offsets: number[];
-  messageRewrites: MessagePrefixRewrite[];
   cliVersionOffset: number;
   complete: boolean;
-}
-
-interface MessagePrefixRewrite {
-  offset: number;
-  original: Buffer;
-  replacement: Buffer;
 }
 
 async function scanLegacyItemIds(
@@ -249,7 +236,6 @@ async function scanLegacyItemIds(
   sessionId: string,
 ): Promise<LegacyItemIdScan | null> {
   const offsets: number[] = [];
-  const messageRewrites: MessagePrefixRewrite[] = [];
   let cliVersionOffset: number | null = null;
   let complete = true;
   let firstLine = true;
@@ -292,6 +278,11 @@ async function scanLegacyItemIds(
       const nextTurnIndex = turnIndex + 1;
       if (hasVsCodeEvents && stringField(payload, "turn_id") === deterministicCodexUuid(`${sessionId}:turn:${nextTurnIndex}`)) {
         turnIndex = nextTurnIndex;
+      } else if (hasVsCodeEvents && turnIndex < 0 && stringField(payload, "turn_id") === sessionId) {
+        // The first App migration writer represented its whole snapshot as one
+        // turn. Keep scanning its known migration prefix so later synthetic
+        // tool rows can still be repaired.
+        turnIndex = 0;
       } else {
         return true;
       }
@@ -324,10 +315,17 @@ async function scanLegacyItemIds(
           if (offset !== null) offsets.push(offset);
         }
       } else if (!id) {
-        const rewrite = missingMessageIdRewrite(line, lineStart, stringField(row, "timestamp"), messageIndex);
-        if (!rewrite) throw new Error("Unsupported legacy Codex message layout.");
-        messageRewrites.push(rewrite);
-      } else if (id !== repairedMessageId(messageIndex)) {
+        // Older AgentRecall snapshots intentionally left local IDs absent.
+        // Keep those messages byte-identical: current Codex resumes them
+        // without sending a server-backed item reference. Continue scanning,
+        // because a later AgentRecall subagent row can still carry a bad ID.
+        // Once that known migration prefix is fully inspected, the one-byte
+        // marker avoids rescanning the same large, already-safe history.
+      } else {
+        // A short unprefixed ID comes from a partially completed repair built
+        // before full RFC3339 timestamps were enforced. Keep the marker as
+        // `migration` so it is never mistaken for a fully repaired rollout.
+        complete = false;
         return true;
       }
       messageIndex += 1;
@@ -362,41 +360,7 @@ async function scanLegacyItemIds(
   });
 
   if (firstLine || cliVersionOffset === null) return null;
-  return { offsets, messageRewrites, cliVersionOffset, complete };
-}
-
-function missingMessageIdRewrite(
-  line: Buffer,
-  lineStart: number,
-  timestamp: string,
-  messageIndex: number,
-): MessagePrefixRewrite | null {
-  const payloadPrefix = Buffer.from('"payload":{"type":"message",');
-  const payloadOffset = line.indexOf(payloadPrefix);
-  if (payloadOffset < 0 || !line.subarray(0, payloadOffset).includes(Buffer.from('"timestamp":'))) return null;
-  const original = Buffer.from(line.subarray(0, payloadOffset + payloadPrefix.length));
-  const itemId = repairedMessageId(messageIndex);
-  // These older rows have no spare field for an ID. Keep the required
-  // timestamp string (normally retaining its date), use the freed precision
-  // for a short per-file ID, and pad the prefix so every later byte stays put.
-  const availableTimestampLength = Buffer.byteLength(timestamp) - Buffer.byteLength(itemId) - 8;
-  if (availableTimestampLength < 0) return null;
-  const retainedTimestamp = availableTimestampLength >= 10 && /^\d{4}-\d{2}-\d{2}/.test(timestamp)
-    ? timestamp.slice(0, 10)
-    : availableTimestampLength >= 4 && /^\d{4}/.test(timestamp)
-      ? timestamp.slice(0, 4)
-      : "";
-  const replacementText = Buffer.from(
-    `{"type":"response_item","timestamp":${JSON.stringify(retainedTimestamp)},"payload":{"type":"message","id":"${itemId}",`,
-  );
-  if (replacementText.length > original.length) return null;
-  const replacement = Buffer.alloc(original.length, 0x20);
-  replacementText.copy(replacement);
-  return { offset: lineStart, original, replacement };
-}
-
-function repairedMessageId(messageIndex: number): string {
-  return messageIndex.toString(36);
+  return { offsets, cliVersionOffset, complete };
 }
 
 async function visitJsonlLines(

--- a/apps/main-2.0/src/core/session-migration-writers.test.ts
+++ b/apps/main-2.0/src/core/session-migration-writers.test.ts
@@ -132,7 +132,7 @@ function loadWrittenSession(
 }
 
 describe("writeMigratedSession", () => {
-  it("emits native Codex subagent activity linked to a reserved child thread", async () => {
+  it("emits native Codex subagent activity without model-visible synthetic tool history", async () => {
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "migration-writer-subagent-activity-"));
     try {
       const session = {
@@ -159,21 +159,18 @@ describe("writeMigratedSession", () => {
         now: NOW,
       });
       const rows = readRows(result.filePath);
-      const spawn = rows.find((row) => row.type === "response_item" && row.payload?.name === "spawn_agent");
-      const spawnOutput = rows.find((row) => row.type === "response_item" && row.payload?.type === "function_call_output");
       const activity = rows.find((row) => row.type === "event_msg" && row.payload?.type === "sub_agent_activity");
+      const syntheticToolRows = rows.filter((row) => row.type === "response_item"
+        && (row.payload?.type === "function_call" || row.payload?.type === "function_call_output"));
 
       expect(result.sessionId).toBe(SESSION_ID);
-      expect(JSON.parse(spawn?.payload.arguments)).toMatchObject({ task_name: "child", message: "Research child" });
-      expect(spawn?.payload.id).toBeUndefined();
-      expect(spawnOutput?.payload.id).toBeUndefined();
-      expect(spawnOutput?.payload.call_id).toBe(spawn?.payload.call_id);
+      expect(syntheticToolRows).toHaveLength(0);
       expect(activity?.payload).toMatchObject({
-        event_id: spawn?.payload.call_id,
         agent_thread_id: CHILD_SESSION_ID,
         agent_path: "/root/migrated_child",
         kind: "started",
       });
+      expect(activity?.payload.event_id).toMatch(/^[0-9a-f-]{36}$/);
     } finally {
       fs.rmSync(homeDir, { recursive: true, force: true });
     }
@@ -234,7 +231,8 @@ describe("writeMigratedSession", () => {
       expect(messageRows.map((row) => row.payload.role)).toEqual(["user", "assistant", "user", "assistant"]);
       expect(messageRows[1].payload.content[0].text).toContain("过程更新 1\n\n过程更新 2");
       expect(messageRows[1].payload.content[0].text).toContain("过程更新 260");
-      expect(messageRows.every((row) => row.payload.id === undefined)).toBe(true);
+      expect(messageRows.every((row) => /^[0-9a-f-]{36}$/.test(row.payload.id) && !row.payload.id.includes("_"))).toBe(true);
+      expect(new Set(messageRows.map((row) => row.payload.id)).size).toBe(messageRows.length);
       expect(messageRows.filter((row) => row.payload.role === "assistant").every((row) => row.payload.phase === "final_answer")).toBe(true);
       expect(rows.filter((row) => row.payload?.type === "task_started")).toHaveLength(2);
     } finally {

--- a/apps/main-2.0/src/core/session-migration-writers.test.ts
+++ b/apps/main-2.0/src/core/session-migration-writers.test.ts
@@ -160,11 +160,16 @@ describe("writeMigratedSession", () => {
       });
       const rows = readRows(result.filePath);
       const spawn = rows.find((row) => row.type === "response_item" && row.payload?.name === "spawn_agent");
+      const spawnOutput = rows.find((row) => row.type === "response_item" && row.payload?.type === "function_call_output");
       const activity = rows.find((row) => row.type === "event_msg" && row.payload?.type === "sub_agent_activity");
 
       expect(result.sessionId).toBe(SESSION_ID);
       expect(JSON.parse(spawn?.payload.arguments)).toMatchObject({ task_name: "child", message: "Research child" });
+      expect(spawn?.payload.id).toBeUndefined();
+      expect(spawnOutput?.payload.id).toBeUndefined();
+      expect(spawnOutput?.payload.call_id).toBe(spawn?.payload.call_id);
       expect(activity?.payload).toMatchObject({
+        event_id: spawn?.payload.call_id,
         agent_thread_id: CHILD_SESSION_ID,
         agent_path: "/root/migrated_child",
         kind: "started",
@@ -229,7 +234,7 @@ describe("writeMigratedSession", () => {
       expect(messageRows.map((row) => row.payload.role)).toEqual(["user", "assistant", "user", "assistant"]);
       expect(messageRows[1].payload.content[0].text).toContain("过程更新 1\n\n过程更新 2");
       expect(messageRows[1].payload.content[0].text).toContain("过程更新 260");
-      expect(messageRows.every((row) => /^msg_[0-9a-f-]{36}$/.test(row.payload.id))).toBe(true);
+      expect(messageRows.every((row) => row.payload.id === undefined)).toBe(true);
       expect(messageRows.filter((row) => row.payload.role === "assistant").every((row) => row.payload.phase === "final_answer")).toBe(true);
       expect(rows.filter((row) => row.payload?.type === "task_started")).toHaveLength(2);
     } finally {

--- a/apps/main-2.0/src/core/session-migration-writers.ts
+++ b/apps/main-2.0/src/core/session-migration-writers.ts
@@ -205,13 +205,11 @@ function serializeCodex(
     }
 
     for (const message of messages) {
-      const messageId = codexMessageId(sessionId, turnIndex, message.index);
       rows.push({
         type: "response_item",
         timestamp: message.timestamp,
         payload: {
           type: "message",
-          id: messageId,
           role: message.role,
           content: [{
             type: message.role === "user" ? "input_text" : "output_text",
@@ -290,7 +288,6 @@ function codexSubagentActivityRows(
         timestamp: subagent.startedAt,
         payload: {
           type: "function_call",
-          id: `fc_${digest}`,
           name: "spawn_agent",
           namespace: "collaboration",
           arguments: JSON.stringify({
@@ -317,7 +314,6 @@ function codexSubagentActivityRows(
         timestamp: subagent.startedAt,
         payload: {
           type: "function_call_output",
-          id: `fco_${digest}`,
           call_id: callId,
           output: JSON.stringify({ task_name: agentPath }),
           internal_chat_message_metadata_passthrough: { turn_id: turnId },
@@ -347,10 +343,6 @@ function codexTurnBoundaries(session: PortableSession): number[] {
 
 function codexTurnId(sessionId: string, turnIndex: number): string {
   return deterministicCodexUuid(`${sessionId}:turn:${turnIndex}`);
-}
-
-function codexMessageId(sessionId: string, turnIndex: number, messageIndex: number): string {
-  return `msg_${deterministicCodexUuid(`${sessionId}:turn:${turnIndex}:message:${messageIndex}`)}`;
 }
 
 function deterministicCodexUuid(seed: string): string {
@@ -1089,7 +1081,7 @@ function validateCodexStructure(
         row?.type !== "response_item"
         || row.timestamp !== message.timestamp
         || messagePayload?.type !== "message"
-        || messagePayload.id !== codexMessageId(sessionId, turnIndex, message.index)
+        || messagePayload.id !== undefined
         || messagePayload.role !== message.role
         || (message.role === "assistant" && messagePayload.phase !== "final_answer")
         || (message.role === "user" && messagePayload.phase !== undefined)

--- a/apps/main-2.0/src/core/session-migration-writers.ts
+++ b/apps/main-2.0/src/core/session-migration-writers.ts
@@ -210,6 +210,7 @@ function serializeCodex(
         timestamp: message.timestamp,
         payload: {
           type: "message",
+          id: codexStatelessItemId(`${sessionId}:turn:${turnIndex}:message:${message.index}`),
           role: message.role,
           content: [{
             type: message.role === "user" ? "input_text" : "output_text",
@@ -233,7 +234,7 @@ function serializeCodex(
     }
 
     if (includeVsCodeEvents) {
-      rows.push(...codexSubagentActivityRows(session, sessionId, turnIndex, turnId));
+      rows.push(...codexSubagentActivityRows(session, sessionId, turnIndex));
     }
 
     if (includeVsCodeEvents) {
@@ -261,7 +262,6 @@ function codexSubagentActivityRows(
   session: PortableSession,
   sessionId: string,
   turnIndex: number,
-  turnId: string,
 ): unknown[] {
   const boundaries = codexTurnBoundaries(session);
   const turnStartTimes = boundaries.map((boundary) => timestampMs(session.messages[boundary]?.timestamp ?? session.startedAt));
@@ -277,54 +277,22 @@ function codexSubagentActivityRows(
       return assignedTurn === turnIndex;
     })
     .sort((left, right) => timestampMs(left.startedAt) - timestampMs(right.startedAt))
-    .flatMap((subagent) => {
+    .map((subagent) => {
       const childSessionId = subagent.sourceSessionId!;
-      const digest = crypto.createHash("sha256").update(`${sessionId}:subagent:${childSessionId}`).digest("hex");
-      const callId = `call_migrated_${digest.slice(0, 24)}`;
-      const taskName = codexSubagentTaskName(subagent);
       const agentPath = codexSubagentPath(subagent);
-      return [{
-        type: "response_item",
-        timestamp: subagent.startedAt,
-        payload: {
-          type: "function_call",
-          name: "spawn_agent",
-          namespace: "collaboration",
-          arguments: JSON.stringify({
-            task_name: taskName,
-            fork_turns: "all",
-            message: subagent.title || taskName,
-          }),
-          call_id: callId,
-          internal_chat_message_metadata_passthrough: { turn_id: turnId },
-        },
-      }, {
+      return {
         type: "event_msg",
         timestamp: subagent.startedAt,
         payload: {
           type: "sub_agent_activity",
-          event_id: callId,
+          event_id: codexStatelessItemId(`${sessionId}:subagent:${childSessionId}:activity`),
           occurred_at_ms: timestampMs(subagent.startedAt),
           agent_thread_id: childSessionId,
           agent_path: agentPath,
           kind: "started",
         },
-      }, {
-        type: "response_item",
-        timestamp: subagent.startedAt,
-        payload: {
-          type: "function_call_output",
-          call_id: callId,
-          output: JSON.stringify({ task_name: agentPath }),
-          internal_chat_message_metadata_passthrough: { turn_id: turnId },
-        },
-      }];
+      };
     });
-}
-
-function codexSubagentTaskName(session: PortableSession): string {
-  const sourceId = session.sourceSessionKey.split(":").at(-1) || session.title || "subagent";
-  return sourceId.replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^_+|_+$/g, "").slice(0, 64) || "subagent";
 }
 
 function codexTurnBoundaries(session: PortableSession): number[] {
@@ -343,6 +311,12 @@ function codexTurnBoundaries(session: PortableSession): number[] {
 
 function codexTurnId(sessionId: string, turnIndex: number): string {
   return deterministicCodexUuid(`${sessionId}:turn:${turnIndex}`);
+}
+
+function codexStatelessItemId(seed: string): string {
+  // Codex keeps a non-empty local item id while rebuilding resumed history, then
+  // strips legacy ids without an underscore before a stateless Responses request.
+  return deterministicCodexUuid(`response-item:${seed}`);
 }
 
 function deterministicCodexUuid(seed: string): string {
@@ -1020,7 +994,6 @@ function validateCodexStructure(
         session,
         sessionId,
         turnIndex,
-        codexTurnId(sessionId, turnIndex),
       ))
     : [];
   const expectedRows = 1
@@ -1081,7 +1054,7 @@ function validateCodexStructure(
         row?.type !== "response_item"
         || row.timestamp !== message.timestamp
         || messagePayload?.type !== "message"
-        || messagePayload.id !== undefined
+        || messagePayload.id !== codexStatelessItemId(`${sessionId}:turn:${turnIndex}:message:${message.index}`)
         || messagePayload.role !== message.role
         || (message.role === "assistant" && messagePayload.phase !== "final_answer")
         || (message.role === "user" && messagePayload.phase !== undefined)
@@ -1107,7 +1080,7 @@ function validateCodexStructure(
     }
 
     if (includeVsCodeEvents) {
-      const expectedActivities = codexSubagentActivityRows(session, sessionId, turnIndex, turnId);
+      const expectedActivities = codexSubagentActivityRows(session, sessionId, turnIndex);
       const actualActivities = rows.slice(rowIndex, rowIndex + expectedActivities.length);
       if (JSON.stringify(actualActivities) !== JSON.stringify(expectedActivities)) {
         failValidation("codex", "has invalid subagent activity metadata");

--- a/apps/main-2.0/src/main/index.ts
+++ b/apps/main-2.0/src/main/index.ts
@@ -48,6 +48,7 @@ import {
   revealInFileManager,
 } from "../core/platform";
 import { loadUsageQuotaSnapshot } from "../core/quota";
+import { repairLegacyAgentRecallCodexRollouts } from "../core/codex-migration-repair";
 import { setLiveSessionTerminalTitle } from "../core/session-focus";
 import { setSessionCustomTitleAndSyncTerminal } from "../core/session-title-sync";
 import { createCachedLiveSessionSnapshotLoader } from "../core/session-activity";
@@ -2825,7 +2826,17 @@ app.whenReady().then(async () => {
   }
   const initialIndexSettled = new Promise<void>((resolve) => {
     startupTasks.schedule(INITIAL_INDEX_DELAY_MS, () => {
-      void runIndexSync().then(() => resolve(), () => resolve());
+      void (async () => {
+        try {
+          const repair = await repairLegacyAgentRecallCodexRollouts(homedir());
+          if (repair.failedFiles > 0) {
+            console.warn(`[session-migration] ${repair.failedFiles} legacy Codex rollout(s) could not be repaired; they will be retried on the next startup.`);
+          }
+        } catch (error) {
+          console.warn("[session-migration] Legacy Codex rollout repair failed; startup indexing will continue.", error);
+        }
+        await runIndexSync();
+      })().then(() => resolve(), () => resolve());
     });
   });
   startAutoIndexRefresh();


### PR DESCRIPTION
## 问题

迁移到 Codex 的部分历史记录使用了 AgentRecall 合成的 `msg_`、`fc_` 和 `fco_` 条目 ID。新版 Codex 会把这类带下划线的 ID 看成可被上游引用的 Responses 对象，并在 `store:false` 的续聊请求中带出；无状态上游无法解析后返回 400，界面只显示 `Upstream request failed`。

只修改迁移 writer 无法修复用户已经生成的旧会话；直接重写大会话文件又可能破坏正在追加的 Codex 历史，因此旧文件需要严格限制修改范围。

## 修改

- V1、V2 对新迁移到 Codex/TCodex 的消息写入确定性、非空且无下划线的本地 UUID。Codex 可稳定读取本地历史，并会在无状态请求前清除这些 legacy ID。
- 新迁移不再为子 Agent 伪造 `spawn_agent` 工具调用和输出，避免无关工具历史进入下一轮模型请求；保留 App 使用的 `sub_agent_activity`、目标 thread ID 和父子状态关系。
- 启动时只识别 `agent-recall` / `agent-recall-v2` 且版本为 `migration` 的已有 rollout。对确认属于旧 writer 的 `msg_` / `fc_` / `fco_`，只将下划线原位改为连字符：每项仅修改一个字节，不替换文件、不移动偏移、不碰消息正文、时间戳、原生 Codex 会话或后来追加的原生轮次。
- 更早期的无 ID 消息保持逐字节不变；扫描仍会继续修复其后已知的旧子 Agent 条目。确认完整后只写一个字节的完成标记，避免 V1/V2 每次启动重复扫描大会话。
- T-Codex 没有显式轮次事件时，通过 writer 的确定性 ID 在单调候选范围内恢复真实轮次，支持同一轮包含多条用户消息，同时不会误改后续原生消息。
- 所有受支持来源迁移到 Codex family 都走同一目标 writer，因此覆盖 Cursor、Claude、Codex、CodeBuddy、CodeWiz 等来源，而非只处理 Cursor。
- release note 明确路由到 V1、V2 两条发布线。

## 验证

- 使用隔离的临时 HOME/CODEX_HOME、Codex 0.147 App Server 和严格本地 Responses mock，完成 `thread/read → thread/resume → turn/start`；旧无 ID、旧前缀 ID、Cursor 父子会话和 T-Codex 四类 fixture 均可继续输入并收到 `turn/completed`。
- 真实 `store:false` 请求不含迁移历史的条目 ID；新迁移也不含合成的 `function_call` / `function_call_output`。
- 子 Agent 活动仍指向可读取的 child thread，父子关系保持正确。
- 旧会话修复测试覆盖 V1/V2 originator、Codex/TCodex、旧 ID、无 ID、部分修复、旧单轮格式、非标准轮次、原生会话不变、后续原生轮次不变、文件长度不变和重复执行幂等。
- V1 完整测试：99 个文件，1358 项通过（另 1 项跳过）；79 项脚本测试通过。
- V2 完整测试和 145 项脚本测试通过；V1/V2 TypeScript typecheck 通过。
- `npm run release-note:check` 通过，release target 为 `both`。
- 最终代码审查未发现会导致无法续聊、历史损坏、子 Agent 跳转失效或 V1/V2 不一致的阻断问题。
