### PR TITLE
ci: speed up scoped quality checks

### DIFF
--- a/.github/scripts/quality-check-scope.mjs
+++ b/.github/scripts/quality-check-scope.mjs
@@ -7,17 +7,8 @@ const APPLICATIONS = [
   { app: "v2", label: "V2", directory: "apps/main-2.0" },
 ];
 const OPERATING_SYSTEMS = ["ubuntu-latest", "macos-latest", "windows-latest"];
-const ROOT_DOCUMENTATION = new Set([
+const REPOSITORY_ONLY_FILES = new Set([
   ".gitignore",
-  ".npmignore",
-  "AGENTS.md",
-  "CLAUDE.md",
-  "CONTRIBUTING.md",
-  "Install.md",
-  "LICENSE",
-  "README.md",
-]);
-const REPOSITORY_ONLY_GITHUB_PATHS = new Set([
   ".github/openviking-runtime-inputs.json",
   ".github/pull_request_template.md",
   ".github/scripts/probe-openviking-runtime-release.mjs",
@@ -25,8 +16,13 @@ const REPOSITORY_ONLY_GITHUB_PATHS = new Set([
   ".github/workflows/contributors.yml",
   ".github/workflows/release.yml",
   ".github/workflows/update-star-history.yml",
-]);
-const REPOSITORY_ONLY_ROOT_ASSETS = new Set([
+  ".npmignore",
+  "AGENTS.md",
+  "CLAUDE.md",
+  "CONTRIBUTING.md",
+  "Install.md",
+  "LICENSE",
+  "README.md",
   "assets/app-icon.png",
   "assets/logo.png",
   "assets/show.png",
@@ -35,8 +31,6 @@ const REPOSITORY_ONLY_ROOT_ASSETS = new Set([
   "assets/tray-icon-template.svg",
   "assets/tray-iconTemplate.png",
   "assets/tray-iconTemplate@2x.png",
-]);
-const REPOSITORY_ONLY_SCRIPTS = new Set([
   "scripts/generate-star-history.mjs",
   "scripts/generate-star-history.test.mjs",
   "scripts/install-docs.test.mjs",
@@ -45,63 +39,36 @@ const REPOSITORY_ONLY_SCRIPTS = new Set([
   "scripts/release-notes.test.mjs",
   "scripts/session-toolbar-layout.test.mjs",
 ]);
-const FULL_CHECK_PATHS = new Set([
-  ".github/scripts/quality-check-scope.mjs",
-  ".github/workflows/quality-check.yml",
-  "package-lock.json",
-  "package.json",
-  "scripts/run-package-smokes.mjs",
-  "scripts/setup-app.mjs",
-]);
-
-function normalizePath(file) {
-  return file.replaceAll("\\", "/").replace(/^\.\//u, "");
-}
-
-function isApplicationDocumentation(relativePath) {
-  return relativePath === "README.md"
-    || relativePath === "Install.md"
-    || relativePath === "LICENSE"
-    || relativePath.startsWith("docs/");
-}
 
 function applicationForPath(file) {
   for (const application of APPLICATIONS) {
     const prefix = `${application.directory}/`;
     if (!file.startsWith(prefix)) continue;
     const relativePath = file.slice(prefix.length);
-    return isApplicationDocumentation(relativePath) ? null : application.app;
+    const documentation = relativePath === "README.md"
+      || relativePath === "Install.md"
+      || relativePath === "LICENSE"
+      || relativePath.startsWith("docs/");
+    return documentation ? null : application.app;
   }
   return undefined;
-}
-
-function isRepositoryOnlyPath(file) {
-  return ROOT_DOCUMENTATION.has(file)
-    || REPOSITORY_ONLY_GITHUB_PATHS.has(file)
-    || REPOSITORY_ONLY_ROOT_ASSETS.has(file)
-    || REPOSITORY_ONLY_SCRIPTS.has(file)
-    || file.startsWith(".release-notes/")
-    || file.startsWith("docs/");
 }
 
 function createPlan(paths) {
   const selected = new Set();
   for (const rawPath of paths) {
-    const file = normalizePath(rawPath);
+    const file = rawPath.replaceAll("\\", "/").replace(/^\.\//u, "");
     if (!file) continue;
-
-    if (FULL_CHECK_PATHS.has(file)) {
-      selected.add("v1");
-      selected.add("v2");
-      continue;
-    }
 
     const application = applicationForPath(file);
     if (application) {
       selected.add(application);
       continue;
     }
-    if (application === null || isRepositoryOnlyPath(file)) continue;
+    if (application === null
+      || REPOSITORY_ONLY_FILES.has(file)
+      || file.startsWith(".release-notes/")
+      || file.startsWith("docs/")) continue;
 
     // Unknown shared paths fail closed so new build inputs cannot silently skip checks.
     selected.add("v1");
@@ -113,14 +80,13 @@ function createPlan(paths) {
     ? applications.flatMap((application) => OPERATING_SYSTEMS.map((os) => ({ ...application, os })))
     : [{ app: "repository", label: "Repository", directory: "", os: "ubuntu-latest" }];
   return {
-    v1: selected.has("v1"),
-    v2: selected.has("v2"),
+    verify: applications.length > 0,
     matrix: { include },
   };
 }
 
 function parseArguments(args) {
-  if (args[0] === "--paths") return { paths: args.slice(1) };
+  if (args[0] === "--paths") return args.slice(1);
   if (args.length === 4 && args[0] === "--base" && args[2] === "--head") {
     const base = args[1];
     const head = args[3];
@@ -132,16 +98,14 @@ function parseArguments(args) {
       ["diff", "--name-only", "--no-renames", "-z", `${base}...${head}`],
       { encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
     );
-    return { paths: output.split("\0").filter(Boolean) };
+    return output.split("\0").filter(Boolean);
   }
   throw new Error("Usage: quality-check-scope.mjs --base <sha> --head <sha> | --paths [file ...]");
 }
 
 try {
-  const { paths } = parseArguments(process.argv.slice(2));
-  const plan = createPlan(paths);
-  process.stdout.write(`v1=${plan.v1}\n`);
-  process.stdout.write(`v2=${plan.v2}\n`);
+  const plan = createPlan(parseArguments(process.argv.slice(2)));
+  process.stdout.write(`verify=${plan.verify}\n`);
   process.stdout.write(`matrix=${JSON.stringify(plan.matrix)}\n`);
 } catch (error) {
   process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);

--- a/.github/scripts/quality-check-scope.mjs
+++ b/.github/scripts/quality-check-scope.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+const APPLICATIONS = [
+  { app: "v1", label: "V1", directory: "apps/main-1.0" },
+  { app: "v2", label: "V2", directory: "apps/main-2.0" },
+];
+const OPERATING_SYSTEMS = ["ubuntu-latest", "macos-latest", "windows-latest"];
+const ROOT_DOCUMENTATION = new Set([
+  ".gitignore",
+  ".npmignore",
+  "AGENTS.md",
+  "CLAUDE.md",
+  "CONTRIBUTING.md",
+  "Install.md",
+  "LICENSE",
+  "README.md",
+]);
+const REPOSITORY_ONLY_GITHUB_PATHS = new Set([
+  ".github/openviking-runtime-inputs.json",
+  ".github/pull_request_template.md",
+  ".github/scripts/probe-openviking-runtime-release.mjs",
+  ".github/scripts/probe-v2-stable-release.mjs",
+  ".github/workflows/contributors.yml",
+  ".github/workflows/release.yml",
+  ".github/workflows/update-star-history.yml",
+]);
+const REPOSITORY_ONLY_ROOT_ASSETS = new Set([
+  "assets/app-icon.png",
+  "assets/logo.png",
+  "assets/show.png",
+  "assets/star-history-data.json",
+  "assets/star-history.svg",
+  "assets/tray-icon-template.svg",
+  "assets/tray-iconTemplate.png",
+  "assets/tray-iconTemplate@2x.png",
+]);
+const REPOSITORY_ONLY_SCRIPTS = new Set([
+  "scripts/generate-star-history.mjs",
+  "scripts/generate-star-history.test.mjs",
+  "scripts/install-docs.test.mjs",
+  "scripts/monorepo-layout.test.mjs",
+  "scripts/release-notes.mjs",
+  "scripts/release-notes.test.mjs",
+  "scripts/session-toolbar-layout.test.mjs",
+]);
+const FULL_CHECK_PATHS = new Set([
+  ".github/scripts/quality-check-scope.mjs",
+  ".github/workflows/quality-check.yml",
+  "package-lock.json",
+  "package.json",
+  "scripts/run-package-smokes.mjs",
+  "scripts/setup-app.mjs",
+]);
+
+function normalizePath(file) {
+  return file.replaceAll("\\", "/").replace(/^\.\//u, "");
+}
+
+function isApplicationDocumentation(relativePath) {
+  return relativePath === "README.md"
+    || relativePath === "Install.md"
+    || relativePath === "LICENSE"
+    || relativePath.startsWith("docs/");
+}
+
+function applicationForPath(file) {
+  for (const application of APPLICATIONS) {
+    const prefix = `${application.directory}/`;
+    if (!file.startsWith(prefix)) continue;
+    const relativePath = file.slice(prefix.length);
+    return isApplicationDocumentation(relativePath) ? null : application.app;
+  }
+  return undefined;
+}
+
+function isRepositoryOnlyPath(file) {
+  return ROOT_DOCUMENTATION.has(file)
+    || REPOSITORY_ONLY_GITHUB_PATHS.has(file)
+    || REPOSITORY_ONLY_ROOT_ASSETS.has(file)
+    || REPOSITORY_ONLY_SCRIPTS.has(file)
+    || file.startsWith(".release-notes/")
+    || file.startsWith("docs/");
+}
+
+function createPlan(paths) {
+  const selected = new Set();
+  for (const rawPath of paths) {
+    const file = normalizePath(rawPath);
+    if (!file) continue;
+
+    if (FULL_CHECK_PATHS.has(file)) {
+      selected.add("v1");
+      selected.add("v2");
+      continue;
+    }
+
+    const application = applicationForPath(file);
+    if (application) {
+      selected.add(application);
+      continue;
+    }
+    if (application === null || isRepositoryOnlyPath(file)) continue;
+
+    // Unknown shared paths fail closed so new build inputs cannot silently skip checks.
+    selected.add("v1");
+    selected.add("v2");
+  }
+
+  const applications = APPLICATIONS.filter(({ app }) => selected.has(app));
+  const include = applications.length > 0
+    ? applications.flatMap((application) => OPERATING_SYSTEMS.map((os) => ({ ...application, os })))
+    : [{ app: "repository", label: "Repository", directory: "", os: "ubuntu-latest" }];
+  return {
+    v1: selected.has("v1"),
+    v2: selected.has("v2"),
+    matrix: { include },
+  };
+}
+
+function parseArguments(args) {
+  if (args[0] === "--paths") return { paths: args.slice(1) };
+  if (args.length === 4 && args[0] === "--base" && args[2] === "--head") {
+    const base = args[1];
+    const head = args[3];
+    if (!/^[0-9a-f]{40}$/iu.test(base) || !/^[0-9a-f]{40}$/iu.test(head)) {
+      throw new Error("--base and --head must be full Git commit SHAs.");
+    }
+    const output = execFileSync(
+      "git",
+      ["diff", "--name-only", "--no-renames", "-z", `${base}...${head}`],
+      { encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
+    );
+    return { paths: output.split("\0").filter(Boolean) };
+  }
+  throw new Error("Usage: quality-check-scope.mjs --base <sha> --head <sha> | --paths [file ...]");
+}
+
+try {
+  const { paths } = parseArguments(process.argv.slice(2));
+  const plan = createPlan(paths);
+  process.stdout.write(`v1=${plan.v1}\n`);
+  process.stdout.write(`v2=${plan.v2}\n`);
+  process.stdout.write(`matrix=${JSON.stringify(plan.matrix)}\n`);
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+}

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -9,20 +9,18 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: quality-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
-  verify:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    env:
-      ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
-      npm_config_audit: "false"
-      npm_config_cache: ${{ github.workspace }}/.ci-npm-cache
-      npm_config_fund: "false"
-      npm_config_prefer_offline: "true"
-      AGENT_RECALL_TEST_NPM_CACHE: ${{ github.workspace }}/.ci-npm-cache
+  preflight:
+    name: Plan and repository checks
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.scope.outputs.matrix }}
+      v1: ${{ steps.scope.outputs.v1 }}
+      v2: ${{ steps.scope.outputs.v2 }}
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -33,27 +31,95 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            apps/main-1.0/package-lock.json
-            apps/main-2.0/package-lock.json
 
-      - name: Install dependencies
-        run: |
-          npm ci
-          npm run setup
+      - name: Plan affected application checks
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node .github/scripts/quality-check-scope.mjs --base "$BASE_SHA" --head "$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Validate release note
-        run: node scripts/release-notes.mjs check-range "origin/${{ github.base_ref }}" HEAD
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/release-notes.mjs check-range "$BASE_SHA" "$HEAD_SHA"
 
-      - name: Test complete application suites
-        if: runner.os == 'Linux'
-        run: npm test
+      - name: Test repository tooling
+        run: npm run test:repo
+
+  verify:
+    name: Verify ${{ matrix.label }} (${{ matrix.os }})
+    needs: preflight
+    if: needs.preflight.outputs.v1 == 'true' || needs.preflight.outputs.v2 == 'true'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.preflight.outputs.matrix) }}
+    runs-on: ${{ matrix.os }}
+    env:
+      ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+      npm_config_audit: "false"
+      npm_config_cache: ${{ github.workspace }}/.ci-npm-cache
+      npm_config_fund: "false"
+      npm_config_prefer_offline: "true"
+      AGENT_RECALL_TEST_NPM_CACHE: ${{ github.workspace }}/.ci-npm-cache
+    steps:
+      - name: Summarize application scope
+        run: echo "Checking ${{ matrix.label }} on ${{ matrix.os }}."
+
+      - name: Check out repository
+        if: matrix.app != 'repository'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Node.js
+        if: matrix.app != 'repository'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: ${{ matrix.directory }}/package-lock.json
+
+      - name: Install application dependencies
+        if: matrix.app != 'repository'
+        run: npm run setup:${{ matrix.app }}
+
+      - name: Test complete application suite
+        if: matrix.app != 'repository' && runner.os == 'Linux'
+        run: npm --prefix "${{ matrix.directory }}" test
 
       - name: Test platform-specific scripts
-        if: runner.os != 'Linux'
-        run: npm run test:scripts
+        if: matrix.app != 'repository' && runner.os != 'Linux'
+        run: npm --prefix "${{ matrix.directory }}" run test:scripts
 
-      - name: Build and smoke-test packaged applications
-        run: npm run package:smoke:all
+      - name: Typecheck and smoke-test packaged application
+        if: matrix.app != 'repository'
+        run: |
+          npm --prefix "${{ matrix.directory }}" run typecheck
+          node "${{ matrix.directory }}/scripts/package-smoke.mjs"
+
+  quality-gate:
+    name: Quality gate
+    needs: [preflight, verify]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every check to pass
+        env:
+          CHECK_V1: ${{ needs.preflight.outputs.v1 }}
+          CHECK_V2: ${{ needs.preflight.outputs.v2 }}
+          PREFLIGHT_RESULT: ${{ needs.preflight.result }}
+          VERIFY_RESULT: ${{ needs.verify.result }}
+        run: |
+          test "$PREFLIGHT_RESULT" = "success"
+          case "$CHECK_V1:$CHECK_V2" in
+            true:true|true:false|false:true)
+              test "$VERIFY_RESULT" = "success"
+              ;;
+            false:false)
+              test "$VERIFY_RESULT" = "skipped"
+              ;;
+            *)
+              echo "Invalid application scope: $CHECK_V1:$CHECK_V2" >&2
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -17,10 +17,12 @@ jobs:
   preflight:
     name: Plan and repository checks
     runs-on: ubuntu-latest
+    env:
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     outputs:
       matrix: ${{ steps.scope.outputs.matrix }}
-      v1: ${{ steps.scope.outputs.v1 }}
-      v2: ${{ steps.scope.outputs.v2 }}
+      verify: ${{ steps.scope.outputs.verify }}
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -34,15 +36,9 @@ jobs:
 
       - name: Plan affected application checks
         id: scope
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node .github/scripts/quality-check-scope.mjs --base "$BASE_SHA" --head "$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Validate release note
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node scripts/release-notes.mjs check-range "$BASE_SHA" "$HEAD_SHA"
 
       - name: Test repository tooling
@@ -51,7 +47,7 @@ jobs:
   verify:
     name: Verify ${{ matrix.label }} (${{ matrix.os }})
     needs: preflight
-    if: needs.preflight.outputs.v1 == 'true' || needs.preflight.outputs.v2 == 'true'
+    if: needs.preflight.outputs.verify == 'true'
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.preflight.outputs.matrix) }}
@@ -64,15 +60,10 @@ jobs:
       npm_config_prefer_offline: "true"
       AGENT_RECALL_TEST_NPM_CACHE: ${{ github.workspace }}/.ci-npm-cache
     steps:
-      - name: Summarize application scope
-        run: echo "Checking ${{ matrix.label }} on ${{ matrix.os }}."
-
       - name: Check out repository
-        if: matrix.app != 'repository'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Node.js
-        if: matrix.app != 'repository'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
@@ -80,19 +71,17 @@ jobs:
           cache-dependency-path: ${{ matrix.directory }}/package-lock.json
 
       - name: Install application dependencies
-        if: matrix.app != 'repository'
         run: npm run setup:${{ matrix.app }}
 
       - name: Test complete application suite
-        if: matrix.app != 'repository' && runner.os == 'Linux'
+        if: runner.os == 'Linux'
         run: npm --prefix "${{ matrix.directory }}" test
 
       - name: Test platform-specific scripts
-        if: matrix.app != 'repository' && runner.os != 'Linux'
+        if: runner.os != 'Linux'
         run: npm --prefix "${{ matrix.directory }}" run test:scripts
 
       - name: Typecheck and smoke-test packaged application
-        if: matrix.app != 'repository'
         run: |
           npm --prefix "${{ matrix.directory }}" run typecheck
           node "${{ matrix.directory }}/scripts/package-smoke.mjs"
@@ -105,21 +94,15 @@ jobs:
     steps:
       - name: Require every check to pass
         env:
-          CHECK_V1: ${{ needs.preflight.outputs.v1 }}
-          CHECK_V2: ${{ needs.preflight.outputs.v2 }}
+          SHOULD_VERIFY: ${{ needs.preflight.outputs.verify }}
           PREFLIGHT_RESULT: ${{ needs.preflight.result }}
           VERIFY_RESULT: ${{ needs.verify.result }}
         run: |
-          test "$PREFLIGHT_RESULT" = "success"
-          case "$CHECK_V1:$CHECK_V2" in
-            true:true|true:false|false:true)
-              test "$VERIFY_RESULT" = "success"
-              ;;
-            false:false)
-              test "$VERIFY_RESULT" = "skipped"
+          case "$PREFLIGHT_RESULT:$SHOULD_VERIFY:$VERIFY_RESULT" in
+            success:true:success|success:false:skipped)
               ;;
             *)
-              echo "Invalid application scope: $CHECK_V1:$CHECK_V2" >&2
+              echo "Quality checks did not complete successfully." >&2
               exit 1
               ;;
           esac

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -144,27 +144,24 @@ test("workflows require branch notes and publish accumulated changes every day o
   const releaseWorkflow = await readFile(".github/workflows/release.yml", "utf8");
   assert.match(qualityWorkflow, /pull_request:/);
   assert.match(qualityWorkflow, /concurrency:[\s\S]*cancel-in-progress:\s*true/);
-  assert.match(qualityWorkflow, /- name: Validate release note[\s\S]*?run: node scripts\/release-notes\.mjs check-range/);
-  assert.match(qualityWorkflow, /^\s{2}preflight:\s*$/mu);
-  assert.match(qualityWorkflow, /- name: Test repository tooling\s+run: npm run test:repo/);
+  assert.match(qualityWorkflow, /run: node scripts\/release-notes\.mjs check-range/);
+  assert.match(qualityWorkflow, /quality-check-scope\.mjs --base "\$BASE_SHA" --head "\$HEAD_SHA" >> "\$GITHUB_OUTPUT"/);
+  assert.match(qualityWorkflow, /run: npm run test:repo/);
   assert.match(qualityWorkflow, /matrix:\s*\$\{\{ fromJSON\(needs\.preflight\.outputs\.matrix\) \}\}/);
-  assert.match(qualityWorkflow, /if: needs\.preflight\.outputs\.v1 == 'true' \|\| needs\.preflight\.outputs\.v2 == 'true'/);
+  assert.match(qualityWorkflow, /if: needs\.preflight\.outputs\.verify == 'true'/);
   assert.match(qualityWorkflow, /npm run setup:\$\{\{ matrix\.app \}\}/);
   assert.match(qualityWorkflow, /ELECTRON_SKIP_BINARY_DOWNLOAD:\s*["']1["']/);
   assert.match(qualityWorkflow, /npm_config_cache:\s*\$\{\{ github\.workspace \}\}\/\.ci-npm-cache/);
   assert.match(qualityWorkflow, /AGENT_RECALL_TEST_NPM_CACHE:\s*\$\{\{ github\.workspace \}\}\/\.ci-npm-cache/);
-  assert.match(qualityWorkflow, /- name: Test complete application suite\s+if: matrix\.app != 'repository' && runner\.os == 'Linux'/);
-  assert.match(qualityWorkflow, /- name: Test platform-specific scripts\s+if: matrix\.app != 'repository' && runner\.os != 'Linux'/);
-  assert.doesNotMatch(qualityWorkflow, /- name: Typecheck\r?\n/u);
-  assert.doesNotMatch(qualityWorkflow, /- name: Build\r?\n/u);
-  assert.match(qualityWorkflow, /- name: Typecheck and smoke-test packaged application/);
-  assert.match(qualityWorkflow, /node "\$\{\{ matrix\.directory \}\}\/scripts\/package-smoke\.mjs"/);
+  assert.match(qualityWorkflow, /if: runner\.os == 'Linux'\s+run: npm --prefix "\$\{\{ matrix\.directory \}\}" test/);
+  assert.match(qualityWorkflow, /if: runner\.os != 'Linux'\s+run: npm --prefix "\$\{\{ matrix\.directory \}\}" run test:scripts/);
+  assert.match(qualityWorkflow, /npm --prefix "\$\{\{ matrix\.directory \}\}" run typecheck\s+node "\$\{\{ matrix\.directory \}\}\/scripts\/package-smoke\.mjs"/);
+  assert.equal(qualityWorkflow.match(/run typecheck/gu)?.length, 1);
+  assert.doesNotMatch(qualityWorkflow, /run build(?:\r?\n|$)/u);
   assert.match(qualityWorkflow, /cache-dependency-path: \$\{\{ matrix\.directory \}\}\/package-lock\.json/);
   assert.doesNotMatch(qualityWorkflow, /npm run package:smoke:all/);
-  assert.match(qualityWorkflow, /^\s{2}quality-gate:\s*$/mu);
-  assert.match(qualityWorkflow, /needs: \[preflight, verify\][\s\S]*if: \$\{\{ always\(\) \}\}/);
-  assert.match(qualityWorkflow, /test "\$VERIFY_RESULT" = "skipped"/);
-  assert.match(qualityWorkflow, /Invalid application scope/);
+  assert.match(qualityWorkflow, /name: Quality gate[\s\S]*needs: \[preflight, verify\][\s\S]*if: \$\{\{ always\(\) \}\}/);
+  assert.match(qualityWorkflow, /success:true:success\|success:false:skipped/);
   assert.match(releaseWorkflow, /schedule:[\s\S]*cron:\s*["']0 2 \* \* \*["']/);
   assert.match(releaseWorkflow, /workflow_dispatch:/);
   assert.doesNotMatch(releaseWorkflow, /^\s{2}push:/m);
@@ -737,8 +734,7 @@ function runQualityCheckScope(paths) {
     }),
   );
   return {
-    v1: outputs.v1,
-    v2: outputs.v2,
+    verify: outputs.verify,
     matrix: JSON.parse(outputs.matrix),
   };
 }
@@ -748,27 +744,17 @@ test("quality checks route application changes without dropping platform coverag
     ".release-notes/fix-v2-update.md",
     "apps/main-2.0/bin/update-client.cjs",
   ]);
-  assert.equal(v2.v1, "false");
-  assert.equal(v2.v2, "true");
-  assert.deepEqual(v2.matrix.include.map(({ app, os }) => [app, os]), [
-    ["v2", "ubuntu-latest"],
-    ["v2", "macos-latest"],
-    ["v2", "windows-latest"],
+  assert.equal(v2.verify, "true");
+  assert.deepEqual(v2.matrix.include, [
+    { app: "v2", label: "V2", directory: "apps/main-2.0", os: "ubuntu-latest" },
+    { app: "v2", label: "V2", directory: "apps/main-2.0", os: "macos-latest" },
+    { app: "v2", label: "V2", directory: "apps/main-2.0", os: "windows-latest" },
   ]);
 
   const v1 = runQualityCheckScope(["apps\\main-1.0\\src\\main\\index.ts"]);
-  assert.equal(v1.v1, "true");
-  assert.equal(v1.v2, "false");
-  assert.deepEqual(v1.matrix.include.map(({ app, os }) => [app, os]), [
-    ["v1", "ubuntu-latest"],
-    ["v1", "macos-latest"],
-    ["v1", "windows-latest"],
-  ]);
-
-  const both = runQualityCheckScope(["scripts/setup-app.mjs"]);
-  assert.equal(both.v1, "true");
-  assert.equal(both.v2, "true");
-  assert.equal(both.matrix.include.length, 6);
+  assert.equal(v1.verify, "true");
+  assert.equal(v1.matrix.include.length, 3);
+  assert.ok(v1.matrix.include.every(({ app }) => app === "v1"));
 });
 
 test("quality checks keep infrastructure-only changes on the repository fast path", () => {
@@ -776,27 +762,26 @@ test("quality checks keep infrastructure-only changes on the repository fast pat
     ".github/workflows/release.yml",
     ".github/openviking-runtime-inputs.json",
     ".release-notes/runtime-reuse.md",
+    "README.md",
+    "assets/logo.png",
+    "apps/main-1.0/docs/README.en.md",
     "scripts/release-notes.test.mjs",
     "docs/v2/guide.md",
   ]);
-  assert.equal(repository.v1, "false");
-  assert.equal(repository.v2, "false");
+  assert.equal(repository.verify, "false");
   assert.deepEqual(repository.matrix.include, [
     { app: "repository", label: "Repository", directory: "", os: "ubuntu-latest" },
   ]);
 });
 
-test("quality checks fail closed for their own routing and unknown shared paths", () => {
+test("quality checks fail closed for routing and shared build inputs", () => {
   for (const file of [
-    ".github/workflows/quality-check.yml",
     ".github/scripts/quality-check-scope.mjs",
-    ".github/actions/package/action.yml",
-    "assets/new-build-input.bin",
-    "new-shared-build-input.json",
+    "scripts/setup-app.mjs",
   ]) {
     const plan = runQualityCheckScope([file]);
-    assert.equal(plan.v1, "true", file);
-    assert.equal(plan.v2, "true", file);
+    assert.equal(plan.verify, "true", file);
     assert.equal(plan.matrix.include.length, 6, file);
+    assert.deepEqual([...new Set(plan.matrix.include.map(({ app }) => app))], ["v1", "v2"]);
   }
 });

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -143,18 +143,28 @@ test("workflows require branch notes and publish accumulated changes every day o
   const qualityWorkflow = await readFile(".github/workflows/quality-check.yml", "utf8");
   const releaseWorkflow = await readFile(".github/workflows/release.yml", "utf8");
   assert.match(qualityWorkflow, /pull_request:/);
-  assert.match(qualityWorkflow, /- name: Validate release note\s+run: node scripts\/release-notes\.mjs check-range/);
-  assert.match(qualityWorkflow, /os:\s*\[ubuntu-latest, macos-latest, windows-latest\]/);
-  assert.match(qualityWorkflow, /npm run setup/);
+  assert.match(qualityWorkflow, /concurrency:[\s\S]*cancel-in-progress:\s*true/);
+  assert.match(qualityWorkflow, /- name: Validate release note[\s\S]*?run: node scripts\/release-notes\.mjs check-range/);
+  assert.match(qualityWorkflow, /^\s{2}preflight:\s*$/mu);
+  assert.match(qualityWorkflow, /- name: Test repository tooling\s+run: npm run test:repo/);
+  assert.match(qualityWorkflow, /matrix:\s*\$\{\{ fromJSON\(needs\.preflight\.outputs\.matrix\) \}\}/);
+  assert.match(qualityWorkflow, /if: needs\.preflight\.outputs\.v1 == 'true' \|\| needs\.preflight\.outputs\.v2 == 'true'/);
+  assert.match(qualityWorkflow, /npm run setup:\$\{\{ matrix\.app \}\}/);
   assert.match(qualityWorkflow, /ELECTRON_SKIP_BINARY_DOWNLOAD:\s*["']1["']/);
   assert.match(qualityWorkflow, /npm_config_cache:\s*\$\{\{ github\.workspace \}\}\/\.ci-npm-cache/);
   assert.match(qualityWorkflow, /AGENT_RECALL_TEST_NPM_CACHE:\s*\$\{\{ github\.workspace \}\}\/\.ci-npm-cache/);
-  assert.match(qualityWorkflow, /- name: Test complete application suites\s+if: runner\.os == 'Linux'\s+run: npm test/);
-  assert.match(qualityWorkflow, /- name: Test platform-specific scripts\s+if: runner\.os != 'Linux'\s+run: npm run test:scripts/);
+  assert.match(qualityWorkflow, /- name: Test complete application suite\s+if: matrix\.app != 'repository' && runner\.os == 'Linux'/);
+  assert.match(qualityWorkflow, /- name: Test platform-specific scripts\s+if: matrix\.app != 'repository' && runner\.os != 'Linux'/);
   assert.doesNotMatch(qualityWorkflow, /- name: Typecheck\r?\n/u);
   assert.doesNotMatch(qualityWorkflow, /- name: Build\r?\n/u);
-  assert.match(qualityWorkflow, /- name: Build and smoke-test packaged applications/);
-  assert.match(qualityWorkflow, /run: npm run package:smoke:all/);
+  assert.match(qualityWorkflow, /- name: Typecheck and smoke-test packaged application/);
+  assert.match(qualityWorkflow, /node "\$\{\{ matrix\.directory \}\}\/scripts\/package-smoke\.mjs"/);
+  assert.match(qualityWorkflow, /cache-dependency-path: \$\{\{ matrix\.directory \}\}\/package-lock\.json/);
+  assert.doesNotMatch(qualityWorkflow, /npm run package:smoke:all/);
+  assert.match(qualityWorkflow, /^\s{2}quality-gate:\s*$/mu);
+  assert.match(qualityWorkflow, /needs: \[preflight, verify\][\s\S]*if: \$\{\{ always\(\) \}\}/);
+  assert.match(qualityWorkflow, /test "\$VERIFY_RESULT" = "skipped"/);
+  assert.match(qualityWorkflow, /Invalid application scope/);
   assert.match(releaseWorkflow, /schedule:[\s\S]*cron:\s*["']0 2 \* \* \*["']/);
   assert.match(releaseWorkflow, /workflow_dispatch:/);
   assert.doesNotMatch(releaseWorkflow, /^\s{2}push:/m);
@@ -710,5 +720,83 @@ test("OpenViking runtime fingerprint ignores only release version rewrites", asy
     assert.notEqual((await loadInputs()).inputFingerprint, original.inputFingerprint);
   } finally {
     await rm(directory, { recursive: true, force: true });
+  }
+});
+
+function runQualityCheckScope(paths) {
+  const result = spawnSync(
+    process.execPath,
+    [".github/scripts/quality-check-scope.mjs", "--paths", ...paths],
+    { encoding: "utf8" },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const outputs = Object.fromEntries(
+    result.stdout.trim().split(/\r?\n/u).map((line) => {
+      const separator = line.indexOf("=");
+      return [line.slice(0, separator), line.slice(separator + 1)];
+    }),
+  );
+  return {
+    v1: outputs.v1,
+    v2: outputs.v2,
+    matrix: JSON.parse(outputs.matrix),
+  };
+}
+
+test("quality checks route application changes without dropping platform coverage", () => {
+  const v2 = runQualityCheckScope([
+    ".release-notes/fix-v2-update.md",
+    "apps/main-2.0/bin/update-client.cjs",
+  ]);
+  assert.equal(v2.v1, "false");
+  assert.equal(v2.v2, "true");
+  assert.deepEqual(v2.matrix.include.map(({ app, os }) => [app, os]), [
+    ["v2", "ubuntu-latest"],
+    ["v2", "macos-latest"],
+    ["v2", "windows-latest"],
+  ]);
+
+  const v1 = runQualityCheckScope(["apps\\main-1.0\\src\\main\\index.ts"]);
+  assert.equal(v1.v1, "true");
+  assert.equal(v1.v2, "false");
+  assert.deepEqual(v1.matrix.include.map(({ app, os }) => [app, os]), [
+    ["v1", "ubuntu-latest"],
+    ["v1", "macos-latest"],
+    ["v1", "windows-latest"],
+  ]);
+
+  const both = runQualityCheckScope(["scripts/setup-app.mjs"]);
+  assert.equal(both.v1, "true");
+  assert.equal(both.v2, "true");
+  assert.equal(both.matrix.include.length, 6);
+});
+
+test("quality checks keep infrastructure-only changes on the repository fast path", () => {
+  const repository = runQualityCheckScope([
+    ".github/workflows/release.yml",
+    ".github/openviking-runtime-inputs.json",
+    ".release-notes/runtime-reuse.md",
+    "scripts/release-notes.test.mjs",
+    "docs/v2/guide.md",
+  ]);
+  assert.equal(repository.v1, "false");
+  assert.equal(repository.v2, "false");
+  assert.deepEqual(repository.matrix.include, [
+    { app: "repository", label: "Repository", directory: "", os: "ubuntu-latest" },
+  ]);
+});
+
+test("quality checks fail closed for their own routing and unknown shared paths", () => {
+  for (const file of [
+    ".github/workflows/quality-check.yml",
+    ".github/scripts/quality-check-scope.mjs",
+    ".github/actions/package/action.yml",
+    "assets/new-build-input.bin",
+    "new-shared-build-input.json",
+  ]) {
+    const plan = runQualityCheckScope([file]);
+    assert.equal(plan.v1, "true", file);
+    assert.equal(plan.v2, "true", file);
+    assert.equal(plan.matrix.include.length, 6, file);
   }
 });


### PR DESCRIPTION
## Summary

- plan repository checks once, then route V1/V2 changes into independent Linux, macOS, and Windows jobs
- keep unknown or shared paths fail-closed while letting release-infrastructure and documentation changes use a fast path
- cancel superseded PR runs, preserve per-app npm caches, and remove one duplicate build from CI package smoke validation
- retain the recent updater recovery tests because they cover distinct failure phases and add negligible runtime

## Release note

- Internal CI-only change; the repository policy does not require a product release note.

## Verification

- `npm run test:repo` (41/41)
- V1 and V2 `typecheck`
- V1 and V2 direct package smoke on Windows
- targeted updater rollback/recovery tests
- historical PR scope checks for release-infrastructure-only and V2-only changes
- actionlint v1.7.12
- YAML lint/parse
- `npm run release-note:check`
- `git diff --check`