### PR TITLE
ci: reuse unchanged OpenViking runtimes

### DIFF
--- a/.github/openviking-runtime-inputs.json
+++ b/.github/openviking-runtime-inputs.json
@@ -1,0 +1,34 @@
+{
+  "schemaVersion": 1,
+  "runtimeVersion": "0.4.11-r4",
+  "nodeVersion": "22.23.1",
+  "rustToolchain": "1.97.1",
+  "fingerprintFiles": [
+    "apps/main-2.0/package.json",
+    "apps/main-2.0/package-lock.json",
+    "apps/main-2.0/scripts/build-openviking-runtime.mjs"
+  ],
+  "targets": [
+    {
+      "runner": "macos-15",
+      "platform": "darwin",
+      "arch": "arm64",
+      "python_url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.12.13%2B20260510-aarch64-apple-darwin-install_only_stripped.tar.gz",
+      "python_sha256": "55bc1a5edbc8ac4da0081f4f5731ed2d1ed10c57cb37a820b2a0dbc7cad742e9"
+    },
+    {
+      "runner": "macos-15-intel",
+      "platform": "darwin",
+      "arch": "x64",
+      "python_url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.12.13%2B20260510-x86_64-apple-darwin-install_only_stripped.tar.gz",
+      "python_sha256": "6bab7fa97d4f2ddba86da0e05acff66c53b5edaca1df8edcf00ddca785a9c59b"
+    },
+    {
+      "runner": "windows-2025",
+      "platform": "win32",
+      "arch": "x64",
+      "python_url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.12.13%2B20260510-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
+      "python_sha256": "24168aff2e7d93784c6a436124c4ebb79b076a4e289bde4902c08333507b71d0"
+    }
+  ]
+}

--- a/.github/scripts/probe-openviking-runtime-release.mjs
+++ b/.github/scripts/probe-openviking-runtime-release.mjs
@@ -1,0 +1,526 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MAX_SMALL_ASSET_BYTES = 64 * 1024;
+const REQUIRED_FINGERPRINT_FILES = [
+  "apps/main-2.0/package.json",
+  "apps/main-2.0/package-lock.json",
+  "apps/main-2.0/scripts/build-openviking-runtime.mjs",
+];
+
+export const OPENVIKING_RUNTIME_TARGETS = [
+  { platform: "darwin", arch: "arm64", executablePath: "bin/openviking-server" },
+  { platform: "darwin", arch: "x64", executablePath: "bin/openviking-server" },
+  { platform: "win32", arch: "x64", executablePath: "Scripts/openviking-server.exe" },
+];
+
+export function runtimeReleaseAssetNames(version) {
+  assertToken(version, "version");
+  return OPENVIKING_RUNTIME_TARGETS.flatMap(({ platform, arch }) => {
+    const archive = `openviking-runtime-${version}-${platform}-${arch}.tar.gz`;
+    return [archive, `${archive}.json`];
+  });
+}
+
+export function runtimeInputsSidecarName(version) {
+  assertToken(version, "version");
+  return `openviking-runtime-${version}-inputs.json`;
+}
+
+export async function loadOpenVikingRuntimeInputs({ configPath, rootDirectory = process.cwd() }) {
+  const root = path.resolve(rootDirectory);
+  const resolvedConfig = path.resolve(configPath);
+  assertPathInside(root, resolvedConfig, "runtime input config");
+  const configBytes = await readFile(resolvedConfig);
+  const config = JSON.parse(configBytes.toString("utf8"));
+  validateRuntimeInputConfig(config);
+
+  const fingerprintFiles = [...config.fingerprintFiles].sort();
+  const inputs = [{ name: slashPath(path.relative(root, resolvedConfig)), bytes: configBytes }];
+  for (const name of fingerprintFiles) {
+    const resolved = path.resolve(root, name);
+    assertPathInside(root, resolved, `fingerprint input ${name}`);
+    inputs.push({ name, bytes: normalizeRuntimeFingerprintInput(name, await readFile(resolved)) });
+  }
+
+  const hash = createHash("sha256");
+  hash.update("agent-recall-openviking-runtime-inputs-v1\0");
+  for (const input of inputs) {
+    hash.update(`${input.name}\0${input.bytes.byteLength}\0`);
+    hash.update(input.bytes);
+    hash.update("\0");
+  }
+  const inputFingerprint = `sha256:${hash.digest("hex")}`;
+  return {
+    config,
+    inputFingerprint,
+    matrix: { include: config.targets },
+    sidecarName: runtimeInputsSidecarName(config.runtimeVersion),
+  };
+}
+
+function normalizeRuntimeFingerprintInput(name, bytes) {
+  if (name !== "apps/main-2.0/package.json" && name !== "apps/main-2.0/package-lock.json") {
+    return bytes;
+  }
+
+  const parsed = JSON.parse(bytes.toString("utf8"));
+  parsed.version = "<release-version>";
+  if (name.endsWith("package-lock.json") && parsed.packages?.[""]) {
+    parsed.packages[""].version = "<release-version>";
+  }
+  return Buffer.from(`${JSON.stringify(parsed, null, 2)}\n`);
+}
+
+export function createRuntimeInputsSidecar({ runtimeVersion, inputFingerprint, runtimeAssets }) {
+  assertToken(runtimeVersion, "version");
+  assertFingerprint(inputFingerprint);
+  validateRuntimeAssetRecords(runtimeAssets, runtimeVersion);
+  return Buffer.from(`${JSON.stringify({
+    schemaVersion: 1,
+    runtimeVersion,
+    inputFingerprint,
+    runtimeAssets,
+  }, null, 2)}\n`);
+}
+
+export async function describeLocalRuntimeAssets(directory, runtimeVersion) {
+  const records = [];
+  for (const name of runtimeReleaseAssetNames(runtimeVersion)) {
+    const filePath = path.join(directory, name);
+    const metadata = await stat(filePath);
+    if (!metadata.isFile() || !Number.isSafeInteger(metadata.size) || metadata.size <= 0) {
+      throw new Error(`OpenViking runtime asset ${name} is invalid.`);
+    }
+    records.push({ name, size: metadata.size, sha256: await sha256File(filePath) });
+  }
+  return records;
+}
+
+export async function verifyLocalRuntimeAssets({ directory, runtimeVersion, inputFingerprint }) {
+  const sidecarName = runtimeInputsSidecarName(runtimeVersion);
+  const sidecar = parseRuntimeInputsSidecar(
+    await readFile(path.join(directory, sidecarName)),
+    { runtimeVersion, inputFingerprint },
+  );
+  for (const record of sidecar.runtimeAssets) {
+    const filePath = path.join(directory, record.name);
+    const metadata = await stat(filePath);
+    if (
+      !metadata.isFile()
+      || metadata.size !== record.size
+      || await sha256File(filePath) !== record.sha256
+    ) {
+      throw new Error(`OpenViking runtime asset ${record.name} does not match its input sidecar.`);
+    }
+  }
+  for (const target of OPENVIKING_RUNTIME_TARGETS) {
+    const archiveName = `openviking-runtime-${runtimeVersion}-${target.platform}-${target.arch}.tar.gz`;
+    const manifestName = `${archiveName}.json`;
+    const archiveRecord = sidecar.runtimeAssets.find(({ name }) => name === archiveName);
+    const manifest = JSON.parse(await readFile(path.join(directory, manifestName), "utf8"));
+    if (!validRuntimeManifest(manifest, { runtimeVersion, target, archiveName, archiveSha256: archiveRecord.sha256 })) {
+      throw new Error(`OpenViking runtime manifest ${manifestName} does not match its archive.`);
+    }
+  }
+  return sidecar;
+}
+
+function validateRuntimeAssetRecords(records, runtimeVersion) {
+  const expectedNames = runtimeReleaseAssetNames(runtimeVersion);
+  if (!Array.isArray(records) || records.length !== expectedNames.length) {
+    throw new Error("OpenViking runtime input sidecar has an invalid asset set.");
+  }
+  for (let index = 0; index < expectedNames.length; index += 1) {
+    const record = records[index];
+    if (
+      !record
+      || typeof record !== "object"
+      || Array.isArray(record)
+      || Object.keys(record).sort().join(",") !== "name,sha256,size"
+      || record.name !== expectedNames[index]
+      || !Number.isSafeInteger(record.size)
+      || record.size <= 0
+      || typeof record.sha256 !== "string"
+      || !/^[a-f0-9]{64}$/u.test(record.sha256)
+    ) {
+      throw new Error(`OpenViking runtime input sidecar has an invalid asset record at index ${index}.`);
+    }
+  }
+}
+
+function parseRuntimeInputsSidecar(bytes, { runtimeVersion, inputFingerprint }) {
+  if (!Buffer.isBuffer(bytes) || bytes.byteLength <= 0 || bytes.byteLength > MAX_SMALL_ASSET_BYTES) {
+    throw new Error("OpenViking runtime input sidecar is invalid.");
+  }
+  let sidecar;
+  try {
+    sidecar = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new Error("OpenViking runtime input sidecar is not valid JSON.");
+  }
+  if (
+    !sidecar
+    || typeof sidecar !== "object"
+    || Array.isArray(sidecar)
+    || Object.keys(sidecar).sort().join(",") !== "inputFingerprint,runtimeAssets,runtimeVersion,schemaVersion"
+    || sidecar.schemaVersion !== 1
+    || sidecar.runtimeVersion !== runtimeVersion
+  ) {
+    throw new Error("OpenViking runtime input sidecar metadata is invalid.");
+  }
+  assertFingerprint(sidecar.inputFingerprint);
+  if (sidecar.inputFingerprint !== inputFingerprint) {
+    const error = new Error("OpenViking runtime input fingerprint changed without a runtime revision bump.");
+    error.code = "FINGERPRINT_MISMATCH";
+    throw error;
+  }
+  validateRuntimeAssetRecords(sidecar.runtimeAssets, runtimeVersion);
+  return sidecar;
+}
+
+function validRuntimeManifest(manifest, {
+  runtimeVersion,
+  target,
+  archiveName,
+  archiveSha256,
+}) {
+  return manifest
+    && typeof manifest === "object"
+    && !Array.isArray(manifest)
+    && manifest.version === runtimeVersion
+    && manifest.platform === target.platform
+    && manifest.arch === target.arch
+    && manifest.sha256 === archiveSha256
+    && manifest.archiveType === "tar.gz"
+    && manifest.executablePath === target.executablePath
+    && manifest.file === archiveName;
+}
+
+export function probeOpenVikingRuntimeRelease({
+  release,
+  expectedTag,
+  runtimeVersion,
+  inputFingerprint,
+  smallAssets,
+}) {
+  assertToken(runtimeVersion, "version");
+  assertFingerprint(inputFingerprint);
+  if (!/^v2-[0-9]+\.[0-9]+\.[0-9]+$/u.test(String(expectedTag ?? ""))) {
+    return miss("source tag is not a versioned V2 release tag");
+  }
+  if (
+    !release
+    || typeof release !== "object"
+    || release.tag_name !== expectedTag
+    || release.draft !== false
+    || release.prerelease !== false
+    || typeof release.published_at !== "string"
+    || !Number.isFinite(Date.parse(release.published_at))
+  ) {
+    return miss("release metadata does not identify the expected published V2 release");
+  }
+  if (!Array.isArray(release.assets)) return miss("release assets are missing");
+
+  const expectedRuntimeAssets = runtimeReleaseAssetNames(runtimeVersion);
+  const sidecarName = runtimeInputsSidecarName(runtimeVersion);
+  const expectedCurrentAssets = new Set([...expectedRuntimeAssets, sidecarName]);
+  const currentRuntimePrefix = `openviking-runtime-${runtimeVersion}-`;
+  const assets = new Map();
+  for (const asset of release.assets) {
+    if (!asset || typeof asset !== "object" || typeof asset.name !== "string") continue;
+    if (assets.has(asset.name)) return miss(`release contains duplicate asset ${asset.name}`);
+    if (asset.name.startsWith(currentRuntimePrefix) && !expectedCurrentAssets.has(asset.name)) {
+      return miss(`release contains unexpected current runtime asset ${asset.name}`);
+    }
+    assets.set(asset.name, asset);
+  }
+
+  const sidecarAsset = assets.get(sidecarName);
+  if (!sidecarAsset) {
+    return miss("published release predates runtime input sidecars", { legacyBootstrap: true });
+  }
+  const sidecarDigest = validAssetDigest(sidecarAsset, { maxSize: MAX_SMALL_ASSET_BYTES });
+  const sidecarBytes = smallAssets?.get(sidecarName);
+  if (!sidecarDigest || !Buffer.isBuffer(sidecarBytes)) return miss("trusted runtime input sidecar is invalid");
+  if (sidecarBytes.byteLength !== sidecarAsset.size) return miss("runtime input sidecar size does not match GitHub");
+  if (sha256(sidecarBytes) !== sidecarDigest) return miss("runtime input sidecar digest does not match GitHub");
+
+  let sidecar;
+  try {
+    sidecar = parseRuntimeInputsSidecar(sidecarBytes, { runtimeVersion, inputFingerprint });
+  } catch (error) {
+    return miss(
+      error?.code === "FINGERPRINT_MISMATCH"
+        ? "runtime input fingerprint changed without a runtime revision bump"
+        : "runtime input sidecar does not match the current build inputs",
+      { hardFailure: error?.code === "FINGERPRINT_MISMATCH" },
+    );
+  }
+  const records = new Map(sidecar.runtimeAssets.map((record) => [record.name, record]));
+
+  for (const target of OPENVIKING_RUNTIME_TARGETS) {
+    const archiveName = `openviking-runtime-${runtimeVersion}-${target.platform}-${target.arch}.tar.gz`;
+    const manifestName = `${archiveName}.json`;
+    const archiveAsset = assets.get(archiveName);
+    const manifestAsset = assets.get(manifestName);
+    const archiveDigest = validAssetDigest(archiveAsset, { maxSize: Number.MAX_SAFE_INTEGER });
+    const manifestDigest = validAssetDigest(manifestAsset, { maxSize: MAX_SMALL_ASSET_BYTES });
+    if (!archiveDigest || !manifestDigest) {
+      return miss(`release is missing trusted metadata for ${target.platform}-${target.arch}`);
+    }
+    const archiveRecord = records.get(archiveName);
+    const manifestRecord = records.get(manifestName);
+    if (
+      archiveRecord.size !== archiveAsset.size
+      || archiveRecord.sha256 !== archiveDigest
+      || manifestRecord.size !== manifestAsset.size
+      || manifestRecord.sha256 !== manifestDigest
+    ) {
+      return miss(`runtime input sidecar does not match GitHub metadata for ${target.platform}-${target.arch}`);
+    }
+
+    const bytes = smallAssets?.get(manifestName);
+    if (!Buffer.isBuffer(bytes)) return miss(`downloaded manifest ${manifestName} is missing`);
+    if (bytes.byteLength !== manifestAsset.size) return miss(`manifest ${manifestName} size does not match GitHub`);
+    if (sha256(bytes) !== manifestDigest) return miss(`manifest ${manifestName} digest does not match GitHub`);
+
+    let manifest;
+    try {
+      manifest = JSON.parse(bytes.toString("utf8"));
+    } catch {
+      return miss(`manifest ${manifestName} is not valid JSON`);
+    }
+    if (!validRuntimeManifest(manifest, {
+      runtimeVersion,
+      target,
+      archiveName,
+      archiveSha256: archiveDigest,
+    })) {
+      return miss(`manifest ${manifestName} does not match its GitHub archive asset`);
+    }
+  }
+
+  return { reusable: true, runtimeSourceTag: expectedTag };
+}
+
+async function probeFromFiles({ releaseJson, smallAssetDirectory, expectedTag, inputs }) {
+  const release = JSON.parse(await readFile(releaseJson, "utf8"));
+  const smallAssets = new Map();
+  const names = [
+    runtimeInputsSidecarName(inputs.config.runtimeVersion),
+    ...runtimeReleaseAssetNames(inputs.config.runtimeVersion).filter((name) => name.endsWith(".json")),
+  ];
+  for (const name of names) {
+    try {
+      smallAssets.set(name, await readFile(path.join(smallAssetDirectory, name)));
+    } catch {
+      // The pure probe reports missing files as a reusable-cache miss.
+    }
+  }
+  return probeOpenVikingRuntimeRelease({
+    release,
+    expectedTag,
+    runtimeVersion: inputs.config.runtimeVersion,
+    inputFingerprint: inputs.inputFingerprint,
+    smallAssets,
+  });
+}
+
+function validateRuntimeInputConfig(config) {
+  if (!config || typeof config !== "object" || Array.isArray(config) || config.schemaVersion !== 1) {
+    throw new Error("OpenViking runtime input config is invalid.");
+  }
+  assertToken(config.runtimeVersion, "version");
+  assertToken(config.nodeVersion, "Node.js version");
+  assertToken(config.rustToolchain, "Rust toolchain");
+  if (!Array.isArray(config.fingerprintFiles) || !Array.isArray(config.targets)) {
+    throw new Error("OpenViking runtime input config is incomplete.");
+  }
+  const fingerprints = new Set();
+  for (const name of config.fingerprintFiles) {
+    if (!isSafeRepositoryPath(name) || fingerprints.has(name)) {
+      throw new Error("OpenViking runtime fingerprint file list is invalid.");
+    }
+    fingerprints.add(name);
+  }
+  for (const required of REQUIRED_FINGERPRINT_FILES) {
+    if (!fingerprints.has(required)) throw new Error(`OpenViking runtime fingerprint omits ${required}.`);
+  }
+
+  const expectedTargets = new Map(OPENVIKING_RUNTIME_TARGETS.map((target) => [
+    `${target.platform}-${target.arch}`,
+    target,
+  ]));
+  const actualTargets = new Set();
+  for (const target of config.targets) {
+    const key = `${target?.platform}-${target?.arch}`;
+    if (
+      !expectedTargets.has(key)
+      || actualTargets.has(key)
+      || typeof target.runner !== "string"
+      || !target.runner.trim()
+      || typeof target.python_url !== "string"
+      || !isTrustedPythonUrl(target.python_url)
+      || typeof target.python_sha256 !== "string"
+      || !/^[a-f0-9]{64}$/u.test(target.python_sha256)
+    ) {
+      throw new Error("OpenViking runtime target matrix is invalid.");
+    }
+    actualTargets.add(key);
+  }
+  if (actualTargets.size !== expectedTargets.size) throw new Error("OpenViking runtime target matrix is incomplete.");
+}
+
+function isTrustedPythonUrl(value) {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:"
+      && url.hostname === "github.com"
+      && url.pathname.startsWith("/astral-sh/python-build-standalone/releases/download/");
+  } catch {
+    return false;
+  }
+}
+
+function validAssetDigest(asset, { maxSize }) {
+  if (
+    !asset
+    || typeof asset !== "object"
+    || asset.state !== "uploaded"
+    || !Number.isSafeInteger(asset.size)
+    || asset.size <= 0
+    || asset.size > maxSize
+    || typeof asset.digest !== "string"
+    || !/^sha256:[a-f0-9]{64}$/u.test(asset.digest)
+  ) return null;
+  return asset.digest.slice("sha256:".length);
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function sha256File(filePath) {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(filePath)) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+function miss(reason, options = {}) {
+  return {
+    reusable: false,
+    reason,
+    legacyBootstrap: options.legacyBootstrap === true,
+    hardFailure: options.hardFailure === true,
+  };
+}
+
+function assertFingerprint(value) {
+  if (!/^sha256:[a-f0-9]{64}$/u.test(String(value ?? ""))) {
+    throw new Error("OpenViking runtime input fingerprint is invalid.");
+  }
+}
+
+function assertToken(value, label) {
+  if (!/^[0-9A-Za-z][0-9A-Za-z._-]{0,63}$/u.test(String(value ?? ""))) {
+    throw new Error(`OpenViking runtime ${label} is invalid.`);
+  }
+}
+
+function isSafeRepositoryPath(value) {
+  return typeof value === "string"
+    && value.length > 0
+    && !path.isAbsolute(value)
+    && !value.includes("\\")
+    && value.split("/").every((segment) => segment && segment !== "." && segment !== "..");
+}
+
+function assertPathInside(root, candidate, label) {
+  const relative = path.relative(root, candidate);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`OpenViking ${label} must stay inside the repository.`);
+  }
+}
+
+function slashPath(value) {
+  return value.split(path.sep).join("/");
+}
+
+function argumentValue(args, name) {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+async function main(args) {
+  const configPath = argumentValue(args, "--config");
+  if (!configPath) throw new Error("--config is required.");
+  const inputs = await loadOpenVikingRuntimeInputs({ configPath });
+
+  if (args.includes("--describe")) {
+    process.stdout.write(`${JSON.stringify({
+      runtimeVersion: inputs.config.runtimeVersion,
+      nodeVersion: inputs.config.nodeVersion,
+      rustToolchain: inputs.config.rustToolchain,
+      inputFingerprint: inputs.inputFingerprint,
+      matrix: inputs.matrix,
+      sidecarName: inputs.sidecarName,
+    })}\n`);
+    return;
+  }
+
+  const sidecarOutput = argumentValue(args, "--write-sidecar");
+  if (sidecarOutput) {
+    const outputDirectory = path.dirname(path.resolve(sidecarOutput));
+    await mkdir(outputDirectory, { recursive: true });
+    const runtimeAssets = await describeLocalRuntimeAssets(
+      outputDirectory,
+      inputs.config.runtimeVersion,
+    );
+    await writeFile(sidecarOutput, createRuntimeInputsSidecar({
+      runtimeVersion: inputs.config.runtimeVersion,
+      inputFingerprint: inputs.inputFingerprint,
+      runtimeAssets,
+    }));
+    process.stdout.write(`${inputs.inputFingerprint}\n`);
+    return;
+  }
+
+  const localAssetDirectory = argumentValue(args, "--verify-local-assets");
+  if (localAssetDirectory) {
+    await verifyLocalRuntimeAssets({
+      directory: path.resolve(localAssetDirectory),
+      runtimeVersion: inputs.config.runtimeVersion,
+      inputFingerprint: inputs.inputFingerprint,
+    });
+    process.stdout.write(`${inputs.inputFingerprint}\n`);
+    return;
+  }
+
+  const releaseJson = argumentValue(args, "--release-json");
+  const smallAssetDirectory = argumentValue(args, "--small-assets-dir");
+  const expectedTag = argumentValue(args, "--tag");
+  if (!releaseJson || !smallAssetDirectory || !expectedTag) {
+    throw new Error("Probe requires --release-json, --small-assets-dir, and --tag.");
+  }
+  const result = await probeFromFiles({ releaseJson, smallAssetDirectory, expectedTag, inputs });
+  if (!result.reusable) {
+    process.stderr.write(`OpenViking runtime reuse miss: ${result.reason}\n`);
+    process.exitCode = result.hardFailure ? 1 : 2;
+    return;
+  }
+  process.stdout.write(`${result.runtimeSourceTag}\n`);
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/probe-v2-stable-release.mjs
+++ b/.github/scripts/probe-v2-stable-release.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const V2_STABLE_ASSET_NAMES = [
+  "agent-recall-v2.tgz",
+  "agent-recall-v2.tgz.sha256",
+  "update-v2.json",
+];
+
+const VERSIONED_V2_TAG = /^v2-(\d+\.\d+\.\d+)$/u;
+const COMMIT_SHA = /^[a-f0-9]{40}$/iu;
+const ASSET_DIGEST = /^sha256:[a-f0-9]{64}$/u;
+
+/**
+ * Returns true when the rolling v2-latest release must be repaired.
+ *
+ * The versioned source is authoritative, so malformed source metadata is a
+ * hard error. The rolling release is recoverable state: anything missing or
+ * inconsistent there simply requests a repair.
+ */
+export function probeV2StableRelease({
+  sourceRelease,
+  stableRelease,
+  sourceCommitSha,
+  stableCommitSha,
+}) {
+  const source = validateSourceRelease(sourceRelease, sourceCommitSha);
+  if (!isPublishedStableRelease(stableRelease)) return true;
+  if (!isCommitSha(stableCommitSha)) return true;
+  if (stableCommitSha.toLowerCase() !== source.commitSha) return true;
+
+  const stableAssets = collectStableAssets(stableRelease.assets);
+  if (!stableAssets) return true;
+  return V2_STABLE_ASSET_NAMES.some((name) => {
+    const expected = source.assets.get(name);
+    const actual = stableAssets.get(name);
+    return actual.size !== expected.size || actual.digest !== expected.digest;
+  });
+}
+
+function validateSourceRelease(release, commitSha) {
+  if (!release || typeof release !== "object" || Array.isArray(release)) {
+    throw new Error("Latest published V2 source release metadata is invalid.");
+  }
+  if (!VERSIONED_V2_TAG.test(String(release.tag_name ?? ""))) {
+    throw new Error("Latest published V2 source must use a versioned v2-x.y.z tag.");
+  }
+  if (
+    release.draft !== false
+    || release.prerelease !== false
+    || typeof release.published_at !== "string"
+    || !Number.isFinite(Date.parse(release.published_at))
+  ) {
+    throw new Error("Latest V2 source release is not a published stable release.");
+  }
+  if (!isCommitSha(commitSha)) {
+    throw new Error("Latest V2 source tag commit SHA is invalid.");
+  }
+  if (!Array.isArray(release.assets)) {
+    throw new Error("Latest V2 source release assets are missing.");
+  }
+
+  const assets = new Map();
+  for (const name of V2_STABLE_ASSET_NAMES) {
+    const matches = release.assets.filter((asset) => asset?.name === name);
+    if (matches.length !== 1 || !isTrustedAsset(matches[0])) {
+      throw new Error(`Latest V2 source release has an invalid ${name} asset.`);
+    }
+    assets.set(name, { size: matches[0].size, digest: matches[0].digest });
+  }
+  return { assets, commitSha: commitSha.toLowerCase() };
+}
+
+function isPublishedStableRelease(release) {
+  return Boolean(
+    release
+    && typeof release === "object"
+    && !Array.isArray(release)
+    && release.tag_name === "v2-latest"
+    && release.draft === false
+    && release.prerelease === false
+    && typeof release.published_at === "string"
+    && Number.isFinite(Date.parse(release.published_at))
+    && Array.isArray(release.assets),
+  );
+}
+
+function collectStableAssets(assets) {
+  const result = new Map();
+  for (const name of V2_STABLE_ASSET_NAMES) {
+    const matches = assets.filter((asset) => asset?.name === name);
+    if (matches.length !== 1 || !isTrustedAsset(matches[0])) return null;
+    result.set(name, { size: matches[0].size, digest: matches[0].digest });
+  }
+  return result;
+}
+
+function isTrustedAsset(asset) {
+  return Boolean(
+    asset
+    && typeof asset === "object"
+    && !Array.isArray(asset)
+    && asset.state === "uploaded"
+    && Number.isSafeInteger(asset.size)
+    && asset.size > 0
+    && typeof asset.digest === "string"
+    && ASSET_DIGEST.test(asset.digest),
+  );
+}
+
+function isCommitSha(value) {
+  return typeof value === "string" && COMMIT_SHA.test(value);
+}
+
+function argumentValue(args, name) {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+function usage() {
+  return [
+    "Usage:",
+    "  node .github/scripts/probe-v2-stable-release.mjs \\",
+    "    --source-release-json <path> \\",
+    "    --source-commit-sha <sha> \\",
+    "    [--stable-release-json <path>] \\",
+    "    [--stable-commit-sha <sha>]",
+    "",
+    "Prints true when v2-latest needs repair, otherwise false.",
+  ].join("\n");
+}
+
+async function readJson(filePath, label) {
+  let bytes;
+  try {
+    bytes = await readFile(path.resolve(filePath), "utf8");
+  } catch (error) {
+    throw new Error(`Could not read ${label}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  try {
+    return JSON.parse(bytes);
+  } catch {
+    throw new Error(`${label} is not valid JSON.`);
+  }
+}
+
+export async function runCli(args) {
+  if (args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+
+  const sourceReleasePath = argumentValue(args, "--source-release-json");
+  const sourceCommitSha = argumentValue(args, "--source-commit-sha");
+  const stableReleasePath = argumentValue(args, "--stable-release-json");
+  const stableCommitSha = argumentValue(args, "--stable-commit-sha");
+  if (!sourceReleasePath || !sourceCommitSha) {
+    throw new Error(usage());
+  }
+
+  const sourceRelease = await readJson(sourceReleasePath, "V2 source release JSON");
+  const stableRelease = stableReleasePath
+    ? await readJson(stableReleasePath, "v2-latest release JSON")
+    : null;
+  const repair = probeV2StableRelease({
+    sourceRelease,
+    stableRelease,
+    sourceCommitSha,
+    stableCommitSha,
+  });
+  process.stdout.write(`${repair}\n`);
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  runCli(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,34 +6,30 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: publish-release
   cancel-in-progress: false
 
+env:
+  OPENVIKING_RUNTIME_VERSION: 0.4.11-r4
+
 jobs:
-  openviking-runtime:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner: macos-15
-            platform: darwin
-            arch: arm64
-            python_url: https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.12.13%2B20260510-aarch64-apple-darwin-install_only_stripped.tar.gz
-            python_sha256: 55bc1a5edbc8ac4da0081f4f5731ed2d1ed10c57cb37a820b2a0dbc7cad742e9
-          - runner: macos-15-intel
-            platform: darwin
-            arch: x64
-            python_url: https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.12.13%2B20260510-x86_64-apple-darwin-install_only_stripped.tar.gz
-            python_sha256: 6bab7fa97d4f2ddba86da0e05acff66c53b5edaca1df8edcf00ddca785a9c59b
-          - runner: windows-2025
-            platform: win32
-            arch: x64
-            python_url: https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.12.13%2B20260510-x86_64-pc-windows-msvc-install_only_stripped.tar.gz
-            python_sha256: 24168aff2e7d93784c6a436124c4ebb79b076a4e289bde4902c08333507b71d0
-    runs-on: ${{ matrix.runner }}
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      v2_publish: ${{ steps.pending.outputs.v2_publish }}
+      latest_v2_tag: ${{ steps.pending.outputs.latest_v2_tag }}
+      v2_base_tag: ${{ steps.pending.outputs.v2_base_tag }}
+      v2_stable_repair: ${{ steps.stable.outputs.v2_stable_repair }}
+      runtime_reuse: ${{ steps.runtime.outputs.runtime_reuse }}
+      runtime_source_tag: ${{ steps.runtime.outputs.runtime_source_tag }}
+      runtime_fingerprint: ${{ steps.inputs.outputs.runtime_fingerprint }}
+      runtime_matrix: ${{ steps.inputs.outputs.runtime_matrix }}
+      runtime_node_version: ${{ steps.inputs.outputs.runtime_node_version }}
+      runtime_rust_toolchain: ${{ steps.inputs.outputs.runtime_rust_toolchain }}
+      runtime_sidecar_name: ${{ steps.inputs.outputs.runtime_sidecar_name }}
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -44,6 +40,24 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
+
+      - name: Describe OpenViking runtime inputs
+        id: inputs
+        shell: bash
+        run: |
+          description="$(node .github/scripts/probe-openviking-runtime-release.mjs \
+            --describe \
+            --config .github/openviking-runtime-inputs.json)"
+          configured_version="$(jq -r '.runtimeVersion' <<< "$description")"
+          if [ "$configured_version" != "$OPENVIKING_RUNTIME_VERSION" ]; then
+            echo "Workflow OpenViking runtime version does not match its input config." >&2
+            exit 1
+          fi
+          echo "runtime_fingerprint=$(jq -r '.inputFingerprint' <<< "$description")" >> "$GITHUB_OUTPUT"
+          echo "runtime_matrix=$(jq -c '.matrix' <<< "$description")" >> "$GITHUB_OUTPUT"
+          echo "runtime_node_version=$(jq -r '.nodeVersion' <<< "$description")" >> "$GITHUB_OUTPUT"
+          echo "runtime_rust_toolchain=$(jq -r '.rustToolchain' <<< "$description")" >> "$GITHUB_OUTPUT"
+          echo "runtime_sidecar_name=$(jq -r '.sidecarName' <<< "$description")" >> "$GITHUB_OUTPUT"
 
       - name: Detect pending V2 release
         id: pending
@@ -64,11 +78,9 @@ jobs:
               break
             fi
           done < <(printf '%s\n' "$published_tags_output")
-          if [ -z "$latest_v2_tag" ]; then
-            latest_v2_tag="$V2_BOOTSTRAP_TAG"
-          fi
-          git rev-parse "$latest_v2_tag" >/dev/null 2>&1 || {
-            echo "Published V2 release tag $latest_v2_tag does not exist in the checkout." >&2
+          v2_base_tag="${latest_v2_tag:-$V2_BOOTSTRAP_TAG}"
+          git rev-parse "$v2_base_tag" >/dev/null 2>&1 || {
+            echo "V2 release base tag $v2_base_tag does not exist in the checkout." >&2
             exit 1
           }
           v2_publish=false
@@ -79,23 +91,129 @@ jobs:
               v2_publish=true
               break
             fi
-          done < <(git diff --name-only --diff-filter=A "$latest_v2_tag" "$RELEASE_SHA" -- .release-notes | grep -Ev '/README\.md$' || true)
-          echo "publish=$v2_publish" >> "$GITHUB_OUTPUT"
+          done < <(git diff --name-only --diff-filter=A "$v2_base_tag" "$RELEASE_SHA" -- .release-notes | grep -Ev '/README\.md$' || true)
+          echo "v2_publish=$v2_publish" >> "$GITHUB_OUTPUT"
+          echo "latest_v2_tag=$latest_v2_tag" >> "$GITHUB_OUTPUT"
+          echo "v2_base_tag=$v2_base_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Detect stale V2 stable install release
+        id: stable
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LATEST_V2_TAG: ${{ steps.pending.outputs.latest_v2_tag }}
+          V2_LATEST_TAG: v2-latest
+        run: |
+          repair=false
+          if [ -n "$LATEST_V2_TAG" ]; then
+            probe_root="$(mktemp -d)"
+            trap 'rm -rf "$probe_root"' EXIT
+            source_release_json="$probe_root/source-release.json"
+            stable_release_json="$probe_root/stable-release.json"
+            stable_error="$probe_root/stable-error.txt"
+            gh api "repos/${GITHUB_REPOSITORY}/releases/tags/$LATEST_V2_TAG" > "$source_release_json"
+            source_commit_sha="$(git rev-parse "${LATEST_V2_TAG}^{commit}")"
+
+            stable_args=()
+            if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/$V2_LATEST_TAG" \
+                > "$stable_release_json" 2> "$stable_error"; then
+              stable_args+=(--stable-release-json "$stable_release_json")
+              if stable_commit_sha="$(git rev-parse -q --verify "refs/tags/${V2_LATEST_TAG}^{commit}")"; then
+                stable_args+=(--stable-commit-sha "$stable_commit_sha")
+              fi
+            elif ! grep -Eq 'HTTP 404|Not Found' "$stable_error"; then
+              cat "$stable_error" >&2
+              exit 1
+            fi
+
+            repair="$(node .github/scripts/probe-v2-stable-release.mjs \
+              --source-release-json "$source_release_json" \
+              --source-commit-sha "$source_commit_sha" \
+              "${stable_args[@]}")"
+          fi
+          echo "v2_stable_repair=$repair" >> "$GITHUB_OUTPUT"
+
+      - name: Probe published OpenViking runtime assets
+        id: runtime
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LATEST_V2_TAG: ${{ steps.pending.outputs.latest_v2_tag }}
+          RUNTIME_SIDECAR_NAME: ${{ steps.inputs.outputs.runtime_sidecar_name }}
+          V2_PUBLISH: ${{ steps.pending.outputs.v2_publish }}
+        run: |
+          runtime_reuse=false
+          runtime_source_tag=""
+          if [ "$V2_PUBLISH" = "true" ] && [ -n "$LATEST_V2_TAG" ]; then
+            probe_root="$(mktemp -d)"
+            trap 'rm -rf "$probe_root"' EXIT
+            release_json="$probe_root/release.json"
+            small_assets="$probe_root/small-assets"
+            mkdir -p "$small_assets"
+            gh api "repos/${GITHUB_REPOSITORY}/releases/tags/$LATEST_V2_TAG" > "$release_json"
+            download_status=0
+            gh release download "$LATEST_V2_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --dir "$small_assets" \
+              --pattern "$RUNTIME_SIDECAR_NAME" \
+              --pattern "openviking-runtime-${OPENVIKING_RUNTIME_VERSION}-darwin-arm64.tar.gz.json" \
+              --pattern "openviking-runtime-${OPENVIKING_RUNTIME_VERSION}-darwin-x64.tar.gz.json" \
+              --pattern "openviking-runtime-${OPENVIKING_RUNTIME_VERSION}-win32-x64.tar.gz.json" || download_status="$?"
+            probe_error="$probe_root/probe-error.txt"
+            if probed_tag="$(node .github/scripts/probe-openviking-runtime-release.mjs \
+                --config .github/openviking-runtime-inputs.json \
+                --release-json "$release_json" \
+                --small-assets-dir "$small_assets" \
+                --tag "$LATEST_V2_TAG" 2>"$probe_error")"; then
+              runtime_reuse=true
+              runtime_source_tag="$probed_tag"
+              echo "Reusing OpenViking runtime assets from $runtime_source_tag."
+            else
+              probe_status="$?"
+              if [ "$probe_status" = "2" ]; then
+                cat "$probe_error"
+                if [ "$download_status" != "0" ]; then
+                  echo "::notice::Published runtime metadata could not be downloaded completely."
+                fi
+                echo "::notice::Published runtime assets are not reusable; rebuilding all platforms."
+              else
+                cat "$probe_error" >&2
+                exit "$probe_status"
+              fi
+            fi
+          fi
+          echo "runtime_reuse=$runtime_reuse" >> "$GITHUB_OUTPUT"
+          echo "runtime_source_tag=$runtime_source_tag" >> "$GITHUB_OUTPUT"
+
+  openviking-runtime:
+    needs: plan
+    if: needs.plan.outputs.v2_publish == 'true' && needs.plan.outputs.runtime_reuse != 'true'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.runtime_matrix) }}
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ needs.plan.outputs.runtime_node_version }}
 
       - name: Install runtime build dependencies
-        if: steps.pending.outputs.publish == 'true'
-        run: npm run setup:v2
+        run: npm ci --prefix apps/main-2.0 --ignore-scripts
 
       - name: Prepare isolated Rust toolchain
-        if: steps.pending.outputs.publish == 'true'
         shell: bash
         env:
           RUSTUP_HOME: ${{ runner.temp }}/openviking-rustup
           CARGO_HOME: ${{ runner.temp }}/openviking-cargo
-        run: rustup default stable
+        run: rustup default "${{ needs.plan.outputs.runtime_rust_toolchain }}"
 
       - name: Build isolated OpenViking runtime
-        if: steps.pending.outputs.publish == 'true'
         shell: bash
         env:
           BUILD_HOME: ${{ runner.temp }}/openviking-build-home
@@ -106,7 +224,7 @@ jobs:
           PYTHON_SHA256: ${{ matrix.python_sha256 }}
         run: |
           node apps/main-2.0/scripts/build-openviking-runtime.mjs \
-            --version 0.4.11-r4 \
+            --version "$OPENVIKING_RUNTIME_VERSION" \
             --platform "${{ matrix.platform }}" \
             --arch "${{ matrix.arch }}" \
             --build-home "$BUILD_HOME" \
@@ -115,16 +233,34 @@ jobs:
             --python-sha256 "$PYTHON_SHA256"
 
       - name: Upload OpenViking runtime artifact
-        if: steps.pending.outputs.publish == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: openviking-runtime-${{ matrix.platform }}-${{ matrix.arch }}
           path: ${{ runner.temp }}/openviking-release/openviking-runtime-*
           if-no-files-found: error
+          overwrite: true
 
   release:
-    needs: openviking-runtime
+    needs: [plan, openviking-runtime]
+    if: >-
+      always() &&
+      !cancelled() &&
+      needs.plan.result == 'success' &&
+      (
+        needs.openviking-runtime.result == 'success' ||
+        (
+          needs.openviking-runtime.result == 'skipped' &&
+          (
+            needs.plan.outputs.v2_publish == 'false' ||
+            needs.plan.outputs.runtime_reuse == 'true'
+          )
+        )
+      )
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      v2_tag: ${{ steps.v2_version.outputs.tag }}
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -307,17 +443,77 @@ jobs:
               --output "$GITHUB_WORKSPACE/release/v2"
           fi
 
-      - name: Download OpenViking runtime artifacts
-        if: steps.pending.outputs.v2_publish == 'true' && steps.v2_version.outputs.release_required == 'true'
+      - name: Download reused OpenViking runtime artifacts
+        if: steps.pending.outputs.v2_publish == 'true' && steps.v2_version.outputs.release_required == 'true' && needs.plan.outputs.runtime_reuse == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUNTIME_SIDECAR_NAME: ${{ needs.plan.outputs.runtime_sidecar_name }}
+          RUNTIME_SOURCE_TAG: ${{ needs.plan.outputs.runtime_source_tag }}
+        run: |
+          gh release download "$RUNTIME_SOURCE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir release/v2 \
+            --pattern "$RUNTIME_SIDECAR_NAME" \
+            --pattern "openviking-runtime-${OPENVIKING_RUNTIME_VERSION}-darwin-arm64.tar.gz" \
+            --pattern "openviking-runtime-${OPENVIKING_RUNTIME_VERSION}-darwin-arm64.tar.gz.json" \
+            --pattern "openviking-runtime-${OPENVIKING_RUNTIME_VERSION}-darwin-x64.tar.gz" \
+            --pattern "openviking-runtime-${OPENVIKING_RUNTIME_VERSION}-darwin-x64.tar.gz.json" \
+            --pattern "openviking-runtime-${OPENVIKING_RUNTIME_VERSION}-win32-x64.tar.gz" \
+            --pattern "openviking-runtime-${OPENVIKING_RUNTIME_VERSION}-win32-x64.tar.gz.json"
+
+      - name: Reverify reused OpenViking runtime source
+        if: steps.pending.outputs.v2_publish == 'true' && steps.v2_version.outputs.release_required == 'true' && needs.plan.outputs.runtime_reuse == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUNTIME_SOURCE_TAG: ${{ needs.plan.outputs.runtime_source_tag }}
+        run: |
+          source_release_json="$RUNNER_TEMP/openviking-source-release.json"
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/$RUNTIME_SOURCE_TAG" > "$source_release_json"
+          verified_tag="$(node .github/scripts/probe-openviking-runtime-release.mjs \
+            --config .github/openviking-runtime-inputs.json \
+            --release-json "$source_release_json" \
+            --small-assets-dir release/v2 \
+            --tag "$RUNTIME_SOURCE_TAG")"
+          if [ "$verified_tag" != "$RUNTIME_SOURCE_TAG" ]; then
+            echo "Reused OpenViking runtime source changed after planning." >&2
+            exit 1
+          fi
+
+      - name: Download freshly built OpenViking runtime artifacts
+        if: steps.pending.outputs.v2_publish == 'true' && steps.v2_version.outputs.release_required == 'true' && needs.plan.outputs.runtime_reuse != 'true'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: openviking-runtime-*
           path: release/v2
           merge-multiple: true
 
+      - name: Write OpenViking runtime input sidecar
+        if: steps.pending.outputs.v2_publish == 'true' && steps.v2_version.outputs.release_required == 'true' && needs.plan.outputs.runtime_reuse != 'true'
+        env:
+          EXPECTED_RUNTIME_FINGERPRINT: ${{ needs.plan.outputs.runtime_fingerprint }}
+          RUNTIME_SIDECAR_NAME: ${{ needs.plan.outputs.runtime_sidecar_name }}
+        run: |
+          actual_fingerprint="$(node .github/scripts/probe-openviking-runtime-release.mjs \
+            --config .github/openviking-runtime-inputs.json \
+            --write-sidecar "release/v2/$RUNTIME_SIDECAR_NAME")"
+          if [ "$actual_fingerprint" != "$EXPECTED_RUNTIME_FINGERPRINT" ]; then
+            echo "OpenViking runtime inputs changed after planning." >&2
+            exit 1
+          fi
+
       - name: Verify OpenViking runtime artifacts
         if: steps.pending.outputs.v2_publish == 'true' && steps.v2_version.outputs.release_required == 'true'
-        run: node apps/main-2.0/scripts/verify-openviking-runtime-assets.mjs release/v2 0.4.11-r4
+        env:
+          EXPECTED_RUNTIME_FINGERPRINT: ${{ needs.plan.outputs.runtime_fingerprint }}
+        run: |
+          node apps/main-2.0/scripts/verify-openviking-runtime-assets.mjs release/v2 "$OPENVIKING_RUNTIME_VERSION"
+          actual_fingerprint="$(node .github/scripts/probe-openviking-runtime-release.mjs \
+            --config .github/openviking-runtime-inputs.json \
+            --verify-local-assets release/v2)"
+          if [ "$actual_fingerprint" != "$EXPECTED_RUNTIME_FINGERPRINT" ]; then
+            echo "OpenViking runtime inputs changed after planning." >&2
+            exit 1
+          fi
 
       - name: Publish V1 GitHub Release
         if: steps.pending.outputs.v1_publish == 'true' && steps.v1_version.outputs.release_required == 'true'
@@ -362,7 +558,9 @@ jobs:
       - name: Publish V2 GitHub Release
         if: steps.pending.outputs.v2_publish == 'true' && steps.v2_version.outputs.release_required == 'true'
         env:
+          EXPECTED_RUNTIME_FINGERPRINT: ${{ needs.plan.outputs.runtime_fingerprint }}
           GH_TOKEN: ${{ github.token }}
+          RUNTIME_SIDECAR_NAME: ${{ needs.plan.outputs.runtime_sidecar_name }}
           V2_TAG: ${{ steps.v2_version.outputs.tag }}
           V2_VERSION: ${{ steps.v2_version.outputs.version }}
           MERGED_SHA: ${{ github.sha }}
@@ -382,7 +580,14 @@ jobs:
           else
             gh release create "$V2_TAG" --draft --verify-tag --title "agent-recall-v2 v${V2_VERSION}" --notes-file release/v2/release-notes-v2.md --latest=false
           fi
-          gh release upload "$V2_TAG" release/v2/*.tgz release/v2/*.sha256 release/v2/update-v2.json release/v2/openviking-runtime-*.tar.gz release/v2/openviking-runtime-*.tar.gz.json --clobber
+          gh release upload "$V2_TAG" \
+            release/v2/*.tgz \
+            release/v2/*.sha256 \
+            release/v2/update-v2.json \
+            release/v2/openviking-runtime-*.tar.gz \
+            release/v2/openviking-runtime-*.tar.gz.json \
+            "release/v2/$RUNTIME_SIDECAR_NAME" \
+            --clobber
           verify_directory="$(mktemp -d)"
           trap 'rm -rf "$verify_directory"' EXIT
           gh release download "$V2_TAG" \
@@ -398,28 +603,110 @@ jobs:
             --version "$V2_VERSION" \
             --repository "$GITHUB_REPOSITORY" \
             --output "$verify_directory"
-          node apps/main-2.0/scripts/verify-openviking-runtime-assets.mjs "$verify_directory" 0.4.11-r4
+          node apps/main-2.0/scripts/verify-openviking-runtime-assets.mjs "$verify_directory" "$OPENVIKING_RUNTIME_VERSION"
+          downloaded_fingerprint="$(node .github/scripts/probe-openviking-runtime-release.mjs \
+            --config .github/openviking-runtime-inputs.json \
+            --verify-local-assets "$verify_directory")"
+          if [ "$downloaded_fingerprint" != "$EXPECTED_RUNTIME_FINGERPRINT" ]; then
+            echo "Downloaded OpenViking runtime sidecar does not match the planned inputs." >&2
+            exit 1
+          fi
           gh release edit "$V2_TAG" --draft=false --latest=false
 
-      # V1's updater hardcodes `releases/latest/download/update.json`, so the
-      # repository-wide "Latest" marker cannot move to V2 without silently breaking
-      # auto-update for every installed V1 client. Keep a rolling `v2-latest`
-      # release instead so V2 has one stable install URL of its own.
-      # Mirror the package, checksum, and update manifest. The updater can read
-      # the small manifest directly when GitHub's release API is slow or blocked;
-      # OpenViking remains on `v2-<version>` using the version baked into the tarball.
-      - name: Refresh V2 stable install release
-        if: steps.pending.outputs.v2_publish == 'true' && steps.v2_version.outputs.release_required == 'true'
+  # V1's updater owns GitHub's repository-wide "Latest" marker. V2 therefore
+  # mirrors its install package through a rolling `v2-latest` release. Keeping
+  # this in a separate job lets a failed pointer refresh be retried after the
+  # immutable versioned V2 release is already public.
+  refresh-v2-stable:
+    needs: [plan, release]
+    if: >-
+      always() &&
+      !cancelled() &&
+      needs.plan.result == 'success' &&
+      needs.release.result == 'success' &&
+      (
+        needs.plan.outputs.v2_publish == 'true' ||
+        needs.plan.outputs.v2_stable_repair == 'true'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+
+      - name: Resolve latest published V2 release
+        id: source
         env:
           GH_TOKEN: ${{ github.token }}
-          V2_TAG: ${{ steps.v2_version.outputs.tag }}
-          V2_VERSION: ${{ steps.v2_version.outputs.version }}
+          NEW_V2_TAG: ${{ needs.release.outputs.v2_tag }}
+        run: |
+          v2_tag="$NEW_V2_TAG"
+          if [ -z "$v2_tag" ]; then
+            published_tags_output="$(
+              gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+                --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name'
+            )"
+            while IFS= read -r tag; do
+              if [[ "$tag" =~ ^v2-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                v2_tag="$tag"
+                break
+              fi
+            done < <(printf '%s\n' "$published_tags_output")
+          fi
+          if ! [[ "$v2_tag" =~ ^v2-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "No published versioned V2 release is available for the stable install pointer." >&2
+            exit 1
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/$v2_tag" \
+            --jq 'select(.draft == false and .prerelease == false) | .tag_name' | grep -Fx "$v2_tag" >/dev/null
+          echo "v2_tag=$v2_tag" >> "$GITHUB_OUTPUT"
+          echo "v2_version=${v2_tag#v2-}" >> "$GITHUB_OUTPUT"
+          echo "v2_source_sha=$(git rev-parse "${v2_tag}^{commit}")" >> "$GITHUB_OUTPUT"
+
+      - name: Download and verify V2 stable source assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          V2_TAG: ${{ steps.source.outputs.v2_tag }}
+          V2_VERSION: ${{ steps.source.outputs.v2_version }}
+        run: |
+          mkdir -p release/v2
+          gh release download "$V2_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir release/v2 \
+            --pattern "agent-recall-v2-${V2_VERSION}.tgz" \
+            --pattern "agent-recall-v2-${V2_VERSION}.tgz.sha256" \
+            --pattern "agent-recall-v2.tgz" \
+            --pattern "agent-recall-v2.tgz.sha256" \
+            --pattern "update-v2.json"
+          node apps/main-2.0/scripts/create-release-assets.mjs \
+            --validate \
+            --version "$V2_VERSION" \
+            --repository "$GITHUB_REPOSITORY" \
+            --output release/v2
+          node apps/main-2.0/scripts/verify-stable-install-assets.mjs \
+            --stable release/v2 \
+            --release release/v2 \
+            --version "$V2_VERSION"
+
+      - name: Refresh V2 stable install release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          V2_TAG: ${{ steps.source.outputs.v2_tag }}
+          V2_VERSION: ${{ steps.source.outputs.v2_version }}
+          V2_SOURCE_SHA: ${{ steps.source.outputs.v2_source_sha }}
           V2_LATEST_TAG: v2-latest
-          MERGED_SHA: ${{ github.sha }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -f -a "$V2_LATEST_TAG" "$MERGED_SHA" -m "agent-recall-v2 stable install pointer (v${V2_VERSION})"
+          git tag -f -a "$V2_LATEST_TAG" "$V2_SOURCE_SHA" -m "agent-recall-v2 stable install pointer (v${V2_VERSION})"
           git push --force origin "refs/tags/$V2_LATEST_TAG"
 
           notes_file="$RUNNER_TEMP/agent-recall-v2-latest-note.md"

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -1,6 +1,24 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { test } from "node:test";
+
+import {
+  OPENVIKING_RUNTIME_TARGETS,
+  createRuntimeInputsSidecar,
+  loadOpenVikingRuntimeInputs,
+  probeOpenVikingRuntimeRelease,
+  runtimeReleaseAssetNames,
+  runtimeInputsSidecarName,
+  verifyLocalRuntimeAssets,
+} from "../.github/scripts/probe-openviking-runtime-release.mjs";
+import {
+  V2_STABLE_ASSET_NAMES,
+  probeV2StableRelease,
+} from "../.github/scripts/probe-v2-stable-release.mjs";
 
 import {
   bumpVersion,
@@ -160,7 +178,11 @@ test("workflows require branch notes and publish accumulated changes every day o
   assert.match(releaseWorkflow, /release-notes\.mjs combine --target v2/);
   assert.doesNotMatch(releaseWorkflow, /release-notes\.mjs dual/);
   assert.match(releaseWorkflow, /cancel-in-progress:\s*false/);
-  assert.match(releaseWorkflow, /openviking-runtime:\s+strategy:\s+fail-fast:\s*false/);
+  assert.match(releaseWorkflow, /^\s{2}plan:\s*\r?\n\s{4}runs-on:\s*ubuntu-latest/mu);
+  assert.match(
+    releaseWorkflow,
+    /openviking-runtime:\s+needs:\s*plan\s+if:\s*needs\.plan\.outputs\.v2_publish == 'true' && needs\.plan\.outputs\.runtime_reuse != 'true'[\s\S]*fail-fast:\s*false/,
+  );
   assert.match(releaseWorkflow, /working-directory: apps\/main-1\.0/);
   assert.match(releaseWorkflow, /working-directory: apps\/main-2\.0/);
   assert.match(releaseWorkflow, /npm test[\s\S]*npm run typecheck[\s\S]*npm run build/);
@@ -200,26 +222,82 @@ test("manual contributor updates only write the default branch", async () => {
   assert.match(workflow, /contrib-readme-job:\s+if:\s+github\.ref == 'refs\/heads\/main'/);
 });
 
-test("V2 releases publish the complete OpenViking runtime set", async () => {
+test("V2 releases reuse only fingerprinted complete OpenViking runtime sets", async () => {
   const releaseWorkflow = await readFile(".github/workflows/release.yml", "utf8");
+  const runtimeConfig = JSON.parse(await readFile(".github/openviking-runtime-inputs.json", "utf8"));
   const runtimeInputScript = await readFile("apps/main-2.0/scripts/verify-openviking-runtime-inputs.mjs", "utf8");
+  const runtimeResolver = await readFile("apps/main-2.0/src/main/services/openviking-artifact-resolver.ts", "utf8");
+  const planJob = releaseWorkflow.slice(
+    releaseWorkflow.indexOf("  plan:"),
+    releaseWorkflow.indexOf("  openviking-runtime:"),
+  );
   const runtimeJob = releaseWorkflow.slice(
     releaseWorkflow.indexOf("  openviking-runtime:"),
     releaseWorkflow.indexOf("  release:"),
   );
+  const stableJobStart = releaseWorkflow.indexOf("  refresh-v2-stable:");
+  assert.ok(stableJobStart > releaseWorkflow.indexOf("  release:"));
+  const releaseJob = releaseWorkflow.slice(releaseWorkflow.indexOf("  release:"), stableJobStart);
+  const stableJob = releaseWorkflow.slice(stableJobStart);
 
+  assert.match(releaseWorkflow, /permissions:\s+contents:\s*read/);
+  assert.match(releaseJob, /permissions:\s+contents:\s*write/);
+  assert.match(planJob, /runs-on:\s*ubuntu-latest/);
+  assert.match(planJob, /latest_v2_tag:[\s\S]*runtime_reuse:[\s\S]*runtime_source_tag:/);
+  assert.match(planJob, /v2_stable_repair:[\s\S]*probe-v2-stable-release\.mjs/);
+  assert.match(planJob, /probe-openviking-runtime-release\.mjs[\s\S]*--describe/);
+  assert.match(planJob, /download_status=0[\s\S]*probe_status[\s\S]*probe_status" = "2"/);
+  assert.match(planJob, /Published runtime assets are not reusable; rebuilding all platforms/);
+  assert.match(planJob, /--pattern "\$RUNTIME_SIDECAR_NAME"/);
+  assert.equal(
+    (planJob.match(/--pattern "openviking-runtime-\$\{OPENVIKING_RUNTIME_VERSION\}-[^"\r\n]+\.tar\.gz\.json"/gu) ?? []).length,
+    3,
+  );
+  assert.doesNotMatch(
+    planJob,
+    /--pattern "openviking-runtime-\$\{OPENVIKING_RUNTIME_VERSION\}-[^"\r\n]+\.tar\.gz"\s*(?:\\)?\r?\n/u,
+  );
   assert.match(releaseWorkflow, /^\s{2}openviking-runtime:\s*$/m);
+  assert.match(runtimeJob, /needs:\s*plan/);
+  assert.match(runtimeJob, /if:\s*needs\.plan\.outputs\.v2_publish == 'true' && needs\.plan\.outputs\.runtime_reuse != 'true'/);
+  assert.match(runtimeJob, /matrix:\s*\$\{\{ fromJSON\(needs\.plan\.outputs\.runtime_matrix\) \}\}/);
   assert.doesNotMatch(runtimeJob, /\bmapfile\b/);
-  assert.match(releaseWorkflow, /runner:\s*macos-15[\s\S]*platform:\s*darwin[\s\S]*arch:\s*arm64/);
-  assert.match(releaseWorkflow, /runner:\s*macos-15-intel[\s\S]*platform:\s*darwin[\s\S]*arch:\s*x64/);
-  assert.match(releaseWorkflow, /runner:\s*windows-2025[\s\S]*platform:\s*win32[\s\S]*arch:\s*x64/);
+  assert.deepEqual(runtimeConfig.targets.map(({ runner, platform, arch }) => ({ runner, platform, arch })), [
+    { runner: "macos-15", platform: "darwin", arch: "arm64" },
+    { runner: "macos-15-intel", platform: "darwin", arch: "x64" },
+    { runner: "windows-2025", platform: "win32", arch: "x64" },
+  ]);
   assert.match(releaseWorkflow, /apps\/main-2\.0\/scripts\/build-openviking-runtime\.mjs/);
-  const releaseRuntimeVersion = /--version\s+(\S+)/u.exec(runtimeJob)?.[1];
+  assert.match(runtimeJob, /npm ci --prefix apps\/main-2\.0 --ignore-scripts/);
+  assert.doesNotMatch(runtimeJob, /npm run setup:v2/);
+  const releaseRuntimeVersion = /OPENVIKING_RUNTIME_VERSION:\s*(\S+)/u.exec(releaseWorkflow)?.[1];
   assert.ok(releaseRuntimeVersion, "release workflow must pin the OpenViking runtime version");
+  assert.equal(releaseRuntimeVersion, runtimeConfig.runtimeVersion);
+  assert.equal(
+    releaseRuntimeVersion,
+    /OPENVIKING_RUNTIME_VERSION = "([^"]+)"/u.exec(runtimeResolver)?.[1],
+  );
   assert.match(runtimeInputScript, new RegExp(`OPENVIKING_VERSION = "${releaseRuntimeVersion.replace(/-r[1-9][0-9]*$/u, "")}"`, "u"));
-  assert.match(runtimeJob, /name:\s*Prepare isolated Rust toolchain[\s\S]*rustup default stable/);
+  assert.equal(runtimeConfig.nodeVersion, "22.23.1");
+  assert.equal(runtimeConfig.rustToolchain, "1.97.1");
+  assert.match(runtimeJob, /node-version:\s*\$\{\{ needs\.plan\.outputs\.runtime_node_version \}\}/);
+  assert.match(runtimeJob, /rustup default "\$\{\{ needs\.plan\.outputs\.runtime_rust_toolchain \}\}"/);
   assert.match(runtimeJob, /RUSTUP_HOME:\s*\$\{\{ runner\.temp \}\}\/openviking-rustup/);
   assert.match(runtimeJob, /CARGO_HOME:\s*\$\{\{ runner\.temp \}\}\/openviking-cargo/);
+  assert.match(runtimeJob, /overwrite:\s*true/);
+
+  assert.match(releaseJob, /needs:\s*\[plan, openviking-runtime\]/);
+  assert.match(releaseJob, /always\(\)[\s\S]*!cancelled\(\)[\s\S]*needs\.plan\.result == 'success'/);
+  assert.match(
+    releaseJob,
+    /needs\.openviking-runtime\.result == 'skipped'[\s\S]*needs\.plan\.outputs\.v2_publish == 'false'[\s\S]*needs\.plan\.outputs\.runtime_reuse == 'true'/,
+  );
+  assert.match(releaseJob, /name:\s*Download reused OpenViking runtime artifacts[\s\S]*runtime_reuse == 'true'/);
+  assert.match(releaseJob, /name:\s*Download freshly built OpenViking runtime artifacts[\s\S]*runtime_reuse != 'true'/);
+  assert.match(releaseJob, /name:\s*Reverify reused OpenViking runtime source[\s\S]*--small-assets-dir release\/v2/);
+  assert.match(releaseJob, /name:\s*Write OpenViking runtime input sidecar[\s\S]*--write-sidecar/);
+  assert.match(releaseJob, /name:\s*Verify OpenViking runtime artifacts[\s\S]*--verify-local-assets release\/v2/);
+  assert.match(releaseJob, /name:\s*Publish V2 GitHub Release[\s\S]*--verify-local-assets "\$verify_directory"/);
   assert.match(releaseWorkflow, /pattern:\s*openviking-runtime-\*/);
   assert.match(releaseWorkflow, /apps\/main-2\.0\/scripts\/verify-openviking-runtime-assets\.mjs/);
   assert.match(
@@ -230,4 +308,407 @@ test("V2 releases publish the complete OpenViking runtime set", async () => {
     releaseWorkflow,
     /gh release download "\$V2_TAG"[\s\S]*--pattern "openviking-runtime-\*"/,
   );
+  assert.match(releaseWorkflow, /"release\/v2\/\$RUNTIME_SIDECAR_NAME"/);
+  assert.doesNotMatch(releaseJob, /name:\s*Refresh V2 stable install release|git tag -f/);
+  assert.match(stableJob, /needs:\s*\[plan, release\]/);
+  assert.match(stableJob, /always\(\)[\s\S]*!cancelled\(\)[\s\S]*needs\.release\.result == 'success'/);
+  assert.match(stableJob, /needs\.plan\.outputs\.v2_publish == 'true'[\s\S]*needs\.plan\.outputs\.v2_stable_repair == 'true'/);
+  assert.match(stableJob, /NEW_V2_TAG:\s*\$\{\{ needs\.release\.outputs\.v2_tag \}\}/);
+  assert.match(stableJob, /--pattern "agent-recall-v2-\$\{V2_VERSION\}\.tgz"[\s\S]*--pattern "update-v2\.json"/);
+  const stableSourceValidation = stableJob.indexOf("node apps/main-2.0/scripts/create-release-assets.mjs");
+  const stableSourceVerification = stableJob.indexOf("node apps/main-2.0/scripts/verify-stable-install-assets.mjs");
+  const stableMutation = stableJob.indexOf('git tag -f -a "$V2_LATEST_TAG"');
+  assert.ok(stableSourceValidation >= 0 && stableSourceValidation < stableMutation);
+  assert.ok(stableSourceVerification >= 0 && stableSourceVerification < stableMutation);
+  assert.match(stableJob, /git tag -f -a "\$V2_LATEST_TAG" "\$V2_SOURCE_SHA"/);
+  assert.doesNotMatch(stableJob, /MERGED_SHA|github\.sha/);
+});
+
+test("accepts only a complete published OpenViking runtime release with matching input fingerprint", () => {
+  const runtimeVersion = "0.4.11-r4";
+  const expectedTag = "v2-0.10.1";
+  const inputFingerprint = `sha256:${"a".repeat(64)}`;
+  const smallAssets = new Map();
+  const assets = [];
+  const runtimeAssets = [];
+  for (const target of OPENVIKING_RUNTIME_TARGETS) {
+    const archiveName = `openviking-runtime-${runtimeVersion}-${target.platform}-${target.arch}.tar.gz`;
+    const archiveSha256 = createHash("sha256").update(`archive:${archiveName}`).digest("hex");
+    const manifestName = `${archiveName}.json`;
+    const manifestBytes = Buffer.from(`${JSON.stringify({
+      version: runtimeVersion,
+      platform: target.platform,
+      arch: target.arch,
+      sha256: archiveSha256,
+      archiveType: "tar.gz",
+      executablePath: target.executablePath,
+      file: archiveName,
+    }, null, 2)}\n`);
+    smallAssets.set(manifestName, manifestBytes);
+    const archiveSize = 1_000_000;
+    const manifestSha256 = createHash("sha256").update(manifestBytes).digest("hex");
+    runtimeAssets.push(
+      { name: archiveName, size: archiveSize, sha256: archiveSha256 },
+      { name: manifestName, size: manifestBytes.byteLength, sha256: manifestSha256 },
+    );
+    assets.push(
+      { name: archiveName, state: "uploaded", size: archiveSize, digest: `sha256:${archiveSha256}` },
+      { name: manifestName, state: "uploaded", size: manifestBytes.byteLength, digest: `sha256:${manifestSha256}` },
+    );
+  }
+  const sidecarName = runtimeInputsSidecarName(runtimeVersion);
+  const sidecarBytes = createRuntimeInputsSidecar({ runtimeVersion, inputFingerprint, runtimeAssets });
+  smallAssets.set(sidecarName, sidecarBytes);
+  assets.push({
+    name: sidecarName,
+    state: "uploaded",
+    size: sidecarBytes.byteLength,
+    digest: `sha256:${createHash("sha256").update(sidecarBytes).digest("hex")}`,
+  });
+  const release = {
+    tag_name: expectedTag,
+    draft: false,
+    prerelease: false,
+    published_at: "2026-08-15T00:00:00Z",
+    assets,
+  };
+
+  assert.deepEqual(runtimeReleaseAssetNames(runtimeVersion), assets.slice(0, 6).map(({ name }) => name));
+  assert.deepEqual(
+    probeOpenVikingRuntimeRelease({ release, expectedTag, runtimeVersion, inputFingerprint, smallAssets }),
+    { reusable: true, runtimeSourceTag: expectedTag },
+  );
+
+  const badManifestDigest = structuredClone(release);
+  badManifestDigest.assets.find(({ name }) => name.endsWith(".json")).digest = `sha256:${"0".repeat(64)}`;
+  assert.match(
+    probeOpenVikingRuntimeRelease({
+      release: badManifestDigest, expectedTag, runtimeVersion, inputFingerprint, smallAssets,
+    }).reason,
+    /sidecar does not match GitHub metadata/,
+  );
+
+  const badArchiveDigest = structuredClone(release);
+  badArchiveDigest.assets.find(({ name }) => name.endsWith(".tar.gz")).digest = `sha256:${"f".repeat(64)}`;
+  assert.match(
+    probeOpenVikingRuntimeRelease({
+      release: badArchiveDigest, expectedTag, runtimeVersion, inputFingerprint, smallAssets,
+    }).reason,
+    /sidecar does not match GitHub metadata/,
+  );
+
+  const missingPlatform = structuredClone(release);
+  missingPlatform.assets = missingPlatform.assets.filter(({ name }) => !name.includes("win32-x64"));
+  assert.match(
+    probeOpenVikingRuntimeRelease({
+      release: missingPlatform, expectedTag, runtimeVersion, inputFingerprint, smallAssets,
+    }).reason,
+    /missing trusted metadata for win32-x64/,
+  );
+
+  const wrongManifestSize = structuredClone(release);
+  wrongManifestSize.assets.find(({ name }) => name.endsWith(".json")).size += 1;
+  assert.match(
+    probeOpenVikingRuntimeRelease({
+      release: wrongManifestSize, expectedTag, runtimeVersion, inputFingerprint, smallAssets,
+    }).reason,
+    /sidecar does not match GitHub metadata/,
+  );
+
+  const tamperedSmallAssets = new Map(smallAssets);
+  const manifestName = runtimeAssets.find(({ name }) => name.endsWith(".json")).name;
+  const tamperedManifest = Buffer.from(tamperedSmallAssets.get(manifestName));
+  tamperedManifest[0] ^= 1;
+  tamperedSmallAssets.set(manifestName, tamperedManifest);
+  assert.match(
+    probeOpenVikingRuntimeRelease({
+      release, expectedTag, runtimeVersion, inputFingerprint, smallAssets: tamperedSmallAssets,
+    }).reason,
+    /manifest .* digest does not match GitHub/,
+  );
+
+  const revisionConflict = probeOpenVikingRuntimeRelease({
+    release,
+    expectedTag,
+    runtimeVersion,
+    inputFingerprint: `sha256:${"b".repeat(64)}`,
+    smallAssets,
+  });
+  assert.equal(revisionConflict.hardFailure, true);
+  assert.match(revisionConflict.reason, /fingerprint changed without a runtime revision bump/);
+
+  const legacyRelease = structuredClone(release);
+  legacyRelease.assets = legacyRelease.assets.filter(({ name }) => name !== sidecarName);
+  assert.deepEqual(
+    probeOpenVikingRuntimeRelease({
+      release: legacyRelease, expectedTag, runtimeVersion, inputFingerprint, smallAssets,
+    }),
+    {
+      reusable: false,
+      reason: "published release predates runtime input sidecars",
+      legacyBootstrap: true,
+      hardFailure: false,
+    },
+  );
+
+  const unexpectedAsset = structuredClone(release);
+  unexpectedAsset.assets.push({
+    name: `openviking-runtime-${runtimeVersion}-linux-x64.tar.gz`,
+    state: "uploaded",
+    size: 1,
+    digest: `sha256:${"0".repeat(64)}`,
+  });
+  assert.match(
+    probeOpenVikingRuntimeRelease({
+      release: unexpectedAsset, expectedTag, runtimeVersion, inputFingerprint, smallAssets,
+    }).reason,
+    /unexpected current runtime asset/,
+  );
+});
+
+test("OpenViking runtime probe CLI falls back for ordinary misses but fails a revision conflict", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "agent-recall-openviking-probe-cli-"));
+  const smallAssetsDirectory = path.join(directory, "small-assets");
+  const runtimeVersion = "0.4.11-r4";
+  const expectedTag = "v2-0.10.1";
+  const inputs = await loadOpenVikingRuntimeInputs({ configPath: ".github/openviking-runtime-inputs.json" });
+  assert.equal(inputs.config.runtimeVersion, runtimeVersion);
+  const runtimeAssets = runtimeReleaseAssetNames(runtimeVersion).map((name) => ({
+    name,
+    size: 1,
+    sha256: "0".repeat(64),
+  }));
+  const invokeProbe = () => spawnSync(process.execPath, [
+    ".github/scripts/probe-openviking-runtime-release.mjs",
+    "--config", ".github/openviking-runtime-inputs.json",
+    "--release-json", path.join(directory, "release.json"),
+    "--small-assets-dir", smallAssetsDirectory,
+    "--tag", expectedTag,
+  ], { cwd: process.cwd(), encoding: "utf8" });
+
+  try {
+    await writeFile(path.join(directory, "placeholder"), "fixture");
+    await writeFile(path.join(directory, "release.json"), `${JSON.stringify({
+      tag_name: expectedTag,
+      draft: false,
+      prerelease: false,
+      published_at: "2026-08-15T00:00:00Z",
+      assets: [],
+    })}\n`);
+    const legacyMiss = invokeProbe();
+    assert.equal(legacyMiss.status, 2, legacyMiss.stderr);
+    assert.match(legacyMiss.stderr, /reuse miss/);
+
+    await mkdir(smallAssetsDirectory);
+    const sidecarName = runtimeInputsSidecarName(runtimeVersion);
+    const incompleteSidecar = createRuntimeInputsSidecar({
+      runtimeVersion,
+      inputFingerprint: inputs.inputFingerprint,
+      runtimeAssets,
+    });
+    await writeFile(path.join(smallAssetsDirectory, sidecarName), incompleteSidecar);
+    await writeFile(path.join(directory, "release.json"), `${JSON.stringify({
+      tag_name: expectedTag,
+      draft: false,
+      prerelease: false,
+      published_at: "2026-08-15T00:00:00Z",
+      assets: [{
+        name: sidecarName,
+        state: "uploaded",
+        size: incompleteSidecar.byteLength,
+        digest: `sha256:${createHash("sha256").update(incompleteSidecar).digest("hex")}`,
+      }],
+    })}\n`);
+    const incompleteMiss = invokeProbe();
+    assert.equal(incompleteMiss.status, 2, incompleteMiss.stderr);
+    assert.match(incompleteMiss.stderr, /missing trusted metadata/);
+
+    const conflictingSidecar = createRuntimeInputsSidecar({
+      runtimeVersion,
+      inputFingerprint: `sha256:${"d".repeat(64)}`,
+      runtimeAssets,
+    });
+    await writeFile(path.join(smallAssetsDirectory, sidecarName), conflictingSidecar);
+    await writeFile(path.join(directory, "release.json"), `${JSON.stringify({
+      tag_name: expectedTag,
+      draft: false,
+      prerelease: false,
+      published_at: "2026-08-15T00:00:00Z",
+      assets: [{
+        name: sidecarName,
+        state: "uploaded",
+        size: conflictingSidecar.byteLength,
+        digest: `sha256:${createHash("sha256").update(conflictingSidecar).digest("hex")}`,
+      }],
+    })}\n`);
+    assert.notEqual(inputs.inputFingerprint, `sha256:${"d".repeat(64)}`);
+    const revisionConflict = invokeProbe();
+    assert.equal(revisionConflict.status, 1, revisionConflict.stderr);
+    assert.match(revisionConflict.stderr, /fingerprint changed without a runtime revision bump/);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("OpenViking runtime sidecar binds every downloaded archive and manifest byte-for-byte", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "agent-recall-openviking-sidecar-"));
+  const runtimeVersion = "0.4.11-r4";
+  const inputFingerprint = `sha256:${"c".repeat(64)}`;
+  try {
+    const runtimeAssets = [];
+    for (const target of OPENVIKING_RUNTIME_TARGETS) {
+      const archiveName = `openviking-runtime-${runtimeVersion}-${target.platform}-${target.arch}.tar.gz`;
+      const archiveBytes = Buffer.from(`archive:${target.platform}:${target.arch}`);
+      const archiveSha256 = createHash("sha256").update(archiveBytes).digest("hex");
+      const manifestName = `${archiveName}.json`;
+      const manifestBytes = Buffer.from(`${JSON.stringify({
+        version: runtimeVersion,
+        platform: target.platform,
+        arch: target.arch,
+        sha256: archiveSha256,
+        archiveType: "tar.gz",
+        executablePath: target.executablePath,
+        file: archiveName,
+      }, null, 2)}\n`);
+      runtimeAssets.push(
+        { name: archiveName, size: archiveBytes.byteLength, sha256: archiveSha256 },
+        {
+          name: manifestName,
+          size: manifestBytes.byteLength,
+          sha256: createHash("sha256").update(manifestBytes).digest("hex"),
+        },
+      );
+      await writeFile(path.join(directory, archiveName), archiveBytes);
+      await writeFile(path.join(directory, manifestName), manifestBytes);
+    }
+    await writeFile(
+      path.join(directory, runtimeInputsSidecarName(runtimeVersion)),
+      createRuntimeInputsSidecar({ runtimeVersion, inputFingerprint, runtimeAssets }),
+    );
+
+    const sidecar = await verifyLocalRuntimeAssets({ directory, runtimeVersion, inputFingerprint });
+    assert.deepEqual(sidecar.runtimeAssets, runtimeAssets);
+
+    const archiveName = runtimeAssets[0].name;
+    const tamperedBytes = Buffer.from(await readFile(path.join(directory, archiveName)));
+    tamperedBytes[0] ^= 1;
+    await writeFile(path.join(directory, archiveName), tamperedBytes);
+    await assert.rejects(
+      verifyLocalRuntimeAssets({ directory, runtimeVersion, inputFingerprint }),
+      /does not match its input sidecar/,
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("V2 stable install probe repairs only stale or incomplete rolling releases", () => {
+  const sourceCommitSha = "1".repeat(40);
+  const sourceRelease = {
+    tag_name: "v2-0.11.1",
+    draft: false,
+    prerelease: false,
+    published_at: "2026-08-15T00:00:00Z",
+    assets: V2_STABLE_ASSET_NAMES.map((name, index) => ({
+      name,
+      state: "uploaded",
+      size: index + 1,
+      digest: `sha256:${String(index + 1).repeat(64)}`,
+    })),
+  };
+  const stableRelease = structuredClone(sourceRelease);
+  stableRelease.tag_name = "v2-latest";
+
+  assert.equal(probeV2StableRelease({
+    sourceRelease,
+    stableRelease,
+    sourceCommitSha,
+    stableCommitSha: sourceCommitSha,
+  }), false);
+  assert.equal(probeV2StableRelease({
+    sourceRelease,
+    stableRelease: null,
+    sourceCommitSha,
+    stableCommitSha: "",
+  }), true);
+  assert.equal(probeV2StableRelease({
+    sourceRelease,
+    stableRelease,
+    sourceCommitSha,
+    stableCommitSha: "2".repeat(40),
+  }), true);
+
+  const incompleteStable = structuredClone(stableRelease);
+  incompleteStable.assets.pop();
+  assert.equal(probeV2StableRelease({
+    sourceRelease,
+    stableRelease: incompleteStable,
+    sourceCommitSha,
+    stableCommitSha: sourceCommitSha,
+  }), true);
+
+  const invalidSource = structuredClone(sourceRelease);
+  invalidSource.assets[0].digest = "missing";
+  assert.throws(() => probeV2StableRelease({
+    sourceRelease: invalidSource,
+    stableRelease,
+    sourceCommitSha,
+    stableCommitSha: sourceCommitSha,
+  }), /invalid agent-recall-v2\.tgz asset/);
+});
+
+test("OpenViking runtime fingerprint covers the matrix, builder, and dependency locks", async () => {
+  const inputs = await loadOpenVikingRuntimeInputs({
+    configPath: ".github/openviking-runtime-inputs.json",
+  });
+  assert.match(inputs.inputFingerprint, /^sha256:[a-f0-9]{64}$/u);
+  assert.deepEqual(inputs.matrix.include.map(({ platform, arch }) => `${platform}-${arch}`), [
+    "darwin-arm64",
+    "darwin-x64",
+    "win32-x64",
+  ]);
+  assert.deepEqual(inputs.config.fingerprintFiles, [
+    "apps/main-2.0/package.json",
+    "apps/main-2.0/package-lock.json",
+    "apps/main-2.0/scripts/build-openviking-runtime.mjs",
+  ]);
+  assert.equal(inputs.config.nodeVersion, "22.23.1");
+  assert.equal(inputs.config.rustToolchain, "1.97.1");
+});
+
+test("OpenViking runtime fingerprint ignores only release version rewrites", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "agent-recall-openviking-fingerprint-"));
+  const relativeFiles = [
+    ".github/openviking-runtime-inputs.json",
+    "apps/main-2.0/package.json",
+    "apps/main-2.0/package-lock.json",
+    "apps/main-2.0/scripts/build-openviking-runtime.mjs",
+  ];
+  try {
+    for (const name of relativeFiles) {
+      const destination = path.join(directory, name);
+      await mkdir(path.dirname(destination), { recursive: true });
+      await writeFile(destination, await readFile(name));
+    }
+    const configPath = path.join(directory, ".github/openviking-runtime-inputs.json");
+    const loadInputs = () => loadOpenVikingRuntimeInputs({ configPath, rootDirectory: directory });
+    const original = await loadInputs();
+
+    const packagePath = path.join(directory, "apps/main-2.0/package.json");
+    const lockPath = path.join(directory, "apps/main-2.0/package-lock.json");
+    const packageManifest = JSON.parse(await readFile(packagePath, "utf8"));
+    const packageLock = JSON.parse(await readFile(lockPath, "utf8"));
+    packageManifest.version = "9.8.7";
+    packageLock.version = "9.8.7";
+    packageLock.packages[""].version = "9.8.7";
+    await writeFile(packagePath, `${JSON.stringify(packageManifest, null, 2)}\n`);
+    await writeFile(lockPath, `${JSON.stringify(packageLock, null, 2)}\n`);
+    assert.equal((await loadInputs()).inputFingerprint, original.inputFingerprint);
+
+    packageLock.packages["node_modules/tar"].integrity = `sha512-${"x".repeat(32)}`;
+    await writeFile(lockPath, `${JSON.stringify(packageLock, null, 2)}\n`);
+    assert.notEqual((await loadInputs()).inputFingerprint, original.inputFingerprint);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary
- skip the three-platform OpenViking runtime matrix when the latest published V2 release has a complete, fingerprint-matched asset set
- bind reused archives and manifests to a versioned input sidecar, rebuild on ordinary cache misses, and fail closed when inputs change without a runtime revision bump
- make the rolling v2-latest install release independently repairable after a partial release failure

The currently published V2 release predates runtime sidecars, so the first V2 publication after this lands will seed the reusable set once; later unchanged runtime releases can skip the matrix.

## Validation
- npm run test:repo
- npm run release-note:check
- node --check .github/scripts/probe-openviking-runtime-release.mjs
- node --check .github/scripts/probe-v2-stable-release.mjs
- parsed .github/workflows/release.yml with PyYAML

No product release note is required because every changed path is release infrastructure.