### PR TITLE
feat(sessions): add DeepSeek Harness support

### DIFF
--- a/.release-notes/feat-deepseek-harness-sessions.md
+++ b/.release-notes/feat-deepseek-harness-sessions.md
@@ -1,0 +1,9 @@
+# 支持索引 DeepSeek Harness 会话
+
+<!-- release-target: both -->
+
+## 新增功能
+
+- 新增 DeepSeek Harness（dsh）会话来源，可在设置中开启，索引并搜索本地 DeepSeek Harness 会话，包括对话消息、工具调用记录和 token 用量。
+- 可从会话详情在 DeepSeek Harness 网页中准确打开所选会话，不再只定位到对应工作目录。
+- 删除会话时可直接清理对应的本地 DeepSeek Harness 会话记录。

--- a/apps/main-1.0/bin/setup-mcp.cjs
+++ b/apps/main-1.0/bin/setup-mcp.cjs
@@ -83,6 +83,87 @@ function nodeCommand() {
   return "node";
 }
 
+// --- DeepSeek Harness (~/.dsh/cordis.patch.yml, YAML patch array) -----------
+
+const DSH_MCP_ROW_ID = "mcp-agent-recall";
+const DSH_PATCH_HEADER = "# Agent Recall MCP server — managed by Agent Recall (setup-mcp).";
+const DSH_PATCH_ENTRY = `- insert:
+    - id: ${DSH_MCP_ROW_ID}
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        serverName: agent-recall
+        transport: stdio
+        command: __COMMAND__
+        args: [__SCRIPT__]
+        failOnStartupError: false`;
+
+function yamlScalar(value) {
+  // JSON string literal escaping is a valid YAML double-quoted scalar.
+  return JSON.stringify(value);
+}
+
+function renderDshBlock(command, scriptPath) {
+  return DSH_PATCH_ENTRY
+    .replace("__COMMAND__", yamlScalar(command))
+    .replace("__SCRIPT__", yamlScalar(scriptPath));
+}
+
+function removeDshBlock(contents) {
+  // Drop the managed insert unit (header row + following indented lines), then trim trailing blanks.
+  const lines = (contents || "").split("\n");
+  const out = [];
+  let skipping = false;
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const trimmed = line.trim();
+    // The managed entry is a two-line unit: the "- insert:" opener and the row.
+    if (trimmed === "- insert:" && !skipping) {
+      // Only treat as ours when the next line is the managed row id.
+      const next = lines[index + 1];
+      if (next && next.trim() === `- id: ${DSH_MCP_ROW_ID}`) {
+        skipping = true;
+        continue;
+      }
+    }
+    if (skipping) {
+      if (/^-\s/.test(line) || trimmed === "") {
+        skipping = false;
+      } else {
+        continue;
+      }
+    }
+    out.push(line);
+  }
+  // Remove the header comment if it directly precedes the row.
+  const joined = out.join("\n");
+  return joined
+    .replace(new RegExp(`${DSH_PATCH_HEADER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*\\n?`), "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function applyDshConfig(contents, scriptPath, remove, command = "node") {
+  const stripped = removeDshBlock(contents);
+  const meaningful = stripped
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"));
+  const emptyPatch = meaningful.length === 0 || (meaningful.length === 1 && meaningful[0] === "[]");
+  if (remove) {
+    if (!emptyPatch) return `${stripped}\n`;
+    const comments = stripped
+      .split("\n")
+      .filter((line) => line.trim().startsWith("#"))
+      .join("\n");
+    return comments ? `${comments}\n[]\n` : "[]\n";
+  }
+  const base = emptyPatch
+    ? stripped.split("\n").filter((line) => line.trim() !== "[]").join("\n").trim()
+    : stripped;
+  const block = `${DSH_PATCH_HEADER}\n${renderDshBlock(command, scriptPath)}`;
+  return base ? `${base}\n\n${block}\n` : `# dsh profile patch layer (user-editable).\n${block}\n`;
+}
+
 // --- Claude (~/.claude.json, JSON) -----------------------------------------
 
 function applyClaudeConfig(config, scriptPath, remove, command = "node") {
@@ -178,8 +259,39 @@ function run(remove, options = {}) {
     messages.push("Skipped CodeBuddy (~/.codebuddy not found).");
   }
 
+  // DeepSeek Harness reads its home-level patch layer ~/.dsh/cordis.patch.yml
+  // (applied over every profile). Register there when the harness is present.
+  // Wrapped separately so a dsh failure never blocks the other registrations.
+  const dshHome = process.env.DSH_HOME?.trim() || path.join(home, ".dsh");
+  if (fs.existsSync(dshHome) && (!remove || fs.existsSync(path.join(dshHome, "cordis.patch.yml")))) {
+    try {
+      const dshPatchPath = path.join(dshHome, "cordis.patch.yml");
+      const current = fs.existsSync(dshPatchPath) ? fs.readFileSync(dshPatchPath, "utf8") : "";
+      const next = applyDshConfig(current, scriptPath, remove, command);
+      writeFileAtomic(dshPatchPath, next);
+      messages.push(`${remove ? "Removed" : "Configured"} MCP server in ${dshPatchPath}`);
+    } catch (error) {
+      messages.push(`Failed to configure DeepSeek Harness MCP (${error instanceof Error ? error.message : String(error)}).`);
+    }
+  } else {
+    messages.push("Skipped DeepSeek Harness (~/.dsh not found).");
+  }
+
   if (!remove) messages.push(`Using node: ${command}`);
   return messages;
+}
+
+function serverDefinition() {
+  return {
+    id: "agent-recall-session-search",
+    name: "agent-recall",
+    transport: "stdio",
+    command: nodeCommand(),
+    args: [serverScriptPath()],
+    env: {},
+    createdAt: 0,
+    updatedAt: 0,
+  };
 }
 
 function status(home = homeDir()) {
@@ -191,7 +303,7 @@ function status(home = homeDir()) {
   }
 }
 
-module.exports = { applyClaudeConfig, applyCodexConfig, removeCodexBlock, run, status };
+module.exports = { applyClaudeConfig, applyCodexConfig, applyDshConfig, removeCodexBlock, removeDshBlock, run, serverDefinition, status };
 
 if (require.main === module) {
   const remove = process.argv.includes("uninstall") || process.argv.includes("--remove");

--- a/apps/main-1.0/src/core/deepseek-default-loader.test.ts
+++ b/apps/main-1.0/src/core/deepseek-default-loader.test.ts
@@ -1,0 +1,34 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { zstdCompressSync } from "node:zlib";
+import { loadDefaultSessionsIterator } from "./session-loader";
+
+describe("deepseek enabled end-to-end (synthetic fixture)", () => {
+  it("appears in the default loaders when the setting is on and off", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-dsh-default-"));
+    try {
+      const home = path.join(root, "home");
+      const logPath = path.join(home, ".dsh", "sessions", "--work--", "s1", "session.jsonl.zstd");
+      fs.mkdirSync(path.dirname(logPath), { recursive: true });
+      const lines = [
+        { type: "session", version: 0, id: "s1", createdAt: 1700000000000, cwd: "/work", delegationDepth: 0 },
+        { type: "user/message", seq: 0, time: 1700000000001, data: { id: "m1", role: "user", content: [{ type: "text", text: "hello" }], source: { kind: "user" } }, surfaceOp: "append" },
+      ];
+      const text = lines.map((l) => JSON.stringify(l)).join(String.fromCharCode(10)) + String.fromCharCode(10);
+      fs.writeFileSync(logPath, zstdCompressSync(Buffer.from(text)));
+
+      const off = [...loadDefaultSessionsIterator({ homeDir: home })];
+      expect(off.filter((item) => item.session.source === "deepseek-cli")).toHaveLength(0);
+
+      const on = [...loadDefaultSessionsIterator({ homeDir: home, includeDeepSeekCli: true })];
+      const deepseek = on.filter((item) => item.session.source === "deepseek-cli");
+      expect(deepseek).toHaveLength(1);
+      expect(deepseek[0].session.sessionKey).toBe("deepseek:s1");
+      expect(deepseek[0].session.projectPath).toBe("/work");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/main-1.0/src/core/deepseek-harness.test.ts
+++ b/apps/main-1.0/src/core/deepseek-harness.test.ts
@@ -1,0 +1,181 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  DEEPSEEK_HARNESS_LOG_NAME,
+  deleteDeepSeekCliSessionDirectory,
+  parseDeepSeekSessionLog,
+  scanDeepSeekZstdFrames,
+} from "./deepseek-harness";
+import { loadDeepSeekCliSessions } from "./session-loader";
+
+describe("deepseek harness session parser", () => {
+  it("rejects non-zstd garbage", () => {
+    expect(parseDeepSeekSessionLog(Buffer.from("not zstd"))).toBeNull();
+    expect(() => scanDeepSeekZstdFrames(Buffer.from([1, 2, 3, 4, 5]))).toThrow();
+  });
+
+  it("refuses to recursively delete a lookalike log outside the DSH sessions layout", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-dsh-delete-guard-"));
+    try {
+      const sessionDir = path.join(root, "not-sessions", "project", "session");
+      const logPath = path.join(sessionDir, DEEPSEEK_HARNESS_LOG_NAME);
+      fs.mkdirSync(sessionDir, { recursive: true });
+      fs.writeFileSync(logPath, "fixture");
+      deleteDeepSeekCliSessionDirectory(logPath);
+      expect(fs.existsSync(logPath)).toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("reads concatenated harness frames and stops at a sequence gap", async () => {
+    const { zstdCompressSync } = await import("node:zlib");
+    const header = zstdCompressSync(Buffer.from(`${JSON.stringify({ type: "session", version: 0, id: "framed", createdAt: 1700000000000, cwd: "/work", delegationDepth: 0 })}\n`));
+    const firstBatch = zstdCompressSync(Buffer.from(`${JSON.stringify({
+      type: "user/message",
+      seq: 0,
+      time: 1700000000001,
+      data: { id: "m1", role: "user", content: [{ type: "text", text: "first" }], source: { kind: "user" } },
+    })}\n`));
+    const badBatch = zstdCompressSync(Buffer.from([
+      JSON.stringify({ type: "text-chunks", seq0: 2, time0: 1700000000002, data: { turn: 1, step: 1, index: 0, texts: ["a", "b", "c"], dt: [1, 1] } }),
+      JSON.stringify({ type: "assistant/message", seq: 1, time: 1700000000005, data: { turn: 1, step: 1, message: { id: "m2", role: "assistant", content: [{ type: "text", text: "must not be accepted" }], source: { kind: "model" } } } }),
+      "",
+    ].join("\n")));
+
+    const parsed = parseDeepSeekSessionLog(Buffer.concat([header, firstBatch, badBatch]));
+    expect(parsed?.events).toHaveLength(1);
+    expect(parsed?.committedBytes).toBe(header.length + firstBatch.length);
+  });
+
+  it("parses a synthetic harness log", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-dsh-"));
+    try {
+      const { zstdCompressSync } = await import("node:zlib");
+      const lines = [
+        { type: "session", version: 0, id: "session-abc", createdAt: 1700000000000, cwd: "/work/demo", delegationDepth: 0, agentPreset: "standard" },
+        { type: "permission/preset", seq: 0, time: 1700000000001, data: { preset: "workspace-write" } },
+        { type: "turn/start", seq: 1, time: 1700000000002, data: { turn: 1 } },
+        { type: "step/start", seq: 2, time: 1700000000003, data: { turn: 1, step: 1 } },
+        { type: "user/message", seq: 3, time: 1700000000004, data: { id: "m1", role: "user", content: [{ type: "text", text: "请修复登录 bug" }], source: { kind: "user", rpcId: "rpc1" } }, surfaceOp: "append" },
+        { type: "assistant/message", seq: 4, time: 1700000000005, data: { turn: 1, step: 1, message: { id: "m2", role: "assistant", content: [{ type: "text", text: "好的，先查看代码。" }], source: { kind: "model", provider: "tt-switch", model: "deepseek-v4-pro-ioa" } }, usage: { inputTokens: 10, outputTokens: 5, cacheReadTokens: 2 } }, surfaceOp: "append" },
+        { type: "tool/call", seq: 5, time: 1700000000006, data: { turn: 1, step: 1, callId: "call_1", name: "bash", arguments: "ls" } },
+        { type: "tool/result", seq: 6, time: 1700000000007, data: { turn: 1, step: 1, message: { id: "m3", role: "user", content: [{ type: "tool-result", toolCallId: "call_1", content: [{ type: "text", text: "demo" }] }], source: { kind: "tool", callId: "call_1" } } } },
+        { type: "step/end", seq: 7, time: 1700000000008, data: { turn: 1, step: 1 } },
+        { type: "turn/end", seq: 8, time: 1700000000009, data: { turn: 1, reason: { kind: "completed" } } },
+        { type: "session/title", seq: 9, time: 1700000000010, data: { title: "修复登录 bug", messageSeqs: [3], source: { kind: "fallback" } } },
+      ];
+      const text = lines.map((line) => JSON.stringify(line)).join("\n") + "\n";
+      const compressed = zstdCompressSync(Buffer.from(text));
+      const sessionDir = path.join(root, "sessions", "--work-demo--", "session-abc");
+      fs.mkdirSync(sessionDir, { recursive: true });
+      const logPath = path.join(sessionDir, DEEPSEEK_HARNESS_LOG_NAME);
+      fs.writeFileSync(logPath, compressed);
+
+      const loaded = loadDeepSeekCliSessions(root);
+      expect(loaded).toHaveLength(1);
+      const { session, messages, traceEvents = [] } = loaded[0];
+      expect(session.rawId).toBe("session-abc");
+      expect(session.projectPath).toBe("/work/demo");
+      expect(session.originalTitle).toBe("修复登录 bug");
+      expect(session.source).toBe("deepseek-cli");
+      expect(session.tokenUsage?.inputTokens).toBe(10);
+      expect(session.tokenUsage?.outputTokens).toBe(5);
+      expect(session.tokenUsage?.cachedInputTokens).toBe(2);
+      expect(messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+      expect(messages[0].content).toBe("请修复登录 bug");
+      expect(messages[1].content).toBe("好的，先查看代码。");
+      expect(traceEvents.map((event) => event.kind)).toEqual(["tool_call"]);
+      expect(traceEvents[0].title).toBe("bash");
+      expect(traceEvents[0].status).toBe("completed");
+
+      // Best-effort source deletion removes only the session directory.
+      deleteDeepSeekCliSessionDirectory(logPath);
+      expect(fs.existsSync(sessionDir)).toBe(false);
+      expect(fs.existsSync(root)).toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("skips a log with no human messages and expands packed chunk rows", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-dsh-chunks-"));
+    try {
+      const { zstdCompressSync } = await import("node:zlib");
+      const lines = [
+        { type: "session", version: 0, id: "session-chunks", createdAt: 1700000000000, cwd: "/work/chunks", delegationDepth: 0 },
+        { type: "turn/start", seq: 0, time: 1700000000001, data: { turn: 1 } },
+        { type: "step/start", seq: 1, time: 1700000000002, data: { turn: 1, step: 1 } },
+        { type: "user/message", seq: 2, time: 1700000000003, data: { id: "m1", role: "user", content: [{ type: "text", text: "你好" }], source: { kind: "user" } }, surfaceOp: "append" },
+        { type: "text-chunks", seq0: 3, time0: 1700000000004, data: { turn: 1, step: 1, index: 0, texts: ["你", "好", "呀"], dt: [1, 2] } },
+        { type: "assistant/message", seq: 6, time: 1700000000010, data: { turn: 1, step: 1, message: { id: "m2", role: "assistant", content: [{ type: "text", text: "你好呀" }], source: { kind: "model", provider: "p", model: "m" } }, usage: { inputTokens: 1, outputTokens: 2 } }, surfaceOp: "append" },
+      ];
+      const text = lines.map((line) => JSON.stringify(line)).join("\n") + "\n";
+      const logPath = path.join(root, "sessions", "--work-chunks--", "session-chunks", DEEPSEEK_HARNESS_LOG_NAME);
+      fs.mkdirSync(path.dirname(logPath), { recursive: true });
+      fs.writeFileSync(logPath, zstdCompressSync(Buffer.from(text)));
+
+      const loaded = loadDeepSeekCliSessions(root);
+      expect(loaded).toHaveLength(1);
+      const { messages, traceEvents } = loaded[0];
+      expect(messages.map((message) => message.content)).toEqual(["你好", "你好呀"]);
+      expect(traceEvents).toEqual([]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("skips injected user messages and empty assistant steps", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-dsh-inject-"));
+    try {
+      const { zstdCompressSync } = await import("node:zlib");
+      const lines = [
+        { type: "session", version: 0, id: "session-inject", createdAt: 1700000000000, cwd: "/work/inject", delegationDepth: 0 },
+        { type: "user/message", seq: 0, time: 1700000000001, data: { id: "m1", role: "user", content: [{ type: "text", text: "<system-reminder>AGENTS.md</system-reminder>" }], source: { kind: "instruction-hint" } }, surfaceOp: "append" },
+        { type: "user/message", seq: 1, time: 1700000000002, data: { id: "m2", role: "user", content: [{ type: "text", text: "真正的问题" }], source: { kind: "user" } }, surfaceOp: "append" },
+        { type: "assistant/message", seq: 2, time: 1700000000003, data: { turn: 1, step: 1, message: { id: "m3", role: "assistant", content: [{ type: "reasoning", text: "内部思考" }], source: { kind: "model", provider: "p", model: "m" } } }, surfaceOp: "append" },
+      ];
+      const text = lines.map((line) => JSON.stringify(line)).join("\n") + "\n";
+      const logPath = path.join(root, "sessions", "--work-inject--", "session-inject", DEEPSEEK_HARNESS_LOG_NAME);
+      fs.mkdirSync(path.dirname(logPath), { recursive: true });
+      fs.writeFileSync(logPath, zstdCompressSync(Buffer.from(text)));
+
+      const loaded = loadDeepSeekCliSessions(root);
+      expect(loaded).toHaveLength(1);
+      const { messages } = loaded[0];
+      expect(messages.map((message) => message.content)).toEqual(["真正的问题"]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("discovers sessions from DSH_HOME without reading the real home", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-dsh-home-"));
+    const previous = process.env.DSH_HOME;
+    try {
+      process.env.DSH_HOME = root;
+      const { zstdCompressSync } = await import("node:zlib");
+      const logPath = path.join(root, "sessions", "--work--", "custom-home", DEEPSEEK_HARNESS_LOG_NAME);
+      fs.mkdirSync(path.dirname(logPath), { recursive: true });
+      fs.writeFileSync(logPath, zstdCompressSync(Buffer.from([
+        JSON.stringify({ type: "session", version: 0, id: "custom-home", createdAt: 1700000000000, cwd: "/work", delegationDepth: 0 }),
+        JSON.stringify({
+          type: "user/message",
+          seq: 0,
+          time: 1700000000001,
+          data: { id: "m1", role: "user", content: [{ type: "text", text: "from DSH_HOME" }], source: { kind: "user" } },
+        }),
+        "",
+      ].join("\n"))));
+
+      expect(loadDeepSeekCliSessions()).toHaveLength(1);
+      expect(loadDeepSeekCliSessions()[0].session.rawId).toBe("custom-home");
+    } finally {
+      if (previous === undefined) delete process.env.DSH_HOME;
+      else process.env.DSH_HOME = previous;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/main-1.0/src/core/deepseek-harness.ts
+++ b/apps/main-1.0/src/core/deepseek-harness.ts
@@ -1,0 +1,756 @@
+/**
+ * DeepSeek Harness (dsh) session log parsing.
+ *
+ * The harness persists each session as `~/.dsh/sessions/<project-key>/<session-id>/session.jsonl.zstd`:
+ * a concatenated stream of Zstandard frames whose decompressed payload is a JSONL
+ * event log. The first record is a `session` header line; every following record is
+ * a {@link SessionEvent} envelope `{ type, seq, time, data }` per
+ * deepseek-harness `@deepseek-ai/dsh-session` (SESSION_FORMAT_VERSION 0).
+ *
+ * Files are append-only and may be written while we read them, so we mirror the
+ * harness's own `scanZstdFrames`: walk complete frames structurally, decompress
+ * each with the built-in `node:zlib` zstd API (no third-party dependency), and
+ * stop at a torn tail instead of failing the whole session.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as zlib from "node:zlib";
+
+import { isMeaningfulUserMessage } from "./format-adapters";
+import type { SessionFormat, SessionMessage, SessionTraceEvent, TokenUsageEvent } from "./types";
+
+const ZSTD_MAGIC = 0xfd2fb528;
+
+export const DEEPSEEK_HARNESS_DIR = ".dsh";
+export const DEEPSEEK_HARNESS_LOG_NAME = "session.jsonl.zstd";
+
+/** Structural scan result for a concatenated Zstandard stream. */
+export interface DeepSeekZstdFrame {
+  /** Inclusive frame start. */
+  start: number;
+  /** Exclusive frame end. */
+  end: number;
+}
+
+/**
+ * Locate complete Zstandard frames without decompressing their blocks. Invalid
+ * complete structure rejects; EOF inside the final frame returns what was
+ * found so far. Mirrors deepseek-harness `scanZstdFrames`.
+ */
+export function scanDeepSeekZstdFrames(buffer: Buffer, maxFrames = Number.POSITIVE_INFINITY): DeepSeekZstdFrame[] {
+  const frames: DeepSeekZstdFrame[] = [];
+  let offset = 0;
+
+  while (offset < buffer.length) {
+    const start = offset;
+    if (buffer.length - offset < 4) return frames;
+    if (buffer.readUInt32LE(offset) !== ZSTD_MAGIC) {
+      throw new Error(`corrupt DeepSeek Harness session log: invalid frame magic at byte ${offset}`);
+    }
+    offset += 4;
+
+    if (offset === buffer.length) return frames;
+    const descriptor = buffer.readUInt8(offset);
+    offset += 1;
+    if ((descriptor & 0x18) !== 0) {
+      throw new Error(`corrupt DeepSeek Harness session log: reserved frame-header bit at byte ${offset - 1}`);
+    }
+
+    const contentSizeFlag = descriptor >>> 6;
+    const singleSegment = (descriptor & 0x20) !== 0;
+    const checksum = (descriptor & 0x04) !== 0;
+    const dictionaryFlag = descriptor & 0x03;
+    const dictionaryBytes = dictionaryFlag === 3 ? 4 : dictionaryFlag;
+    const contentSizeBytes = contentSizeFlag === 0
+      ? (singleSegment ? 1 : 0)
+      : 1 << contentSizeFlag;
+    const remainingHeaderBytes = (singleSegment ? 0 : 1) + dictionaryBytes + contentSizeBytes;
+    if (buffer.length - offset < remainingHeaderBytes) return frames;
+    offset += remainingHeaderBytes;
+
+    for (;;) {
+      if (buffer.length - offset < 3) return frames;
+      const blockHeader = buffer.readUIntLE(offset, 3);
+      offset += 3;
+      const lastBlock = (blockHeader & 1) !== 0;
+      const blockType = (blockHeader >>> 1) & 0x03;
+      const blockSize = blockHeader >>> 3;
+      if (blockType === 0x03) {
+        throw new Error(`corrupt DeepSeek Harness session log: reserved block type at byte ${offset - 3}`);
+      }
+      const payloadBytes = blockType === 0x01 ? 1 : blockSize;
+      if (buffer.length - offset < payloadBytes) return frames;
+      offset += payloadBytes;
+      if (lastBlock) break;
+    }
+
+    if (checksum) {
+      if (buffer.length - offset < 4) return frames;
+      offset += 4;
+    }
+    frames.push({ start, end: offset });
+    if (frames.length === maxFrames) return frames;
+  }
+
+  return frames;
+}
+
+/** Decompress a structurally complete Zstandard frame into UTF-8 text. */
+export function decompressDeepSeekZstdFrame(buffer: Buffer, frame: DeepSeekZstdFrame): string {
+  return zlib.zstdDecompressSync(buffer.subarray(frame.start, frame.end)).toString("utf8");
+}
+
+export interface DeepSeekSessionHeader {
+  version: number;
+  id: string;
+  createdAt: number;
+  cwd?: string;
+  parentSession?: string;
+  delegationDepth: number;
+  agentPreset?: string;
+}
+
+export interface DeepSeekSessionEvent {
+  type: string;
+  seq: number;
+  time: number;
+  data?: unknown;
+  sourceEventSeqs?: number[];
+  surfaceOp?: unknown;
+  ignorable?: true;
+}
+
+export interface DeepSeekSessionLog {
+  header: DeepSeekSessionHeader;
+  events: DeepSeekSessionEvent[];
+  /** Byte offset up to which the log is complete; a torn tail was dropped. */
+  committedBytes: number;
+}
+
+function parseDeepSeekJsonLine(line: string): unknown | undefined {
+  const trimmed = line.trim();
+  if (!trimmed) return undefined;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseDeepSeekHeader(raw: unknown): DeepSeekSessionHeader | null {
+  if (!raw || typeof raw !== "object") return null;
+  const line = raw as Record<string, unknown>;
+  if (line.type !== "session") return null;
+  const id = typeof line.id === "string" ? line.id : "";
+  if (!id || !Number.isSafeInteger(line.createdAt)) return null;
+  return {
+    version: typeof line.version === "number" ? line.version : 0,
+    id,
+    createdAt: line.createdAt as number,
+    ...(typeof line.cwd === "string" ? { cwd: line.cwd } : {}),
+    ...(typeof line.parentSession === "string" ? { parentSession: line.parentSession } : {}),
+    delegationDepth: typeof line.delegationDepth === "number" ? line.delegationDepth : 0,
+    ...(typeof line.agentPreset === "string" ? { agentPreset: line.agentPreset } : {}),
+  };
+}
+
+function parseDeepSeekEvent(raw: unknown): DeepSeekSessionEvent | null {
+  if (!raw || typeof raw !== "object") return null;
+  const line = raw as Record<string, unknown>;
+  if (typeof line.type !== "string") return null;
+  const seq = line.seq;
+  const time = line.time;
+  if (!Number.isSafeInteger(seq) || !Number.isSafeInteger(time)) return null;
+  return {
+    type: line.type,
+    seq: seq as number,
+    time: time as number,
+    data: line.data,
+    ...(Array.isArray(line.sourceEventSeqs) ? { sourceEventSeqs: line.sourceEventSeqs as number[] } : {}),
+    ...(line.surfaceOp !== undefined ? { surfaceOp: line.surfaceOp } : {}),
+    ...(line.ignorable === true ? { ignorable: true } : {}),
+  };
+}
+
+function parseDeepSeekEventLines(text: string): DeepSeekSessionEvent[] {
+  const events: DeepSeekSessionEvent[] = [];
+  for (const line of text.split("\n")) {
+    const parsed = parseDeepSeekEvent(parseDeepSeekJsonLine(line));
+    if (parsed) events.push(parsed);
+  }
+  return events;
+}
+
+/**
+ * Storage-row packing: runs of consecutive same-block delta chunks are packed
+ * into ONE row — `text-chunks` / `reasoning-chunks` / `tool-call-chunks`.
+ * Rows are a durable-encoding vocabulary, NOT session events: they carry
+ * `seq0`/`time0` anchors plus member payloads and must be expanded back into
+ * individual `assistant/chunk` events before the transcript is usable.
+ * Mirrors deepseek-harness `decodeStorageRecord`.
+ */
+function expandDeepSeekChunkRow(raw: Record<string, unknown>): DeepSeekSessionEvent[] | null {
+  const type = raw.type;
+  if (type !== "text-chunks" && type !== "reasoning-chunks" && type !== "tool-call-chunks") return null;
+  const seq0 = raw.seq0;
+  const time0 = raw.time0;
+  if (!Number.isSafeInteger(seq0) || !Number.isSafeInteger(time0)) return null;
+  const data = raw.data && typeof raw.data === "object" ? raw.data as Record<string, unknown> : null;
+  if (!data) return null;
+  const payloadKey = type === "tool-call-chunks" ? "args" : "texts";
+  const payload = data[payloadKey];
+  if (!Array.isArray(payload) || payload.length === 0 || payload.some((entry) => typeof entry !== "string")) return null;
+  const dt = data.dt;
+  if (!Array.isArray(dt) || dt.some((gap) => !Number.isSafeInteger(gap)) || dt.length !== payload.length - 1) return null;
+
+  const events: DeepSeekSessionEvent[] = [];
+  let time = time0 as number;
+  for (let k = 0; k < payload.length; k++) {
+    if (k > 0) time += dt[k - 1] as number;
+    let chunk: Record<string, unknown>;
+    if (type === "tool-call-chunks") {
+      chunk = {
+        type: "tool-call-delta",
+        index: data.index,
+        id: data.id,
+        ...(typeof data.name === "string" ? { name: data.name } : {}),
+        argumentsDelta: payload[k],
+      };
+    } else {
+      chunk = {
+        type: type === "text-chunks" ? "text-delta" : "reasoning-delta",
+        index: data.index,
+        text: payload[k],
+      };
+    }
+    events.push({
+      type: "assistant/chunk",
+      seq: (seq0 as number) + k,
+      time,
+      data: { turn: data.turn, step: data.step, chunk },
+    });
+  }
+  return events;
+}
+
+/**
+ * Decompress a complete (possibly torn) log buffer into its header and event
+ * prefix. Each frame decodes independently; a frame that fails to decompress
+ * or starts mid-record ends the scan, so a concurrent append never corrupts
+ * previously committed history.
+ */
+export function parseDeepSeekSessionLog(buffer: Buffer, logPath = ""): DeepSeekSessionLog | null {
+  let frames: DeepSeekZstdFrame[];
+  try {
+    frames = scanDeepSeekZstdFrames(buffer);
+  } catch {
+    return null;
+  }
+  if (frames.length === 0) return null;
+
+  let header: DeepSeekSessionHeader | null = null;
+  const events: DeepSeekSessionEvent[] = [];
+  let committedBytes = 0;
+
+  for (const frame of frames) {
+    let text: string;
+    try {
+      text = decompressDeepSeekZstdFrame(buffer, frame);
+    } catch {
+      break;
+    }
+    const completeFrameText = text.endsWith("\n");
+    let end = text.length;
+    if (!completeFrameText) {
+      // A final partial record crossing frames is a torn tail of an active
+      // append. Everything up to the previous newline is already durable.
+      const lastNewline = text.lastIndexOf("\n");
+      if (lastNewline === -1) break;
+      end = lastNewline + 1;
+    }
+    let contiguous = true;
+    for (const line of text.slice(0, end).split("\n")) {
+      const parsed = parseDeepSeekJsonLine(line);
+      if (parsed === undefined) continue;
+      if (!header) {
+        header = parseDeepSeekHeader(parsed);
+        if (!header) throw new Error(`corrupt session log: first record is not a session header${logPath ? ` (${logPath})` : ""}`);
+        continue;
+      }
+      const parsedRecord = parsed && typeof parsed === "object" ? parsed as Record<string, unknown> : null;
+      const expanded = parsedRecord ? expandDeepSeekChunkRow(parsedRecord) : null;
+      if (expanded) {
+        // A packed chunk run: all members must follow the previous seq exactly.
+        const rowStart = events.length;
+        for (const chunkEvent of expanded) {
+          if (chunkEvent.seq !== events.length) {
+            events.length = rowStart;
+            contiguous = false;
+            break;
+          }
+          events.push(chunkEvent);
+        }
+        if (!contiguous) break;
+        continue;
+      }
+      const event = parseDeepSeekEvent(parsed);
+      if (!event) continue;
+      if (event.seq !== events.length) {
+        contiguous = false;
+        break;
+      }
+      events.push(event);
+    }
+    if (!contiguous || !completeFrameText) break;
+    committedBytes = frame.end;
+  }
+
+  if (!header) return null;
+  return { header, events, committedBytes };
+}
+
+function deepSeekRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? value as Record<string, unknown> : null;
+}
+
+/** First text block of a content array, plus a marker when a leading image was dropped. */
+function deepSeekText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const texts: string[] = [];
+  let imageDropped = false;
+  for (const item of content) {
+    const block = deepSeekRecord(item);
+    if (!block) continue;
+    const type = typeof block.type === "string" ? block.type : "";
+    if (type === "text") {
+      if (typeof block.text === "string" && block.text) texts.push(block.text);
+    } else if (type === "image") {
+      imageDropped = true;
+    }
+  }
+  const text = texts.join("\n");
+  if (!text && imageDropped) return "[Attachment]";
+  return text;
+}
+
+function deepSeekEventTimeMs(event: DeepSeekSessionEvent): number {
+  return Number.isFinite(event.time) ? event.time : 0;
+}
+
+/** Latest `session/title` payload, folded last-write-wins like the harness. */
+function deepSeekTitle(events: DeepSeekSessionEvent[]): string {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i];
+    if (event.type !== "session/title") continue;
+    const data = deepSeekRecord(event.data);
+    const title = data ? data.title : null;
+    if (typeof title === "string" && title.trim()) return title.trim();
+  }
+  return "";
+}
+
+interface DeepSeekUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  reasoningTokens: number;
+  cacheWriteTokens: number;
+}
+
+function deepSeekUsageOf(event: DeepSeekSessionEvent): DeepSeekUsage | null {
+  const data = deepSeekRecord(event.data);
+  const usage = deepSeekRecord(data?.usage);
+  if (!usage) return null;
+  const number = (value: unknown): number => typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+  return {
+    inputTokens: number(usage.inputTokens),
+    outputTokens: number(usage.outputTokens),
+    cacheReadTokens: number(usage.cacheReadTokens),
+    reasoningTokens: number(usage.reasoningTokens),
+    cacheWriteTokens: number(usage.cacheWriteTokens),
+  };
+}
+
+function deepSeekUsageOfEvent(event: DeepSeekSessionEvent): { turn: number; step: number; usage: DeepSeekUsage } | null {
+  const data = deepSeekRecord(event.data);
+  if (data === null) return null;
+  if (event.type === "assistant/message") {
+    const usage = deepSeekUsageOf(event);
+    if (usage === null) return null;
+    return { turn: deepSeekNumber(data.turn), step: deepSeekNumber(data.step), usage };
+  }
+  if (event.type === "assistant/chunk") {
+    const chunk = deepSeekRecord(data.chunk);
+    if (chunk === null || chunk.type !== "usage") return null;
+    const usageRecord = deepSeekRecord(chunk.usage);
+    if (usageRecord === null) return null;
+    const number = (value: unknown): number => typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+    return {
+      turn: deepSeekNumber(data.turn),
+      step: deepSeekNumber(data.step),
+      usage: {
+        inputTokens: number(usageRecord.inputTokens),
+        outputTokens: number(usageRecord.outputTokens),
+        cacheReadTokens: number(usageRecord.cacheReadTokens),
+        reasoningTokens: number(usageRecord.reasoningTokens),
+        cacheWriteTokens: number(usageRecord.cacheWriteTokens),
+      },
+    };
+  }
+  return null;
+}
+
+function deepSeekNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : -1;
+}
+
+/**
+ * Token usage fold that mirrors deepseek-harness tokenUsageProjection:
+ * usage samples for the same turn/step replace each other (last wins) instead
+ * of double counting, and samples for a later step replace the previous step.
+ */
+interface DeepSeekUsageFold {
+  usage: DeepSeekUsage;
+  tokenEvents: TokenUsageEvent[];
+}
+
+function deepSeekTotalUsage(events: DeepSeekSessionEvent[]): DeepSeekUsageFold {
+  const totals: DeepSeekUsage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, reasoningTokens: 0, cacheWriteTokens: 0 };
+  const tokenEvents: TokenUsageEvent[] = [];
+  let last: { turn: number; step: number; usage: DeepSeekUsage } | null = null;
+  for (const event of events) {
+    const sample = deepSeekUsageOfEvent(event);
+    if (sample === null || sample.turn < 0 || sample.step < 0) continue;
+    const dedupeKey = "deepseek:" + sample.turn + ":" + sample.step;
+    if (last !== null && last.turn === sample.turn && last.step === sample.step) {
+      if (
+        last.usage.inputTokens === sample.usage.inputTokens
+        && last.usage.outputTokens === sample.usage.outputTokens
+        && last.usage.cacheReadTokens === sample.usage.cacheReadTokens
+        && last.usage.reasoningTokens === sample.usage.reasoningTokens
+        && last.usage.cacheWriteTokens === sample.usage.cacheWriteTokens
+      ) continue;
+      totals.inputTokens -= last.usage.inputTokens;
+      totals.outputTokens -= last.usage.outputTokens;
+      totals.cacheReadTokens -= last.usage.cacheReadTokens;
+      totals.reasoningTokens -= last.usage.reasoningTokens;
+      totals.cacheWriteTokens -= last.usage.cacheWriteTokens;
+      tokenEvents.pop();
+    }
+    totals.inputTokens += sample.usage.inputTokens;
+    totals.outputTokens += sample.usage.outputTokens;
+    totals.cacheReadTokens += sample.usage.cacheReadTokens;
+    totals.reasoningTokens += sample.usage.reasoningTokens;
+    totals.cacheWriteTokens += sample.usage.cacheWriteTokens;
+    tokenEvents.push({
+      inputTokens: sample.usage.inputTokens,
+      outputTokens: sample.usage.outputTokens,
+      cachedInputTokens: sample.usage.cacheReadTokens,
+      reasoningOutputTokens: sample.usage.reasoningTokens,
+      totalTokens: sample.usage.inputTokens + sample.usage.outputTokens + sample.usage.cacheReadTokens + sample.usage.reasoningTokens,
+      timestamp: deepSeekEventTimeMs(event),
+      dedupeKey,
+      sourceTurnId: sample.turn + ":" + sample.step,
+    });
+    last = sample;
+  }
+  return { usage: totals, tokenEvents };
+}
+
+function deepSeekSourceKind(event: DeepSeekSessionEvent): string {
+  const message = deepSeekRecord(event.data) ?? deepSeekRecord(deepSeekRecord(event.data)?.message);
+  const source = deepSeekRecord(message?.source);
+  return typeof source?.kind === "string" ? source.kind : "";
+}
+
+function deepSeekTimestampOf(event: DeepSeekSessionEvent, iso: string | undefined): string {
+  const ms = deepSeekEventTimeMs(event);
+  if (!ms) return "";
+  if (typeof iso === "string" && iso) return iso;
+  return new Date(ms).toISOString();
+}
+
+function deepSeekToolArguments(event: DeepSeekSessionEvent): string {
+  const data = deepSeekRecord(event.data);
+  if (!data) return "";
+  if (typeof data.arguments === "string") return data.arguments;
+  return "";
+}
+
+function deepSeekSessionMessages(log: DeepSeekSessionLog): SessionMessage[] {
+  const messages: SessionMessage[] = [];
+  for (const event of log.events) {
+    if (event.type === "user/message") {
+      const data = deepSeekRecord(event.data);
+      if (!data) continue;
+      // The harness's surface distinguishes human prompts (`source.kind ===
+      // "user"`) from injected context and goal continuations, all of which
+      // project into the user role. Only real prompts become transcript
+      // messages; injected context would otherwise dominate search results.
+      const kind = deepSeekSourceKind(event);
+      if (kind && kind !== "user") continue;
+      const content = deepSeekText(data.content);
+      if (!content || !isMeaningfulUserMessage(content)) continue;
+      messages.push({
+        role: "user",
+        content,
+        timestamp: deepSeekTimestampOf(event, typeof data.timestamp === "string" ? data.timestamp : undefined),
+        index: messages.length,
+      });
+    } else if (event.type === "assistant/message") {
+      const data = deepSeekRecord(event.data);
+      const message = deepSeekRecord(data?.message);
+      if (!message) continue;
+      const content = deepSeekText(message.content);
+      if (!content) continue;
+      messages.push({
+        role: "assistant",
+        content,
+        timestamp: deepSeekTimestampOf(event, typeof message.timestamp === "string" ? message.timestamp : undefined),
+        index: messages.length,
+      });
+    }
+  }
+  return messages;
+}
+
+function deepSeekToolResultBlock(value: unknown): { callId: string; isError: boolean; text: string } | null {
+  const message = deepSeekRecord(value);
+  if (message === null) return null;
+  const source = deepSeekRecord(message.source);
+  const callId = typeof source?.callId === "string" ? source.callId : "";
+  const blocks = Array.isArray(message.content) ? message.content : [];
+  let isError = false;
+  let text = "";
+  for (const item of blocks) {
+    const block = deepSeekRecord(item);
+    if (block === null || block.type !== "tool-result") continue;
+    if (block.isError === true) isError = true;
+    const nested = Array.isArray(block.content) ? block.content : [];
+    const nestedText = deepSeekText(nested);
+    if (nestedText) text = text ? text + "\n" + nestedText : nestedText;
+  }
+  return { callId, isError, text };
+}
+
+function deepSeekSessionTraceEvents(log: DeepSeekSessionLog, source: SessionFormat): SessionTraceEvent[] {
+  const events: SessionTraceEvent[] = [];
+  const results = new Map<string, { status: "completed" | "failed"; detail: string }>();
+  for (const event of log.events) {
+    if (event.type === "tool/call") {
+      const data = deepSeekRecord(event.data);
+      const name = typeof data?.name === "string" && data.name ? data.name : "tool";
+      const callId = typeof data?.callId === "string" ? data.callId : "";
+      const argumentsText = deepSeekToolArguments(event);
+      const detail = name === "bash"
+        ? argumentsText
+        : argumentsText
+          ? (() => {
+              try {
+                return JSON.stringify(JSON.parse(argumentsText), null, 2);
+              } catch {
+                return argumentsText;
+              }
+            })()
+          : "";
+      events.push({
+        index: events.length,
+        kind: "tool_call",
+        source,
+        title: name,
+        detail,
+        timestamp: deepSeekTimestampOf(event, undefined),
+        callId: callId || null,
+        eventType: null,
+        status: null,
+      });
+    } else if (event.type === "tool/result") {
+      const data = deepSeekRecord(event.data);
+      const block = deepSeekToolResultBlock(data?.message);
+      const callId = (block !== null && block.callId) || (typeof data?.callId === "string" ? data.callId : "");
+      const failed = (block !== null && block.isError) || data?.isError === true || Boolean(data?.error);
+      results.set(callId, {
+        status: failed ? "failed" : "completed",
+        detail: block?.text ?? "",
+      });
+    }
+  }
+  // Attach result facts to their call so the detail pane pairs them.
+  for (const event of events) {
+    if (!event.callId) continue;
+    const result = results.get(event.callId);
+    if (!result) continue;
+    event.status = result.status;
+    if (result.detail) event.detail = event.detail ? `${event.detail}\n\n${result.detail}` : result.detail;
+  }
+  return events;
+}
+
+export interface DeepSeekSessionView {
+  title: string;
+  messages: SessionMessage[];
+  traceEvents: SessionTraceEvent[];
+  usage: DeepSeekUsage;
+  tokenEvents: TokenUsageEvent[];
+}
+
+/**
+ * Project a parsed session log into a searchable transcript view: visible
+ * user/assistant messages, tool trace events, the latest title, and usage.
+ */
+export function projectDeepSeekSession(log: DeepSeekSessionLog, source: SessionFormat = "deepseek"): DeepSeekSessionView {
+  const fold = deepSeekTotalUsage(log.events);
+  return {
+    title: deepSeekTitle(log.events),
+    messages: deepSeekSessionMessages(log),
+    traceEvents: deepSeekSessionTraceEvents(log, source),
+    usage: fold.usage,
+    tokenEvents: fold.tokenEvents,
+  };
+}
+
+/**
+ * Delete the DeepSeek Harness session directory owning `filePath` (the
+ * `session.jsonl.zstd` log). Only removes the session's own directory when it
+ * still points at a DeepSeek log, never project siblings. Errors are ignored:
+ * the index record is still removed by the caller.
+ */
+export function deleteDeepSeekCliSessionDirectory(filePath: string): void {
+  try {
+    const sessionDir = path.dirname(filePath);
+    if (path.basename(filePath) !== DEEPSEEK_HARNESS_LOG_NAME) return;
+    const projectDir = path.dirname(sessionDir);
+    const sessionsDir = path.dirname(projectDir);
+    if (path.basename(sessionsDir) !== "sessions") return;
+    const logStat = fs.lstatSync(filePath);
+    if (!logStat.isFile() || logStat.isSymbolicLink()) return;
+    for (const directory of [sessionsDir, projectDir, sessionDir]) {
+      const stat = fs.lstatSync(directory);
+      if (!stat.isDirectory() || stat.isSymbolicLink()) return;
+    }
+    fs.rmSync(sessionDir, { recursive: true, force: true });
+  } catch {
+    // Best-effort source cleanup; index deletion is the authoritative step.
+  }
+}
+/**
+ * Encode one path segment the way deepseek-harness does on disk: safe code
+ * units pass through, every other UTF-16 code unit becomes `~XXXX`. Mirrors
+ * deepseek-harness `encodeSegment` so migrated sessions land in the same
+ * directories the harness itself would create.
+ */
+export function encodeDeepSeekPathSegment(segment: string): string {
+  let out = "";
+  for (let i = 0; i < segment.length; i++) {
+    const code = segment.charCodeAt(i);
+    const ch = String.fromCharCode(code);
+    if (ch !== "~" && /^[A-Za-z0-9._-]$/.test(ch)) {
+      out += ch;
+    } else {
+      out += "~" + code.toString(16).toUpperCase().padStart(4, "0");
+    }
+  }
+  return out || "~002E";
+}
+
+/**
+ * Build the harness project-directory key for a cwd: separators collapse into
+ * a single dash and the slug is bounded like the harness (`--...--`). Mirrors
+ * deepseek-harness `projectKey`.
+ */
+export function encodeDeepSeekProjectKey(cwd: string): string {
+  let readable = "";
+  let separatorRun = false;
+  for (let i = 0; i < cwd.length; i++) {
+    const code = cwd.charCodeAt(i);
+    const ch = String.fromCharCode(code);
+    if (ch === "/" || ch === "\\" || ch === ":") {
+      if (!separatorRun) readable += "-";
+      separatorRun = true;
+    } else if (ch !== "~" && /^[A-Za-z0-9._-]$/.test(ch)) {
+      readable += ch;
+      separatorRun = false;
+    } else {
+      readable += "~" + code.toString(16).toUpperCase().padStart(4, "0");
+      separatorRun = false;
+    }
+  }
+  const slug = readable.replace(/^-+/, "") || "root";
+  return `--${slug.slice(0, 251)}--`;
+}
+
+/** The harness `_no-cwd` project directory for sessions without a cwd. */
+export const DEEPSEEK_HARNESS_NO_CWD_DIR = "_no-cwd";
+
+/**
+ * Serialize a session transcript into the deepseek-harness on-disk format:
+ * one header line plus surface events with contiguous sequence numbers,
+ * compressed as a single Zstandard frame (`session.jsonl.zstd`). Messages are
+ * projected back onto the surface as text blocks, so a migrated log reads and
+ * resumes exactly like a harness-written one.
+ */
+export function serializeDeepSeekSessionLog(options: {
+  sessionId: string;
+  createdAt: number;
+  cwd: string;
+  messages: readonly { role: "user" | "assistant"; content: string; time: number }[];
+  title?: string;
+}): Buffer {
+  const lines: string[] = [];
+  lines.push(JSON.stringify({
+    type: "session",
+    version: 0,
+    id: options.sessionId,
+    createdAt: options.createdAt,
+    cwd: options.cwd,
+    delegationDepth: 0,
+  }));
+
+  let seq = 0;
+  const event = (type: string, time: number, data: unknown, extra: Record<string, unknown> = {}) => {
+    lines.push(JSON.stringify({ type, seq: seq++, time, data, ...extra }));
+  };
+
+  let turn = 1;
+  const titleTime = options.title ? options.messages[0]?.time ?? options.createdAt : undefined;
+  for (let i = 0; i < options.messages.length; i++) {
+    const message = options.messages[i];
+    const time = Number.isFinite(message.time) && message.time > 0 ? message.time : options.createdAt;
+    event("turn/start", time, { turn });
+    event("step/start", time, { turn, step: 1 });
+    if (message.role === "user") {
+      event("user/message", time, {
+        id: `migrated-${turn}`,
+        role: "user",
+        content: [{ type: "text", text: message.content }],
+        source: { kind: "user" },
+      }, { surfaceOp: "append" });
+    } else {
+      event("assistant/message", time, {
+        turn,
+        step: 1,
+        message: {
+          id: `migrated-assistant-${turn}`,
+          role: "assistant",
+          content: [{ type: "text", text: message.content }],
+          source: { kind: "model", provider: "agent-recall-migration", model: "session-migration" },
+        },
+      }, { surfaceOp: "append", sourceEventSeqs: [] });
+    }
+    event("step/end", time, { turn, step: 1 });
+    event("turn/end", time, { turn, reason: "complete" });
+    turn += 1;
+  }
+
+  if (options.title) {
+    event("session/title", titleTime ?? options.createdAt, {
+      title: options.title,
+      messageSeqs: [],
+      source: { kind: "fallback" },
+    });
+  }
+
+  return zlib.zstdCompressSync(Buffer.from(lines.join("\n") + "\n", "utf8"));
+}

--- a/apps/main-1.0/src/core/deepseek-platform.test.ts
+++ b/apps/main-1.0/src/core/deepseek-platform.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import { defaultSettings, getResumeCommand, openDeepSeekWebInTerminal } from "./platform";
+import type { SessionSearchResult } from "./types";
+
+describe("DeepSeek Harness resume", () => {
+  it("builds an exact command-line fallback through the TUI profile", () => {
+    const session = {
+      source: "deepseek-cli",
+      rawId: "session-1",
+      projectPath: "/repo",
+    } as SessionSearchResult;
+    expect(getResumeCommand(session, defaultSettings, { platform: "darwin" })).toBe(
+      "cd /repo && dsh --profile tui --resume session-1",
+    );
+  });
+
+  it("starts the DeepSeek web profile in the selected workspace", async () => {
+    const runProcess = vi.fn(async () => undefined);
+    await openDeepSeekWebInTerminal("/repo", defaultSettings, { platform: "linux", runProcess });
+    expect(runProcess).toHaveBeenCalledWith("sh", ["-lc", "cd /repo && dsh --profile web"]);
+  });
+});

--- a/apps/main-1.0/src/core/format-adapters.ts
+++ b/apps/main-1.0/src/core/format-adapters.ts
@@ -324,6 +324,7 @@ export const zcodeAdapter = genericAdapter("zcode");
 export const codeWizAdapter = genericAdapter("codewiz");
 export const traeAdapter = genericAdapter("trae");
 export const qoderAdapter = genericAdapter("qoder");
+export const deepseekAdapter = genericAdapter("deepseek");
 export const piAdapter: FormatAdapter = {
   format: "pi",
   parseLine(raw) {
@@ -369,6 +370,7 @@ export function getAdapter(sourceOrFormat: SessionSource | SessionFormat): Forma
   if (sourceOrFormat === "trae") return traeAdapter;
   if (sourceOrFormat === "qoder") return qoderAdapter;
   if (sourceOrFormat === "pi") return piAdapter;
+  if (sourceOrFormat === "deepseek") return deepseekAdapter;
   const format = getFormatForSource(sourceOrFormat);
   if (format === "claude") return claudeAdapter;
   if (format === "codebuddy") return codebuddyAdapter;
@@ -382,6 +384,7 @@ export function getAdapter(sourceOrFormat: SessionSource | SessionFormat): Forma
   if (format === "trae") return traeAdapter;
   if (format === "qoder") return qoderAdapter;
   if (format === "pi") return piAdapter;
+  if (format === "deepseek") return deepseekAdapter;
   return codexAdapter;
 }
 

--- a/apps/main-1.0/src/core/indexer.ts
+++ b/apps/main-1.0/src/core/indexer.ts
@@ -13,6 +13,7 @@ import {
   type SessionLoadOptions,
 } from "./session-loader";
 import { migrationTargetDescriptor } from "./migration-targets";
+import { loadDeepSeekCliSessionFile, safeStat } from "./session-loader";
 import type { SessionStore } from "./session-store";
 import type { LoadedSession, MigrationTarget } from "./types";
 
@@ -364,6 +365,10 @@ export function indexMigratedSessionFile(
 
 function loadMigratedSessionFile(target: MigrationTarget, filePath: string, sessionId?: string): LoadedSession | null {
   if (target === "cursor") return loadCursorTranscriptFile(filePath);
+  if (target === "deepseek") {
+    const stat = safeStat(filePath);
+    return loadDeepSeekCliSessionFile(filePath, stat);
+  }
 
   const descriptor = migrationTargetDescriptor(target);
   if (descriptor.family === "codebuddy") return loadCodeBuddyCliSessionFile(filePath);

--- a/apps/main-1.0/src/core/mcp-migration.test.ts
+++ b/apps/main-1.0/src/core/mcp-migration.test.ts
@@ -16,6 +16,7 @@ import {
   loadCursorTranscriptFile,
   parseJsonlText,
 } from "./session-loader";
+import { parseDeepSeekSessionLog, projectDeepSeekSession } from "./deepseek-harness";
 import { migrationTargetDescriptor } from "./migration-targets";
 import { defaultSettings } from "./platform";
 import type { IndexedSession, MigrationTarget, SessionMessage, SessionMigrationStrategy, SessionSource } from "./types";
@@ -65,6 +66,10 @@ function seedLocalSession(
 
 function loadMigratedSessionFileForTest(target: MigrationTarget, filePath: string) {
   if (target === "cursor") return loadCursorTranscriptFile(filePath);
+  if (target === "deepseek") {
+    const log = parseDeepSeekSessionLog(fs.readFileSync(filePath));
+    return log ? projectDeepSeekSession(log) : null;
+  }
 
   const descriptor = migrationTargetDescriptor(target);
   if (descriptor.family === "codebuddy") return loadCodeBuddyCliSessionFile(filePath);
@@ -83,6 +88,7 @@ const allMigrationTargetsEnabled = {
   ...defaultSettings,
   includeTclaude: true,
   includeTcodex: true,
+  includeDeepSeekCli: true,
 };
 
 const targetSources: Record<MigrationTarget, SessionSource> = {
@@ -93,6 +99,7 @@ const targetSources: Record<MigrationTarget, SessionSource> = {
   cursor: "cursor-agent",
   tclaude: "tclaude-cli",
   tcodex: "tcodex-cli",
+  deepseek: "deepseek-cli",
 };
 
 describe("migrateSessionForMcp — happy path", () => {
@@ -115,6 +122,11 @@ describe("migrateSessionForMcp — happy path", () => {
         expect(result.strategy).toBe("complete");
         expect(result.resumeCommand).toContain(result.targetSessionId);
         expect(result.resumeCommand).toContain(projectPath);
+        if (target === "deepseek") {
+          expect(result.resumeCommand).toContain("dsh");
+          expect(result.resumeCommand).toContain("--profile");
+          expect(result.resumeCommand).toContain("tui");
+        }
         expect(result.indexed).toBe(true);
         expect(fs.existsSync(result.targetFilePath)).toBe(true);
 
@@ -123,7 +135,9 @@ describe("migrateSessionForMcp — happy path", () => {
         expect(loaded?.messages.length).toBeGreaterThan(0);
 
         // The migrated session is immediately searchable in the DB.
-        const indexedSessionKey = loaded?.session.sessionKey ?? `${target}:${result.targetSessionId}`;
+        const indexedSessionKey = (loaded && "session" in loaded && loaded.session)
+          ? (loaded as { session: { sessionKey: string } }).session.sessionKey
+          : `${target}:${result.targetSessionId}`;
         const found = store.getSession(indexedSessionKey);
         expect(found).not.toBeNull();
         expect(found?.source).toBe(targetSources[target]);

--- a/apps/main-1.0/src/core/mcp-server.test.ts
+++ b/apps/main-1.0/src/core/mcp-server.test.ts
@@ -395,7 +395,7 @@ describe("MCP migrate_session tool", () => {
   const migrateSession = mcp.migrateSession as (db: Db, args: Record<string, unknown>) => Promise<MigrationResult>;
   const migrationTargetSchema = mcp.migrationTargetSchema as (zod: typeof z) => Promise<ReturnType<typeof z.enum>>;
 
-  it("uses the seven-target schema for the real migrate_session tool contract", async () => {
+  it("uses the eight-target schema for the real migrate_session tool contract", async () => {
     const schema = await migrationTargetSchema(z);
     expect(schema.parse("codewiz")).toBe("codewiz");
     expect(schema.parse("tclaude")).toBe("tclaude");
@@ -408,6 +408,7 @@ describe("MCP migrate_session tool", () => {
       "cursor",
       "tclaude",
       "tcodex",
+      "deepseek",
     ]);
   });
 

--- a/apps/main-1.0/src/core/migration-targets.test.ts
+++ b/apps/main-1.0/src/core/migration-targets.test.ts
@@ -12,6 +12,7 @@ import {
 const allDisabled: MigrationTargetSettings = {
   includeTclaude: false,
   includeTcodex: false,
+  includeDeepSeekCli: false,
 };
 
 describe("migration target registry", () => {
@@ -24,6 +25,7 @@ describe("migration target registry", () => {
       "cursor",
       "tclaude",
       "tcodex",
+      "deepseek",
     ]);
     expect(new Set(MIGRATION_TARGET_IDS).size).toBe(MIGRATION_TARGET_IDS.length);
     expect(MIGRATION_TARGETS.map(({ id }) => id)).toEqual(MIGRATION_TARGET_IDS);
@@ -70,7 +72,7 @@ describe("migration target registry", () => {
     ]);
   });
 
-  it("maps the two optional migration targets", () => {
+  it("maps the optional migration targets", () => {
     expect(MIGRATION_TARGETS.slice(5)).toEqual([
       {
         id: "tclaude",
@@ -86,6 +88,13 @@ describe("migration target registry", () => {
         source: "tcodex-cli",
         enabledSetting: "includeTcodex",
       },
+      {
+        id: "deepseek",
+        label: "DeepSeek Harness",
+        family: "deepseek",
+        source: "deepseek-cli",
+        enabledSetting: "includeDeepSeekCli",
+      },
     ]);
   });
 
@@ -100,6 +109,7 @@ describe("migration target registry", () => {
     expect(enabledMigrationTargets({
       includeTclaude: true,
       includeTcodex: true,
+      includeDeepSeekCli: true,
     })).toEqual(MIGRATION_TARGET_IDS);
   });
 

--- a/apps/main-1.0/src/core/migration-targets.ts
+++ b/apps/main-1.0/src/core/migration-targets.ts
@@ -2,9 +2,10 @@ import type { MigrationAgent, MigrationTarget, SessionSource } from "./types";
 
 export type OptionalMigrationTargetSetting =
   | "includeTclaude"
-  | "includeTcodex";
+  | "includeTcodex"
+  | "includeDeepSeekCli";
 
-export type MigrationTargetSettings = Record<OptionalMigrationTargetSetting, boolean>;
+export type MigrationTargetSettings = Partial<Record<OptionalMigrationTargetSetting, boolean>>;
 
 export interface MigrationTargetDescriptor {
   id: MigrationTarget;
@@ -52,6 +53,13 @@ export const MIGRATION_TARGETS: readonly MigrationTargetDescriptor[] = [
     source: "tcodex-cli",
     enabledSetting: "includeTcodex",
   },
+  {
+    id: "deepseek",
+    label: "DeepSeek Harness",
+    family: "deepseek",
+    source: "deepseek-cli",
+    enabledSetting: "includeDeepSeekCli",
+  },
 ] as const satisfies readonly MigrationTargetDescriptor[];
 
 export const MIGRATION_TARGET_IDS = [
@@ -62,6 +70,7 @@ export const MIGRATION_TARGET_IDS = [
   "cursor",
   "tclaude",
   "tcodex",
+  "deepseek",
 ] as const satisfies readonly MigrationTarget[];
 
 export const BASE_MIGRATION_TARGETS = ["claude", "codex", "codebuddy", "codewiz", "cursor"] as const satisfies readonly MigrationTarget[];

--- a/apps/main-1.0/src/core/platform.ts
+++ b/apps/main-1.0/src/core/platform.ts
@@ -77,6 +77,7 @@ export interface AppSettings {
   cursorBinary: string;
   tclaudeBinary: string;
   tcodexBinary: string;
+  deepseekBinary: string;
   includeTclaude: boolean;
   includeTcodex: boolean;
   includeCodeBuddyCli: boolean;
@@ -90,6 +91,7 @@ export interface AppSettings {
   includeTrae: boolean;
   includeQoder: boolean;
   includePi: boolean;
+  includeDeepSeekCli: boolean;
   rulesSyncEnabled: boolean;
   memoriesSyncEnabled: boolean;
   hideCodexQuota: boolean;
@@ -148,6 +150,7 @@ export const defaultSettings: AppSettings = {
   cursorBinary: "cursor-agent",
   tclaudeBinary: "tclaude",
   tcodexBinary: "tcodex",
+  deepseekBinary: "dsh",
   includeTclaude: false,
   includeTcodex: false,
   includeCodeBuddyCli: false,
@@ -161,6 +164,7 @@ export const defaultSettings: AppSettings = {
   includeTrae: false,
   includeQoder: false,
   includePi: false,
+  includeDeepSeekCli: false,
   rulesSyncEnabled: false,
   memoriesSyncEnabled: false,
   hideCodexQuota: false,
@@ -250,6 +254,7 @@ export function migrationBinary(target: MigrationTarget, settings: AppSettings):
   if (target === "codebuddy") return settings.codeBuddyBinary;
   if (target === "codewiz") return settings.codeWizBinary;
   if (target === "cursor") return settings.cursorBinary;
+  if (target === "deepseek") return settings.deepseekBinary;
   return settings.codexBinary;
 }
 
@@ -260,6 +265,7 @@ function migrationTargetDisplayName(target: MigrationTarget): string {
   if (target === "codebuddy") return "CodeBuddy";
   if (target === "codewiz") return "CodeWiz";
   if (target === "cursor") return "Cursor";
+  if (target === "deepseek") return "DeepSeek Harness";
   return "Codex";
 }
 
@@ -268,6 +274,8 @@ function migrationResumeArgs(target: MigrationTarget, sessionId: string): string
     ? ["resume", sessionId]
     : target === "codewiz"
       ? ["--session", sessionId]
+      : target === "deepseek"
+        ? ["--profile", "tui", "--resume", sessionId]
     : ["--resume", sessionId];
 }
 
@@ -313,6 +321,7 @@ const MIGRATION_CLI_VERSION_RULES: Record<MigrationTarget, VersionRule[]> = {
     { label: "@tencent/tcodex", pattern: /^\s*@tencent\/tcodex\s*:?[ \t]*v?(\d+\.\d+\.\d+)[ \t]*$/im, minimum: version(0, 0, 13) },
     { label: "@openai/codex", pattern: /^\s*@openai\/codex\s*:?[ \t]*v?(\d+\.\d+\.\d+)[ \t]*$/im, minimum: version(0, 142, 4) },
   ],
+  deepseek: [{ label: "dsh", pattern: /^\s*v?(\d+\.\d+\.\d+)(?:-[\w.-]+)?\s*$/im, minimum: version(0, 0, 0) }],
 };
 
 function migrationTargetForResumeSource(source: SessionSource): MigrationTarget | null {
@@ -1074,6 +1083,56 @@ export async function openMigrationResumeInTerminal(
   }
 
   await openCommandInTerminal(commands, projectPath, settings, deps);
+}
+
+export async function openDeepSeekWebInTerminal(
+  projectPath: string,
+  settings: AppSettings,
+  deps: {
+    platform?: NodeJS.Platform;
+    runProcess?: ProcessRunner;
+    spawnDetached?: typeof spawnDetached;
+    resolveMacApplicationName?: typeof resolveMacApplicationName;
+  } = {},
+): Promise<void> {
+  const spec = { command: settings.deepseekBinary, args: ["--profile", "web"] };
+  const commands = buildMigrationResumeCommands(spec, projectPath, (deps.platform ?? process.platform) !== "win32");
+  const run = deps.runProcess ?? runProcess;
+  if ((deps.platform ?? process.platform) === "darwin" && settings.defaultTerminal === "Warp") {
+    await runWarpCommand(commands.posix, run);
+    return;
+  }
+  await openCommandInTerminal(commands, projectPath, settings, deps);
+}
+
+export async function probeDeepSeekWeb(
+  fetchImpl: typeof fetch = fetch,
+  timeoutMs = 1200,
+): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl("http://127.0.0.1:3080/", { signal: controller.signal, redirect: "manual" });
+    return response.status < 500;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function waitForDeepSeekWeb(
+  probe: () => Promise<boolean> = () => probeDeepSeekWeb(),
+  timeoutMs = 8_000,
+  intervalMs = 200,
+): Promise<boolean> {
+  const deadline = Date.now() + Math.max(0, timeoutMs);
+  for (;;) {
+    if (await probe()) return true;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return false;
+    await new Promise((resolve) => setTimeout(resolve, Math.min(Math.max(0, intervalMs), remaining)));
+  }
 }
 
 export async function resolveMacApplicationName(names: string[], runner: ProcessRunner = runProcess): Promise<string | null> {

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -19,6 +19,12 @@ import {
   sanitizeCodexTraceValue,
 } from "./session-loaders/codex-rollout";
 import { truncateTraceDetail } from "./trace-detail";
+import {
+  DEEPSEEK_HARNESS_DIR,
+  DEEPSEEK_HARNESS_LOG_NAME,
+  parseDeepSeekSessionLog,
+  projectDeepSeekSession,
+} from "./deepseek-harness";
 import type {
   CodeBuddyConversationLine,
   ClaudeAppSessionFile,
@@ -69,6 +75,7 @@ export interface SessionLoadOptions {
   includeCursorAgent?: boolean;
   includeTrae?: boolean;
   includeQoder?: boolean;
+  includeDeepSeekCli?: boolean;
   cursorStateDbPath?: string;
   cursorWorkspacePathMap?: ReadonlyMap<string, string>;
   shouldSkipFile?: (filePath: string, stat: VirtualSessionFileStat, dependencyMtimeMs?: number) => boolean;
@@ -198,7 +205,7 @@ function codexTurnContextProjectPath(value: unknown): string {
   return roots.find((root): root is string => typeof root === "string" && usableCodexProjectPath(root))?.trim() || "";
 }
 
-function safeStat(filePath: string): VirtualSessionFileStat {
+export function safeStat(filePath: string): VirtualSessionFileStat {
   try {
     const stat = fs.statSync(filePath);
     return { mtimeMs: stat.mtimeMs, size: stat.size };
@@ -1357,7 +1364,7 @@ function readGitBranchAt(gitPath: string): string | null {
 }
 
 function createIndexedSession(input: {
-  keyPrefix: "claude" | "codex" | "tclaude" | "tcodex" | "codebuddy" | "workbuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder" | "pi";
+  keyPrefix: "claude" | "codex" | "tclaude" | "tcodex" | "codebuddy" | "workbuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder" | "pi" | "deepseek";
   rawId: string;
   source: SessionSource;
   projectPath: string;
@@ -2874,6 +2881,80 @@ function createSourceTokenUsage(inputTokens: number, outputTokens: number, cache
   );
 }
 
+export function loadDeepSeekCliSessionFile(filePath: string, stat: VirtualSessionFileStat): LoadedSession | null {
+  let buffer: Buffer;
+  try {
+    buffer = fs.readFileSync(filePath);
+  } catch {
+    return null;
+  }
+  const log = parseDeepSeekSessionLog(buffer, filePath);
+  if (!log) return null;
+  const view = projectDeepSeekSession(log);
+  if (view.messages.length === 0) return null;
+  const question = firstQuestion(view.messages);
+  const usage = createSourceTokenUsage(
+    view.usage.inputTokens,
+    view.usage.outputTokens,
+    view.usage.cacheReadTokens,
+    view.usage.reasoningTokens,
+  );
+  return {
+    session: createIndexedSession({
+      keyPrefix: "deepseek",
+      rawId: log.header.id,
+      source: "deepseek-cli",
+      projectPath: log.header.cwd || "",
+      filePath,
+      originalTitle: view.title || cleanTitle(question) || log.header.id,
+      firstQuestion: cleanTitle(question),
+      timestamp: log.header.createdAt || stat.mtimeMs,
+      tokenUsage: usage,
+      isSubagent: log.header.delegationDepth > 0,
+      parentSessionId: log.header.parentSession ?? null,
+      stat,
+    }),
+    messages: view.messages,
+    tokenEvents: view.tokenEvents,
+    traceEvents: view.traceEvents,
+  };
+}
+
+export function loadDeepSeekCliSessions(deepSeekDir?: string): LoadedSession[] {
+  return [...loadDeepSeekCliSessionsIterator(deepSeekDir)];
+}
+
+export function* loadDeepSeekCliSessionsIterator(
+  deepSeekDir = process.env.DSH_HOME?.trim() || path.join(os.homedir(), DEEPSEEK_HARNESS_DIR),
+  options: SessionLoadOptions = {},
+): Generator<LoadedSession> {
+  const sessionsDir = path.join(deepSeekDir, "sessions");
+  let projectEntries: fs.Dirent[];
+  try {
+    projectEntries = fs.readdirSync(sessionsDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const projectEntry of projectEntries) {
+    if (!projectEntry.isDirectory()) continue;
+    const projectDir = path.join(sessionsDir, projectEntry.name);
+    let sessionEntries: fs.Dirent[];
+    try {
+      sessionEntries = fs.readdirSync(projectDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const sessionEntry of sessionEntries) {
+      if (!sessionEntry.isDirectory()) continue;
+      const filePath = path.join(projectDir, sessionEntry.name, DEEPSEEK_HARNESS_LOG_NAME);
+      const stat = safeStat(filePath);
+      if (shouldSkipFile(options, filePath, stat)) continue;
+      const loaded = loadDeepSeekCliSessionFile(filePath, stat);
+      if (loaded) yield loaded;
+    }
+  }
+}
+
 export function loadHermesSessions(hermesDir = path.join(os.homedir(), ".hermes")): LoadedSession[] {
   const dbPath = path.join(hermesDir, "state.db");
   const db = readOnlyDatabase(dbPath);
@@ -3838,6 +3919,12 @@ export function* loadDefaultSessionsIterator(options: SessionLoadOptions = {}): 
     for (const dirName of TRAE_DIR_NAMES) yield* loadTraeSessionsIterator(path.join(homeDir, dirName), options);
   }
   if (options.includeQoder) yield* loadQoderSessionsIterator(path.join(homeDir, QODER_DIR), options);
+  if (options.includeDeepSeekCli) {
+    const deepSeekDir = options.homeDir === undefined
+      ? process.env.DSH_HOME?.trim() || path.join(homeDir, DEEPSEEK_HARNESS_DIR)
+      : path.join(homeDir, DEEPSEEK_HARNESS_DIR);
+    yield* loadDeepSeekCliSessionsIterator(deepSeekDir, options);
+  }
   if (options.includeTclaude) yield* loadClaudeCliSessionsIterator(path.join(homeDir, TCLAUDE_DIR), "tclaude-cli", options);
   if (options.includeTcodex) yield* loadCodexSessionsIterator(path.join(homeDir, TCODEX_DIR), "tcodex-cli", options);
   if (options.includeCodeBuddyCli) yield* loadCodeBuddyCliSessionsIterator(path.join(homeDir, CODEBUDDY_DIR), options);
@@ -3869,6 +3956,12 @@ export async function* loadDefaultSessionsAsyncIterator(options: SessionLoadOpti
     for (const dirName of TRAE_DIR_NAMES) yield* loadTraeSessionsIterator(path.join(homeDir, dirName), options);
   }
   if (options.includeQoder) yield* loadQoderSessionsIterator(path.join(homeDir, QODER_DIR), options);
+  if (options.includeDeepSeekCli) {
+    const deepSeekDir = options.homeDir === undefined
+      ? process.env.DSH_HOME?.trim() || path.join(homeDir, DEEPSEEK_HARNESS_DIR)
+      : path.join(homeDir, DEEPSEEK_HARNESS_DIR);
+    yield* loadDeepSeekCliSessionsIterator(deepSeekDir, options);
+  }
   if (options.includeTclaude) yield* loadClaudeCliSessionsIterator(path.join(homeDir, TCLAUDE_DIR), "tclaude-cli", options);
   if (options.includeTcodex) yield* loadCodexSessionsAsyncIterator(path.join(homeDir, TCODEX_DIR), "tcodex-cli", options);
   if (options.includeCodeBuddyCli) yield* loadCodeBuddyCliSessionsIterator(path.join(homeDir, CODEBUDDY_DIR), options);

--- a/apps/main-1.0/src/core/session-migration-writers.test.ts
+++ b/apps/main-1.0/src/core/session-migration-writers.test.ts
@@ -1085,6 +1085,30 @@ describe("writeMigratedSession", () => {
     },
   );
 
+  it("uses DSH_HOME normally but keeps an explicit test home isolated", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "migration-writer-dsh-home-"));
+    const explicitHome = path.join(root, "explicit-home");
+    const dshHome = path.join(root, "custom-dsh-home");
+    const previous = process.env.DSH_HOME;
+    try {
+      process.env.DSH_HOME = dshHome;
+      const isolated = await writeMigratedSession({
+        target: "deepseek", session: portable(), sessionId: SESSION_ID, homeDir: explicitHome, now: NOW,
+      });
+      expect(isolated.filePath.startsWith(path.join(explicitHome, ".dsh"))).toBe(true);
+      expect(isolated.filePath.startsWith(dshHome)).toBe(false);
+
+      const configured = await writeMigratedSession({
+        target: "deepseek", session: portable(), sessionId: SESSION_ID, now: NOW,
+      });
+      expect(configured.filePath.startsWith(dshHome)).toBe(true);
+    } finally {
+      if (previous === undefined) delete process.env.DSH_HOME;
+      else process.env.DSH_HOME = previous;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("rejects a tampered Codex model provider before rename", async () => {
     await expectTamperedSessionRejected("codex", (rows) => {
       rows[0].payload.model_provider = "tampered-provider";

--- a/apps/main-1.0/src/core/session-migration-writers.ts
+++ b/apps/main-1.0/src/core/session-migration-writers.ts
@@ -19,6 +19,15 @@ import {
   parseCursorTranscriptPath,
   parseJsonlText,
 } from "./session-loader";
+import {
+  DEEPSEEK_HARNESS_LOG_NAME,
+  DEEPSEEK_HARNESS_NO_CWD_DIR,
+  encodeDeepSeekPathSegment,
+  encodeDeepSeekProjectKey,
+  parseDeepSeekSessionLog,
+  projectDeepSeekSession,
+  serializeDeepSeekSessionLog,
+} from "./deepseek-harness";
 import { loadMigrationTargetRuntimeMetadata, type MigrationTargetRuntimeMetadata } from "./migration-target-runtime";
 import { migrationTargetDescriptor } from "./migration-targets";
 import type { LoadedSession, MigrationTarget, PortableSession } from "./types";
@@ -61,6 +70,12 @@ export async function writeMigratedSession(options: WriteMigratedSessionOptions)
   if (options.target === "codewiz") {
     return writeMigratedCodeWizSession({ ...options, homeDir, now, idFactory: createId }, sessionId);
   }
+  if (options.target === "deepseek") {
+    const deepSeekHome = options.homeDir === undefined
+      ? process.env.DSH_HOME?.trim() || path.join(homeDir, ".dsh")
+      : path.join(homeDir, ".dsh");
+    return writeMigratedDeepSeekSession({ ...options, homeDir, deepSeekHome, now }, sessionId);
+  }
   const session = migrationTargetDescriptor(options.target).family === "codex"
     ? normalizeCodexSession(options.session)
     : options.session;
@@ -92,6 +107,61 @@ export async function writeMigratedSession(options: WriteMigratedSessionOptions)
     finalFileCreated = true;
     await updateCodexSessionIndex(options.target, targetHome, session, sessionId, now);
     updateCodexAppServerState(options.target, targetHome, filePath, session, sessionId, now, runtimeMetadata, codexRuntimeCwd);
+    return { sessionId, filePath };
+  } catch (error) {
+    await fs.promises.rm(tempPath, { force: true });
+    if (finalFileCreated) await fs.promises.rm(filePath, { force: true });
+    throw error;
+  }
+}
+
+async function writeMigratedDeepSeekSession(
+  options: WriteMigratedSessionOptions & { deepSeekHome: string; homeDir: string; now: Date },
+  sessionId: string,
+): Promise<WrittenMigratedSession> {
+  const projectPath = options.session.projectPath.trim();
+  const cwd = projectPath || options.homeDir;
+  const projectDir = projectPath ? encodeDeepSeekProjectKey(cwd) : DEEPSEEK_HARNESS_NO_CWD_DIR;
+  const filePath = path.join(
+    options.deepSeekHome,
+    "sessions",
+    projectDir,
+    encodeDeepSeekPathSegment(sessionId),
+    DEEPSEEK_HARNESS_LOG_NAME,
+  );
+
+  const startedAt = Date.parse(options.session.startedAt);
+  const createdAt = Number.isFinite(startedAt) && startedAt > 0 ? startedAt : options.now.getTime();
+  const payload = serializeDeepSeekSessionLog({
+    sessionId,
+    createdAt,
+    cwd,
+    title: cleanTitle(options.session.title),
+    messages: options.session.messages.map((message) => ({
+      role: message.role,
+      content: message.content,
+      time: Date.parse(message.timestamp) || createdAt,
+    })),
+  });
+
+  const tempPath = `${filePath}.tmp-${crypto.randomUUID()}`;
+  let finalFileCreated = false;
+  await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+  try {
+    await fs.promises.writeFile(tempPath, payload);
+    const parsed = parseDeepSeekSessionLog(payload);
+    if (!parsed || parsed.header.id !== sessionId) {
+      throw new Error("DeepSeek migration writer produced an unreadable session log.");
+    }
+    const view = projectDeepSeekSession(parsed);
+    const loadedMessages = view.messages.map((message) => ({ role: message.role, content: message.content }));
+    const expected = options.session.messages.map((message) => ({ role: message.role, content: message.content }));
+    if (JSON.stringify(loadedMessages) !== JSON.stringify(expected)) {
+      throw new Error("DeepSeek migration round trip did not preserve the transcript.");
+    }
+    await fs.promises.chmod(tempPath, 0o600);
+    await fs.promises.rename(tempPath, filePath);
+    finalFileCreated = true;
     return { sessionId, filePath };
   } catch (error) {
     await fs.promises.rm(tempPath, { force: true });
@@ -133,6 +203,10 @@ function serializeSession(
   codexRuntimeCwd: string,
 ): unknown[] {
   if (target === "cursor") return serializeCursor(session);
+  if (target === "deepseek") {
+    // DeepSeek sessions are written as zstd harness logs, not JSONL rows.
+    return [];
+  }
   const family = migrationTargetDescriptor(target).family;
   if (family === "codex") {
     return serializeCodex(
@@ -610,6 +684,12 @@ export function targetFilePath(
     );
   }
 
+  if (target === "deepseek") {
+    const key = encodeDeepSeekProjectKey(projectPath);
+    const dshHome = process.env.DSH_HOME?.trim() || path.join(homeDir, root);
+    return path.join(dshHome, "sessions", key, encodeDeepSeekPathSegment(sessionId), DEEPSEEK_HARNESS_LOG_NAME);
+  }
+
   return path.join(homeDir, root, "projects", encodeCodeBuddyProjectDir(projectPath), `${sessionId}.jsonl`);
 }
 
@@ -631,6 +711,7 @@ const TARGET_ROOTS: Record<MigrationTarget, string> = {
   codebuddy: ".codebuddy",
   codewiz: path.join(".local", "share", "codewiz"),
   cursor: ".cursor",
+  deepseek: ".dsh",
 };
 const NO_PROJECT_DIRECTORY = "empty-window";
 

--- a/apps/main-1.0/src/core/session-sources.test.ts
+++ b/apps/main-1.0/src/core/session-sources.test.ts
@@ -27,6 +27,7 @@ const ALL_SOURCES = [
   "trae",
   "qoder",
   "pi-cli",
+  "deepseek-cli",
 ] as const satisfies readonly SessionSource[];
 
 describe("session source capability registry", () => {
@@ -40,7 +41,10 @@ describe("session source capability registry", () => {
     for (const descriptor of SESSION_SOURCE_DESCRIPTORS) {
       expect(descriptor.capabilities.live).toBe(descriptor.liveFamily !== null);
       expect(descriptor.capabilities.migrate).toBe(descriptor.migrationAgent !== null);
-      if (descriptor.migrationAgent !== null) expect(descriptor.capabilities.sessionSync).toBe(true);
+      // Migrating targets sync remotely; deepseek migrates locally only.
+      if (descriptor.migrationAgent !== null && descriptor.remoteFamily !== null) {
+        expect(descriptor.capabilities.sessionSync).toBe(true);
+      }
       expect(descriptor.capabilities.openApp).toBe(descriptor.nativeAppFamily !== null);
       if (descriptor.capabilities.resume) expect(descriptor.resumeTarget).not.toBeNull();
       if (descriptor.remoteCollectorOptional) expect(descriptor.optionalSetting).not.toBeNull();
@@ -62,6 +66,7 @@ describe("session source capability registry", () => {
       "includeTrae",
       "includeQoder",
       "includePi",
+      "includeDeepSeekCli",
     ]);
     expect(sessionSourceDescriptor("tclaude-cli")).toMatchObject({ liveFamily: "tclaude", migrationAgent: "claude" });
     expect(sessionSourceDescriptor("tcodex-cli")).toMatchObject({ liveFamily: "tcodex", migrationAgent: "codex" });

--- a/apps/main-1.0/src/core/session-sources.ts
+++ b/apps/main-1.0/src/core/session-sources.ts
@@ -13,7 +13,8 @@ export type OptionalSessionSourceSetting =
   | "includeCursorAgent"
   | "includeTrae"
   | "includeQoder"
-  | "includePi";
+  | "includePi"
+  | "includeDeepSeekCli";
 
 export type SessionSourceFamily =
   | "claude"
@@ -30,7 +31,8 @@ export type SessionSourceFamily =
   | "cursor"
   | "trae"
   | "qoder"
-  | "pi";
+  | "pi"
+  | "deepseek";
 
 export type SessionSourceUiFamily = "claude" | "codex" | "codebuddy" | "codewiz" | "zcode" | "other";
 
@@ -165,6 +167,12 @@ export const SESSION_SOURCE_REGISTRY = {
     optionalSetting: "includePi", pendingKey: "pi", remoteCollectorOptional: false, liveFamily: null, migrationAgent: null,
     resumeTarget: null, remoteFamily: null, nativeAppFamily: null,
     capabilities: { live: false, resume: false, migrate: false, sessionSync: true, openApp: false },
+  },
+  "deepseek-cli": {
+    id: "deepseek-cli", label: "DeepSeek Harness", format: "deepseek", family: "deepseek", uiFamily: "other", statsGroup: null,
+    optionalSetting: "includeDeepSeekCli", pendingKey: "deepseek", remoteCollectorOptional: false, liveFamily: null, migrationAgent: "deepseek",
+    resumeTarget: "deepseek", remoteFamily: null, nativeAppFamily: null,
+    capabilities: { live: false, resume: true, migrate: true, sessionSync: false, openApp: false },
   },
 } as const satisfies Record<SessionSource, SessionSourceDescriptor>;
 

--- a/apps/main-1.0/src/core/store/session-tree-delete.test.ts
+++ b/apps/main-1.0/src/core/store/session-tree-delete.test.ts
@@ -109,6 +109,33 @@ describe("SessionsStore tree deletion", () => {
     }
   });
 
+  it("deletes DeepSeek Harness parent and descendant session directories together", () => {
+    const { database, store } = createStore();
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-v1-dsh-tree-delete-"));
+    const parentFile = path.join(root, "sessions", "--work--", "parent", "session.jsonl.zstd");
+    const childFile = path.join(root, "sessions", "--work--", "child", "session.jsonl.zstd");
+    for (const filePath of [parentFile, childFile]) {
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, "fixture");
+    }
+    insertSession(database, {
+      sessionKey: "deepseek:parent", rawId: "parent", source: "deepseek-cli", filePath: parentFile,
+    });
+    insertSession(database, {
+      sessionKey: "deepseek:child", rawId: "child", source: "deepseek-cli", filePath: childFile,
+      parentSessionId: "parent",
+    });
+
+    try {
+      expect(store.deleteSession("deepseek:parent")).toBe(true);
+      expect(fs.existsSync(path.dirname(parentFile))).toBe(false);
+      expect(fs.existsSync(path.dirname(childFile))).toBe(false);
+      expect(database.prepare("SELECT session_key FROM sessions").all()).toEqual([]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("deletes a ZCode parent and descendants in one shared database operation", () => {
     const { database, store } = createStore();
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-v1-zcode-tree-delete-"));

--- a/apps/main-1.0/src/core/store/sessions.ts
+++ b/apps/main-1.0/src/core/store/sessions.ts
@@ -37,6 +37,7 @@ import type {
 } from "../types";
 import type { SessionStoreDatabase } from "./database";
 import { EnvironmentStore, localEnvironment } from "./environments";
+import { deleteDeepSeekCliSessionDirectory } from "../deepseek-harness";
 import { deleteHermesSession } from "../hermes-session-writer";
 import { deleteLocalSessionSources } from "../session-source-delete";
 import { SESSION_SOURCE_DESCRIPTORS, sessionSourceDescriptor } from "../session-sources";
@@ -59,6 +60,7 @@ const LIVE_SESSION_KEY_SQL = `
     WHEN source = 'cursor-agent' THEN 'cursor:' || raw_id
     WHEN source = 'trae' THEN 'trae:' || raw_id
     WHEN source = 'qoder' THEN 'qoder:' || raw_id
+    WHEN source = 'deepseek-cli' THEN 'deepseek:' || raw_id
     ELSE NULL
   END
 `;
@@ -725,6 +727,13 @@ export class SessionsStore {
     }
     if (row.source === "hermes") {
       if (row.sourceAvailable) deleteHermesSession(row.filePath, row.rawId);
+      return this.deleteSessionRecords(targets.map((target) => target.sessionKey), false).includes(sessionKey);
+    }
+    if (row.source === "deepseek-cli") {
+      for (const target of targets) {
+        if (!target.sourceAvailable) continue;
+        deleteDeepSeekCliSessionDirectory(target.filePath);
+      }
       return this.deleteSessionRecords(targets.map((target) => target.sessionKey), false).includes(sessionKey);
     }
     if (row.source === "cursor-agent" && /(^|[\\/])state\.vscdb$/i.test(row.filePath)) {

--- a/apps/main-1.0/src/core/types.ts
+++ b/apps/main-1.0/src/core/types.ts
@@ -15,8 +15,9 @@ export type SessionSource =
   | "cursor-agent"
   | "trae"
   | "qoder"
-  | "pi-cli";
-export type SessionFormat = "claude" | "codex" | "codebuddy" | "workbuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder" | "pi";
+  | "pi-cli"
+  | "deepseek-cli";
+export type SessionFormat = "claude" | "codex" | "codebuddy" | "workbuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder" | "pi" | "deepseek";
 export type SessionSortBy = "smart" | "activity" | "created";
 export type EnvironmentKind = "local" | "wsl" | "ssh";
 export type EnvironmentSyncState = "idle" | "syncing" | "watching" | "disconnected" | "error";
@@ -89,7 +90,7 @@ export interface SessionMessageEvent {
   timestamp: number;
 }
 
-export type MigrationAgent = "claude" | "codex" | "codebuddy" | "codewiz" | "cursor";
+export type MigrationAgent = "claude" | "codex" | "codebuddy" | "codewiz" | "cursor" | "deepseek";
 export type MigrationTarget = MigrationAgent | "tclaude" | "tcodex";
 export type RemoteSessionAgent = MigrationAgent | "hermes" | "pi";
 export type SessionMigrationStrategy = "complete" | "ai-compressed" | "locally-truncated";

--- a/apps/main-1.0/src/main/deepseek-web-session.test.ts
+++ b/apps/main-1.0/src/main/deepseek-web-session.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEEPSEEK_WEB_STORAGE_KEY,
+  DEEPSEEK_WEB_URL,
+  openDeepSeekWebSessionPage,
+} from "./deepseek-web-session";
+
+describe("openDeepSeekWebSessionPage", () => {
+  it("selects the requested session before showing the web page", async () => {
+    const calls: string[] = [];
+    const page = {
+      loadURL: vi.fn(async (url: string) => { calls.push(`load:${url}`); }),
+      executeJavaScript: vi.fn(async (script: string) => { calls.push(`script:${script}`); }),
+      show: vi.fn(() => { calls.push("show"); }),
+      focus: vi.fn(() => { calls.push("focus"); }),
+    };
+
+    await openDeepSeekWebSessionPage(page, "session-1");
+
+    expect(calls).toEqual([
+      `load:${DEEPSEEK_WEB_URL}`,
+      `script:localStorage.setItem(${JSON.stringify(DEEPSEEK_WEB_STORAGE_KEY)}, ${JSON.stringify(JSON.stringify({ sessionId: "session-1" }))})`,
+      `load:${DEEPSEEK_WEB_URL}`,
+      "show",
+      "focus",
+    ]);
+  });
+
+  it("quotes an untrusted session id as data in the storage script", async () => {
+    const page = {
+      loadURL: vi.fn(async () => undefined),
+      executeJavaScript: vi.fn(async () => undefined),
+      show: vi.fn(),
+      focus: vi.fn(),
+    };
+    const sessionId = `session-\";globalThis.compromised=true;//`;
+
+    await openDeepSeekWebSessionPage(page, sessionId);
+
+    expect(page.executeJavaScript).toHaveBeenCalledWith(
+      `localStorage.setItem(${JSON.stringify(DEEPSEEK_WEB_STORAGE_KEY)}, ${JSON.stringify(JSON.stringify({ sessionId }))})`,
+    );
+  });
+});

--- a/apps/main-1.0/src/main/deepseek-web-session.ts
+++ b/apps/main-1.0/src/main/deepseek-web-session.ts
@@ -1,0 +1,23 @@
+export const DEEPSEEK_WEB_URL = "http://127.0.0.1:3080/";
+export const DEEPSEEK_WEB_STORAGE_KEY = "dsh.sessions.current";
+
+export interface DeepSeekWebSessionPage {
+  loadURL(url: string): Promise<unknown>;
+  executeJavaScript(script: string): Promise<unknown>;
+  show(): void;
+  focus(): void;
+}
+
+export async function openDeepSeekWebSessionPage(
+  page: DeepSeekWebSessionPage,
+  sessionId: string,
+): Promise<void> {
+  await page.loadURL(DEEPSEEK_WEB_URL);
+  const selection = JSON.stringify({ sessionId });
+  await page.executeJavaScript(
+    `localStorage.setItem(${JSON.stringify(DEEPSEEK_WEB_STORAGE_KEY)}, ${JSON.stringify(selection)})`,
+  );
+  await page.loadURL(DEEPSEEK_WEB_URL);
+  page.show();
+  page.focus();
+}

--- a/apps/main-1.0/src/main/index.ts
+++ b/apps/main-1.0/src/main/index.ts
@@ -51,12 +51,16 @@ import {
   inspectMigrationCli,
   mergeAppSettings,
   normalizeTerminal,
+  openDeepSeekWebInTerminal,
   openNativeApp,
   openMigrationResumeInTerminal,
   openResumeInSpecificTerminal,
   openResumeInTerminal,
+  probeDeepSeekWeb,
   revealInFileManager,
+  waitForDeepSeekWeb,
 } from "../core/platform";
+import { DEEPSEEK_WEB_URL, openDeepSeekWebSessionPage } from "./deepseek-web-session";
 import { loadUsageQuotaSnapshot } from "../core/quota";
 import { repairLegacyAgentRecallCodexRollouts } from "../core/codex-migration-repair";
 import { focusLiveSessionTerminal, setLiveSessionTerminalTitle } from "../core/session-focus";
@@ -236,6 +240,7 @@ bootstrapApplicationPaths({
 
 let mainWindow: BrowserWindow | null = null;
 let quickSearchWindow: BrowserWindow | null = null;
+let deepSeekWebWindow: BrowserWindow | null = null;
 const interfaceZoomController = createInterfaceZoomController(() => [mainWindow, quickSearchWindow]);
 let tray: Tray | null = null;
 let store: SessionStore;
@@ -916,6 +921,57 @@ function createQuickSearchWindow(): BrowserWindow {
   return window;
 }
 
+function getDeepSeekWebWindow(): BrowserWindow {
+  if (deepSeekWebWindow && !deepSeekWebWindow.isDestroyed()) return deepSeekWebWindow;
+  const allowedOrigin = new URL(DEEPSEEK_WEB_URL).origin;
+  const window = new BrowserWindow({
+    width: 1280,
+    height: 840,
+    minWidth: 860,
+    minHeight: 600,
+    show: false,
+    title: "DeepSeek Harness",
+    backgroundColor: "#0a0b0d",
+    webPreferences: {
+      sandbox: true,
+      contextIsolation: true,
+      nodeIntegration: false,
+      partition: "persist:deepseek-harness-web",
+    },
+  });
+  window.webContents.setWindowOpenHandler(({ url }) => {
+    const externalUrl = normalizeExternalLink(url);
+    if (externalUrl) void shell.openExternal(externalUrl);
+    return { action: "deny" };
+  });
+  window.webContents.on("will-navigate", (event, url) => {
+    try {
+      if (new URL(url).origin === allowedOrigin) return;
+    } catch {
+      // Invalid URLs are denied below.
+    }
+    event.preventDefault();
+    const externalUrl = normalizeExternalLink(url);
+    if (externalUrl) void shell.openExternal(externalUrl);
+  });
+  window.on("closed", () => {
+    if (deepSeekWebWindow === window) deepSeekWebWindow = null;
+  });
+  deepSeekWebWindow = window;
+  return window;
+}
+
+async function showDeepSeekWebSession(sessionId: string): Promise<void> {
+  const window = getDeepSeekWebWindow();
+  window.hide();
+  await openDeepSeekWebSessionPage({
+    loadURL: (url) => window.loadURL(url),
+    executeJavaScript: (script) => window.webContents.executeJavaScript(script),
+    show: () => window.show(),
+    focus: () => window.focus(),
+  }, sessionId);
+}
+
 function showQuickSearch(): void {
   if (!quickSearchWindow || quickSearchWindow.isDestroyed()) {
     quickSearchWindow = createQuickSearchWindow();
@@ -1203,6 +1259,7 @@ function runIndexSync(): Promise<IndexStatus> {
         includeCursorAgent: settings.includeCursorAgent,
         includeTrae: settings.includeTrae,
         includeQoder: settings.includeQoder,
+        includeDeepSeekCli: settings.includeDeepSeekCli,
       },
     }, {
       onEnvironmentsChanged: emitEnvironmentsUpdated,
@@ -2229,6 +2286,17 @@ function registerIpc(): void {
     if (!isLocalSessionEnvironment(session)) {
       await ensureRemoteResumePreflight(session);
       await openResumeInTerminal(session, getSettings(), { sshArgs });
+      store.markResumed(sessionKey);
+      return { route: "resume" as const };
+    }
+    if (session.source === "deepseek-cli") {
+      if (!await probeDeepSeekWeb()) {
+        await openDeepSeekWebInTerminal(session.projectPath || homedir(), getSettings());
+        if (!await waitForDeepSeekWeb()) {
+          throw new Error("DeepSeek Harness Web did not start on http://127.0.0.1:3080.");
+        }
+      }
+      await showDeepSeekWebSession(session.rawId);
       store.markResumed(sessionKey);
       return { route: "resume" as const };
     }

--- a/apps/main-1.0/src/main/services/session-bulk-delete-service.ts
+++ b/apps/main-1.0/src/main/services/session-bulk-delete-service.ts
@@ -6,6 +6,7 @@ import type {
   SessionBulkDeleteResult,
   SessionBulkDeleteTarget,
 } from "../../core/session-bulk-delete";
+import { deleteDeepSeekCliSessionDirectory } from "../../core/deepseek-harness";
 import { deleteLocalSessionSources } from "../../core/session-source-delete";
 import { sessionSourceDescriptor } from "../../core/session-sources";
 import type { SessionEnvironment, SessionSource } from "../../core/types";
@@ -185,6 +186,10 @@ async function deleteTargetFamily(
     for (const group of groupBy(availableTargets, (target) => target.filePath).values()) {
       deleteZcodeSessions(group[0].filePath, group.map((target) => target.rawId));
     }
+    return;
+  }
+  if (availableTargets[0].source === "deepseek-cli") {
+    for (const target of availableTargets) deleteDeepSeekCliSessionDirectory(target.filePath);
     return;
   }
   if (availableTargets[0].environmentKind === "wsl") {

--- a/apps/main-1.0/src/main/session-index-worker-protocol.ts
+++ b/apps/main-1.0/src/main/session-index-worker-protocol.ts
@@ -18,6 +18,7 @@ export type SessionIndexWorkerLoadOptions = Pick<
   | "includeCursorAgent"
   | "includeTrae"
   | "includeQoder"
+  | "includeDeepSeekCli"
 >;
 
 interface SessionIndexWorkerBaseInput {

--- a/apps/main-1.0/src/renderer/src/components/session-dialogs.tsx
+++ b/apps/main-1.0/src/renderer/src/components/session-dialogs.tsx
@@ -103,6 +103,11 @@ export function DeleteSessionDialog({
                 "This permanently deletes this Hermes session and its messages from the local Hermes database. Other Hermes sessions stay intact. This cannot be undone.",
                 "这会从本地 Hermes 数据库永久删除该会话及其消息，不影响其他 Hermes 会话，无法撤销。",
               )
+            : session.source === "deepseek-cli"
+            ? l(
+                "This permanently deletes this DeepSeek Harness session and its messages from the local DeepSeek Harness log. Other DeepSeek Harness sessions stay intact. This cannot be undone.",
+                "这会从本地 DeepSeek Harness 日志永久删除该会话及其消息，不影响其他 DeepSeek Harness 会话，无法撤销。",
+              )
             : l(
                 "This deletes the original Codex or Claude Code session file and removes it from this app. This cannot be undone.",
                 "这会删除 Codex 或 Claude Code 的原始会话文件，并从本应用移除，无法撤销。",

--- a/apps/main-1.0/src/renderer/src/features/search/group-logic.ts
+++ b/apps/main-1.0/src/renderer/src/features/search/group-logic.ts
@@ -1,5 +1,5 @@
 import { codexTaskWorkspaceDate } from "../../../../core/project-identity";
-import { sessionSourceDescriptor } from "../../../../core/session-sources";
+import { isSessionSource, sessionSourceDescriptor } from "../../../../core/session-sources";
 import type { SessionSource } from "../../../../core/types";
 
 export type GroupMode = "flat" | "project" | "source" | "time";
@@ -48,7 +48,9 @@ export function isNoProjectGroupKey(key: string): boolean {
 }
 
 function projectGroupKey(session: GroupableSession): string {
-  const sourceFamily = sessionSourceDescriptor(session.source).family;
+  const sourceFamily = isSessionSource(session.source)
+    ? sessionSourceDescriptor(session.source).family
+    : String(session.source);
   const isCodexTaskWorkspace = sourceFamily === "codex"
     && codexTaskWorkspaceDate(session.projectPath) !== null;
   return !session.projectPath || isCodexTaskWorkspace

--- a/apps/main-1.0/src/renderer/src/features/session-detail/detail-panel.tsx
+++ b/apps/main-1.0/src/renderer/src/features/session-detail/detail-panel.tsx
@@ -25,7 +25,7 @@ import {
 import { readInitialToolEventsVisibility, storeToolEventsVisibility } from "../../tool-events-visibility";
 import type { SessionFamily } from "../../../../core/session-family";
 import { canDeleteSessionLocally } from "../../../../core/session-environment";
-import { sessionSourceDescriptor } from "../../../../core/session-sources";
+import { isSessionSource, sessionSourceDescriptor } from "../../../../core/session-sources";
 import { SubagentSessionTree } from "./subagent-session-tree";
 import { SessionContextComponentsPanel } from "./session-context-components-panel";
 import { collaborationMessageMetadata } from "./collaboration-message";
@@ -261,7 +261,8 @@ export function DetailPanel({
     && !messages.some((message) => message.role === roleFilter);
   const localOnlyDisabled = isRemoteSession(session);
   const canDelete = canDeleteSessionLocally(session);
-  const canSyncSession = sessionSourceDescriptor(session.source).capabilities.sessionSync;
+  const canSyncSession = isSessionSource(session.source)
+    && sessionSourceDescriptor(session.source).capabilities.sessionSync;
   const revealTitle = localOnlyDisabled ? remoteRevealTitle(language) : l(`Show in ${revealLabel}`, `在${revealLabel}中显示`);
 
   const toggleTools = () => {

--- a/apps/main-1.0/src/renderer/src/features/settings/settings-dialog.tsx
+++ b/apps/main-1.0/src/renderer/src/features/settings/settings-dialog.tsx
@@ -705,6 +705,19 @@ export function SettingsDialog({
                     onChange={(event) => onSettingsChange({ includeQoder: event.currentTarget.checked })}
                   />
                 </label>
+                <label className="settings-field settings-toggle">
+                  <div className="settings-field-text">
+                    <span className="settings-field-title">Include DeepSeek Harness</span>
+                    <span className="settings-field-sub">{l("Indexes local DeepSeek Harness (dsh) sessions from DSH_HOME (default: ~/.dsh).", "从 DSH_HOME（默认 ~/.dsh）索引本地 DeepSeek Harness（dsh）会话。")}</span>
+                  </div>
+                  <input
+                    type="checkbox"
+                    className="switch"
+                    checked={Boolean(settings?.includeDeepSeekCli)}
+                    disabled={!settings}
+                    onChange={(event) => onSettingsChange({ includeDeepSeekCli: event.currentTarget.checked })}
+                  />
+                </label>
               </section>
             ) : null}
             {activeSection === "usage" ? (

--- a/apps/main-1.0/src/renderer/src/live-filter.test.ts
+++ b/apps/main-1.0/src/renderer/src/live-filter.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { liveSessionKeyForSession } from "./live-filter";
+
+describe("live session filtering", () => {
+  it("treats an unknown persisted source as non-live", () => {
+    expect(liveSessionKeyForSession({
+      source: "legacy-source" as never,
+      rawId: "session-1",
+      lastActivityAt: Date.now(),
+    })).toBeNull();
+  });
+});

--- a/apps/main-1.0/src/renderer/src/live-filter.ts
+++ b/apps/main-1.0/src/renderer/src/live-filter.ts
@@ -1,5 +1,5 @@
 import type { SessionSource } from "../../core/types";
-import { sessionSourceDescriptor } from "../../core/session-sources";
+import { isSessionSource, sessionSourceDescriptor } from "../../core/session-sources";
 import { LIVE_SESSION_INACTIVITY_TIMEOUT_MS } from "../../core/refresh-policy";
 
 export type LiveSessionState = "open" | "closed";
@@ -12,6 +12,9 @@ export interface LiveFilterableSession {
 }
 
 export function liveSessionKeyForSession(session: LiveFilterableSession): string | null {
+  // Persisted sessions can outlive a source rename or a development branch.
+  // Treat an unknown runtime value as non-live instead of crashing the list.
+  if (!isSessionSource(session.source)) return null;
   const family = sessionSourceDescriptor(session.source).liveFamily;
   if (!family) return null;
   return `${family}:${session.rawId}`;

--- a/apps/main-1.0/src/renderer/src/session-ui.test.ts
+++ b/apps/main-1.0/src/renderer/src/session-ui.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { defaultSettings } from "../../core/platform";
-import { canMigrateSession, migrationTargetsForSession, sourceFilters } from "./session-ui";
+import { canMigrateSession, migrationTargetsForSession, sourceFilters, sourceMigrationAgent, sourceUiFamily, supportsResumeSource } from "./session-ui";
 
 const settings = { includeTclaude: false, includeTcodex: false };
 
@@ -24,6 +24,15 @@ describe("migrationTargetsForSession", () => {
   it("keeps local and WSL target behavior", () => {
     expect(migrationTargetsForSession({ source: "claude-cli", environmentId: "local", environmentKind: "local" }, settings)).toEqual(["claude", "codex", "codebuddy", "codewiz", "cursor"]);
     expect(migrationTargetsForSession({ source: "codex-cli", environmentId: "wsl-1", environmentKind: "wsl" }, settings)).toEqual(["claude", "codex"]);
+  });
+
+  it("safely disables actions for a stale persisted source", () => {
+    const source = "workbuddy-cli" as never;
+    const session = { source, environmentId: "local", environmentKind: "local" } as const;
+    expect(sourceUiFamily(source)).toBe("other");
+    expect(supportsResumeSource(source)).toBe(false);
+    expect(sourceMigrationAgent(source)).toBeNull();
+    expect(migrationTargetsForSession(session, settings)).toEqual([]);
   });
 });
 

--- a/apps/main-1.0/src/renderer/src/session-ui.ts
+++ b/apps/main-1.0/src/renderer/src/session-ui.ts
@@ -15,6 +15,7 @@ import { enabledMigrationTargets, migrationTargetDescriptor, type MigrationTarge
 import {
   OPTIONAL_SESSION_SOURCE_DESCRIPTORS,
   SESSION_SOURCE_DESCRIPTORS,
+  isSessionSource,
   sessionSourceDescriptor,
   type SessionSourceUiFamily,
 } from "../../core/session-sources";
@@ -34,6 +35,7 @@ export interface UsageStatsDisplayRow extends SessionStatsSummary {
 }
 
 function usageStatsDisplayGroup(source: SessionSource): { key: string; label: string } {
+  if (!isSessionSource(source)) return { key: String(source), label: String(source) };
   const descriptor = sessionSourceDescriptor(source);
   if (descriptor.statsGroup) {
     return { key: descriptor.statsGroup, label: descriptor.statsGroup === "claude" ? "Claude Code" : "Codex" };
@@ -124,10 +126,12 @@ export function displayTagName(tagName: string): string {
 }
 
 export function sourceUiFamily(source: SessionSource): SessionSourceUiFamily {
+  if (!isSessionSource(source)) return "other";
   return sessionSourceDescriptor(source).uiFamily;
 }
 
 export function supportsResumeSource(source: SessionSource): boolean {
+  if (!isSessionSource(source)) return false;
   return sessionSourceDescriptor(source).capabilities.resume;
 }
 
@@ -136,6 +140,7 @@ export function supportsMigrationSource(source: SessionSource): boolean {
 }
 
 export function migrationTargetsForSource(source: SessionSource, settings: MigrationTargetSettings): MigrationTarget[] {
+  if (!isSessionSource(source)) return [];
   return supportedMigrationTargets(source, enabledMigrationTargets(settings));
 }
 
@@ -165,6 +170,7 @@ export function migrationAgentLabel(target: MigrationTarget): string {
 }
 
 export function sourceMigrationAgent(source: SessionSource): MigrationAgent | null {
+  if (!isSessionSource(source)) return null;
   return sessionSourceDescriptor(source).migrationAgent;
 }
 

--- a/apps/main-2.0/bin/setup-mcp.cjs
+++ b/apps/main-2.0/bin/setup-mcp.cjs
@@ -81,6 +81,87 @@ function nodeCommand() {
   return "node";
 }
 
+// --- DeepSeek Harness (~/.dsh/cordis.patch.yml, YAML patch array) -----------
+
+const DSH_MCP_ROW_ID = "mcp-agent-recall";
+const DSH_PATCH_HEADER = "# Agent Recall MCP server — managed by Agent Recall (setup-mcp).";
+const DSH_PATCH_ENTRY = `- insert:
+    - id: ${DSH_MCP_ROW_ID}
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        serverName: agent-recall
+        transport: stdio
+        command: __COMMAND__
+        args: [__SCRIPT__]
+        failOnStartupError: false`;
+
+function yamlScalar(value) {
+  // JSON string literal escaping is a valid YAML double-quoted scalar.
+  return JSON.stringify(value);
+}
+
+function renderDshBlock(command, scriptPath) {
+  return DSH_PATCH_ENTRY
+    .replace("__COMMAND__", yamlScalar(command))
+    .replace("__SCRIPT__", yamlScalar(scriptPath));
+}
+
+function removeDshBlock(contents) {
+  // Drop the managed insert unit (header row + following indented lines), then trim trailing blanks.
+  const lines = (contents || "").split("\n");
+  const out = [];
+  let skipping = false;
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const trimmed = line.trim();
+    // The managed entry is a two-line unit: the "- insert:" opener and the row.
+    if (trimmed === "- insert:" && !skipping) {
+      // Only treat as ours when the next line is the managed row id.
+      const next = lines[index + 1];
+      if (next && next.trim() === `- id: ${DSH_MCP_ROW_ID}`) {
+        skipping = true;
+        continue;
+      }
+    }
+    if (skipping) {
+      if (/^-\s/.test(line) || trimmed === "") {
+        skipping = false;
+      } else {
+        continue;
+      }
+    }
+    out.push(line);
+  }
+  // Remove the header comment if it directly precedes the row.
+  const joined = out.join("\n");
+  return joined
+    .replace(new RegExp(`${DSH_PATCH_HEADER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*\\n?`), "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function applyDshConfig(contents, scriptPath, remove, command = "node") {
+  const stripped = removeDshBlock(contents);
+  const meaningful = stripped
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"));
+  const emptyPatch = meaningful.length === 0 || (meaningful.length === 1 && meaningful[0] === "[]");
+  if (remove) {
+    if (!emptyPatch) return `${stripped}\n`;
+    const comments = stripped
+      .split("\n")
+      .filter((line) => line.trim().startsWith("#"))
+      .join("\n");
+    return comments ? `${comments}\n[]\n` : "[]\n";
+  }
+  const base = emptyPatch
+    ? stripped.split("\n").filter((line) => line.trim() !== "[]").join("\n").trim()
+    : stripped;
+  const block = `${DSH_PATCH_HEADER}\n${renderDshBlock(command, scriptPath)}`;
+  return base ? `${base}\n\n${block}\n` : `# dsh profile patch layer (user-editable).\n${block}\n`;
+}
+
 // --- Claude (~/.claude.json, JSON) -----------------------------------------
 
 function applyClaudeConfig(config, scriptPath, remove, command = "node") {
@@ -176,6 +257,24 @@ function run(remove, options = {}) {
     messages.push("Skipped CodeBuddy (~/.codebuddy not found).");
   }
 
+  // DeepSeek Harness reads its home-level patch layer ~/.dsh/cordis.patch.yml
+  // (applied over every profile). Register there when the harness is present.
+  // Wrapped separately so a dsh failure never blocks the other registrations.
+  const dshHome = process.env.DSH_HOME?.trim() || path.join(home, ".dsh");
+  if (fs.existsSync(dshHome) && (!remove || fs.existsSync(path.join(dshHome, "cordis.patch.yml")))) {
+    try {
+      const dshPatchPath = path.join(dshHome, "cordis.patch.yml");
+      const current = fs.existsSync(dshPatchPath) ? fs.readFileSync(dshPatchPath, "utf8") : "";
+      const next = applyDshConfig(current, scriptPath, remove, command);
+      writeFileAtomic(dshPatchPath, next);
+      messages.push(`${remove ? "Removed" : "Configured"} MCP server in ${dshPatchPath}`);
+    } catch (error) {
+      messages.push(`Failed to configure DeepSeek Harness MCP (${error instanceof Error ? error.message : String(error)}).`);
+    }
+  } else {
+    messages.push("Skipped DeepSeek Harness (~/.dsh not found).");
+  }
+
   if (!remove) messages.push(`Using node: ${command}`);
   return messages;
 }
@@ -205,7 +304,7 @@ function serverDefinition() {
   };
 }
 
-module.exports = { applyClaudeConfig, applyCodexConfig, removeCodexBlock, run, serverDefinition, status };
+module.exports = { applyClaudeConfig, applyCodexConfig, applyDshConfig, removeCodexBlock, removeDshBlock, run, serverDefinition, status };
 
 if (require.main === module) {
   const remove = process.argv.includes("uninstall") || process.argv.includes("--remove");

--- a/apps/main-2.0/package.json
+++ b/apps/main-2.0/package.json
@@ -26,7 +26,10 @@
     "node": ">=22.13.0"
   },
   "files": [
-    "out",
+    "out/main",
+    "out/preload",
+    "out/renderer",
+    "out/mcp/*.js",
     "dist/main/index.js",
     "bin",
     "assets",

--- a/apps/main-2.0/scripts/pack-release.mjs
+++ b/apps/main-2.0/scripts/pack-release.mjs
@@ -29,6 +29,11 @@ export async function packReleaseArchive({ root, destination, environment = proc
     shell: process.platform === "win32",
   });
   const packed = parsePackResult(stdout);
+  const bundledMcpSourceMap = packed.files?.find(({ path: filePath }) =>
+    filePath.startsWith("out/mcp/") && filePath.endsWith(".map"));
+  if (bundledMcpSourceMap) {
+    throw new Error(`Release package must not include MCP source maps: ${bundledMcpSourceMap.path}`);
+  }
   return path.join(destination, packed.filename);
 }
 

--- a/apps/main-2.0/scripts/pack-release.test.mjs
+++ b/apps/main-2.0/scripts/pack-release.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile as execFileCallback } from "node:child_process";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -68,6 +68,37 @@ test("prints the package filename when invoked from the release workflow", async
     });
 
     assert.equal(stdout.trim(), "agent-recall-pack-fixture-1.0.0.tgz");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects MCP source maps from the release archive", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "agent-recall-pack-release-mcp-map-"));
+  try {
+    await writeFile(path.join(root, "package.json"), JSON.stringify({
+      name: "agent-recall-pack-fixture",
+      version: "1.0.0",
+      files: ["out"],
+    }, null, 2) + "\n", "utf8");
+    const mcpOutput = path.join(root, "out", "mcp");
+    await mkdir(mcpOutput, { recursive: true });
+    await writeFile(path.join(mcpOutput, "migration-entry.js"), "export {};\n", "utf8");
+    await writeFile(path.join(mcpOutput, "migration-entry.js.map"), "{}\n", "utf8");
+
+    await assert.rejects(
+      packReleaseArchive({
+        root,
+        destination: path.join(root, "archives"),
+        environment: {
+          ...process.env,
+          HOME: path.join(root, "home"),
+          USERPROFILE: path.join(root, "home"),
+          npm_config_cache: path.join(root, "npm-cache"),
+        },
+      }),
+      /must not include MCP source maps: out\/mcp\/migration-entry\.js\.map/,
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/apps/main-2.0/src/core/deepseek-default-loader.test.ts
+++ b/apps/main-2.0/src/core/deepseek-default-loader.test.ts
@@ -1,0 +1,34 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { zstdCompressSync } from "node:zlib";
+import { loadDefaultSessionsIterator } from "./session-loader";
+
+describe("deepseek enabled end-to-end (synthetic fixture)", () => {
+  it("appears in the default loaders when the setting is on and off", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-dsh-default-"));
+    try {
+      const home = path.join(root, "home");
+      const logPath = path.join(home, ".dsh", "sessions", "--work--", "s1", "session.jsonl.zstd");
+      fs.mkdirSync(path.dirname(logPath), { recursive: true });
+      const lines = [
+        { type: "session", version: 0, id: "s1", createdAt: 1700000000000, cwd: "/work", delegationDepth: 0 },
+        { type: "user/message", seq: 0, time: 1700000000001, data: { id: "m1", role: "user", content: [{ type: "text", text: "hello" }], source: { kind: "user" } }, surfaceOp: "append" },
+      ];
+      const text = lines.map((l) => JSON.stringify(l)).join(String.fromCharCode(10)) + String.fromCharCode(10);
+      fs.writeFileSync(logPath, zstdCompressSync(Buffer.from(text)));
+
+      const off = [...loadDefaultSessionsIterator({ homeDir: home })];
+      expect(off.filter((item) => item.session.source === "deepseek-cli")).toHaveLength(0);
+
+      const on = [...loadDefaultSessionsIterator({ homeDir: home, includeDeepSeekCli: true })];
+      const deepseek = on.filter((item) => item.session.source === "deepseek-cli");
+      expect(deepseek).toHaveLength(1);
+      expect(deepseek[0].session.sessionKey).toBe("deepseek:s1");
+      expect(deepseek[0].session.projectPath).toBe("/work");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/main-2.0/src/core/deepseek-harness.test.ts
+++ b/apps/main-2.0/src/core/deepseek-harness.test.ts
@@ -1,0 +1,181 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  DEEPSEEK_HARNESS_LOG_NAME,
+  deleteDeepSeekCliSessionDirectory,
+  parseDeepSeekSessionLog,
+  scanDeepSeekZstdFrames,
+} from "./deepseek-harness";
+import { loadDeepSeekCliSessions } from "./session-loader";
+
+describe("deepseek harness session parser", () => {
+  it("rejects non-zstd garbage", () => {
+    expect(parseDeepSeekSessionLog(Buffer.from("not zstd"))).toBeNull();
+    expect(() => scanDeepSeekZstdFrames(Buffer.from([1, 2, 3, 4, 5]))).toThrow();
+  });
+
+  it("refuses to recursively delete a lookalike log outside the DSH sessions layout", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-dsh-delete-guard-"));
+    try {
+      const sessionDir = path.join(root, "not-sessions", "project", "session");
+      const logPath = path.join(sessionDir, DEEPSEEK_HARNESS_LOG_NAME);
+      fs.mkdirSync(sessionDir, { recursive: true });
+      fs.writeFileSync(logPath, "fixture");
+      deleteDeepSeekCliSessionDirectory(logPath);
+      expect(fs.existsSync(logPath)).toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("reads concatenated harness frames and stops at a sequence gap", async () => {
+    const { zstdCompressSync } = await import("node:zlib");
+    const header = zstdCompressSync(Buffer.from(`${JSON.stringify({ type: "session", version: 0, id: "framed", createdAt: 1700000000000, cwd: "/work", delegationDepth: 0 })}\n`));
+    const firstBatch = zstdCompressSync(Buffer.from(`${JSON.stringify({
+      type: "user/message",
+      seq: 0,
+      time: 1700000000001,
+      data: { id: "m1", role: "user", content: [{ type: "text", text: "first" }], source: { kind: "user" } },
+    })}\n`));
+    const badBatch = zstdCompressSync(Buffer.from([
+      JSON.stringify({ type: "text-chunks", seq0: 2, time0: 1700000000002, data: { turn: 1, step: 1, index: 0, texts: ["a", "b", "c"], dt: [1, 1] } }),
+      JSON.stringify({ type: "assistant/message", seq: 1, time: 1700000000005, data: { turn: 1, step: 1, message: { id: "m2", role: "assistant", content: [{ type: "text", text: "must not be accepted" }], source: { kind: "model" } } } }),
+      "",
+    ].join("\n")));
+
+    const parsed = parseDeepSeekSessionLog(Buffer.concat([header, firstBatch, badBatch]));
+    expect(parsed?.events).toHaveLength(1);
+    expect(parsed?.committedBytes).toBe(header.length + firstBatch.length);
+  });
+
+  it("parses a synthetic harness log", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-dsh-"));
+    try {
+      const { zstdCompressSync } = await import("node:zlib");
+      const lines = [
+        { type: "session", version: 0, id: "session-abc", createdAt: 1700000000000, cwd: "/work/demo", delegationDepth: 0, agentPreset: "standard" },
+        { type: "permission/preset", seq: 0, time: 1700000000001, data: { preset: "workspace-write" } },
+        { type: "turn/start", seq: 1, time: 1700000000002, data: { turn: 1 } },
+        { type: "step/start", seq: 2, time: 1700000000003, data: { turn: 1, step: 1 } },
+        { type: "user/message", seq: 3, time: 1700000000004, data: { id: "m1", role: "user", content: [{ type: "text", text: "请修复登录 bug" }], source: { kind: "user", rpcId: "rpc1" } }, surfaceOp: "append" },
+        { type: "assistant/message", seq: 4, time: 1700000000005, data: { turn: 1, step: 1, message: { id: "m2", role: "assistant", content: [{ type: "text", text: "好的，先查看代码。" }], source: { kind: "model", provider: "tt-switch", model: "deepseek-v4-pro-ioa" } }, usage: { inputTokens: 10, outputTokens: 5, cacheReadTokens: 2 } }, surfaceOp: "append" },
+        { type: "tool/call", seq: 5, time: 1700000000006, data: { turn: 1, step: 1, callId: "call_1", name: "bash", arguments: "ls" } },
+        { type: "tool/result", seq: 6, time: 1700000000007, data: { turn: 1, step: 1, message: { id: "m3", role: "user", content: [{ type: "tool-result", toolCallId: "call_1", content: [{ type: "text", text: "demo" }] }], source: { kind: "tool", callId: "call_1" } } } },
+        { type: "step/end", seq: 7, time: 1700000000008, data: { turn: 1, step: 1 } },
+        { type: "turn/end", seq: 8, time: 1700000000009, data: { turn: 1, reason: { kind: "completed" } } },
+        { type: "session/title", seq: 9, time: 1700000000010, data: { title: "修复登录 bug", messageSeqs: [3], source: { kind: "fallback" } } },
+      ];
+      const text = lines.map((line) => JSON.stringify(line)).join("\n") + "\n";
+      const compressed = zstdCompressSync(Buffer.from(text));
+      const sessionDir = path.join(root, "sessions", "--work-demo--", "session-abc");
+      fs.mkdirSync(sessionDir, { recursive: true });
+      const logPath = path.join(sessionDir, DEEPSEEK_HARNESS_LOG_NAME);
+      fs.writeFileSync(logPath, compressed);
+
+      const loaded = loadDeepSeekCliSessions(root);
+      expect(loaded).toHaveLength(1);
+      const { session, messages, traceEvents = [] } = loaded[0];
+      expect(session.rawId).toBe("session-abc");
+      expect(session.projectPath).toBe("/work/demo");
+      expect(session.originalTitle).toBe("修复登录 bug");
+      expect(session.source).toBe("deepseek-cli");
+      expect(session.tokenUsage?.inputTokens).toBe(10);
+      expect(session.tokenUsage?.outputTokens).toBe(5);
+      expect(session.tokenUsage?.cachedInputTokens).toBe(2);
+      expect(messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+      expect(messages[0].content).toBe("请修复登录 bug");
+      expect(messages[1].content).toBe("好的，先查看代码。");
+      expect(traceEvents.map((event) => event.kind)).toEqual(["tool_call"]);
+      expect(traceEvents[0].title).toBe("bash");
+      expect(traceEvents[0].status).toBe("completed");
+
+      // Best-effort source deletion removes only the session directory.
+      deleteDeepSeekCliSessionDirectory(logPath);
+      expect(fs.existsSync(sessionDir)).toBe(false);
+      expect(fs.existsSync(root)).toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("skips a log with no human messages and expands packed chunk rows", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-dsh-chunks-"));
+    try {
+      const { zstdCompressSync } = await import("node:zlib");
+      const lines = [
+        { type: "session", version: 0, id: "session-chunks", createdAt: 1700000000000, cwd: "/work/chunks", delegationDepth: 0 },
+        { type: "turn/start", seq: 0, time: 1700000000001, data: { turn: 1 } },
+        { type: "step/start", seq: 1, time: 1700000000002, data: { turn: 1, step: 1 } },
+        { type: "user/message", seq: 2, time: 1700000000003, data: { id: "m1", role: "user", content: [{ type: "text", text: "你好" }], source: { kind: "user" } }, surfaceOp: "append" },
+        { type: "text-chunks", seq0: 3, time0: 1700000000004, data: { turn: 1, step: 1, index: 0, texts: ["你", "好", "呀"], dt: [1, 2] } },
+        { type: "assistant/message", seq: 6, time: 1700000000010, data: { turn: 1, step: 1, message: { id: "m2", role: "assistant", content: [{ type: "text", text: "你好呀" }], source: { kind: "model", provider: "p", model: "m" } }, usage: { inputTokens: 1, outputTokens: 2 } }, surfaceOp: "append" },
+      ];
+      const text = lines.map((line) => JSON.stringify(line)).join("\n") + "\n";
+      const logPath = path.join(root, "sessions", "--work-chunks--", "session-chunks", DEEPSEEK_HARNESS_LOG_NAME);
+      fs.mkdirSync(path.dirname(logPath), { recursive: true });
+      fs.writeFileSync(logPath, zstdCompressSync(Buffer.from(text)));
+
+      const loaded = loadDeepSeekCliSessions(root);
+      expect(loaded).toHaveLength(1);
+      const { messages, traceEvents } = loaded[0];
+      expect(messages.map((message) => message.content)).toEqual(["你好", "你好呀"]);
+      expect(traceEvents).toEqual([]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("skips injected user messages and empty assistant steps", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-dsh-inject-"));
+    try {
+      const { zstdCompressSync } = await import("node:zlib");
+      const lines = [
+        { type: "session", version: 0, id: "session-inject", createdAt: 1700000000000, cwd: "/work/inject", delegationDepth: 0 },
+        { type: "user/message", seq: 0, time: 1700000000001, data: { id: "m1", role: "user", content: [{ type: "text", text: "<system-reminder>AGENTS.md</system-reminder>" }], source: { kind: "instruction-hint" } }, surfaceOp: "append" },
+        { type: "user/message", seq: 1, time: 1700000000002, data: { id: "m2", role: "user", content: [{ type: "text", text: "真正的问题" }], source: { kind: "user" } }, surfaceOp: "append" },
+        { type: "assistant/message", seq: 2, time: 1700000000003, data: { turn: 1, step: 1, message: { id: "m3", role: "assistant", content: [{ type: "reasoning", text: "内部思考" }], source: { kind: "model", provider: "p", model: "m" } } }, surfaceOp: "append" },
+      ];
+      const text = lines.map((line) => JSON.stringify(line)).join("\n") + "\n";
+      const logPath = path.join(root, "sessions", "--work-inject--", "session-inject", DEEPSEEK_HARNESS_LOG_NAME);
+      fs.mkdirSync(path.dirname(logPath), { recursive: true });
+      fs.writeFileSync(logPath, zstdCompressSync(Buffer.from(text)));
+
+      const loaded = loadDeepSeekCliSessions(root);
+      expect(loaded).toHaveLength(1);
+      const { messages } = loaded[0];
+      expect(messages.map((message) => message.content)).toEqual(["真正的问题"]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("discovers sessions from DSH_HOME without reading the real home", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-dsh-home-"));
+    const previous = process.env.DSH_HOME;
+    try {
+      process.env.DSH_HOME = root;
+      const { zstdCompressSync } = await import("node:zlib");
+      const logPath = path.join(root, "sessions", "--work--", "custom-home", DEEPSEEK_HARNESS_LOG_NAME);
+      fs.mkdirSync(path.dirname(logPath), { recursive: true });
+      fs.writeFileSync(logPath, zstdCompressSync(Buffer.from([
+        JSON.stringify({ type: "session", version: 0, id: "custom-home", createdAt: 1700000000000, cwd: "/work", delegationDepth: 0 }),
+        JSON.stringify({
+          type: "user/message",
+          seq: 0,
+          time: 1700000000001,
+          data: { id: "m1", role: "user", content: [{ type: "text", text: "from DSH_HOME" }], source: { kind: "user" } },
+        }),
+        "",
+      ].join("\n"))));
+
+      expect(loadDeepSeekCliSessions()).toHaveLength(1);
+      expect(loadDeepSeekCliSessions()[0].session.rawId).toBe("custom-home");
+    } finally {
+      if (previous === undefined) delete process.env.DSH_HOME;
+      else process.env.DSH_HOME = previous;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/main-2.0/src/core/deepseek-harness.ts
+++ b/apps/main-2.0/src/core/deepseek-harness.ts
@@ -1,0 +1,750 @@
+/**
+ * DeepSeek Harness (dsh) session log parsing.
+ *
+ * The harness persists each session as `~/.dsh/sessions/<project-key>/<session-id>/session.jsonl.zstd`:
+ * a concatenated stream of Zstandard frames whose decompressed payload is a JSONL
+ * event log. The first record is a `session` header line; every following record is
+ * a {@link SessionEvent} envelope `{ type, seq, time, data }` per
+ * deepseek-harness `@deepseek-ai/dsh-session` (SESSION_FORMAT_VERSION 0).
+ *
+ * Files are append-only and may be written while we read them, so we mirror the
+ * harness's own `scanZstdFrames`: walk complete frames structurally, decompress
+ * each with the built-in `node:zlib` zstd API (no third-party dependency), and
+ * stop at a torn tail instead of failing the whole session.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as zlib from "node:zlib";
+
+import { isMeaningfulUserMessage } from "./format-adapters";
+import type { SessionFormat, SessionMessage, SessionTraceEvent, TokenUsageEvent } from "./types";
+
+const ZSTD_MAGIC = 0xfd2fb528;
+
+export const DEEPSEEK_HARNESS_DIR = ".dsh";
+export const DEEPSEEK_HARNESS_LOG_NAME = "session.jsonl.zstd";
+
+/** Structural scan result for a concatenated Zstandard stream. */
+export interface DeepSeekZstdFrame {
+  /** Inclusive frame start. */
+  start: number;
+  /** Exclusive frame end. */
+  end: number;
+}
+
+/**
+ * Locate complete Zstandard frames without decompressing their blocks. Invalid
+ * complete structure rejects; EOF inside the final frame returns what was
+ * found so far. Mirrors deepseek-harness `scanZstdFrames`.
+ */
+export function scanDeepSeekZstdFrames(buffer: Buffer, maxFrames = Number.POSITIVE_INFINITY): DeepSeekZstdFrame[] {
+  const frames: DeepSeekZstdFrame[] = [];
+  let offset = 0;
+
+  while (offset < buffer.length) {
+    const start = offset;
+    if (buffer.length - offset < 4) return frames;
+    if (buffer.readUInt32LE(offset) !== ZSTD_MAGIC) {
+      throw new Error(`corrupt DeepSeek Harness session log: invalid frame magic at byte ${offset}`);
+    }
+    offset += 4;
+
+    if (offset === buffer.length) return frames;
+    const descriptor = buffer.readUInt8(offset);
+    offset += 1;
+    if ((descriptor & 0x18) !== 0) {
+      throw new Error(`corrupt DeepSeek Harness session log: reserved frame-header bit at byte ${offset - 1}`);
+    }
+
+    const contentSizeFlag = descriptor >>> 6;
+    const singleSegment = (descriptor & 0x20) !== 0;
+    const checksum = (descriptor & 0x04) !== 0;
+    const dictionaryFlag = descriptor & 0x03;
+    const dictionaryBytes = dictionaryFlag === 3 ? 4 : dictionaryFlag;
+    const contentSizeBytes = contentSizeFlag === 0
+      ? (singleSegment ? 1 : 0)
+      : 1 << contentSizeFlag;
+    const remainingHeaderBytes = (singleSegment ? 0 : 1) + dictionaryBytes + contentSizeBytes;
+    if (buffer.length - offset < remainingHeaderBytes) return frames;
+    offset += remainingHeaderBytes;
+
+    for (;;) {
+      if (buffer.length - offset < 3) return frames;
+      const blockHeader = buffer.readUIntLE(offset, 3);
+      offset += 3;
+      const lastBlock = (blockHeader & 1) !== 0;
+      const blockType = (blockHeader >>> 1) & 0x03;
+      const blockSize = blockHeader >>> 3;
+      if (blockType === 0x03) {
+        throw new Error(`corrupt DeepSeek Harness session log: reserved block type at byte ${offset - 3}`);
+      }
+      const payloadBytes = blockType === 0x01 ? 1 : blockSize;
+      if (buffer.length - offset < payloadBytes) return frames;
+      offset += payloadBytes;
+      if (lastBlock) break;
+    }
+
+    if (checksum) {
+      if (buffer.length - offset < 4) return frames;
+      offset += 4;
+    }
+    frames.push({ start, end: offset });
+    if (frames.length === maxFrames) return frames;
+  }
+
+  return frames;
+}
+
+/** Decompress a structurally complete Zstandard frame into UTF-8 text. */
+export function decompressDeepSeekZstdFrame(buffer: Buffer, frame: DeepSeekZstdFrame): string {
+  return zlib.zstdDecompressSync(buffer.subarray(frame.start, frame.end)).toString("utf8");
+}
+
+export interface DeepSeekSessionHeader {
+  version: number;
+  id: string;
+  createdAt: number;
+  cwd?: string;
+  parentSession?: string;
+  delegationDepth: number;
+  agentPreset?: string;
+}
+
+export interface DeepSeekSessionEvent {
+  type: string;
+  seq: number;
+  time: number;
+  data?: unknown;
+  sourceEventSeqs?: number[];
+  surfaceOp?: unknown;
+  ignorable?: true;
+}
+
+export interface DeepSeekSessionLog {
+  header: DeepSeekSessionHeader;
+  events: DeepSeekSessionEvent[];
+  /** Byte offset up to which the log is complete; a torn tail was dropped. */
+  committedBytes: number;
+}
+
+function parseDeepSeekJsonLine(line: string): unknown | undefined {
+  const trimmed = line.trim();
+  if (!trimmed) return undefined;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseDeepSeekHeader(raw: unknown): DeepSeekSessionHeader | null {
+  if (!raw || typeof raw !== "object") return null;
+  const line = raw as Record<string, unknown>;
+  if (line.type !== "session") return null;
+  const id = typeof line.id === "string" ? line.id : "";
+  if (!id || !Number.isSafeInteger(line.createdAt)) return null;
+  return {
+    version: typeof line.version === "number" ? line.version : 0,
+    id,
+    createdAt: line.createdAt as number,
+    ...(typeof line.cwd === "string" ? { cwd: line.cwd } : {}),
+    ...(typeof line.parentSession === "string" ? { parentSession: line.parentSession } : {}),
+    delegationDepth: typeof line.delegationDepth === "number" ? line.delegationDepth : 0,
+    ...(typeof line.agentPreset === "string" ? { agentPreset: line.agentPreset } : {}),
+  };
+}
+
+function parseDeepSeekEvent(raw: unknown): DeepSeekSessionEvent | null {
+  if (!raw || typeof raw !== "object") return null;
+  const line = raw as Record<string, unknown>;
+  if (typeof line.type !== "string") return null;
+  const seq = line.seq;
+  const time = line.time;
+  if (!Number.isSafeInteger(seq) || !Number.isSafeInteger(time)) return null;
+  return {
+    type: line.type,
+    seq: seq as number,
+    time: time as number,
+    data: line.data,
+    ...(Array.isArray(line.sourceEventSeqs) ? { sourceEventSeqs: line.sourceEventSeqs as number[] } : {}),
+    ...(line.surfaceOp !== undefined ? { surfaceOp: line.surfaceOp } : {}),
+    ...(line.ignorable === true ? { ignorable: true } : {}),
+  };
+}
+
+
+/**
+ * Storage-row packing: runs of consecutive same-block delta chunks are packed
+ * into ONE row — `text-chunks` / `reasoning-chunks` / `tool-call-chunks`.
+ * Rows are a durable-encoding vocabulary, NOT session events: they carry
+ * `seq0`/`time0` anchors plus member payloads and must be expanded back into
+ * individual `assistant/chunk` events before the transcript is usable.
+ * Mirrors deepseek-harness `decodeStorageRecord`.
+ */
+function expandDeepSeekChunkRow(raw: Record<string, unknown>): DeepSeekSessionEvent[] | null {
+  const type = raw.type;
+  if (type !== "text-chunks" && type !== "reasoning-chunks" && type !== "tool-call-chunks") return null;
+  const seq0 = raw.seq0;
+  const time0 = raw.time0;
+  if (!Number.isSafeInteger(seq0) || !Number.isSafeInteger(time0)) return null;
+  const data = raw.data && typeof raw.data === "object" ? raw.data as Record<string, unknown> : null;
+  if (!data) return null;
+  const payloadKey = type === "tool-call-chunks" ? "args" : "texts";
+  const payload = data[payloadKey];
+  if (!Array.isArray(payload) || payload.length === 0 || payload.some((entry) => typeof entry !== "string")) return null;
+  const dt = data.dt;
+  if (!Array.isArray(dt) || dt.some((gap) => !Number.isSafeInteger(gap)) || dt.length !== payload.length - 1) return null;
+
+  const events: DeepSeekSessionEvent[] = [];
+  let time = time0 as number;
+  for (let k = 0; k < payload.length; k++) {
+    if (k > 0) time += dt[k - 1] as number;
+    let chunk: Record<string, unknown>;
+    if (type === "tool-call-chunks") {
+      chunk = {
+        type: "tool-call-delta",
+        index: data.index,
+        id: data.id,
+        ...(typeof data.name === "string" ? { name: data.name } : {}),
+        argumentsDelta: payload[k],
+      };
+    } else {
+      chunk = {
+        type: type === "text-chunks" ? "text-delta" : "reasoning-delta",
+        index: data.index,
+        text: payload[k],
+      };
+    }
+    events.push({
+      type: "assistant/chunk",
+      seq: (seq0 as number) + k,
+      time,
+      data: { turn: data.turn, step: data.step, chunk },
+    });
+  }
+  return events;
+}
+
+/**
+ * Decompress a complete (possibly torn) log buffer into its header and event
+ * prefix. Each frame decodes independently; a frame that fails to decompress
+ * or starts mid-record ends the scan, so a concurrent append never corrupts
+ * previously committed history.
+ */
+export function parseDeepSeekSessionLog(buffer: Buffer, logPath = ""): DeepSeekSessionLog | null {
+  let frames: DeepSeekZstdFrame[];
+  try {
+    frames = scanDeepSeekZstdFrames(buffer);
+  } catch {
+    return null;
+  }
+  if (frames.length === 0) return null;
+
+  let header: DeepSeekSessionHeader | null = null;
+  const events: DeepSeekSessionEvent[] = [];
+  let committedBytes = 0;
+
+  for (const frame of frames) {
+    let text: string;
+    try {
+      text = decompressDeepSeekZstdFrame(buffer, frame);
+    } catch {
+      break;
+    }
+    const completeFrameText = text.endsWith("\n");
+    let end = text.length;
+    if (!completeFrameText) {
+      // A final partial record crossing frames is a torn tail of an active
+      // append. Everything up to the previous newline is already durable.
+      const lastNewline = text.lastIndexOf("\n");
+      if (lastNewline === -1) break;
+      end = lastNewline + 1;
+    }
+    let contiguous = true;
+    for (const line of text.slice(0, end).split("\n")) {
+      const parsed = parseDeepSeekJsonLine(line);
+      if (parsed === undefined) continue;
+      if (!header) {
+        header = parseDeepSeekHeader(parsed);
+        if (!header) throw new Error(`corrupt session log: first record is not a session header${logPath ? ` (${logPath})` : ""}`);
+        continue;
+      }
+      const parsedRecord = parsed && typeof parsed === "object" ? parsed as Record<string, unknown> : null;
+      const expanded = parsedRecord ? expandDeepSeekChunkRow(parsedRecord) : null;
+      if (expanded) {
+        // A packed chunk run: all members must follow the previous seq exactly.
+        const rowStart = events.length;
+        for (const chunkEvent of expanded) {
+          if (chunkEvent.seq !== events.length) {
+            events.length = rowStart;
+            contiguous = false;
+            break;
+          }
+          events.push(chunkEvent);
+        }
+        if (!contiguous) break;
+        continue;
+      }
+      const event = parseDeepSeekEvent(parsed);
+      if (!event) continue;
+      if (event.seq !== events.length) {
+        contiguous = false;
+        break;
+      }
+      events.push(event);
+    }
+    if (!contiguous || !completeFrameText) break;
+    committedBytes = frame.end;
+  }
+
+  if (!header) return null;
+  return { header, events, committedBytes };
+}
+
+function deepSeekRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? value as Record<string, unknown> : null;
+}
+
+/** First text block of a content array, plus a marker when a leading image was dropped. */
+function deepSeekText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const texts: string[] = [];
+  let imageDropped = false;
+  for (const item of content) {
+    const block = deepSeekRecord(item);
+    if (!block) continue;
+    const type = typeof block.type === "string" ? block.type : "";
+    if (type === "text") {
+      if (typeof block.text === "string" && block.text) texts.push(block.text);
+    } else if (type === "image") {
+      imageDropped = true;
+    }
+  }
+  const text = texts.join("\n");
+  if (!text && imageDropped) return "[Attachment]";
+  return text;
+}
+
+function deepSeekEventTimeMs(event: DeepSeekSessionEvent): number {
+  return Number.isFinite(event.time) ? event.time : 0;
+}
+
+/** Latest `session/title` payload, folded last-write-wins like the harness. */
+function deepSeekTitle(events: DeepSeekSessionEvent[]): string {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i];
+    if (event.type !== "session/title") continue;
+    const data = deepSeekRecord(event.data);
+    const title = data ? data.title : null;
+    if (typeof title === "string" && title.trim()) return title.trim();
+  }
+  return "";
+}
+
+interface DeepSeekUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  reasoningTokens: number;
+  cacheWriteTokens: number;
+}
+
+function deepSeekUsageOf(event: DeepSeekSessionEvent): DeepSeekUsage | null {
+  const data = deepSeekRecord(event.data);
+  const usage = deepSeekRecord(data?.usage);
+  if (!usage) return null;
+  const number = (value: unknown): number => typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+  return {
+    inputTokens: number(usage.inputTokens),
+    outputTokens: number(usage.outputTokens),
+    cacheReadTokens: number(usage.cacheReadTokens),
+    reasoningTokens: number(usage.reasoningTokens),
+    cacheWriteTokens: number(usage.cacheWriteTokens),
+  };
+}
+
+function deepSeekUsageOfEvent(event: DeepSeekSessionEvent): { turn: number; step: number; usage: DeepSeekUsage } | null {
+  const data = deepSeekRecord(event.data);
+  if (data === null) return null;
+  if (event.type === "assistant/message") {
+    const usage = deepSeekUsageOf(event);
+    if (usage === null) return null;
+    return { turn: deepSeekNumber(data.turn), step: deepSeekNumber(data.step), usage };
+  }
+  if (event.type === "assistant/chunk") {
+    const chunk = deepSeekRecord(data.chunk);
+    if (chunk === null || chunk.type !== "usage") return null;
+    const usageRecord = deepSeekRecord(chunk.usage);
+    if (usageRecord === null) return null;
+    const number = (value: unknown): number => typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+    return {
+      turn: deepSeekNumber(data.turn),
+      step: deepSeekNumber(data.step),
+      usage: {
+        inputTokens: number(usageRecord.inputTokens),
+        outputTokens: number(usageRecord.outputTokens),
+        cacheReadTokens: number(usageRecord.cacheReadTokens),
+        reasoningTokens: number(usageRecord.reasoningTokens),
+        cacheWriteTokens: number(usageRecord.cacheWriteTokens),
+      },
+    };
+  }
+  return null;
+}
+
+function deepSeekNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : -1;
+}
+
+/**
+ * Token usage fold that mirrors deepseek-harness tokenUsageProjection:
+ * usage samples for the same turn/step replace each other (last wins) instead
+ * of double counting, and samples for a later step replace the previous step.
+ */
+interface DeepSeekUsageFold {
+  usage: DeepSeekUsage;
+  tokenEvents: TokenUsageEvent[];
+}
+
+function deepSeekTotalUsage(events: DeepSeekSessionEvent[]): DeepSeekUsageFold {
+  const totals: DeepSeekUsage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, reasoningTokens: 0, cacheWriteTokens: 0 };
+  const tokenEvents: TokenUsageEvent[] = [];
+  let last: { turn: number; step: number; usage: DeepSeekUsage } | null = null;
+  for (const event of events) {
+    const sample = deepSeekUsageOfEvent(event);
+    if (sample === null || sample.turn < 0 || sample.step < 0) continue;
+    const dedupeKey = "deepseek:" + sample.turn + ":" + sample.step;
+    if (last !== null && last.turn === sample.turn && last.step === sample.step) {
+      if (
+        last.usage.inputTokens === sample.usage.inputTokens
+        && last.usage.outputTokens === sample.usage.outputTokens
+        && last.usage.cacheReadTokens === sample.usage.cacheReadTokens
+        && last.usage.reasoningTokens === sample.usage.reasoningTokens
+        && last.usage.cacheWriteTokens === sample.usage.cacheWriteTokens
+      ) continue;
+      totals.inputTokens -= last.usage.inputTokens;
+      totals.outputTokens -= last.usage.outputTokens;
+      totals.cacheReadTokens -= last.usage.cacheReadTokens;
+      totals.reasoningTokens -= last.usage.reasoningTokens;
+      totals.cacheWriteTokens -= last.usage.cacheWriteTokens;
+      tokenEvents.pop();
+    }
+    totals.inputTokens += sample.usage.inputTokens;
+    totals.outputTokens += sample.usage.outputTokens;
+    totals.cacheReadTokens += sample.usage.cacheReadTokens;
+    totals.reasoningTokens += sample.usage.reasoningTokens;
+    totals.cacheWriteTokens += sample.usage.cacheWriteTokens;
+    tokenEvents.push({
+      inputTokens: sample.usage.inputTokens,
+      outputTokens: sample.usage.outputTokens,
+      cachedInputTokens: sample.usage.cacheReadTokens,
+      reasoningOutputTokens: sample.usage.reasoningTokens,
+      totalTokens: sample.usage.inputTokens + sample.usage.outputTokens + sample.usage.cacheReadTokens + sample.usage.reasoningTokens,
+      timestamp: deepSeekEventTimeMs(event),
+      dedupeKey,
+      sourceTurnId: sample.turn + ":" + sample.step,
+    });
+    last = sample;
+  }
+  return { usage: totals, tokenEvents };
+}
+
+function deepSeekSourceKind(event: DeepSeekSessionEvent): string {
+  const message = deepSeekRecord(event.data) ?? deepSeekRecord(deepSeekRecord(event.data)?.message);
+  const source = deepSeekRecord(message?.source);
+  return typeof source?.kind === "string" ? source.kind : "";
+}
+
+function deepSeekTimestampOf(event: DeepSeekSessionEvent, iso: string | undefined): string {
+  const ms = deepSeekEventTimeMs(event);
+  if (!ms) return "";
+  if (typeof iso === "string" && iso) return iso;
+  return new Date(ms).toISOString();
+}
+
+function deepSeekToolArguments(event: DeepSeekSessionEvent): string {
+  const data = deepSeekRecord(event.data);
+  if (!data) return "";
+  if (typeof data.arguments === "string") return data.arguments;
+  return "";
+}
+
+function deepSeekSessionMessages(log: DeepSeekSessionLog): SessionMessage[] {
+  const messages: SessionMessage[] = [];
+  for (const event of log.events) {
+    if (event.type === "user/message") {
+      const data = deepSeekRecord(event.data);
+      if (!data) continue;
+      // The harness's surface distinguishes human prompts (`source.kind ===
+      // "user"`) from injected context and goal continuations, all of which
+      // project into the user role. Only real prompts become transcript
+      // messages; injected context would otherwise dominate search results.
+      const kind = deepSeekSourceKind(event);
+      if (kind && kind !== "user") continue;
+      const content = deepSeekText(data.content);
+      if (!content || !isMeaningfulUserMessage(content)) continue;
+      messages.push({
+        role: "user",
+        content,
+        timestamp: deepSeekTimestampOf(event, typeof data.timestamp === "string" ? data.timestamp : undefined),
+        index: messages.length,
+      });
+    } else if (event.type === "assistant/message") {
+      const data = deepSeekRecord(event.data);
+      const message = deepSeekRecord(data?.message);
+      if (!message) continue;
+      const content = deepSeekText(message.content);
+      if (!content) continue;
+      messages.push({
+        role: "assistant",
+        content,
+        timestamp: deepSeekTimestampOf(event, typeof message.timestamp === "string" ? message.timestamp : undefined),
+        index: messages.length,
+      });
+    }
+  }
+  return messages;
+}
+
+function deepSeekToolResultBlock(value: unknown): { callId: string; isError: boolean; text: string } | null {
+  const message = deepSeekRecord(value);
+  if (message === null) return null;
+  const source = deepSeekRecord(message.source);
+  const callId = typeof source?.callId === "string" ? source.callId : "";
+  const blocks = Array.isArray(message.content) ? message.content : [];
+  let isError = false;
+  let text = "";
+  for (const item of blocks) {
+    const block = deepSeekRecord(item);
+    if (block === null || block.type !== "tool-result") continue;
+    if (block.isError === true) isError = true;
+    const nested = Array.isArray(block.content) ? block.content : [];
+    const nestedText = deepSeekText(nested);
+    if (nestedText) text = text ? text + "\n" + nestedText : nestedText;
+  }
+  return { callId, isError, text };
+}
+
+function deepSeekSessionTraceEvents(log: DeepSeekSessionLog, source: SessionFormat): SessionTraceEvent[] {
+  const events: SessionTraceEvent[] = [];
+  const results = new Map<string, { status: "completed" | "failed"; detail: string }>();
+  for (const event of log.events) {
+    if (event.type === "tool/call") {
+      const data = deepSeekRecord(event.data);
+      const name = typeof data?.name === "string" && data.name ? data.name : "tool";
+      const callId = typeof data?.callId === "string" ? data.callId : "";
+      const argumentsText = deepSeekToolArguments(event);
+      const detail = name === "bash"
+        ? argumentsText
+        : argumentsText
+          ? (() => {
+              try {
+                return JSON.stringify(JSON.parse(argumentsText), null, 2);
+              } catch {
+                return argumentsText;
+              }
+            })()
+          : "";
+      events.push({
+        index: events.length,
+        kind: "tool_call",
+        source,
+        title: name,
+        detail,
+        timestamp: deepSeekTimestampOf(event, undefined),
+        callId: callId || null,
+        eventType: null,
+        status: null,
+      });
+    } else if (event.type === "tool/result") {
+      const data = deepSeekRecord(event.data);
+      const block = deepSeekToolResultBlock(data?.message);
+      const callId = (block !== null && block.callId) || (typeof data?.callId === "string" ? data.callId : "");
+      const failed = (block !== null && block.isError) || data?.isError === true || Boolean(data?.error);
+      results.set(callId, {
+        status: failed ? "failed" : "completed",
+        detail: block?.text ?? "",
+      });
+    }
+  }
+  // Attach result facts to their call so the detail pane pairs them.
+  for (const event of events) {
+    if (!event.callId) continue;
+    const result = results.get(event.callId);
+    if (!result) continue;
+    event.status = result.status;
+    if (result.detail) event.detail = event.detail ? `${event.detail}\n\n${result.detail}` : result.detail;
+  }
+  return events;
+}
+
+export interface DeepSeekSessionView {
+  title: string;
+  messages: SessionMessage[];
+  traceEvents: SessionTraceEvent[];
+  usage: DeepSeekUsage;
+  tokenEvents: TokenUsageEvent[];
+}
+
+/**
+ * Project a parsed session log into a searchable transcript view: visible
+ * user/assistant messages, tool trace events, the latest title, and usage.
+ */
+export function projectDeepSeekSession(log: DeepSeekSessionLog, source: SessionFormat = "deepseek"): DeepSeekSessionView {
+  const fold = deepSeekTotalUsage(log.events);
+  return {
+    title: deepSeekTitle(log.events),
+    messages: deepSeekSessionMessages(log),
+    traceEvents: deepSeekSessionTraceEvents(log, source),
+    usage: fold.usage,
+    tokenEvents: fold.tokenEvents,
+  };
+}
+
+/**
+ * Delete the DeepSeek Harness session directory owning `filePath` (the
+ * `session.jsonl.zstd` log). Only removes the session's own directory when it
+ * still points at a DeepSeek log, never project siblings. Errors are ignored:
+ * the index record is still removed by the caller.
+ */
+export function deleteDeepSeekCliSessionDirectory(filePath: string): void {
+  try {
+    const sessionDir = path.dirname(filePath);
+    if (path.basename(filePath) !== DEEPSEEK_HARNESS_LOG_NAME) return;
+    const projectDir = path.dirname(sessionDir);
+    const sessionsDir = path.dirname(projectDir);
+    if (path.basename(sessionsDir) !== "sessions") return;
+    const logStat = fs.lstatSync(filePath);
+    if (!logStat.isFile() || logStat.isSymbolicLink()) return;
+    for (const directory of [sessionsDir, projectDir, sessionDir]) {
+      const stat = fs.lstatSync(directory);
+      if (!stat.isDirectory() || stat.isSymbolicLink()) return;
+    }
+    fs.rmSync(sessionDir, { recursive: true, force: true });
+  } catch {
+    // Best-effort source cleanup; index deletion is the authoritative step.
+  }
+}
+/**
+ * Encode one path segment the way deepseek-harness does on disk: safe code
+ * units pass through, every other UTF-16 code unit becomes `~XXXX`. Mirrors
+ * deepseek-harness `encodeSegment` so migrated sessions land in the same
+ * directories the harness itself would create.
+ */
+export function encodeDeepSeekPathSegment(segment: string): string {
+  if (segment === ".") return "~002E";
+  if (segment === "..") return "~002E~002E";
+  let out = "";
+  for (let i = 0; i < segment.length; i++) {
+    const code = segment.charCodeAt(i);
+    const ch = String.fromCharCode(code);
+    if (ch !== "~" && /^[A-Za-z0-9._-]$/.test(ch)) {
+      out += ch;
+    } else {
+      out += "~" + code.toString(16).toUpperCase().padStart(4, "0");
+    }
+  }
+  return out || "~002E";
+}
+
+/**
+ * Build the harness project-directory key for a cwd: separators collapse into
+ * a single dash and the slug is bounded like the harness (`--...--`). Mirrors
+ * deepseek-harness `projectKey`.
+ */
+export function encodeDeepSeekProjectKey(cwd: string): string {
+  let readable = "";
+  let separatorRun = false;
+  for (let i = 0; i < cwd.length; i++) {
+    const code = cwd.charCodeAt(i);
+    const ch = String.fromCharCode(code);
+    if (ch === "/" || ch === "\\" || ch === ":") {
+      if (!separatorRun) readable += "-";
+      separatorRun = true;
+    } else if (ch !== "~" && /^[A-Za-z0-9._-]$/.test(ch)) {
+      readable += ch;
+      separatorRun = false;
+    } else {
+      readable += "~" + code.toString(16).toUpperCase().padStart(4, "0");
+      separatorRun = false;
+    }
+  }
+  const slug = readable.replace(/^-+/, "") || "root";
+  return `--${slug.slice(0, 251)}--`;
+}
+
+/** The harness `_no-cwd` project directory for sessions without a cwd. */
+export const DEEPSEEK_HARNESS_NO_CWD_DIR = "_no-cwd";
+
+/**
+ * Serialize a session transcript into the deepseek-harness on-disk format:
+ * one header line plus surface events with contiguous sequence numbers,
+ * compressed as a single Zstandard frame (`session.jsonl.zstd`). Messages are
+ * projected back onto the surface as text blocks, so a migrated log reads and
+ * resumes exactly like a harness-written one.
+ */
+export function serializeDeepSeekSessionLog(options: {
+  sessionId: string;
+  createdAt: number;
+  cwd: string;
+  messages: readonly { role: "user" | "assistant"; content: string; time: number }[];
+  title?: string;
+}): Buffer {
+  const lines: string[] = [];
+  lines.push(JSON.stringify({
+    type: "session",
+    version: 0,
+    id: options.sessionId,
+    createdAt: options.createdAt,
+    cwd: options.cwd,
+    delegationDepth: 0,
+  }));
+
+  let seq = 0;
+  const event = (type: string, time: number, data: unknown, extra: Record<string, unknown> = {}) => {
+    lines.push(JSON.stringify({ type, seq: seq++, time, data, ...extra }));
+  };
+
+  let turn = 1;
+  const titleTime = options.title ? options.messages[0]?.time ?? options.createdAt : undefined;
+  for (let i = 0; i < options.messages.length; i++) {
+    const message = options.messages[i];
+    const time = Number.isFinite(message.time) && message.time > 0 ? message.time : options.createdAt;
+    event("turn/start", time, { turn });
+    event("step/start", time, { turn, step: 1 });
+    if (message.role === "user") {
+      event("user/message", time, {
+        id: `migrated-${turn}`,
+        role: "user",
+        content: [{ type: "text", text: message.content }],
+        source: { kind: "user" },
+      }, { surfaceOp: "append" });
+    } else {
+      event("assistant/message", time, {
+        turn,
+        step: 1,
+        message: {
+          id: `migrated-assistant-${turn}`,
+          role: "assistant",
+          content: [{ type: "text", text: message.content }],
+          source: { kind: "model", provider: "agent-recall-migration", model: "session-migration" },
+        },
+      }, { surfaceOp: "append", sourceEventSeqs: [] });
+    }
+    event("step/end", time, { turn, step: 1 });
+    event("turn/end", time, { turn, reason: "complete" });
+    turn += 1;
+  }
+
+  if (options.title) {
+    event("session/title", titleTime ?? options.createdAt, {
+      title: options.title,
+      messageSeqs: [],
+      source: { kind: "fallback" },
+    });
+  }
+
+  return zlib.zstdCompressSync(Buffer.from(lines.join("\n") + "\n", "utf8"));
+}

--- a/apps/main-2.0/src/core/deepseek-platform.test.ts
+++ b/apps/main-2.0/src/core/deepseek-platform.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import { defaultSettings, getResumeCommand, openDeepSeekWebInTerminal } from "./platform";
+import type { SessionSearchResult } from "./types";
+
+describe("DeepSeek Harness resume", () => {
+  it("builds an exact command-line fallback through the TUI profile", () => {
+    const session = {
+      source: "deepseek-cli",
+      rawId: "session-1",
+      projectPath: "/repo",
+    } as SessionSearchResult;
+    expect(getResumeCommand(session, defaultSettings, { platform: "darwin" })).toBe(
+      "cd /repo && dsh --profile tui --resume session-1",
+    );
+  });
+
+  it("starts the DeepSeek web profile in the selected workspace", async () => {
+    const runProcess = vi.fn(async () => undefined);
+    await openDeepSeekWebInTerminal("/repo", defaultSettings, { platform: "linux", runProcess });
+    expect(runProcess).toHaveBeenCalledWith("sh", ["-lc", "cd /repo && dsh --profile web"]);
+  });
+});

--- a/apps/main-2.0/src/core/format-adapters.ts
+++ b/apps/main-2.0/src/core/format-adapters.ts
@@ -322,6 +322,7 @@ export const zcodeAdapter = genericAdapter("zcode");
 export const codeWizAdapter = genericAdapter("codewiz");
 export const traeAdapter = genericAdapter("trae");
 export const qoderAdapter = genericAdapter("qoder");
+export const deepseekAdapter = genericAdapter("deepseek");
 export const piAdapter: FormatAdapter = {
   format: "pi",
   parseLine(raw) {
@@ -367,6 +368,7 @@ export function getAdapter(sourceOrFormat: SessionSource | SessionFormat): Forma
   if (sourceOrFormat === "trae") return traeAdapter;
   if (sourceOrFormat === "qoder") return qoderAdapter;
   if (sourceOrFormat === "pi") return piAdapter;
+  if (sourceOrFormat === "deepseek") return deepseekAdapter;
   const format = getFormatForSource(sourceOrFormat);
   if (format === "claude") return claudeAdapter;
   if (format === "codebuddy") return codebuddyAdapter;
@@ -380,6 +382,7 @@ export function getAdapter(sourceOrFormat: SessionSource | SessionFormat): Forma
   if (format === "trae") return traeAdapter;
   if (format === "qoder") return qoderAdapter;
   if (format === "pi") return piAdapter;
+  if (format === "deepseek") return deepseekAdapter;
   return codexAdapter;
 }
 

--- a/apps/main-2.0/src/core/indexer.ts
+++ b/apps/main-2.0/src/core/indexer.ts
@@ -12,6 +12,8 @@ import {
   parseJsonlText,
   type SessionLoadOptions,
 } from "./session-loader";
+import { loadDeepSeekCliSessionFile } from "./session-loaders/alternative-sources";
+import { safeStat } from "./session-loaders/common";
 import { migrationTargetDescriptor } from "./migration-targets";
 import type { SessionStore } from "./session-store";
 import type { LoadedSession, MigrationTarget, SessionEnvironment } from "./types";
@@ -461,6 +463,10 @@ export async function indexMigratedSessionFile(
 
 function loadMigratedSessionFile(target: MigrationTarget, filePath: string, sessionId?: string): LoadedSession | null {
   if (target === "cursor") return loadCursorTranscriptFile(filePath);
+  if (target === "deepseek") {
+    const stat = safeStat(filePath);
+    return loadDeepSeekCliSessionFile(filePath, stat);
+  }
 
   const descriptor = migrationTargetDescriptor(target);
   if (descriptor.family === "codebuddy") return loadCodeBuddyCliSessionFile(filePath);

--- a/apps/main-2.0/src/core/mcp-migration.test.ts
+++ b/apps/main-2.0/src/core/mcp-migration.test.ts
@@ -16,6 +16,7 @@ import {
   loadCursorTranscriptFile,
   parseJsonlText,
 } from "./session-loader";
+import { parseDeepSeekSessionLog, projectDeepSeekSession } from "./deepseek-harness";
 import { migrationTargetDescriptor } from "./migration-targets";
 import { defaultSettings } from "./platform";
 import type { IndexedSession, MigrationTarget, SessionMessage, SessionSource } from "./types";
@@ -65,6 +66,10 @@ async function seedLocalSession(
 
 function loadMigratedSessionFileForTest(target: MigrationTarget, filePath: string) {
   if (target === "cursor") return loadCursorTranscriptFile(filePath);
+  if (target === "deepseek") {
+    const log = parseDeepSeekSessionLog(fs.readFileSync(filePath));
+    return log ? projectDeepSeekSession(log) : null;
+  }
 
   const descriptor = migrationTargetDescriptor(target);
   if (descriptor.family === "codebuddy") return loadCodeBuddyCliSessionFile(filePath);
@@ -83,6 +88,7 @@ const allMigrationTargetsEnabled = {
   ...defaultSettings,
   includeTclaude: true,
   includeTcodex: true,
+  includeDeepSeekCli: true,
 };
 
 const targetSources: Record<MigrationTarget, SessionSource> = {
@@ -93,6 +99,7 @@ const targetSources: Record<MigrationTarget, SessionSource> = {
   cursor: "cursor-agent",
   tclaude: "tclaude-cli",
   tcodex: "tcodex-cli",
+  deepseek: "deepseek-cli",
 };
 
 describe("migrateSessionForMcp — happy path", () => {
@@ -115,6 +122,11 @@ describe("migrateSessionForMcp — happy path", () => {
         expect(result.strategy).toBe("complete");
         expect(result.resumeCommand).toContain(result.targetSessionId);
         expect(result.resumeCommand).toContain(projectPath);
+        if (target === "deepseek") {
+          expect(result.resumeCommand).toContain("dsh");
+          expect(result.resumeCommand).toContain("--profile");
+          expect(result.resumeCommand).toContain("tui");
+        }
         expect(result.indexed).toBe(true);
         expect(fs.existsSync(result.targetFilePath)).toBe(true);
 
@@ -123,7 +135,9 @@ describe("migrateSessionForMcp — happy path", () => {
         expect(loaded?.messages.length).toBeGreaterThan(0);
 
         // The migrated session is immediately searchable in the DB.
-        const indexedSessionKey = loaded?.session.sessionKey ?? `${target}:${result.targetSessionId}`;
+        const indexedSessionKey = (loaded && "session" in loaded && loaded.session)
+          ? (loaded as { session: { sessionKey: string } }).session.sessionKey
+          : `${target}:${result.targetSessionId}`;
         const found = await store.getSession(indexedSessionKey);
         expect(found).not.toBeNull();
         expect(found?.source).toBe(targetSources[target]);

--- a/apps/main-2.0/src/core/migration-targets.ts
+++ b/apps/main-2.0/src/core/migration-targets.ts
@@ -2,9 +2,10 @@ import type { MigrationAgent, MigrationTarget, SessionSource } from "./types";
 
 export type OptionalMigrationTargetSetting =
   | "includeTclaude"
-  | "includeTcodex";
+  | "includeTcodex"
+  | "includeDeepSeekCli";
 
-export type MigrationTargetSettings = Record<OptionalMigrationTargetSetting, boolean>;
+export type MigrationTargetSettings = Partial<Record<OptionalMigrationTargetSetting, boolean>>;
 
 export interface MigrationTargetDescriptor {
   id: MigrationTarget;
@@ -52,6 +53,13 @@ export const MIGRATION_TARGETS: readonly MigrationTargetDescriptor[] = [
     source: "tcodex-cli",
     enabledSetting: "includeTcodex",
   },
+  {
+    id: "deepseek",
+    label: "DeepSeek Harness",
+    family: "deepseek",
+    source: "deepseek-cli",
+    enabledSetting: "includeDeepSeekCli",
+  },
 ] as const satisfies readonly MigrationTargetDescriptor[];
 
 export const MIGRATION_TARGET_IDS = [
@@ -62,6 +70,7 @@ export const MIGRATION_TARGET_IDS = [
   "cursor",
   "tclaude",
   "tcodex",
+  "deepseek",
 ] as const satisfies readonly MigrationTarget[];
 
 export const BASE_MIGRATION_TARGETS = ["claude", "codex", "codebuddy", "codewiz", "cursor"] as const satisfies readonly MigrationTarget[];

--- a/apps/main-2.0/src/core/platform.ts
+++ b/apps/main-2.0/src/core/platform.ts
@@ -88,6 +88,7 @@ export interface AppSettings {
   tclaudeBinary: string;
   tcodexBinary: string;
   includeStepcode: boolean;
+  deepseekBinary: string;
   includeTclaude: boolean;
   includeTcodex: boolean;
   includeCodeBuddyCli: boolean;
@@ -101,6 +102,7 @@ export interface AppSettings {
   includeTrae: boolean;
   includeQoder: boolean;
   includePi: boolean;
+  includeDeepSeekCli: boolean;
   rulesSyncEnabled: boolean;
   memoriesSyncEnabled: boolean;
   evalEnabled: boolean;
@@ -181,6 +183,7 @@ export const defaultSettings: AppSettings = {
   tclaudeBinary: "tclaude",
   tcodexBinary: "tcodex",
   includeStepcode: false,
+  deepseekBinary: "dsh",
   includeTclaude: false,
   includeTcodex: false,
   includeCodeBuddyCli: false,
@@ -194,6 +197,7 @@ export const defaultSettings: AppSettings = {
   includeTrae: false,
   includeQoder: false,
   includePi: false,
+  includeDeepSeekCli: false,
   rulesSyncEnabled: false,
   memoriesSyncEnabled: false,
   evalEnabled: false,
@@ -326,6 +330,7 @@ export function migrationBinary(target: MigrationTarget, settings: AppSettings):
   if (target === "codebuddy") return settings.codeBuddyBinary;
   if (target === "codewiz") return settings.codeWizBinary;
   if (target === "cursor") return settings.cursorBinary;
+  if (target === "deepseek") return settings.deepseekBinary;
   return settings.codexBinary;
 }
 
@@ -336,6 +341,7 @@ function migrationTargetDisplayName(target: MigrationTarget): string {
   if (target === "codebuddy") return "CodeBuddy";
   if (target === "codewiz") return "CodeWiz";
   if (target === "cursor") return "Cursor";
+  if (target === "deepseek") return "DeepSeek Harness";
   return "Codex";
 }
 
@@ -344,6 +350,8 @@ function migrationResumeArgs(target: MigrationTarget, sessionId: string): string
     ? ["resume", sessionId]
     : target === "codewiz"
       ? ["--session", sessionId]
+      : target === "deepseek"
+        ? ["--profile", "tui", "--resume", sessionId]
     : ["--resume", sessionId];
 }
 
@@ -389,6 +397,7 @@ const MIGRATION_CLI_VERSION_RULES: Record<MigrationTarget, VersionRule[]> = {
     { label: "@tencent/tcodex", pattern: /^\s*@tencent\/tcodex\s*:?[ \t]*v?(\d+\.\d+\.\d+)[ \t]*$/im, minimum: version(0, 0, 13) },
     { label: "@openai/codex", pattern: /^\s*@openai\/codex\s*:?[ \t]*v?(\d+\.\d+\.\d+)[ \t]*$/im, minimum: version(0, 142, 4) },
   ],
+  deepseek: [{ label: "dsh", pattern: /^\s*v?(\d+\.\d+\.\d+)(?:-[\w.-]+)?\s*$/im, minimum: version(0, 0, 0) }],
 };
 
 function migrationTargetForResumeSource(source: SessionSource): MigrationTarget | null {
@@ -1157,6 +1166,56 @@ export async function openMigrationResumeInTerminal(
   }
 
   await openCommandInTerminal(commands, projectPath, settings, deps);
+}
+
+export async function openDeepSeekWebInTerminal(
+  projectPath: string,
+  settings: AppSettings,
+  deps: {
+    platform?: NodeJS.Platform;
+    runProcess?: ProcessRunner;
+    spawnDetached?: typeof spawnDetached;
+    resolveMacApplicationName?: typeof resolveMacApplicationName;
+  } = {},
+): Promise<void> {
+  const spec = { command: settings.deepseekBinary, args: ["--profile", "web"] };
+  const commands = buildMigrationResumeCommands(spec, projectPath, (deps.platform ?? process.platform) !== "win32");
+  const run = deps.runProcess ?? runProcess;
+  if ((deps.platform ?? process.platform) === "darwin" && settings.defaultTerminal === "Warp") {
+    await runWarpCommand(commands.posix, run);
+    return;
+  }
+  await openCommandInTerminal(commands, projectPath, settings, deps);
+}
+
+export async function probeDeepSeekWeb(
+  fetchImpl: typeof fetch = fetch,
+  timeoutMs = 1200,
+): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl("http://127.0.0.1:3080/", { signal: controller.signal, redirect: "manual" });
+    return response.status < 500;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function waitForDeepSeekWeb(
+  probe: () => Promise<boolean> = () => probeDeepSeekWeb(),
+  timeoutMs = 8_000,
+  intervalMs = 200,
+): Promise<boolean> {
+  const deadline = Date.now() + Math.max(0, timeoutMs);
+  for (;;) {
+    if (await probe()) return true;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return false;
+    await new Promise((resolve) => setTimeout(resolve, Math.min(Math.max(0, intervalMs), remaining)));
+  }
 }
 
 export async function resolveMacApplicationName(names: string[], runner: ProcessRunner = runProcess): Promise<string | null> {

--- a/apps/main-2.0/src/core/session-loader.ts
+++ b/apps/main-2.0/src/core/session-loader.ts
@@ -11,12 +11,16 @@ import {
   sanitizeCodexTraceValue,
 } from "./session-loaders/codex-rollout";
 import {
+  DEEPSEEK_HARNESS_DIR,
+} from "./deepseek-harness";
+import {
   CODEWIZ_SHARE_DIR,
   PI_SESSIONS_DIR,
   QODER_DIR,
   TRAE_DIR_NAMES,
   loadCodeWizSessions,
   loadCursorAgentSessionsIterator,
+  loadDeepSeekCliSessionsIterator,
   loadHermesSessions,
   loadOpenClawSessionsIterator,
   loadOpenCodeSessions,
@@ -1909,6 +1913,12 @@ export function* loadDefaultSessionsIterator(options: SessionLoadOptions = {}): 
     for (const dirName of TRAE_DIR_NAMES) yield* loadTraeSessionsIterator(path.join(homeDir, dirName), options);
   }
   if (options.includeQoder) yield* loadQoderSessionsIterator(path.join(homeDir, QODER_DIR), options);
+  if (options.includeDeepSeekCli) {
+    const deepSeekDir = options.homeDir === undefined
+      ? process.env.DSH_HOME?.trim() || path.join(homeDir, DEEPSEEK_HARNESS_DIR)
+      : path.join(homeDir, DEEPSEEK_HARNESS_DIR);
+    yield* loadDeepSeekCliSessionsIterator(deepSeekDir, options);
+  }
   if (options.includePi) yield* loadPiSessionsIterator(path.join(homeDir, PI_SESSIONS_DIR), options);
   if (options.includeTclaude) yield* loadClaudeCliSessionsIterator(path.join(homeDir, TCLAUDE_DIR), "tclaude-cli", options);
   if (options.includeTcodex) yield* loadCodexSessionsIterator(path.join(homeDir, TCODEX_DIR), "tcodex-cli", options);
@@ -1948,6 +1958,12 @@ export async function* loadDefaultSessionsAsyncIterator(options: SessionLoadOpti
     for (const dirName of TRAE_DIR_NAMES) yield* loadTraeSessionsIterator(path.join(homeDir, dirName), options);
   }
   if (options.includeQoder) yield* loadQoderSessionsIterator(path.join(homeDir, QODER_DIR), options);
+  if (options.includeDeepSeekCli) {
+    const deepSeekDir = options.homeDir === undefined
+      ? process.env.DSH_HOME?.trim() || path.join(homeDir, DEEPSEEK_HARNESS_DIR)
+      : path.join(homeDir, DEEPSEEK_HARNESS_DIR);
+    yield* loadDeepSeekCliSessionsIterator(deepSeekDir, options);
+  }
   if (options.includePi) yield* loadPiSessionsIterator(path.join(homeDir, PI_SESSIONS_DIR), options);
   if (options.includeTclaude) yield* loadClaudeCliSessionsIterator(path.join(homeDir, TCLAUDE_DIR), "tclaude-cli", options);
   if (options.includeTcodex) yield* loadCodexSessionsAsyncIterator(path.join(homeDir, TCODEX_DIR), "tcodex-cli", options);

--- a/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
+++ b/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
@@ -9,6 +9,12 @@ import {
   extractCursorUserQuery,
   isMeaningfulUserMessage,
 } from "../format-adapters";
+import {
+  DEEPSEEK_HARNESS_DIR,
+  DEEPSEEK_HARNESS_LOG_NAME,
+  parseDeepSeekSessionLog,
+  projectDeepSeekSession,
+} from "../deepseek-harness";
 import type {
   LoadedSession,
   SessionFormat,
@@ -607,6 +613,80 @@ function createSourceTokenUsage(inputTokens: number, outputTokens: number, cache
     Math.max(0, cachedInputTokens),
     Math.max(0, reasoningOutputTokens),
   );
+}
+
+export function loadDeepSeekCliSessionFile(filePath: string, stat: VirtualSessionFileStat): LoadedSession | null {
+  let buffer: Buffer;
+  try {
+    buffer = fs.readFileSync(filePath);
+  } catch {
+    return null;
+  }
+  const log = parseDeepSeekSessionLog(buffer, filePath);
+  if (!log) return null;
+  const view = projectDeepSeekSession(log);
+  if (view.messages.length === 0) return null;
+  const question = firstQuestion(view.messages);
+  const usage = createSourceTokenUsage(
+    view.usage.inputTokens,
+    view.usage.outputTokens,
+    view.usage.cacheReadTokens,
+    view.usage.reasoningTokens,
+  );
+  return {
+    session: createIndexedSession({
+      keyPrefix: "deepseek",
+      rawId: log.header.id,
+      source: "deepseek-cli",
+      projectPath: log.header.cwd || "",
+      filePath,
+      originalTitle: view.title || cleanTitle(question) || log.header.id,
+      firstQuestion: cleanTitle(question),
+      timestamp: log.header.createdAt || stat.mtimeMs,
+      tokenUsage: usage,
+      isSubagent: log.header.delegationDepth > 0,
+      parentSessionId: log.header.parentSession ?? null,
+      stat,
+    }),
+    messages: view.messages,
+    tokenEvents: view.tokenEvents,
+    traceEvents: view.traceEvents,
+  };
+}
+
+export function loadDeepSeekCliSessions(deepSeekDir?: string): LoadedSession[] {
+  return [...loadDeepSeekCliSessionsIterator(deepSeekDir)];
+}
+
+export function* loadDeepSeekCliSessionsIterator(
+  deepSeekDir = process.env.DSH_HOME?.trim() || path.join(os.homedir(), DEEPSEEK_HARNESS_DIR),
+  options: SessionLoadOptions = {},
+): Generator<LoadedSession> {
+  const sessionsDir = path.join(deepSeekDir, "sessions");
+  let projectEntries: fs.Dirent[];
+  try {
+    projectEntries = fs.readdirSync(sessionsDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const projectEntry of projectEntries) {
+    if (!projectEntry.isDirectory()) continue;
+    const projectDir = path.join(sessionsDir, projectEntry.name);
+    let sessionEntries: fs.Dirent[];
+    try {
+      sessionEntries = fs.readdirSync(projectDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const sessionEntry of sessionEntries) {
+      if (!sessionEntry.isDirectory()) continue;
+      const filePath = path.join(projectDir, sessionEntry.name, DEEPSEEK_HARNESS_LOG_NAME);
+      const stat = safeStat(filePath);
+      if (shouldSkipFile(options, filePath, stat)) continue;
+      const loaded = loadDeepSeekCliSessionFile(filePath, stat);
+      if (loaded) yield loaded;
+    }
+  }
 }
 
 export function loadHermesSessions(hermesDir = path.join(os.homedir(), ".hermes")): LoadedSession[] {

--- a/apps/main-2.0/src/core/session-loaders/common.ts
+++ b/apps/main-2.0/src/core/session-loaders/common.ts
@@ -33,6 +33,7 @@ export interface SessionLoadOptions {
   includeTrae?: boolean;
   includeQoder?: boolean;
   includePi?: boolean;
+  includeDeepSeekCli?: boolean;
   cursorStateDbPath?: string;
   cursorWorkspacePathMap?: ReadonlyMap<string, string>;
   shouldSkipFile?: (
@@ -311,7 +312,8 @@ export function createIndexedSession(input: {
     | "cursor"
     | "trae"
     | "qoder"
-    | "pi";
+    | "pi"
+    | "deepseek";
   rawId: string;
   source: SessionSource;
   projectPath: string;

--- a/apps/main-2.0/src/core/session-migration-writers.test.ts
+++ b/apps/main-2.0/src/core/session-migration-writers.test.ts
@@ -1099,6 +1099,30 @@ describe("writeMigratedSession", () => {
     },
   );
 
+  it("uses DSH_HOME normally but keeps an explicit test home isolated", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "migration-writer-dsh-home-"));
+    const explicitHome = path.join(root, "explicit-home");
+    const dshHome = path.join(root, "custom-dsh-home");
+    const previous = process.env.DSH_HOME;
+    try {
+      process.env.DSH_HOME = dshHome;
+      const isolated = await writeMigratedSession({
+        target: "deepseek", session: portable(), sessionId: SESSION_ID, homeDir: explicitHome, now: NOW,
+      });
+      expect(isolated.filePath.startsWith(path.join(explicitHome, ".dsh"))).toBe(true);
+      expect(isolated.filePath.startsWith(dshHome)).toBe(false);
+
+      const configured = await writeMigratedSession({
+        target: "deepseek", session: portable(), sessionId: SESSION_ID, now: NOW,
+      });
+      expect(configured.filePath.startsWith(dshHome)).toBe(true);
+    } finally {
+      if (previous === undefined) delete process.env.DSH_HOME;
+      else process.env.DSH_HOME = previous;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("rejects a tampered Codex model provider before rename", async () => {
     await expectTamperedSessionRejected("codex", (rows) => {
       rows[0].payload.model_provider = "tampered-provider";

--- a/apps/main-2.0/src/core/session-migration-writers.ts
+++ b/apps/main-2.0/src/core/session-migration-writers.ts
@@ -19,6 +19,15 @@ import {
   parseCursorTranscriptPath,
   parseJsonlText,
 } from "./session-loader";
+import {
+  DEEPSEEK_HARNESS_LOG_NAME,
+  DEEPSEEK_HARNESS_NO_CWD_DIR,
+  encodeDeepSeekPathSegment,
+  encodeDeepSeekProjectKey,
+  parseDeepSeekSessionLog,
+  projectDeepSeekSession,
+  serializeDeepSeekSessionLog,
+} from "./deepseek-harness";
 import { loadMigrationTargetRuntimeMetadata, type MigrationTargetRuntimeMetadata } from "./migration-target-runtime";
 import { migrationTargetDescriptor } from "./migration-targets";
 import type { LoadedSession, MigrationTarget, PortableSession } from "./types";
@@ -61,6 +70,12 @@ export async function writeMigratedSession(options: WriteMigratedSessionOptions)
   if (options.target === "codewiz") {
     return writeMigratedCodeWizSession({ ...options, homeDir, now, idFactory: createId }, sessionId);
   }
+  if (options.target === "deepseek") {
+    const deepSeekHome = options.homeDir === undefined
+      ? process.env.DSH_HOME?.trim() || path.join(homeDir, ".dsh")
+      : path.join(homeDir, ".dsh");
+    return writeMigratedDeepSeekSession({ ...options, homeDir, deepSeekHome, now }, sessionId);
+  }
   const session = migrationTargetDescriptor(options.target).family === "codex"
     ? normalizeCodexSession(options.session)
     : options.session;
@@ -92,6 +107,61 @@ export async function writeMigratedSession(options: WriteMigratedSessionOptions)
     finalFileCreated = true;
     await updateCodexSessionIndex(options.target, targetHome, session, sessionId, now);
     updateCodexAppServerState(options.target, targetHome, filePath, session, sessionId, now, runtimeMetadata, codexRuntimeCwd);
+    return { sessionId, filePath };
+  } catch (error) {
+    await fs.promises.rm(tempPath, { force: true });
+    if (finalFileCreated) await fs.promises.rm(filePath, { force: true });
+    throw error;
+  }
+}
+
+async function writeMigratedDeepSeekSession(
+  options: WriteMigratedSessionOptions & { deepSeekHome: string; homeDir: string; now: Date },
+  sessionId: string,
+): Promise<WrittenMigratedSession> {
+  const projectPath = options.session.projectPath.trim();
+  const cwd = projectPath || options.homeDir;
+  const projectDir = projectPath ? encodeDeepSeekProjectKey(cwd) : DEEPSEEK_HARNESS_NO_CWD_DIR;
+  const filePath = path.join(
+    options.deepSeekHome,
+    "sessions",
+    projectDir,
+    encodeDeepSeekPathSegment(sessionId),
+    DEEPSEEK_HARNESS_LOG_NAME,
+  );
+
+  const startedAt = Date.parse(options.session.startedAt);
+  const createdAt = Number.isFinite(startedAt) && startedAt > 0 ? startedAt : options.now.getTime();
+  const payload = serializeDeepSeekSessionLog({
+    sessionId,
+    createdAt,
+    cwd,
+    title: cleanTitle(options.session.title),
+    messages: options.session.messages.map((message) => ({
+      role: message.role,
+      content: message.content,
+      time: Date.parse(message.timestamp) || createdAt,
+    })),
+  });
+
+  const tempPath = `${filePath}.tmp-${crypto.randomUUID()}`;
+  let finalFileCreated = false;
+  await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+  try {
+    await fs.promises.writeFile(tempPath, payload);
+    const parsed = parseDeepSeekSessionLog(payload);
+    if (!parsed || parsed.header.id !== sessionId) {
+      throw new Error("DeepSeek migration writer produced an unreadable session log.");
+    }
+    const view = projectDeepSeekSession(parsed);
+    const loadedMessages = view.messages.map((message) => ({ role: message.role, content: message.content }));
+    const expected = options.session.messages.map((message) => ({ role: message.role, content: message.content }));
+    if (JSON.stringify(loadedMessages) !== JSON.stringify(expected)) {
+      throw new Error("DeepSeek migration round trip did not preserve the transcript.");
+    }
+    await fs.promises.chmod(tempPath, 0o600);
+    await fs.promises.rename(tempPath, filePath);
+    finalFileCreated = true;
     return { sessionId, filePath };
   } catch (error) {
     await fs.promises.rm(tempPath, { force: true });
@@ -610,6 +680,12 @@ export function targetFilePath(
     );
   }
 
+  if (target === "deepseek") {
+    const key = encodeDeepSeekProjectKey(projectPath);
+    const dshHome = process.env.DSH_HOME?.trim() || path.join(homeDir, root);
+    return path.join(dshHome, "sessions", key, encodeDeepSeekPathSegment(sessionId), DEEPSEEK_HARNESS_LOG_NAME);
+  }
+
   return path.join(homeDir, root, "projects", encodeCodeBuddyProjectDir(projectPath), `${sessionId}.jsonl`);
 }
 
@@ -631,6 +707,7 @@ const TARGET_ROOTS: Record<MigrationTarget, string> = {
   codebuddy: ".codebuddy",
   codewiz: path.join(".local", "share", "codewiz"),
   cursor: ".cursor",
+  deepseek: ".dsh",
 };
 const NO_PROJECT_DIRECTORY = "empty-window";
 

--- a/apps/main-2.0/src/core/session-sources.ts
+++ b/apps/main-2.0/src/core/session-sources.ts
@@ -14,7 +14,8 @@ export type OptionalSessionSourceSetting =
   | "includeCursorAgent"
   | "includeTrae"
   | "includeQoder"
-  | "includePi";
+  | "includePi"
+  | "includeDeepSeekCli";
 
 export type SessionSourceFamily =
   | "claude"
@@ -32,7 +33,8 @@ export type SessionSourceFamily =
   | "cursor"
   | "trae"
   | "qoder"
-  | "pi";
+  | "pi"
+  | "deepseek";
 
 export type SessionSourceUiFamily = "claude" | "codex" | "codebuddy" | "codewiz" | "zcode" | "other";
 
@@ -179,6 +181,12 @@ export const SESSION_SOURCE_REGISTRY = {
     optionalSetting: "includePi", pendingKey: "pi", remoteCollectorOptional: false, liveFamily: null, migrationAgent: null,
     resumeTarget: null, remoteFamily: null, nativeAppFamily: null,
     capabilities: { live: false, resume: false, migrate: false, sessionSync: true, openApp: false },
+  },
+  "deepseek-cli": {
+    id: "deepseek-cli", label: "DeepSeek Harness", format: "deepseek", family: "deepseek", uiFamily: "other", statsGroup: null,
+    optionalSetting: "includeDeepSeekCli", pendingKey: "deepseek", remoteCollectorOptional: false, liveFamily: null, migrationAgent: "deepseek",
+    resumeTarget: "deepseek", remoteFamily: null, nativeAppFamily: null,
+    capabilities: { live: false, resume: true, migrate: true, sessionSync: false, openApp: false },
   },
 } as const satisfies Record<SessionSource, SessionSourceDescriptor>;
 

--- a/apps/main-2.0/src/core/session-store.test.ts
+++ b/apps/main-2.0/src/core/session-store.test.ts
@@ -306,6 +306,34 @@ describe("SessionStore PostgreSQL facade", () => {
     }
   });
 
+  it("deletes DeepSeek Harness parent and descendant session directories together", async () => {
+    const store = createStore();
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-v2-dsh-tree-delete-"));
+    const parentFile = path.join(root, "sessions", "--work--", "parent", "session.jsonl.zstd");
+    const childFile = path.join(root, "sessions", "--work--", "child", "session.jsonl.zstd");
+    for (const filePath of [parentFile, childFile]) {
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, "fixture");
+    }
+    await store.upsertIndexedSession(indexedSession({
+      sessionKey: "deepseek:parent", rawId: "parent", source: "deepseek-cli", filePath: parentFile,
+    }), messages);
+    await store.upsertIndexedSession(indexedSession({
+      sessionKey: "deepseek:child", rawId: "child", source: "deepseek-cli", filePath: childFile,
+      isSubagent: true, parentSessionId: "parent",
+    }), messages);
+
+    try {
+      await expect(store.deleteSession("deepseek:parent")).resolves.toBe(true);
+      expect(fs.existsSync(path.dirname(parentFile))).toBe(false);
+      expect(fs.existsSync(path.dirname(childFile))).toBe(false);
+      await expect(store.getSession("deepseek:parent")).resolves.toBeNull();
+      await expect(store.getSession("deepseek:child")).resolves.toBeNull();
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("finds orphaned subagent trees after an explicit record-only prune", async () => {
     const store = createStore();
     await store.upsertIndexedSession(indexedSession({ sessionKey: "codex:parent", rawId: "parent" }), messages);

--- a/apps/main-2.0/src/core/session-store.ts
+++ b/apps/main-2.0/src/core/session-store.ts
@@ -1,3 +1,4 @@
+import { deleteDeepSeekCliSessionDirectory } from "./deepseek-harness";
 import { deleteHermesSession } from "./hermes-session-writer";
 import { isLocalSessionStorage } from "./session-environment";
 import { deleteLocalSessionSources } from "./session-source-delete";
@@ -252,6 +253,12 @@ export class SessionStore {
     }
     if (target.source === "hermes") {
       if (target.sourceAvailable) deleteHermesSession(target.filePath, target.rawId);
+      return this.deleteSessionTargetRecords(targets, sessionKey);
+    }
+    if (target.source === "deepseek-cli") {
+      for (const item of targets) {
+        if (item.sourceAvailable) deleteDeepSeekCliSessionDirectory(item.filePath);
+      }
       return this.deleteSessionTargetRecords(targets, sessionKey);
     }
     if (target.source === "opencode-cli") throw new Error("Cannot delete shared OpenCode source database.");

--- a/apps/main-2.0/src/core/setup-mcp.test.ts
+++ b/apps/main-2.0/src/core/setup-mcp.test.ts
@@ -21,7 +21,7 @@ describe("setup-mcp Claude config", () => {
   it("adds the server while preserving existing config", () => {
     const next = applyClaudeConfig({ projects: { a: 1 } }, "/abs/server.mjs", false);
     expect(next).toMatchObject({ projects: { a: 1 } });
-    expect(next.mcpServers).toEqual({ "agent-recall": { command: "node", args: ["/abs/server.mjs"] } });
+    expect(next.mcpServers).toEqual({ "agent-recall-v2": { command: "node", args: ["/abs/server.mjs"] } });
   });
 
   it("removes only our server", () => {
@@ -39,10 +39,10 @@ describe("setup-mcp Claude config", () => {
 describe("setup-mcp Codex config", () => {
   it("appends the block and is idempotent", () => {
     const once = applyCodexConfig("[other]\nx = 1\n", "/abs/server.mjs", false);
-    expect(once).toContain("[mcp_servers.agent_recall]");
+    expect(once).toContain("[mcp_servers.agent_recall_v2]");
     expect(once).toContain('args = ["/abs/server.mjs"]');
     const twice = applyCodexConfig(once, "/abs/server.mjs", false);
-    expect(twice.match(/\[mcp_servers\.agent_recall\]/g)).toHaveLength(1);
+    expect(twice.match(/\[mcp_servers\.agent_recall_v2\]/g)).toHaveLength(1);
     expect(twice).toContain("[other]");
   });
 

--- a/apps/main-2.0/src/core/types.ts
+++ b/apps/main-2.0/src/core/types.ts
@@ -17,8 +17,9 @@ export type SessionSource =
   | "cursor-agent"
   | "trae"
   | "qoder"
-  | "pi-cli";
-export type SessionFormat = "claude" | "codex" | "codebuddy" | "workbuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder" | "pi";
+  | "pi-cli"
+  | "deepseek-cli";
+export type SessionFormat = "claude" | "codex" | "codebuddy" | "workbuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder" | "pi" | "deepseek";
 export type SessionSortBy = "smart" | "activity" | "created";
 export type EnvironmentKind = "local" | "wsl" | "ssh";
 export type EnvironmentSyncState = "idle" | "syncing" | "watching" | "disconnected" | "error";
@@ -91,7 +92,7 @@ export interface SessionMessageEvent {
   timestamp: number;
 }
 
-export type MigrationAgent = "claude" | "codex" | "codebuddy" | "codewiz" | "cursor";
+export type MigrationAgent = "claude" | "codex" | "codebuddy" | "codewiz" | "cursor" | "deepseek";
 export type MigrationTarget = MigrationAgent | "tclaude" | "tcodex";
 export type RemoteSessionAgent = MigrationAgent | "hermes" | "pi";
 export type SessionMigrationStrategy = "complete" | "ai-compressed" | "locally-truncated";

--- a/apps/main-2.0/src/main/deepseek-web-session.test.ts
+++ b/apps/main-2.0/src/main/deepseek-web-session.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEEPSEEK_WEB_STORAGE_KEY,
+  DEEPSEEK_WEB_URL,
+  openDeepSeekWebSessionPage,
+} from "./deepseek-web-session";
+
+describe("openDeepSeekWebSessionPage", () => {
+  it("selects the requested session before showing the web page", async () => {
+    const calls: string[] = [];
+    const page = {
+      loadURL: vi.fn(async (url: string) => { calls.push(`load:${url}`); }),
+      executeJavaScript: vi.fn(async (script: string) => { calls.push(`script:${script}`); }),
+      show: vi.fn(() => { calls.push("show"); }),
+      focus: vi.fn(() => { calls.push("focus"); }),
+    };
+
+    await openDeepSeekWebSessionPage(page, "session-1");
+
+    expect(calls).toEqual([
+      `load:${DEEPSEEK_WEB_URL}`,
+      `script:localStorage.setItem(${JSON.stringify(DEEPSEEK_WEB_STORAGE_KEY)}, ${JSON.stringify(JSON.stringify({ sessionId: "session-1" }))})`,
+      `load:${DEEPSEEK_WEB_URL}`,
+      "show",
+      "focus",
+    ]);
+  });
+
+  it("quotes an untrusted session id as data in the storage script", async () => {
+    const page = {
+      loadURL: vi.fn(async () => undefined),
+      executeJavaScript: vi.fn(async () => undefined),
+      show: vi.fn(),
+      focus: vi.fn(),
+    };
+    const sessionId = `session-\";globalThis.compromised=true;//`;
+
+    await openDeepSeekWebSessionPage(page, sessionId);
+
+    expect(page.executeJavaScript).toHaveBeenCalledWith(
+      `localStorage.setItem(${JSON.stringify(DEEPSEEK_WEB_STORAGE_KEY)}, ${JSON.stringify(JSON.stringify({ sessionId }))})`,
+    );
+  });
+});

--- a/apps/main-2.0/src/main/deepseek-web-session.ts
+++ b/apps/main-2.0/src/main/deepseek-web-session.ts
@@ -1,0 +1,23 @@
+export const DEEPSEEK_WEB_URL = "http://127.0.0.1:3080/";
+export const DEEPSEEK_WEB_STORAGE_KEY = "dsh.sessions.current";
+
+export interface DeepSeekWebSessionPage {
+  loadURL(url: string): Promise<unknown>;
+  executeJavaScript(script: string): Promise<unknown>;
+  show(): void;
+  focus(): void;
+}
+
+export async function openDeepSeekWebSessionPage(
+  page: DeepSeekWebSessionPage,
+  sessionId: string,
+): Promise<void> {
+  await page.loadURL(DEEPSEEK_WEB_URL);
+  const selection = JSON.stringify({ sessionId });
+  await page.executeJavaScript(
+    `localStorage.setItem(${JSON.stringify(DEEPSEEK_WEB_STORAGE_KEY)}, ${JSON.stringify(selection)})`,
+  );
+  await page.loadURL(DEEPSEEK_WEB_URL);
+  page.show();
+  page.focus();
+}

--- a/apps/main-2.0/src/main/index.ts
+++ b/apps/main-2.0/src/main/index.ts
@@ -48,6 +48,7 @@ import {
   openMigrationResumeInTerminal,
   revealInFileManager,
 } from "../core/platform";
+import { DEEPSEEK_WEB_URL, openDeepSeekWebSessionPage } from "./deepseek-web-session";
 import { loadUsageQuotaSnapshot } from "../core/quota";
 import { repairLegacyAgentRecallCodexRollouts } from "../core/codex-migration-repair";
 import { setLiveSessionTerminalTitle } from "../core/session-focus";
@@ -341,6 +342,7 @@ let postgresRuntime: PostgresRuntime | null = null;
 let postgresRuntimeStartup: Promise<PostgresRuntime> | null = null;
 let postgresDatabase: PostgresDatabase | null = null;
 let quickSearchWindow: BrowserWindow | null = null;
+let deepSeekWebWindow: BrowserWindow | null = null;
 const interfaceZoomController = createInterfaceZoomController(() => [mainWindow, quickSearchWindow]);
 let tray: Tray | null = null;
 let store: SessionStore;
@@ -1470,6 +1472,57 @@ function createQuickSearchWindow(): BrowserWindow {
   return window;
 }
 
+function getDeepSeekWebWindow(): BrowserWindow {
+  if (deepSeekWebWindow && !deepSeekWebWindow.isDestroyed()) return deepSeekWebWindow;
+  const allowedOrigin = new URL(DEEPSEEK_WEB_URL).origin;
+  const window = new BrowserWindow({
+    width: 1280,
+    height: 840,
+    minWidth: 860,
+    minHeight: 600,
+    show: false,
+    title: "DeepSeek Harness",
+    backgroundColor: "#0a0b0d",
+    webPreferences: {
+      sandbox: true,
+      contextIsolation: true,
+      nodeIntegration: false,
+      partition: "persist:deepseek-harness-web",
+    },
+  });
+  window.webContents.setWindowOpenHandler(({ url }) => {
+    const externalUrl = normalizeExternalLink(url);
+    if (externalUrl) void shell.openExternal(externalUrl);
+    return { action: "deny" };
+  });
+  window.webContents.on("will-navigate", (event, url) => {
+    try {
+      if (new URL(url).origin === allowedOrigin) return;
+    } catch {
+      // Invalid URLs are denied below.
+    }
+    event.preventDefault();
+    const externalUrl = normalizeExternalLink(url);
+    if (externalUrl) void shell.openExternal(externalUrl);
+  });
+  window.on("closed", () => {
+    if (deepSeekWebWindow === window) deepSeekWebWindow = null;
+  });
+  deepSeekWebWindow = window;
+  return window;
+}
+
+async function showDeepSeekWebSession(sessionId: string): Promise<void> {
+  const window = getDeepSeekWebWindow();
+  window.hide();
+  await openDeepSeekWebSessionPage({
+    loadURL: (url) => window.loadURL(url),
+    executeJavaScript: (script) => window.webContents.executeJavaScript(script),
+    show: () => window.show(),
+    focus: () => window.focus(),
+  }, sessionId);
+}
+
 function showQuickSearch(): void {
   if (!quickSearchWindow || quickSearchWindow.isDestroyed()) {
     quickSearchWindow = createQuickSearchWindow();
@@ -1743,6 +1796,7 @@ function runIndexSync(): Promise<IndexStatus> {
         includeCursorAgent: settings.includeCursorAgent,
         includeTrae: settings.includeTrae,
         includeQoder: settings.includeQoder,
+        includeDeepSeekCli: settings.includeDeepSeekCli,
       },
       indexFailureLogPath: indexFailureLogger.logPath,
       logIndexFailure: indexFailureLogger.write,
@@ -2096,7 +2150,16 @@ function localSessionMigrationRuntime(event: IpcMainInvokeEvent) {
       completeTokenLimit: number,
     ) => applyMigrationLengthPolicy(portable, compressor, onProgress, completeTokenLimit),
     write: (migrationTarget: MigrationTarget, portable: PortableSession, targetSessionId?: string) =>
-      writeMigratedSession({ target: migrationTarget, session: portable, sessionId: targetSessionId }),
+      writeMigratedSession({
+        target: migrationTarget,
+        session: portable,
+        sessionId: targetSessionId,
+        // Test/sandboxed launches may redirect the migration home so writes
+        // to ~/.codex, ~/.dsh, ... never hit a TCC-protected real home.
+        ...process.env.AGENT_RECALL_MIGRATION_HOME
+          ? { homeDir: process.env.AGENT_RECALL_MIGRATION_HOME }
+          : {},
+      }),
     record: (record: Parameters<SessionStore["recordSessionMigration"]>[0]) => store.recordSessionMigration(record),
     refreshIndex: async (migrationTarget: MigrationTarget, writtenFilePath: string, targetSessionId: string) => {
       const status = await indexMigratedSessionFile(store, migrationTarget, writtenFilePath, targetSessionId);
@@ -2712,6 +2775,7 @@ function registerIpc(): void {
     }),
     copyText: (text) => clipboard.writeText(text),
     openExternal: (url) => shell.openExternal(url),
+    openDeepSeekWebSession: showDeepSeekWebSession,
     chooseMarkdownPath: chooseMarkdownExportPath,
     chooseJsonFormat: chooseJsonExportFormat,
     chooseJsonPath: chooseJsonExportPath,

--- a/apps/main-2.0/src/main/services/session-bulk-delete-service.ts
+++ b/apps/main-2.0/src/main/services/session-bulk-delete-service.ts
@@ -6,6 +6,7 @@ import type {
   SessionBulkDeleteResult,
   SessionBulkDeleteTarget,
 } from "../../core/session-bulk-delete";
+import { deleteDeepSeekCliSessionDirectory } from "../../core/deepseek-harness";
 import { deleteLocalSessionSources } from "../../core/session-source-delete";
 import { sessionSourceDescriptor } from "../../core/session-sources";
 import type { SessionEnvironment, SessionSource } from "../../core/types";
@@ -188,6 +189,10 @@ async function deleteTargetFamily(
     for (const group of groupBy(availableTargets, (target) => target.filePath).values()) {
       deleteZcodeSessions(group[0].filePath, group.map((target) => target.rawId));
     }
+    return;
+  }
+  if (availableTargets[0].source === "deepseek-cli") {
+    for (const target of availableTargets) deleteDeepSeekCliSessionDirectory(target.filePath);
     return;
   }
   if (availableTargets[0].environmentKind === "wsl") {

--- a/apps/main-2.0/src/main/services/session-command-service.ts
+++ b/apps/main-2.0/src/main/services/session-command-service.ts
@@ -1,3 +1,4 @@
+import { homedir } from "node:os";
 import {
   reconstructCodexResponsesRequest,
   resolveCodexResponsesRequest,
@@ -13,10 +14,13 @@ import {
 } from "../../core/format-session";
 import {
   getResumeCommand,
+  openDeepSeekWebInTerminal,
   openNativeApp,
   openResumeInSpecificTerminal,
   openResumeInTerminal,
+  probeDeepSeekWeb,
   revealInFileManager,
+  waitForDeepSeekWeb,
   type AppSettings,
 } from "../../core/platform";
 import { routeResumeSession, type ResumeRouteResult } from "../../core/resume-router";
@@ -43,6 +47,7 @@ export interface SessionCommandServiceDependencies {
   loadLiveSessions(): Promise<LiveSessionSnapshot>;
   copyText(text: string): void;
   openExternal(url: string): Promise<unknown>;
+  openDeepSeekWebSession(sessionId: string): Promise<void>;
   chooseMarkdownPath(defaultFileName: string): Promise<string | null>;
   chooseJsonFormat(): Promise<JsonExportFormat | null>;
   chooseJsonPath(defaultFileName: string): Promise<string | null>;
@@ -125,6 +130,18 @@ export class SessionCommandService {
     if (!isLocalSessionEnvironment(resumeSession)) {
       await this.dependencies.remoteAccess.ensureResumePreflight(resumeSession);
       await openResumeInTerminal(resumeSession, this.dependencies.getSettings(), { sshArgs });
+      await this.dependencies.store.markResumed(sessionKey);
+      return { route: "resume" };
+    }
+
+    if (session.source === "deepseek-cli") {
+      if (!await probeDeepSeekWeb()) {
+        await openDeepSeekWebInTerminal(session.projectPath || homedir(), this.dependencies.getSettings());
+        if (!await waitForDeepSeekWeb()) {
+          throw new Error("DeepSeek Harness Web did not start on http://127.0.0.1:3080.");
+        }
+      }
+      await this.dependencies.openDeepSeekWebSession(session.rawId);
       await this.dependencies.store.markResumed(sessionKey);
       return { route: "resume" };
     }

--- a/apps/main-2.0/src/main/services/v1-session-import-service.ts
+++ b/apps/main-2.0/src/main/services/v1-session-import-service.ts
@@ -67,7 +67,7 @@ const V1_SETTINGS_KEYS = [
 const SESSION_SOURCES = new Set<SessionSource>([
   "claude-cli", "claude-app", "codex-cli", "codex-app", "tclaude-cli", "tcodex-cli",
   "codebuddy-cli", "workbuddy-cli", "codewiz-cli", "openclaw", "hermes", "opencode-cli", "zcode-cli",
-  "cursor-agent", "trae", "qoder", "pi-cli",
+  "cursor-agent", "trae", "qoder", "pi-cli", "deepseek-cli",
 ]);
 
 interface V1SessionRow {

--- a/apps/main-2.0/src/renderer/src/components/session-dialogs.tsx
+++ b/apps/main-2.0/src/renderer/src/components/session-dialogs.tsx
@@ -103,6 +103,11 @@ export function DeleteSessionDialog({
                 "This permanently deletes this Hermes session and its messages from the local Hermes database. Other Hermes sessions stay intact. This cannot be undone.",
                 "这会从本地 Hermes 数据库永久删除该会话及其消息，不影响其他 Hermes 会话，无法撤销。",
               )
+            : session.source === "deepseek-cli"
+            ? l(
+                "This permanently deletes this DeepSeek Harness session and its messages from the local DeepSeek Harness log. Other DeepSeek Harness sessions stay intact. This cannot be undone.",
+                "这会从本地 DeepSeek Harness 日志永久删除该会话及其消息，不影响其他 DeepSeek Harness 会话，无法撤销。",
+              )
             : l(
                 "This deletes the original Codex or Claude Code session file and removes it from this app. This cannot be undone.",
                 "这会删除 Codex 或 Claude Code 的原始会话文件，并从本应用移除，无法撤销。",

--- a/apps/main-2.0/src/renderer/src/features/search/group-logic.ts
+++ b/apps/main-2.0/src/renderer/src/features/search/group-logic.ts
@@ -1,5 +1,5 @@
 import { codexTaskWorkspaceDate } from "../../../../core/project-identity";
-import { sessionSourceDescriptor } from "../../../../core/session-sources";
+import { isSessionSource, sessionSourceDescriptor } from "../../../../core/session-sources";
 import type { SessionSource } from "../../../../core/types";
 
 export type GroupMode = "flat" | "project" | "source" | "time";
@@ -48,7 +48,9 @@ export function isNoProjectGroupKey(key: string): boolean {
 }
 
 function projectGroupKey(session: GroupableSession): string {
-  const sourceFamily = sessionSourceDescriptor(session.source).family;
+  const sourceFamily = isSessionSource(session.source)
+    ? sessionSourceDescriptor(session.source).family
+    : String(session.source);
   const isCodexTaskWorkspace = sourceFamily === "codex"
     && codexTaskWorkspaceDate(session.projectPath) !== null;
   return !session.projectPath || isCodexTaskWorkspace

--- a/apps/main-2.0/src/renderer/src/features/session-detail/detail-panel.tsx
+++ b/apps/main-2.0/src/renderer/src/features/session-detail/detail-panel.tsx
@@ -34,7 +34,7 @@ import { TurnAccordion, type TurnMessageRoleFilter } from "./turn-accordion";
 import { MessageHead } from "./message-shell";
 import type { SessionFamily } from "../../../../core/session-family";
 import { canDeleteSessionLocally } from "../../../../core/session-environment";
-import { sessionSourceDescriptor } from "../../../../core/session-sources";
+import { isSessionSource, sessionSourceDescriptor } from "../../../../core/session-sources";
 import { SubagentSessionTree } from "./subagent-session-tree";
 import { SessionContextComponentsPanel } from "./session-context-components-panel";
 import { collaborationMessageMetadata } from "./collaboration-message";
@@ -279,7 +279,8 @@ export function DetailPanel({
     && !messages.some((message) => message.role === roleFilter);
   const localOnlyDisabled = isRemoteSession(session);
   const canDelete = canDeleteSessionLocally(session);
-  const canSyncSession = sessionSourceDescriptor(session.source).capabilities.sessionSync;
+  const canSyncSession = isSessionSource(session.source)
+    && sessionSourceDescriptor(session.source).capabilities.sessionSync;
   const revealTitle = localOnlyDisabled ? remoteRevealTitle(language) : l(`Show in ${revealLabel}`, `在${revealLabel}中显示`);
 
   const toggleTools = () => {

--- a/apps/main-2.0/src/renderer/src/features/settings/settings-dialog.tsx
+++ b/apps/main-2.0/src/renderer/src/features/settings/settings-dialog.tsx
@@ -784,6 +784,19 @@ export function SettingsDialog({
                     onChange={(event) => onSettingsChange({ includeQoder: event.currentTarget.checked })}
                   />
                 </label>
+                <label className="settings-field settings-toggle">
+                  <div className="settings-field-text">
+                    <span className="settings-field-title">Include DeepSeek Harness</span>
+                    <span className="settings-field-sub">{l("Indexes local DeepSeek Harness (dsh) sessions from DSH_HOME (default: ~/.dsh).", "从 DSH_HOME（默认 ~/.dsh）索引本地 DeepSeek Harness（dsh）会话。")}</span>
+                  </div>
+                  <input
+                    type="checkbox"
+                    className="switch"
+                    checked={Boolean(settings?.includeDeepSeekCli)}
+                    disabled={!settings}
+                    onChange={(event) => onSettingsChange({ includeDeepSeekCli: event.currentTarget.checked })}
+                  />
+                </label>
               </section>
             ) : null}
             {activeSection === "usage" ? (

--- a/apps/main-2.0/src/renderer/src/live-filter.test.ts
+++ b/apps/main-2.0/src/renderer/src/live-filter.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { liveSessionKeyForSession } from "./live-filter";
+
+describe("live session filtering", () => {
+  it("treats an unknown persisted source as non-live", () => {
+    expect(liveSessionKeyForSession({
+      source: "legacy-source" as never,
+      rawId: "session-1",
+      lastActivityAt: Date.now(),
+    })).toBeNull();
+  });
+});

--- a/apps/main-2.0/src/renderer/src/live-filter.ts
+++ b/apps/main-2.0/src/renderer/src/live-filter.ts
@@ -1,5 +1,5 @@
 import type { SessionSource } from "../../core/types";
-import { sessionSourceDescriptor } from "../../core/session-sources";
+import { isSessionSource, sessionSourceDescriptor } from "../../core/session-sources";
 import { LIVE_SESSION_INACTIVITY_TIMEOUT_MS } from "../../core/refresh-policy";
 
 export type LiveSessionState = "open" | "closed";
@@ -12,6 +12,9 @@ export interface LiveFilterableSession {
 }
 
 export function liveSessionKeyForSession(session: LiveFilterableSession): string | null {
+  // Persisted sessions can outlive a source rename or a development branch.
+  // Treat an unknown runtime value as non-live instead of crashing the list.
+  if (!isSessionSource(session.source)) return null;
   const family = sessionSourceDescriptor(session.source).liveFamily;
   if (!family) return null;
   return `${family}:${session.rawId}`;

--- a/apps/main-2.0/src/renderer/src/session-ui.test.ts
+++ b/apps/main-2.0/src/renderer/src/session-ui.test.ts
@@ -6,7 +6,10 @@ import {
   environmentBadgeTitle,
   migrationTargetsForSession,
   sessionAvailableSources,
+  sourceMigrationAgent,
   sourceFilters,
+  sourceUiFamily,
+  supportsResumeSource,
   usageCacheRate,
 } from "./session-ui";
 
@@ -32,6 +35,15 @@ describe("migrationTargetsForSession", () => {
   it("keeps local and WSL target behavior", () => {
     expect(migrationTargetsForSession({ source: "claude-cli", environmentId: "local", environmentKind: "local" }, settings)).toEqual(["claude", "codex", "codebuddy", "codewiz", "cursor"]);
     expect(migrationTargetsForSession({ source: "codex-cli", environmentId: "wsl-1", environmentKind: "wsl" }, settings)).toEqual(["claude", "codex"]);
+  });
+
+  it("safely disables actions for a stale persisted source", () => {
+    const source = "workbuddy-cli" as never;
+    const session = { source, environmentId: "local", environmentKind: "local" } as const;
+    expect(sourceUiFamily(source)).toBe("other");
+    expect(supportsResumeSource(source)).toBe(false);
+    expect(sourceMigrationAgent(source)).toBeNull();
+    expect(migrationTargetsForSession(session, settings)).toEqual([]);
   });
 });
 

--- a/apps/main-2.0/src/renderer/src/session-ui.ts
+++ b/apps/main-2.0/src/renderer/src/session-ui.ts
@@ -15,6 +15,7 @@ import { enabledMigrationTargets, migrationTargetDescriptor, type MigrationTarge
 import {
   OPTIONAL_SESSION_SOURCE_DESCRIPTORS,
   SESSION_SOURCE_DESCRIPTORS,
+  isSessionSource,
   sessionSourceDescriptor,
   type SessionSourceUiFamily,
 } from "../../core/session-sources";
@@ -41,6 +42,7 @@ export interface UsageStatsDisplayRow extends SessionStatsSummary {
 }
 
 function usageStatsDisplayGroup(source: SessionSource): { key: string; label: string } {
+  if (!isSessionSource(source)) return { key: String(source), label: String(source) };
   const descriptor = sessionSourceDescriptor(source);
   if (descriptor.statsGroup) {
     return { key: descriptor.statsGroup, label: descriptor.statsGroup === "claude" ? "Claude Code" : "Codex" };
@@ -158,10 +160,12 @@ export function displayTagName(tagName: string): string {
 }
 
 export function sourceUiFamily(source: SessionSource): SessionSourceUiFamily {
+  if (!isSessionSource(source)) return "other";
   return sessionSourceDescriptor(source).uiFamily;
 }
 
 export function supportsResumeSource(source: SessionSource): boolean {
+  if (!isSessionSource(source)) return false;
   return sessionSourceDescriptor(source).capabilities.resume;
 }
 
@@ -170,6 +174,7 @@ export function supportsMigrationSource(source: SessionSource): boolean {
 }
 
 export function migrationTargetsForSource(source: SessionSource, settings: MigrationTargetSettings): MigrationTarget[] {
+  if (!isSessionSource(source)) return [];
   return supportedMigrationTargets(source, enabledMigrationTargets(settings));
 }
 
@@ -199,6 +204,7 @@ export function migrationAgentLabel(target: MigrationTarget): string {
 }
 
 export function sourceMigrationAgent(source: SessionSource): MigrationAgent | null {
+  if (!isSessionSource(source)) return null;
   return sessionSourceDescriptor(source).migrationAgent;
 }
 


### PR DESCRIPTION
close #414 
## 变更内容

- V1、V2 新增 DeepSeek Harness（dsh）会话来源，可选择启用本地会话索引与搜索
- 支持消息、工具调用、token 用量、会话迁移、MCP 配置和本地会话删除
- Resume 会启动或复用 DSH Web，并在网页中准确选中目标会话，而不是只打开工作目录
- 对未知或旧版会话来源增加安全降级，避免会话列表因残留数据崩溃

## 原因

此前 AgentRecall 未识别 DeepSeek Harness 会话；DSH Web 的当前会话只保存在同源 localStorage 中，单纯打开目录或网页根地址无法保证恢复到用户选中的会话。

## 用户影响

用户可在 V1、V2 中统一检索和管理 DSH 会话，并从详情页直接回到准确的 DSH 网页会话。

## 验证

- V1 DSH 相关回归：157 tests passed
- V2 DSH 相关回归：137 tests passed
- V1、V2 typecheck 通过
- `npm run release-note:check` 通过
- macOS 源码实测 V1、V2 可在 DSH Web 精确切换到最新及历史会话
