### PR TITLE
feat(v2): expose cloud Skills and shared install target

### DIFF
--- a/.release-notes/improve-skill-cloud-install.md
+++ b/.release-notes/improve-skill-cloud-install.md
@@ -5,3 +5,4 @@
 
 - 云端 Skill 现在会在 Skill 页面直接列出并支持预览，不再需要先选中一个本地 Skill 才能找到云端内容。
 - Skill 安装目标新增 Codex shared（`~/.agents/skills`），可让多个 Codex 工作区共用已安装的 Skill。
+- 修复安装目标列表中 Codex、Claude Code、CodeBuddy、Qoder、Trae 和 Pi 名称显示为空的问题。

--- a/.release-notes/improve-skill-cloud-install.md
+++ b/.release-notes/improve-skill-cloud-install.md
@@ -1,0 +1,7 @@
+# Skill 云端浏览与共享安装
+<!-- release-target: v2 -->
+
+## Bug 修复
+
+- 云端 Skill 现在会在 Skill 页面直接列出并支持预览，不再需要先选中一个本地 Skill 才能找到云端内容。
+- Skill 安装目标新增 Codex shared（`~/.agents/skills`），可让多个 Codex 工作区共用已安装的 Skill。

--- a/apps/main-2.0/src/core/agent-skill-registry.ts
+++ b/apps/main-2.0/src/core/agent-skill-registry.ts
@@ -11,7 +11,7 @@ import * as path from "node:path";
 export type SkillAgent = "codex" | "claude" | "codebuddy" | "qoder" | "trae" | "pi";
 
 /** An agent directory a managed Skill can be installed into. */
-export type SkillInstallTarget = "codex" | "claude" | "codebuddy" | "qoder" | "trae" | "pi";
+export type SkillInstallTarget = "codex" | "codex-shared" | "claude" | "codebuddy" | "qoder" | "trae" | "pi";
 
 /** Portability scope used by cross-device Skill sync. */
 export type SkillPortableScope = "agent-recall-v2" | "codex-user" | "claude-user" | "qoder-user" | "shared";
@@ -119,7 +119,8 @@ export const SKILL_AGENTS: readonly SkillAgent[] = AGENT_SKILL_REGISTRY.map((ent
 
 export const SKILL_INSTALL_TARGETS: readonly SkillInstallTarget[] = AGENT_SKILL_REGISTRY
   .map((entry) => entry.installTarget)
-  .filter((target): target is SkillInstallTarget => target !== null);
+  .filter((target): target is SkillInstallTarget => target !== null)
+  .flatMap((target) => target === "codex" ? [target, "codex-shared"] : [target]);
 
 export function agentEntry(id: SkillAgent): AgentSkillRegistryEntry {
   const entry = AGENT_SKILL_REGISTRY.find((candidate) => candidate.id === id);
@@ -139,6 +140,7 @@ export function agentSkillDir(id: SkillAgent, homeDir: string): string | null {
 
 export function agentInstallTargetDir(target: SkillInstallTarget, homeDir: string, codexHome?: string): string {
   if (target === "codex") return path.join(codexHome ?? path.join(homeDir, ".codex"), "skills");
+  if (target === "codex-shared") return path.join(homeDir, ".agents", "skills");
   const entry = AGENT_SKILL_REGISTRY.find((candidate) => candidate.installTarget === target);
   if (!entry?.skillDir) throw new Error(`Unknown install target: ${target}`);
   return path.join(homeDir, entry.skillDir);

--- a/apps/main-2.0/src/core/managed-skill-library.test.ts
+++ b/apps/main-2.0/src/core/managed-skill-library.test.ts
@@ -62,4 +62,22 @@ describe("AgentRecall bundled Skills", () => {
       url: "https://github.com/melodic-software/claude-code-plugins/tree/main/plugins/soft-skills/skills/resume-optimization",
     });
   });
+
+  it("installs a managed Skill into the shared Codex agents directory", () => {
+    const fixtureRoot = mkdtempSync(path.join(tmpdir(), "agent-recall-shared-skill-"));
+    temporaryDirectories.push(fixtureRoot);
+    const homeDir = path.join(fixtureRoot, "home");
+    const library = new ManagedSkillLibrary({
+      libraryRoot: path.join(fixtureRoot, "skills"),
+      homeDir,
+    });
+    const bundledRoot = fileURLToPath(new URL("../../assets/bundled-skills", import.meta.url));
+
+    library.ensureBuiltinSkills(bundledRoot);
+    const updated = library.updateTargets("grill-me", ["codex-shared"]);
+    const installation = updated.installations.find((item) => item.target === "codex-shared");
+
+    expect(installation?.state).toBe("installed");
+    expect(installation?.path).toBe(path.join(homeDir, ".agents", "skills", "grill-me"));
+  });
 });

--- a/apps/main-2.0/src/renderer/src/features/skills/cloud-skill-detail.tsx
+++ b/apps/main-2.0/src/renderer/src/features/skills/cloud-skill-detail.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from "react";
+import type { ReactElement } from "react";
+import { Cloud, Download } from "lucide-react";
+import type { RemoteSkill, RemoteSkillGroup } from "../../../../core/skill-sync";
+import { localize, type LanguageMode } from "../../language";
+import { Markdown } from "../../markdown";
+import { markdownPreview } from "../../markdown-preview";
+
+export function CloudSkillDetail({
+  group,
+  busy,
+  language,
+  onInstall,
+  onFetchVersion,
+}: {
+  group: RemoteSkillGroup;
+  busy: boolean;
+  language: LanguageMode;
+  onInstall: (remoteSkillId: string) => Promise<void>;
+  onFetchVersion: (remoteSkillId: string) => Promise<RemoteSkill>;
+}): ReactElement {
+  const l = (en: string, zh: string) => localize(language, en, zh);
+  const [selectedVersionId, setSelectedVersionId] = useState(group.latest.id);
+  const [markdown, setMarkdown] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const selectedVersion = group.versions.find((version) => version.id === selectedVersionId) ?? group.latest;
+
+  useEffect(() => {
+    setSelectedVersionId(group.latest.id);
+  }, [group.fingerprint, group.latest.id]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setMarkdown("");
+    onFetchVersion(selectedVersion.id)
+      .then((remote) => {
+        if (!cancelled) setMarkdown(remote.markdown);
+      })
+      .catch((reason) => {
+        if (!cancelled) setError(reason instanceof Error ? reason.message : String(reason));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [onFetchVersion, selectedVersion.id]);
+
+  return (
+    <main className="skill-library-detail">
+      <header className="managed-skill-head">
+        <div className="managed-skill-title">
+          <div>
+            <h3>{group.name}</h3>
+            <span>{l("Cloud", "云端")}</span>
+          </div>
+          <p>{group.description || l("No description", "暂无说明")}</p>
+        </div>
+        <div className="managed-skill-actions">
+          <button type="button" className="primary" disabled={busy || group.legacy} onClick={() => void onInstall(selectedVersion.id)}>
+            <Download size={14} />
+            {l("Add to Skill library", "加入 Skill 库")}
+          </button>
+        </div>
+      </header>
+
+      <section className="managed-skill-document">
+        <div className="managed-skill-document-head">
+          <span><Cloud size={12} /> SKILL.md</span>
+          <small>{l(`${group.versions.length} cloud versions`, `${group.versions.length} 个云端版本`)}</small>
+        </div>
+        <div className="managed-skill-version-list cloud-skill-version-list">
+          {group.versions.map((version) => (
+            <button
+              key={version.id}
+              type="button"
+              className={version.id === selectedVersion.id ? "active" : ""}
+              onClick={() => setSelectedVersionId(version.id)}
+            >
+              <strong>v{version.version}</strong>
+              <span>{new Date(version.updatedAt).toLocaleString(language === "zh" ? "zh-CN" : "en-US")}</span>
+            </button>
+          ))}
+        </div>
+        <div className="managed-skill-markdown">
+          {loading ? l("Loading cloud Skill…", "正在加载云端 Skill…") : error ? error : (
+            <Markdown text={markdownPreview(markdown, 18_000, l("…(truncated)", "…（已截断）"))} language={language} />
+          )}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/main-2.0/src/renderer/src/features/skills/skill-library-list.tsx
+++ b/apps/main-2.0/src/renderer/src/features/skills/skill-library-list.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import type { KeyboardEvent as ReactKeyboardEvent, ReactElement } from "react";
 import { Check, ChevronDown, ChevronRight, Search } from "lucide-react";
 import type { ManagedSkill, ManagedSkillOriginKind } from "../../../../core/managed-skill-library";
+import type { RemoteSkillGroup } from "../../../../core/skill-sync";
 import { formatCompactNumber } from "../../format-count";
 import { localize, type LanguageMode } from "../../language";
 
@@ -47,6 +48,9 @@ export function SkillLibraryList({
   onSortChange,
   onSelect,
   onToggleChecked,
+  remoteOnlyGroups,
+  selectedRemoteFingerprint,
+  onSelectRemote,
   evalBadgeCounts,
   onNavigateToEval,
 }: {
@@ -63,6 +67,9 @@ export function SkillLibraryList({
   onSortChange: (sort: ManagedSkillSort) => void;
   onSelect: (managedId: string) => void;
   onToggleChecked: (managedId: string) => void;
+  remoteOnlyGroups: RemoteSkillGroup[];
+  selectedRemoteFingerprint: string | null;
+  onSelectRemote: (fingerprint: string) => void;
   evalBadgeCounts?: Map<string, { low: number; medium: number }>;
   onNavigateToEval?: (skillName: string) => void;
 }): ReactElement {
@@ -135,7 +142,7 @@ export function SkillLibraryList({
 
       <div className="skill-library-scroll" role="listbox" aria-label={l("Managed Skill library", "托管 Skill 库")}>
         {loading && skills.length === 0 ? <div className="skill-library-empty">{l("Loading Skills…", "正在加载 Skill…")}</div> : null}
-        {!loading && skills.length === 0 ? (
+        {!loading && skills.length === 0 && remoteOnlyGroups.length === 0 ? (
           <div className="skill-library-empty">
             <strong>{l("No managed Skills", "Skill 库还是空的")}</strong>
             <span>{l("Import an existing Skill or discover one from skills.sh.", "可以导入本机已有 Skill，或从 skills.sh 发现新 Skill。")}</span>
@@ -218,6 +225,39 @@ export function SkillLibraryList({
             </section>
           );
         })}
+        {remoteOnlyGroups.length > 0 ? (
+          <section className="skill-library-group cloud-only-skill-group">
+            <div className="skill-library-group-header cloud-only-skill-group-header">
+              <span aria-hidden="true" />
+              <span>{l("Cloud only", "仅云端")}</span>
+              <small>{formatCompactNumber(remoteOnlyGroups.length)}</small>
+            </div>
+            {remoteOnlyGroups.map((group) => {
+              const active = group.fingerprint === selectedRemoteFingerprint;
+              return (
+                <div
+                  key={group.fingerprint}
+                  className={`skill-library-row cloud-only-skill-row ${active ? "active" : ""}`}
+                  role="option"
+                  aria-selected={active}
+                  tabIndex={active ? 0 : -1}
+                  onClick={() => onSelectRemote(group.fingerprint)}
+                >
+                  <span className="cloud-only-skill-icon" aria-hidden="true">☁</span>
+                  <div className="skill-library-row-copy">
+                    <div className="skill-library-row-title">
+                      <strong title={group.name}>{group.name}</strong>
+                      <span>v{group.latest.version}</span>
+                    </div>
+                    <div className="skill-library-row-meta">
+                      <span>{l("Cloud version available", "云端已有版本")}</span>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </section>
+        ) : null}
       </div>
     </aside>
   );

--- a/apps/main-2.0/src/renderer/src/features/skills/skill-target-dialog.test.tsx
+++ b/apps/main-2.0/src/renderer/src/features/skills/skill-target-dialog.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ManagedSkill } from "../../../../core/managed-skill-library";
+import { SKILL_INSTALL_TARGETS } from "../../../../core/agent-skill-registry";
+import { SkillTargetDialog } from "./skill-target-dialog";
+
+describe("SkillTargetDialog", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("renders a label for every supported installation target", async () => {
+    const skill = {
+      id: "skill-id",
+      managedId: "skill-id",
+      name: "Example Skill",
+      description: "",
+      agent: "codex",
+      source: "agent-recall-v2",
+      path: "C:/managed/skill-id/SKILL.md",
+      directoryPath: "C:/managed/skill-id",
+      rootPath: "C:/managed",
+      markdown: "# Example",
+      mtimeMs: 0,
+      origin: { kind: "builtin", label: "AgentRecall" },
+      installations: SKILL_INSTALL_TARGETS.map((target) => ({
+        target,
+        path: `C:/target/${target}`,
+        state: "not-installed" as const,
+      })),
+    } as ManagedSkill;
+
+    await act(async () => root.render(createElement(SkillTargetDialog, {
+      open: true,
+      skill,
+      busy: false,
+      language: "zh",
+      onClose: vi.fn(),
+      onSave: vi.fn(async () => undefined),
+    })));
+
+    expect([...container.querySelectorAll(".managed-skill-target-options strong")].map((node) => node.textContent)).toEqual([
+      "Codex",
+      "Codex shared (~/.agents/skills)",
+      "Claude Code",
+      "CodeBuddy",
+      "Qoder",
+      "Trae",
+      "Pi",
+    ]);
+  });
+});

--- a/apps/main-2.0/src/renderer/src/features/skills/skill-target-dialog.tsx
+++ b/apps/main-2.0/src/renderer/src/features/skills/skill-target-dialog.tsx
@@ -5,11 +5,12 @@ import type { ManagedSkill, SkillInstallTarget } from "../../../../core/managed-
 import { AGENT_SKILL_REGISTRY } from "../../../../core/agent-skill-registry";
 import { localize, type LanguageMode } from "../../language";
 
-const TARGET_LABELS: Record<SkillInstallTarget, string> = Object.fromEntries(
+const TARGET_LABELS: Record<SkillInstallTarget, string> = Object.fromEntries([
   AGENT_SKILL_REGISTRY
     .filter((entry) => entry.installTarget !== null)
     .map((entry) => [entry.installTarget!, entry.label]),
-) as Record<SkillInstallTarget, string>;
+  ["codex-shared", "Codex shared (~/.agents/skills)"],
+]) as Record<SkillInstallTarget, string>;
 
 export function SkillTargetDialog({
   open,

--- a/apps/main-2.0/src/renderer/src/features/skills/skill-target-dialog.tsx
+++ b/apps/main-2.0/src/renderer/src/features/skills/skill-target-dialog.tsx
@@ -6,7 +6,7 @@ import { AGENT_SKILL_REGISTRY } from "../../../../core/agent-skill-registry";
 import { localize, type LanguageMode } from "../../language";
 
 const TARGET_LABELS: Record<SkillInstallTarget, string> = Object.fromEntries([
-  AGENT_SKILL_REGISTRY
+  ...AGENT_SKILL_REGISTRY
     .filter((entry) => entry.installTarget !== null)
     .map((entry) => [entry.installTarget!, entry.label]),
   ["codex-shared", "Codex shared (~/.agents/skills)"],

--- a/apps/main-2.0/src/renderer/src/features/skills/skills-page.tsx
+++ b/apps/main-2.0/src/renderer/src/features/skills/skills-page.tsx
@@ -9,6 +9,7 @@ import { localize, type LanguageMode } from "../../language";
 import { buildUnifiedSkillEntries } from "../../skill-sync-view-model";
 import type { SkillsFeedback } from "../../app-types";
 import { LocalSkillsTab } from "./local-skills-tab";
+import { CloudSkillDetail } from "./cloud-skill-detail";
 import { SkillDiscoveryDialog } from "./skill-discovery-dialog";
 import { SkillLibraryDetail } from "./skill-library-detail";
 import {
@@ -74,6 +75,7 @@ export function SkillsPage({
   const [localSkillCount, setLocalSkillCount] = useState(0);
   const [localRefreshVersion, setLocalRefreshVersion] = useState(0);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [selectedRemoteFingerprint, setSelectedRemoteFingerprint] = useState<string | null>(null);
   const [checkedIds, setCheckedIds] = useState<Set<string>>(() => new Set());
   const [discoveryOpen, setDiscoveryOpen] = useState(false);
   const [deleteCandidate, setDeleteCandidate] = useState<ManagedSkill | null>(null);
@@ -85,7 +87,9 @@ export function SkillsPage({
     () => filterManagedSkills(managedSkills, query, originFilter, sort),
     [managedSkills, originFilter, query, sort],
   );
-  const selectedSkill = filteredSkills.find((skill) => skill.managedId === selectedId) ?? filteredSkills[0] ?? null;
+  const selectedSkill = selectedRemoteFingerprint
+    ? null
+    : filteredSkills.find((skill) => skill.managedId === selectedId) ?? filteredSkills[0] ?? null;
   const selectedEntry = selectedSkill
     ? unifiedEntries.find((entry) => entry.local?.path === selectedSkill.path) ?? null
     : null;
@@ -93,6 +97,7 @@ export function SkillsPage({
     () => unifiedEntries.flatMap((entry) => !entry.local && entry.remote ? [entry.remote] : []),
     [unifiedEntries],
   );
+  const selectedRemoteGroup = remoteOnlyGroups.find((group) => group.fingerprint === selectedRemoteFingerprint) ?? null;
   const managedSourcePaths = useMemo(
     () => new Set(managedSkills.flatMap((skill) => skill.origin.kind === "local" && skill.origin.sourcePath
       ? [skill.origin.sourcePath]
@@ -101,6 +106,10 @@ export function SkillsPage({
   );
 
   useEffect(() => {
+    if (selectedRemoteFingerprint) {
+      if (selectedRemoteGroup) return;
+      setSelectedRemoteFingerprint(null);
+    }
     if (pendingSelection && managedSkills.some((skill) => skill.managedId === pendingSelection)) {
       setSelectedId(pendingSelection);
       setPendingSelection(null);
@@ -109,7 +118,7 @@ export function SkillsPage({
     if (!selectedId || !filteredSkills.some((skill) => skill.managedId === selectedId)) {
       setSelectedId(filteredSkills[0]?.managedId ?? null);
     }
-  }, [filteredSkills, managedSkills, pendingSelection, selectedId]);
+  }, [filteredSkills, managedSkills, pendingSelection, selectedId, selectedRemoteFingerprint, selectedRemoteGroup]);
 
   useEffect(() => {
     const existing = new Set(managedSkills.map((skill) => skill.managedId));
@@ -258,17 +267,37 @@ export function SkillsPage({
               onQueryChange={setQuery}
               onOriginFilterChange={setOriginFilter}
               onSortChange={setSort}
-              onSelect={setSelectedId}
+              onSelect={(managedId) => {
+                setSelectedRemoteFingerprint(null);
+                setSelectedId(managedId);
+              }}
               onToggleChecked={(managedId) => setCheckedIds((current) => {
                 const next = new Set(current);
                 if (next.has(managedId)) next.delete(managedId);
                 else next.add(managedId);
                 return next;
               })}
+              remoteOnlyGroups={remoteOnlyGroups}
+              selectedRemoteFingerprint={selectedRemoteFingerprint}
+              onSelectRemote={(fingerprint) => {
+                setSelectedId(null);
+                setSelectedRemoteFingerprint(fingerprint);
+              }}
               evalBadgeCounts={evalBadgeCountsMap}
               onNavigateToEval={onNavigateToEval}
             />
-            <SkillLibraryDetail
+            {selectedRemoteGroup ? (
+              <CloudSkillDetail
+                group={selectedRemoteGroup}
+                busy={loading || batchBusy}
+                language={language}
+                onInstall={async (remoteSkillId) => {
+                  await onInstallRemote(remoteSkillId);
+                  setSelectedRemoteFingerprint(null);
+                }}
+                onFetchVersion={onFetchVersion}
+              />
+            ) : <SkillLibraryDetail
               skill={selectedSkill}
               entry={selectedEntry}
               remoteOnlyGroups={remoteOnlyGroups}
@@ -287,7 +316,7 @@ export function SkillsPage({
               onCopyPath={onCopyPath}
               onReveal={onReveal}
               onRequestDelete={setDeleteCandidate}
-            />
+            />}
           </div>
         </section>
 

--- a/apps/main-2.0/src/renderer/src/styles/skills-page.css
+++ b/apps/main-2.0/src/renderer/src/styles/skills-page.css
@@ -379,6 +379,19 @@
   background: var(--row-selected-bg);
 }
 
+.cloud-only-skill-row {
+  grid-template-columns: 20px minmax(0, 1fr);
+}
+
+.cloud-only-skill-icon {
+  display: grid;
+  width: 16px;
+  height: 16px;
+  place-items: center;
+  color: var(--accent);
+  font-size: 12px;
+}
+
 .skill-library-check {
   display: grid;
   width: 16px;
@@ -762,6 +775,41 @@
 .skill-discovery-markdown > :last-child,
 .managed-skill-version-preview > :last-child {
   margin-bottom: 0;
+}
+
+.cloud-skill-version-list {
+  display: flex;
+  gap: 6px;
+  padding: 9px 18px;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--panel-subtle);
+}
+
+.cloud-skill-version-list button {
+  display: grid;
+  min-width: 112px;
+  gap: 2px;
+  padding: 6px 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 7px;
+  background: var(--panel-bg);
+  color: var(--text-muted);
+  text-align: left;
+}
+
+.cloud-skill-version-list button.active {
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
+}
+
+.cloud-skill-version-list strong {
+  color: var(--text);
+  font-size: 11px;
+}
+
+.cloud-skill-version-list span {
+  font-size: 9.5px;
 }
 
 .managed-skill-sync {

--- a/docs/v2/guide.md
+++ b/docs/v2/guide.md
@@ -351,7 +351,7 @@ Skills 页面包含 **本 App Skill**和**本地 Skill**两个区域。
 
 在 **本 App Skill**中打开 Skill 详情，点击 **管理安装**，选择 Codex、Claude Code、CodeBuddy、Qoder 或 Trae。
 
-这里的安装目标是本机编码 Agent，不是 Runtime 页面中创建的可复用 Agent。如果目标目录已有同名内容，页面会显示冲突，并且不会直接覆盖。
+这里的安装目标是本机编码 Agent，不是 Runtime 页面中创建的可复用 Agent。除了 Codex 私有目录外，还可以选择 **Codex shared (`~/.agents/skills`)**，适合让多个 Codex 工作区共用同一份 Skill；Windows 下对应用户目录中的 `.agents\skills`。如果目标目录已有同名内容，页面会显示冲突，并且不会直接覆盖。
 
 ### 跨设备同步 Skill
 
@@ -362,6 +362,8 @@ Skills 页面包含 **本 App Skill**和**本地 Skill**两个区域。
 - 比较本地与云端文件差异。
 - 在另一台设备把云端 Skill 加入 Skill 库。
 - 恢复指定历史版本。
+
+云端 Skill 会在 **本 App Skill** 左侧单独显示为“仅云端”，选中后可以直接预览任意版本，再加入本 App，不需要先找到一个同名的本地 Skill。
 
 系统、项目或插件管理的 Skill 不一定支持上传。AI 探索公共 Skill 时，可以在设置中指定使用哪个 Runtime；自动模式会选择第一个可用 Runtime。
 


### PR DESCRIPTION
变更：

- 将 Codex shared 安装目标接到 ~/.agents/skills，支持多个 Codex 工作区共用 Skill。
- 将仅云端 Skill 提升到 Skill 库列表，可直接选择、预览版本并加入本 App。
- 更新 V2 使用说明并补充发布说明。

验证：

- npm --prefix apps/main-2.0 run typecheck
- npm --prefix apps/main-2.0 run build
- npm --prefix apps/main-2.0 exec vitest -- run src/core/managed-skill-library.test.ts
- npm run test:repo
- npm run release-note:check