### PR TITLE
fix: show Codex Desktop projects in v1 and v2

### DIFF
--- a/.release-notes/fix-codex-project-sidebar.md
+++ b/.release-notes/fix-codex-project-sidebar.md
@@ -1,0 +1,6 @@
+# 修复 Codex 项目侧栏显示
+<!-- release-target: both -->
+
+## Bug 修复
+
+- 修复从 Codex App 创建的项目在 AgentRecall v1 和 v2 左侧项目列表中不显示的问题；没有聊天记录的空项目也会正常显示。

--- a/apps/main-1.0/src/core/codex-projects.test.ts
+++ b/apps/main-1.0/src/core/codex-projects.test.ts
@@ -1,0 +1,66 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { mergeCodexDesktopProjects, readCodexDesktopProjects } from "./codex-projects";
+import type { ProjectSummary } from "./types";
+
+function indexedProject(overrides: Partial<ProjectSummary> = {}): ProjectSummary {
+  return {
+    path: "E:\\Code\\AgentRecall",
+    label: "AgentRecall",
+    labelKind: "path",
+    labelSuffix: null,
+    sessionCount: 2,
+    environmentId: "local",
+    environmentLabel: "Local",
+    createdAt: 10,
+    lastActivityAt: 20,
+    ...overrides,
+  };
+}
+
+describe("Codex Desktop project discovery", () => {
+  it("reads saved workspace roots and labels, including projects without chats", () => {
+    const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-codex-projects-"));
+    try {
+      fs.writeFileSync(path.join(codexHome, ".codex-global-state.json"), JSON.stringify({
+        "electron-saved-workspace-roots": ["E:\\Code\\AgentRecall", "E:\\Code\\Resume"],
+        "electron-workspace-root-labels": { "E:\\Code\\Resume": "简历" },
+        "project-order": ["E:\\Code\\Resume", "E:\\Code\\AgentRecall"],
+      }));
+
+      expect(readCodexDesktopProjects(codexHome)).toEqual([
+        { path: "E:\\Code\\Resume", label: "简历" },
+        { path: "E:\\Code\\AgentRecall", label: "AgentRecall" },
+      ]);
+    } finally {
+      fs.rmSync(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  it("merges an empty Desktop project with indexed projects without duplicating paths", () => {
+    const merged = mergeCodexDesktopProjects(
+      [indexedProject()],
+      [
+        { path: "E:\\Code\\AgentRecall", label: "AgentRecall" },
+        { path: "E:\\Code\\Resume", label: "简历" },
+      ],
+    );
+
+    expect(merged).toEqual([
+      indexedProject(),
+      {
+        path: "E:\\Code\\Resume",
+        label: "简历",
+        labelKind: "path",
+        labelSuffix: null,
+        sessionCount: 0,
+        environmentId: "local",
+        environmentLabel: "Local",
+        createdAt: 0,
+        lastActivityAt: 0,
+      },
+    ]);
+  });
+});

--- a/apps/main-1.0/src/core/codex-projects.ts
+++ b/apps/main-1.0/src/core/codex-projects.ts
@@ -1,0 +1,96 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ProjectSummary } from "./types";
+
+export interface CodexDesktopProject {
+  path: string;
+  label: string;
+}
+
+const CODEX_GLOBAL_STATE_FILE = ".codex-global-state.json";
+const PROJECT_ROOT_KEYS = ["project-order", "electron-saved-workspace-roots"] as const;
+const PROJECT_LABEL_KEY = "electron-workspace-root-labels";
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function projectKey(value: string): string {
+  return value.trim().replaceAll("\\", "/").replace(/\/+$/u, "").toLocaleLowerCase();
+}
+
+function projectLabel(projectPath: string): string {
+  const parts = projectPath.split(/[\\/]+/u).filter(Boolean);
+  return parts.at(-1) || projectPath;
+}
+
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string" && item.trim().length > 0).map((item) => item.trim())
+    : [];
+}
+
+function readStringMap(value: unknown): Map<string, string> {
+  const map = new Map<string, string>();
+  const object = record(value);
+  if (!object) return map;
+  for (const [key, label] of Object.entries(object)) {
+    if (typeof label === "string" && label.trim()) map.set(projectKey(key), label.trim());
+  }
+  return map;
+}
+
+export function readCodexDesktopProjects(codexHome: string): CodexDesktopProject[] {
+  let state: Record<string, unknown> | null = null;
+  try {
+    state = record(JSON.parse(fs.readFileSync(path.join(codexHome, CODEX_GLOBAL_STATE_FILE), "utf8")));
+  } catch {
+    return [];
+  }
+  if (!state) return [];
+  const roots: string[] = [];
+  const seen = new Set<string>();
+  for (const key of PROJECT_ROOT_KEYS) {
+    for (const root of readStringArray(state[key])) {
+      const identity = projectKey(root);
+      if (!identity || seen.has(identity)) continue;
+      seen.add(identity);
+      roots.push(root);
+    }
+  }
+  const labels = readStringMap(state[PROJECT_LABEL_KEY]);
+  return roots.map((root) => ({ path: root, label: labels.get(projectKey(root)) || projectLabel(root) }));
+}
+
+export function mergeCodexDesktopProjects(
+  indexedProjects: ProjectSummary[],
+  desktopProjects: CodexDesktopProject[],
+): ProjectSummary[] {
+  const merged = indexedProjects.map((project) => ({ ...project }));
+  const byPath = new Map(merged.map((project) => [projectKey(project.path), project]));
+  for (const project of desktopProjects) {
+    const key = projectKey(project.path);
+    if (!key) continue;
+    const indexed = byPath.get(key);
+    if (indexed) {
+      if (indexed.labelKind === "path" && project.label.trim()) indexed.label = project.label.trim();
+      continue;
+    }
+    const emptyProject: ProjectSummary = {
+      path: project.path,
+      label: project.label.trim() || projectLabel(project.path),
+      labelKind: "path",
+      labelSuffix: null,
+      sessionCount: 0,
+      environmentId: "local",
+      environmentLabel: "Local",
+      createdAt: 0,
+      lastActivityAt: 0,
+    };
+    merged.push(emptyProject);
+    byPath.set(key, emptyProject);
+  }
+  return merged;
+}

--- a/apps/main-1.0/src/core/session-loader.test.ts
+++ b/apps/main-1.0/src/core/session-loader.test.ts
@@ -20,6 +20,28 @@ import {
 import { TRACE_DETAIL_PREVIEW_MAX_CHARS } from "./trace-detail";
 
 describe("Codex session loading", () => {
+  it("uses the first real turn_context cwd when Desktop metadata has a local-workspace placeholder", () => {
+    const loaded = loadCodexSessionRows("/tmp/codex-placeholder-workspace.jsonl", [
+      {
+        type: "session_meta",
+        timestamp: "2026-08-18T00:00:00Z",
+        payload: { session_id: "codex-placeholder", cwd: "<local-workspace>", originator: "Codex Desktop" },
+      },
+      {
+        type: "turn_context",
+        timestamp: "2026-08-18T00:00:01Z",
+        payload: { cwd: "E:\\Code\\CreatedProject", workspace_roots: ["E:\\Code\\CreatedProject"] },
+      },
+      {
+        type: "response_item",
+        timestamp: "2026-08-18T00:00:02Z",
+        payload: { type: "message", role: "user", content: [{ type: "input_text", text: "创建项目后的第一条消息" }] },
+      },
+    ]);
+
+    expect(loaded?.session.projectPath).toBe("E:\\Code\\CreatedProject");
+  });
+
   it("preserves explicit timezone offsets as absolute instants", () => {
     const loaded = loadCodexSessionRows("/tmp/codex-offset.jsonl", [
       {

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -52,6 +52,7 @@ const CODEWIZ_SHARE_DIR = path.join(".local", "share", "codewiz");
 const QODER_DIR = ".qoder";
 const PI_SESSIONS_DIR = path.join(".pi", "agent", "sessions");
 const TRAE_DIR_NAMES = [".trae", ".trae-cn"] as const;
+const CODEX_WORKSPACE_PLACEHOLDER = /^<[^>]+>$/u;
 
 export interface SessionLoadOptions {
   homeDir?: string;
@@ -108,28 +109,30 @@ export function parseCodexSessionMetaLine(parsed: unknown): {
   if (!parsed || typeof parsed !== "object") return null;
 
   const line = parsed as CodexConversationLine;
-  if (line.type === "session_meta" && line.payload?.id) {
+  const payload = line.payload;
+  const sessionId = payload?.id || payload?.session_id;
+  if (line.type === "session_meta" && payload && sessionId) {
     const structuredSource =
-      line.payload.source && typeof line.payload.source === "object" ? line.payload.source : null;
+      payload.source && typeof payload.source === "object" ? payload.source : null;
     const structuredParent = structuredSource?.subagent?.thread_spawn?.parent_thread_id;
-    const legacyParent = line.payload.thread_source === "subagent" ? line.payload.parent_thread_id : undefined;
+    const legacyParent = payload.thread_source === "subagent" ? payload.parent_thread_id : undefined;
     const parentSessionId = structuredParent || legacyParent || null;
-    const agentPath = line.payload.agent_path
+    const agentPath = payload.agent_path
       || structuredSource?.subagent?.thread_spawn?.agent_path
       || (parentSessionId === null ? "/root" : null);
     return {
-      id: line.payload.id,
-      projectPath: typeof line.payload.agent_recall_project_path === "string"
-        ? line.payload.agent_recall_project_path
-        : line.payload.cwd || "",
+      id: sessionId,
+      projectPath: typeof payload.agent_recall_project_path === "string"
+        ? payload.agent_recall_project_path
+        : payload.cwd || "",
       ts: line.timestamp ? new Date(line.timestamp).getTime() : 0,
-      title: line.payload.title,
-      gitBranch: line.payload.git?.branch,
-      originator: line.payload.originator,
+      title: payload.title,
+      gitBranch: payload.git?.branch,
+      originator: payload.originator,
       isSubagent: parentSessionId !== null,
       parentSessionId,
       agentPath,
-      historyMode: (line.payload as { history_mode?: unknown }).history_mode === "paginated" ? "paginated" : "legacy",
+      historyMode: (payload as { history_mode?: unknown }).history_mode === "paginated" ? "paginated" : "legacy",
     };
   }
 
@@ -160,7 +163,7 @@ function findCodexSessionMeta(rows: unknown[]): NonNullable<ReturnType<typeof pa
     }
     result = {
       ...result,
-      projectPath: result.projectPath || parsed.projectPath,
+      projectPath: usableCodexProjectPath(result.projectPath) ? result.projectPath : parsed.projectPath || result.projectPath,
       ts: result.ts || parsed.ts,
       title: result.title || parsed.title,
       gitBranch: result.gitBranch || parsed.gitBranch,
@@ -171,7 +174,28 @@ function findCodexSessionMeta(rows: unknown[]): NonNullable<ReturnType<typeof pa
       historyMode: result.historyMode === "paginated" || parsed.historyMode === "paginated" ? "paginated" : "legacy",
     };
   }
+  const turnContextProjectPath = rows
+    .map(codexTurnContextProjectPath)
+    .find((projectPath): projectPath is string => Boolean(projectPath));
+  if (result && !usableCodexProjectPath(result.projectPath) && turnContextProjectPath) {
+    result.projectPath = turnContextProjectPath;
+  }
   return result;
+}
+
+function usableCodexProjectPath(value: string): boolean {
+  const normalized = value.trim();
+  return Boolean(normalized) && !CODEX_WORKSPACE_PLACEHOLDER.test(normalized);
+}
+
+function codexTurnContextProjectPath(value: unknown): string {
+  if (!isRecord(value) || value.type !== "turn_context") return "";
+  const payload = objectField(value, "payload");
+  const cwd = stringField(payload, "cwd").trim();
+  if (usableCodexProjectPath(cwd)) return cwd;
+  const roots = payload?.workspace_roots;
+  if (!Array.isArray(roots)) return "";
+  return roots.find((root): root is string => typeof root === "string" && usableCodexProjectPath(root))?.trim() || "";
 }
 
 function safeStat(filePath: string): VirtualSessionFileStat {
@@ -1783,7 +1807,7 @@ function createCodexScanAccumulator(base?: { offset: number; loaded: LoadedSessi
       if (parsedMeta) {
         meta = meta ? {
           ...meta,
-          projectPath: meta.projectPath || parsedMeta.projectPath,
+          projectPath: usableCodexProjectPath(meta.projectPath) ? meta.projectPath : parsedMeta.projectPath || meta.projectPath,
           ts: meta.ts || parsedMeta.ts,
           title: meta.title || parsedMeta.title,
           gitBranch: meta.gitBranch || parsedMeta.gitBranch,
@@ -1793,6 +1817,10 @@ function createCodexScanAccumulator(base?: { offset: number; loaded: LoadedSessi
           agentPath: meta.agentPath || parsedMeta.agentPath,
           historyMode: meta.historyMode === "paginated" || parsedMeta.historyMode === "paginated" ? "paginated" : "legacy",
         } : parsedMeta;
+      }
+      const turnContextProjectPath = codexTurnContextProjectPath(row);
+      if (meta && !usableCodexProjectPath(meta.projectPath) && turnContextProjectPath) {
+        meta = { ...meta, projectPath: turnContextProjectPath };
       }
 
       if (isRecord(row)) {

--- a/apps/main-1.0/src/main/index.ts
+++ b/apps/main-1.0/src/main/index.ts
@@ -29,6 +29,7 @@ import {
   type CodexRequestFidelity,
 } from "../core/codex-request-export";
 import { extractSessionContextComponents } from "../core/session-context-components";
+import { mergeCodexDesktopProjects, readCodexDesktopProjects } from "../core/codex-projects";
 import { indexMigratedSessionFile, type IndexStatus } from "../core/indexer";
 import { createIndexRunCoordinator } from "../core/index-run-coordinator";
 import { createIndexProgressPublisher } from "./index-progress";
@@ -158,6 +159,7 @@ import type {
   MigrationTarget,
   PortableSession,
   ProjectQueryOptions,
+  ProjectSummary,
   SearchOptions,
   SessionEnvironment,
   SessionMigrationProgress,
@@ -402,7 +404,7 @@ function visibleSearchOptions(options: SearchOptions = {}): SearchOptions {
 }
 
 function createRulesSyncService(): RulesIpcService {
-  const projectDirs = () => store.listProjects(visibleProjectOptions()).map((p) => p.path);
+  const projectDirs = () => listVisibleProjects(visibleProjectOptions()).map((p) => p.path);
   const createClient = () => {
     const settings = getSettings();
     return new SupabaseRulesSyncClient({ url: settings.skillSyncSupabaseUrl, anonKey: settings.skillSyncSupabaseAnonKey });
@@ -525,6 +527,16 @@ function visibleStatsOptions(options: SessionStatsOptions = {}): SessionStatsOpt
 
 function visibleProjectOptions(): { excludeSubagents: boolean } {
   return { excludeSubagents: true };
+}
+
+function codexDesktopHome(): string {
+  return process.env.CODEX_HOME?.trim() || path.join(app.getPath("home"), ".codex");
+}
+
+function listVisibleProjects(options: ProjectQueryOptions = {}): ProjectSummary[] {
+  const indexed = store.listProjects(options);
+  if (options.environmentId && options.environmentId !== "all" && options.environmentId !== "local") return indexed;
+  return mergeCodexDesktopProjects(indexed, readCodexDesktopProjects(codexDesktopHome()));
 }
 
 function disabledOptionalSources(settings: AppSettings): SessionSource[] {
@@ -2003,7 +2015,7 @@ function registerIpc(): void {
           };
         }
         case "list_projects": {
-          const projects = store.listProjects(visibleProjectOptions());
+          const projects = listVisibleProjects(visibleProjectOptions());
           return {
             result: projects.map((project) => ({ project: project.path, sessions: project.sessionCount })),
             sessionKeys: [],
@@ -2065,7 +2077,7 @@ function registerIpc(): void {
     store.listTags({ ...options, ...visibleProjectOptions() }),
   );
   ipcMain.handle("projects:list", (_event, options?: ProjectQueryOptions) =>
-    store.listProjects({ ...options, ...visibleProjectOptions() }),
+    listVisibleProjects({ ...options, ...visibleProjectOptions() }),
   );
   ipcMain.handle("tags:by-project", () => store.listTagsByProject(visibleProjectOptions()));
   ipcMain.handle("environments:list", () => store.listEnvironments());

--- a/apps/main-2.0/src/core/codex-projects.test.ts
+++ b/apps/main-2.0/src/core/codex-projects.test.ts
@@ -1,0 +1,66 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { mergeCodexDesktopProjects, readCodexDesktopProjects } from "./codex-projects";
+import type { ProjectSummary } from "./types";
+
+function indexedProject(overrides: Partial<ProjectSummary> = {}): ProjectSummary {
+  return {
+    path: "E:\\Code\\AgentRecall",
+    label: "AgentRecall",
+    labelKind: "path",
+    labelSuffix: null,
+    sessionCount: 2,
+    environmentId: "local",
+    environmentLabel: "Local",
+    createdAt: 10,
+    lastActivityAt: 20,
+    ...overrides,
+  };
+}
+
+describe("Codex Desktop project discovery", () => {
+  it("reads saved workspace roots and labels, including projects without chats", async () => {
+    const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-codex-projects-"));
+    try {
+      fs.writeFileSync(path.join(codexHome, ".codex-global-state.json"), JSON.stringify({
+        "electron-saved-workspace-roots": ["E:\\Code\\AgentRecall", "E:\\Code\\Resume"],
+        "electron-workspace-root-labels": { "E:\\Code\\Resume": "简历" },
+        "project-order": ["E:\\Code\\Resume", "E:\\Code\\AgentRecall"],
+      }));
+
+      await expect(readCodexDesktopProjects(codexHome)).resolves.toEqual([
+        { path: "E:\\Code\\Resume", label: "简历" },
+        { path: "E:\\Code\\AgentRecall", label: "AgentRecall" },
+      ]);
+    } finally {
+      fs.rmSync(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  it("merges an empty Desktop project with indexed projects without duplicating paths", () => {
+    const merged = mergeCodexDesktopProjects(
+      [indexedProject()],
+      [
+        { path: "E:\\Code\\AgentRecall", label: "AgentRecall" },
+        { path: "E:\\Code\\Resume", label: "简历" },
+      ],
+    );
+
+    expect(merged).toEqual([
+      indexedProject(),
+      {
+        path: "E:\\Code\\Resume",
+        label: "简历",
+        labelKind: "path",
+        labelSuffix: null,
+        sessionCount: 0,
+        environmentId: "local",
+        environmentLabel: "Local",
+        createdAt: 0,
+        lastActivityAt: 0,
+      },
+    ]);
+  });
+});

--- a/apps/main-2.0/src/core/codex-projects.ts
+++ b/apps/main-2.0/src/core/codex-projects.ts
@@ -1,0 +1,96 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { ProjectSummary } from "./types";
+
+export interface CodexDesktopProject {
+  path: string;
+  label: string;
+}
+
+const CODEX_GLOBAL_STATE_FILE = ".codex-global-state.json";
+const PROJECT_ROOT_KEYS = ["project-order", "electron-saved-workspace-roots"] as const;
+const PROJECT_LABEL_KEY = "electron-workspace-root-labels";
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function projectKey(value: string): string {
+  return value.trim().replaceAll("\\", "/").replace(/\/+$/u, "").toLocaleLowerCase();
+}
+
+function projectLabel(projectPath: string): string {
+  const parts = projectPath.split(/[\\/]+/u).filter(Boolean);
+  return parts.at(-1) || projectPath;
+}
+
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string" && item.trim().length > 0).map((item) => item.trim())
+    : [];
+}
+
+function readStringMap(value: unknown): Map<string, string> {
+  const map = new Map<string, string>();
+  const object = record(value);
+  if (!object) return map;
+  for (const [key, label] of Object.entries(object)) {
+    if (typeof label === "string" && label.trim()) map.set(projectKey(key), label.trim());
+  }
+  return map;
+}
+
+export async function readCodexDesktopProjects(codexHome: string): Promise<CodexDesktopProject[]> {
+  let state: Record<string, unknown> | null = null;
+  try {
+    state = record(JSON.parse(await fs.readFile(path.join(codexHome, CODEX_GLOBAL_STATE_FILE), "utf8")));
+  } catch {
+    return [];
+  }
+  if (!state) return [];
+  const roots: string[] = [];
+  const seen = new Set<string>();
+  for (const key of PROJECT_ROOT_KEYS) {
+    for (const root of readStringArray(state[key])) {
+      const identity = projectKey(root);
+      if (!identity || seen.has(identity)) continue;
+      seen.add(identity);
+      roots.push(root);
+    }
+  }
+  const labels = readStringMap(state[PROJECT_LABEL_KEY]);
+  return roots.map((root) => ({ path: root, label: labels.get(projectKey(root)) || projectLabel(root) }));
+}
+
+export function mergeCodexDesktopProjects(
+  indexedProjects: ProjectSummary[],
+  desktopProjects: CodexDesktopProject[],
+): ProjectSummary[] {
+  const merged = indexedProjects.map((project) => ({ ...project }));
+  const byPath = new Map(merged.map((project) => [projectKey(project.path), project]));
+  for (const project of desktopProjects) {
+    const key = projectKey(project.path);
+    if (!key) continue;
+    const indexed = byPath.get(key);
+    if (indexed) {
+      if (indexed.labelKind === "path" && project.label.trim()) indexed.label = project.label.trim();
+      continue;
+    }
+    const emptyProject: ProjectSummary = {
+      path: project.path,
+      label: project.label.trim() || projectLabel(project.path),
+      labelKind: "path",
+      labelSuffix: null,
+      sessionCount: 0,
+      environmentId: "local",
+      environmentLabel: "Local",
+      createdAt: 0,
+      lastActivityAt: 0,
+    };
+    merged.push(emptyProject);
+    byPath.set(key, emptyProject);
+  }
+  return merged;
+}

--- a/apps/main-2.0/src/core/session-loader.test.ts
+++ b/apps/main-2.0/src/core/session-loader.test.ts
@@ -18,6 +18,28 @@ import {
 import { TRACE_DETAIL_PREVIEW_MAX_CHARS } from "./trace-detail";
 
 describe("Codex session loading", () => {
+  it("uses the first real turn_context cwd when Desktop metadata has a local-workspace placeholder", () => {
+    const loaded = loadCodexSessionRows("/tmp/codex-placeholder-workspace.jsonl", [
+      {
+        type: "session_meta",
+        timestamp: "2026-08-18T00:00:00Z",
+        payload: { session_id: "codex-placeholder", cwd: "<local-workspace>", originator: "Codex Desktop" },
+      },
+      {
+        type: "turn_context",
+        timestamp: "2026-08-18T00:00:01Z",
+        payload: { cwd: "E:\\Code\\CreatedProject", workspace_roots: ["E:\\Code\\CreatedProject"] },
+      },
+      {
+        type: "response_item",
+        timestamp: "2026-08-18T00:00:02Z",
+        payload: { type: "message", role: "user", content: [{ type: "input_text", text: "创建项目后的第一条消息" }] },
+      },
+    ]);
+
+    expect(loaded?.session.projectPath).toBe("E:\\Code\\CreatedProject");
+  });
+
   it("preserves explicit timezone offsets as absolute instants", () => {
     const loaded = loadCodexSessionRows("/tmp/codex-offset.jsonl", [
       {

--- a/apps/main-2.0/src/core/session-loader.ts
+++ b/apps/main-2.0/src/core/session-loader.ts
@@ -87,6 +87,7 @@ const TCLAUDE_DIR = ".tclaude";
 const TCODEX_DIR = ".tcodex";
 const CODEBUDDY_DIR = ".codebuddy";
 const WORKBUDDY_DIR = ".workbuddy";
+const CODEX_WORKSPACE_PLACEHOLDER = /^<[^>]+>$/u;
 
 interface CodexSessionMeta {
   id: string;
@@ -105,28 +106,30 @@ export function parseCodexSessionMetaLine(parsed: unknown): CodexSessionMeta | n
   if (!parsed || typeof parsed !== "object") return null;
 
   const line = parsed as CodexConversationLine;
-  if (line.type === "session_meta" && line.payload?.id) {
+  const payload = line.payload;
+  const sessionId = payload?.id || payload?.session_id;
+  if (line.type === "session_meta" && payload && sessionId) {
     const structuredSource =
-      line.payload.source && typeof line.payload.source === "object" ? line.payload.source : null;
+      payload.source && typeof payload.source === "object" ? payload.source : null;
     const structuredParent = structuredSource?.subagent?.thread_spawn?.parent_thread_id;
-    const legacyParent = line.payload.thread_source === "subagent" ? line.payload.parent_thread_id : undefined;
+    const legacyParent = payload.thread_source === "subagent" ? payload.parent_thread_id : undefined;
     const parentSessionId = structuredParent || legacyParent || null;
-    const agentPath = line.payload.agent_path
+    const agentPath = payload.agent_path
       || structuredSource?.subagent?.thread_spawn?.agent_path
       || (parentSessionId === null ? "/root" : null);
     return {
-      id: line.payload.id,
-      projectPath: typeof line.payload.agent_recall_project_path === "string"
-        ? line.payload.agent_recall_project_path
-        : line.payload.cwd || "",
+      id: sessionId,
+      projectPath: typeof payload.agent_recall_project_path === "string"
+        ? payload.agent_recall_project_path
+        : payload.cwd || "",
       ts: line.timestamp ? new Date(line.timestamp).getTime() : 0,
-      title: line.payload.title,
-      gitBranch: line.payload.git?.branch,
-      originator: line.payload.originator,
+      title: payload.title,
+      gitBranch: payload.git?.branch,
+      originator: payload.originator,
       isSubagent: parentSessionId !== null,
       parentSessionId,
       agentPath,
-      historyMode: (line.payload as { history_mode?: unknown }).history_mode === "paginated" ? "paginated" : "legacy",
+      historyMode: (payload as { history_mode?: unknown }).history_mode === "paginated" ? "paginated" : "legacy",
     };
   }
 
@@ -157,7 +160,7 @@ function findCodexSessionMeta(
       result = parsed;
       continue;
     }
-    if (!result.projectPath) result.projectPath = parsed.projectPath;
+    if (!usableCodexProjectPath(result.projectPath) && parsed.projectPath) result.projectPath = parsed.projectPath;
     if (!result.ts) result.ts = parsed.ts;
     if (!result.title) result.title = parsed.title;
     if (!result.gitBranch) result.gitBranch = parsed.gitBranch;
@@ -167,7 +170,28 @@ function findCodexSessionMeta(
     if (!result.agentPath) result.agentPath = parsed.agentPath;
     if (parsed.historyMode === "paginated") result.historyMode = "paginated";
   }
+  const turnContextProjectPath = rows
+    .map(codexTurnContextProjectPath)
+    .find((projectPath): projectPath is string => Boolean(projectPath));
+  if (result && !usableCodexProjectPath(result.projectPath) && turnContextProjectPath) {
+    result.projectPath = turnContextProjectPath;
+  }
   return result;
+}
+
+function usableCodexProjectPath(value: string): boolean {
+  const normalized = value.trim();
+  return Boolean(normalized) && !CODEX_WORKSPACE_PLACEHOLDER.test(normalized);
+}
+
+function codexTurnContextProjectPath(value: unknown): string {
+  if (!isRecord(value) || value.type !== "turn_context") return "";
+  const payload = objectField(value, "payload");
+  const cwd = stringField(payload, "cwd").trim();
+  if (usableCodexProjectPath(cwd)) return cwd;
+  const roots = payload?.workspace_roots;
+  if (!Array.isArray(roots)) return "";
+  return roots.find((root): root is string => typeof root === "string" && usableCodexProjectPath(root))?.trim() || "";
 }
 
 function codexVisibleConversationRows(rows: unknown[]): unknown[] {
@@ -1181,7 +1205,7 @@ function createCodexScanAccumulator(base?: { offset: number; loaded: LoadedSessi
       if (parsedMeta) {
         meta = meta ? {
           ...meta,
-          projectPath: meta.projectPath || parsedMeta.projectPath,
+          projectPath: usableCodexProjectPath(meta.projectPath) ? meta.projectPath : parsedMeta.projectPath || meta.projectPath,
           ts: meta.ts || parsedMeta.ts,
           title: meta.title || parsedMeta.title,
           gitBranch: meta.gitBranch || parsedMeta.gitBranch,
@@ -1191,6 +1215,10 @@ function createCodexScanAccumulator(base?: { offset: number; loaded: LoadedSessi
           agentPath: meta.agentPath || parsedMeta.agentPath,
           historyMode: meta.historyMode === "paginated" || parsedMeta.historyMode === "paginated" ? "paginated" : "legacy",
         } : parsedMeta;
+      }
+      const turnContextProjectPath = codexTurnContextProjectPath(row);
+      if (meta && !usableCodexProjectPath(meta.projectPath) && turnContextProjectPath) {
+        meta = { ...meta, projectPath: turnContextProjectPath };
       }
       if (isRecord(row)) {
         const payload = objectField(row, "payload");

--- a/apps/main-2.0/src/main/index.ts
+++ b/apps/main-2.0/src/main/index.ts
@@ -24,6 +24,7 @@ import { randomUUID } from "node:crypto";
 import { execFile } from "node:child_process";
 import { homedir } from "node:os";
 import { loadActiveCodexSummaryEndpointDefaults } from "../core/codex-profile";
+import { mergeCodexDesktopProjects, readCodexDesktopProjects } from "../core/codex-projects";
 import type { CodexRequestFidelity } from "../core/codex-request-export";
 import { indexMigratedSessionFile, syncDefaultSessionsInBatches, type IndexStatus } from "../core/indexer";
 import { createIndexRunCoordinator } from "../core/index-run-coordinator";
@@ -199,6 +200,8 @@ import type {
   MigrationAgent,
   MigrationTarget,
   PortableSession,
+  ProjectQueryOptions,
+  ProjectSummary,
   SearchOptions,
   SessionEnvironment,
   SessionMigrationProgress,
@@ -740,7 +743,7 @@ function visibleSearchOptions(options: SearchOptions = {}): SearchOptions {
 
 function createRulesSyncService(): RulesIpcService {
   const projectDirs = async () =>
-    (await store.listProjects(visibleProjectOptions())).map((project) => project.path);
+    (await listVisibleProjects(visibleProjectOptions())).map((project) => project.path);
   const createClient = () => {
     const settings = getSettings();
     return new SupabaseRulesSyncClient({ url: settings.skillSyncSupabaseUrl, anonKey: settings.skillSyncSupabaseAnonKey });
@@ -863,6 +866,16 @@ function visibleStatsOptions(options: SessionStatsOptions = {}): SessionStatsOpt
 
 function visibleProjectOptions(): { excludeSubagents: boolean } {
   return { excludeSubagents: true };
+}
+
+function codexDesktopHome(): string {
+  return process.env.CODEX_HOME?.trim() || path.join(app.getPath("home"), ".codex");
+}
+
+async function listVisibleProjects(options: ProjectQueryOptions = {}): Promise<ProjectSummary[]> {
+  const indexed = await store.listProjects(options);
+  if (options.environmentId && options.environmentId !== "all" && options.environmentId !== "local") return indexed;
+  return mergeCodexDesktopProjects(indexed, await readCodexDesktopProjects(codexDesktopHome()));
 }
 
 async function pruneDisabledOptionalSources(settings: AppSettings): Promise<void> {
@@ -2387,6 +2400,7 @@ function registerIpc(): void {
   });
   registerSessionCatalogIpc(ipcMain, new SessionCatalogService({
     store,
+    listProjects: listVisibleProjects,
     visibleSearchOptions,
     visibleStatsOptions,
     visibleProjectOptions,
@@ -2558,7 +2572,7 @@ function registerIpc(): void {
           };
         }
         case "list_projects": {
-          const projects = await store.listProjects(visibleProjectOptions());
+          const projects = await listVisibleProjects(visibleProjectOptions());
           return {
             result: projects.map((project) => ({ project: project.path, sessions: project.sessionCount })),
             sessionKeys: [],

--- a/apps/main-2.0/src/main/services/session-catalog-service.ts
+++ b/apps/main-2.0/src/main/services/session-catalog-service.ts
@@ -33,6 +33,7 @@ import { SessionBulkDeleteService } from "./session-bulk-delete-service";
 
 export interface SessionCatalogServiceDependencies {
   store: SessionStore;
+  listProjects?: (options?: ProjectQueryOptions) => Promise<ProjectSummary[]>;
   visibleSearchOptions(options?: SearchOptions): SearchOptions;
   visibleStatsOptions(options?: SessionStatsOptions): SessionStatsOptions;
   visibleProjectOptions(): ProjectQueryOptions;
@@ -150,10 +151,13 @@ export class SessionCatalogService {
   }
 
   listProjects(options?: ProjectQueryOptions): Promise<ProjectSummary[]> {
-    return this.dependencies.store.listProjects({
+    const query = {
       ...this.dependencies.visibleProjectOptions(),
       ...options,
-    });
+    };
+    return this.dependencies.listProjects
+      ? this.dependencies.listProjects(query)
+      : this.dependencies.store.listProjects(query);
   }
 
   listTagsByProject(): Promise<ProjectTagEntry[]> {


### PR DESCRIPTION
Read Codex Desktop workspace roots and labels so empty projects appear in the AgentRecall sidebar, and recover real project paths from turn context metadata. Apply the session metadata compatibility to both V1 and V2.

Tests: npx vitest run src/core/codex-projects.test.ts src/core/session-loader.test.ts (apps/main-1.0)

Tests: npx vitest run src/core/codex-projects.test.ts src/core/session-loader.test.ts (apps/main-2.0)

Builds: npm run build (apps/main-1.0, apps/main-2.0)

Note: full Vitest suites still have pre-existing Windows/SQLite environment failures.

## 变更概述

<!-- 简要说明本次 MR 的目标。 -->

## 更新说明检查

- [ ] 本分支已新增且仅新增一个 `.release-notes/<branch-slug>.md`
- [ ] 更新说明已在标题后显式声明 `release-target: v1`、`v2` 或 `both`，并覆盖会收到本次用户可见结果的应用；测试、文档或兼容辅助改动本身不要求 `both`
- [ ] 更新说明包含面向用户的“新增功能”或“Bug 修复”列表
- [ ] 更新说明已移除 MR、分支、CI、发布流程、内部服务、路径及其他不应暴露的实现或敏感信息
- [ ] 已运行 `npm run release-note:check`

> 更新说明文件会原样显示在 GitHub Release、终端更新提示和 App“关于”页面中，请不要在这里只写一份无法被自动发布读取的副本。

## 验证

<!-- 列出实际执行的测试或检查。 -->
