### PR TITLE
fix: clean stale Codex App sessions on delete

### DIFF
--- a/.release-notes/fix-codex-app-restore-delete.md
+++ b/.release-notes/fix-codex-app-restore-delete.md
@@ -1,0 +1,6 @@
+# 清理 Codex App 的失效会话
+<!-- release-target: both -->
+
+## Bug 修复
+
+- 删除 Codex App 会话时同步清理本地状态记录，避免最近列表残留无法打开、也无法再次删除的会话。

--- a/apps/main-1.0/src/core/session-source-delete.test.ts
+++ b/apps/main-1.0/src/core/session-source-delete.test.ts
@@ -1,8 +1,12 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { createRequire } from "node:module";
 import { describe, expect, it } from "vitest";
 import { deleteLocalSessionSources, sessionSourceDeletionPaths } from "./session-source-delete";
+
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require("node:sqlite") as { DatabaseSync: typeof import("node:sqlite").DatabaseSync };
 
 describe("session source deletion", () => {
   it("rejects relative source paths before deleting anything", () => {
@@ -145,6 +149,42 @@ describe("session source deletion", () => {
       expect(fs.existsSync(parentFile)).toBe(true);
       expect(fs.existsSync(childFile)).toBe(true);
       expect(fs.existsSync(subagentsDirectory)).toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("removes stale Codex App state rows when the rollout file is already missing", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-codex-app-state-delete-"));
+    const codexHome = path.join(root, ".codex");
+    const rolloutPath = path.join(codexHome, "sessions", "2026", "08", "18", "rollout-stale.jsonl");
+    const statePath = path.join(codexHome, "state_1.sqlite");
+    const sessionId = "550e8400-e29b-41d4-a716-446655440000";
+    fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+    const db = new DatabaseSync(statePath);
+    db.exec(`
+      CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT NOT NULL);
+      CREATE TABLE thread_spawn_edges (parent_thread_id TEXT NOT NULL, child_thread_id TEXT NOT NULL PRIMARY KEY);
+    `);
+    db.prepare("INSERT INTO threads (id, rollout_path) VALUES (?, ?)").run(sessionId, rolloutPath);
+    db.prepare("INSERT INTO thread_spawn_edges (parent_thread_id, child_thread_id) VALUES (?, ?)").run(sessionId, "child");
+    db.close();
+
+    try {
+      deleteLocalSessionSources([{
+        source: "codex-app",
+        rawId: sessionId,
+        filePath: rolloutPath,
+        isSubagent: false,
+      }]);
+
+      const verify = new DatabaseSync(statePath);
+      try {
+        expect(verify.prepare("SELECT id FROM threads WHERE id = ?").get(sessionId)).toBeUndefined();
+        expect(verify.prepare("SELECT child_thread_id FROM thread_spawn_edges WHERE parent_thread_id = ?").get(sessionId)).toBeUndefined();
+      } finally {
+        verify.close();
+      }
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }

--- a/apps/main-1.0/src/core/session-source-delete.test.ts
+++ b/apps/main-1.0/src/core/session-source-delete.test.ts
@@ -199,4 +199,42 @@ describe("session source deletion", () => {
       fs.rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("does not fail source deletion when Codex state cleanup is unavailable", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-codex-app-state-best-effort-"));
+    const codexHome = path.join(root, ".codex");
+    const rolloutPath = path.join(codexHome, "sessions", "2026", "08", "19", "rollout-busy.jsonl");
+    const statePath = path.join(codexHome, "state_1.sqlite");
+    const sessionId = "750e8400-e29b-41d4-a716-446655440000";
+    fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+    fs.writeFileSync(rolloutPath, "fixture", "utf8");
+    fs.writeFileSync(
+      path.join(codexHome, "session_index.jsonl"),
+      `${JSON.stringify({ id: sessionId, thread_name: "busy" })}\n`,
+    );
+    const db = new DatabaseSync(statePath);
+    db.exec(`
+      CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT NOT NULL);
+      CREATE TRIGGER block_thread_delete
+      BEFORE DELETE ON threads
+      BEGIN
+        SELECT RAISE(ABORT, 'state cleanup blocked');
+      END;
+    `);
+    db.prepare("INSERT INTO threads (id, rollout_path) VALUES (?, ?)").run(sessionId, rolloutPath);
+    db.close();
+
+    try {
+      expect(() => deleteLocalSessionSources([{
+        source: "codex-app",
+        rawId: sessionId,
+        filePath: rolloutPath,
+        isSubagent: false,
+      }])).not.toThrow();
+      expect(fs.existsSync(rolloutPath)).toBe(false);
+      expect(fs.readFileSync(path.join(codexHome, "session_index.jsonl"), "utf8")).toBe("");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/apps/main-1.0/src/core/session-source-delete.test.ts
+++ b/apps/main-1.0/src/core/session-source-delete.test.ts
@@ -160,14 +160,20 @@ describe("session source deletion", () => {
     const rolloutPath = path.join(codexHome, "sessions", "2026", "08", "18", "rollout-stale.jsonl");
     const statePath = path.join(codexHome, "state_1.sqlite");
     const sessionId = "550e8400-e29b-41d4-a716-446655440000";
+    const childId = "650e8400-e29b-41d4-a716-446655440000";
     fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+    fs.writeFileSync(
+      path.join(codexHome, "session_index.jsonl"),
+      `${JSON.stringify({ id: sessionId, thread_name: "stale" })}\n${JSON.stringify({ id: "keep", thread_name: "keep" })}\n`,
+    );
     const db = new DatabaseSync(statePath);
     db.exec(`
       CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT NOT NULL);
       CREATE TABLE thread_spawn_edges (parent_thread_id TEXT NOT NULL, child_thread_id TEXT NOT NULL PRIMARY KEY);
     `);
     db.prepare("INSERT INTO threads (id, rollout_path) VALUES (?, ?)").run(sessionId, rolloutPath);
-    db.prepare("INSERT INTO thread_spawn_edges (parent_thread_id, child_thread_id) VALUES (?, ?)").run(sessionId, "child");
+    db.prepare("INSERT INTO threads (id, rollout_path) VALUES (?, ?)").run(childId, `${rolloutPath}.child`);
+    db.prepare("INSERT INTO thread_spawn_edges (parent_thread_id, child_thread_id) VALUES (?, ?)").run(sessionId, childId);
     db.close();
 
     try {
@@ -181,10 +187,14 @@ describe("session source deletion", () => {
       const verify = new DatabaseSync(statePath);
       try {
         expect(verify.prepare("SELECT id FROM threads WHERE id = ?").get(sessionId)).toBeUndefined();
+        expect(verify.prepare("SELECT id FROM threads WHERE id = ?").get(childId)).toBeUndefined();
         expect(verify.prepare("SELECT child_thread_id FROM thread_spawn_edges WHERE parent_thread_id = ?").get(sessionId)).toBeUndefined();
       } finally {
         verify.close();
       }
+      expect(fs.readFileSync(path.join(codexHome, "session_index.jsonl"), "utf8")).toBe(
+        `${JSON.stringify({ id: "keep", thread_name: "keep" })}\n`,
+      );
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }

--- a/apps/main-1.0/src/core/session-source-delete.ts
+++ b/apps/main-1.0/src/core/session-source-delete.ts
@@ -1,8 +1,14 @@
 import * as fs from "node:fs";
+import { createRequire } from "node:module";
 import * as path from "node:path";
+import type { DatabaseSync as DatabaseSyncType } from "node:sqlite";
 import type { SessionSource } from "./types";
 
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require("node:sqlite") as { DatabaseSync: typeof DatabaseSyncType };
+
 const CLAUDE_SESSION_FILE_SOURCES = new Set<SessionSource>(["claude-cli", "claude-app"]);
+const CODEX_APP_SESSION_SOURCES = new Set<SessionSource>(["codex-app"]);
 
 export interface SessionSourceDeleteTarget {
   source: SessionSource;
@@ -80,6 +86,95 @@ export function deleteLocalSessionSources(targets: readonly SessionSourceDeleteT
   for (const filePath of deletionPaths.files) deleteRegularFile(filePath);
   for (const directoryPath of deletionPaths.directories) deleteOwnedDirectory(directoryPath);
   for (const directoryPath of deletionPaths.emptyDirectories) removeEmptyDirectory(directoryPath);
+  deleteCodexAppStateRows(targets);
+}
+
+function deleteCodexAppStateRows(targets: readonly SessionSourceDeleteTarget[]): void {
+  const idsByDatabase = new Map<string, Set<string>>();
+  for (const target of targets) {
+    if (!CODEX_APP_SESSION_SOURCES.has(target.source) || !target.rawId) continue;
+    const codexHome = codexHomeForRollout(target.filePath);
+    if (!codexHome) continue;
+    for (const entry of listCodexStateDatabases(codexHome)) {
+      const ids = idsByDatabase.get(entry) ?? new Set<string>();
+      ids.add(target.rawId);
+      idsByDatabase.set(entry, ids);
+    }
+  }
+
+  for (const [databasePath, ids] of idsByDatabase) {
+    const database = openCodexStateDatabase(databasePath);
+    if (!database) continue;
+    try {
+      deleteCodexThreadRows(database, [...ids]);
+    } finally {
+      database.close();
+    }
+  }
+}
+
+function codexHomeForRollout(filePath: string): string | null {
+  let current = path.dirname(filePath);
+  for (;;) {
+    if (path.basename(current).toLowerCase() === "sessions") {
+      const codexHome = path.dirname(current);
+      return path.basename(codexHome).toLowerCase() === ".codex" ? codexHome : null;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function listCodexStateDatabases(codexHome: string): string[] {
+  try {
+    return fs.readdirSync(codexHome, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && /^state_\d+\.sqlite$/iu.test(entry.name))
+      .map((entry) => path.join(codexHome, entry.name));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+function openCodexStateDatabase(databasePath: string): DatabaseSyncType | null {
+  try {
+    return new DatabaseSync(databasePath, { timeout: 5_000 });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function deleteCodexThreadRows(database: DatabaseSyncType, sessionIds: string[]): void {
+  const ids = [...new Set(sessionIds.filter(Boolean))];
+  if (ids.length === 0 || !sqliteTableHasColumns(database, "threads", ["id"])) return;
+  const placeholders = ids.map(() => "?").join(", ");
+  database.exec("BEGIN IMMEDIATE");
+  try {
+    if (sqliteTableHasColumns(database, "thread_spawn_edges", ["parent_thread_id", "child_thread_id"])) {
+      database.prepare(
+        `DELETE FROM thread_spawn_edges WHERE parent_thread_id IN (${placeholders}) OR child_thread_id IN (${placeholders})`,
+      ).run(...ids, ...ids);
+    }
+    database.prepare(`DELETE FROM threads WHERE id IN (${placeholders})`).run(...ids);
+    database.exec("COMMIT");
+  } catch (error) {
+    try { database.exec("ROLLBACK"); } catch { /* preserve the original error */ }
+    throw error;
+  }
+}
+
+function sqliteTableHasColumns(database: DatabaseSyncType, table: string, columns: string[]): boolean {
+  const present = database.prepare(
+    "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?",
+  ).get(table);
+  if (!present) return false;
+  const available = new Set(
+    (database.prepare(`PRAGMA table_info("${table.replaceAll('"', '""')}")`).all() as Array<{ name?: unknown }>)
+      .map((column) => typeof column.name === "string" ? column.name : ""),
+  );
+  return columns.every((column) => available.has(column));
 }
 
 function validateDeletionPaths(deletionPaths: SessionSourceDeletionPaths): void {

--- a/apps/main-1.0/src/core/session-source-delete.ts
+++ b/apps/main-1.0/src/core/session-source-delete.ts
@@ -8,7 +8,6 @@ const require = createRequire(import.meta.url);
 const { DatabaseSync } = require("node:sqlite") as { DatabaseSync: typeof DatabaseSyncType };
 
 const CLAUDE_SESSION_FILE_SOURCES = new Set<SessionSource>(["claude-cli", "claude-app"]);
-const CODEX_APP_SESSION_SOURCES = new Set<SessionSource>(["codex-app"]);
 
 export interface SessionSourceDeleteTarget {
   source: SessionSource;
@@ -92,7 +91,7 @@ export function deleteLocalSessionSources(targets: readonly SessionSourceDeleteT
 function deleteCodexAppStateRows(targets: readonly SessionSourceDeleteTarget[]): void {
   const idsByCodexHome = new Map<string, Set<string>>();
   for (const target of targets) {
-    if (!CODEX_APP_SESSION_SOURCES.has(target.source) || !target.rawId) continue;
+    if (target.source !== "codex-app" || !target.rawId) continue;
     const codexHome = codexHomeForRollout(target.filePath);
     if (!codexHome) continue;
     const ids = idsByCodexHome.get(codexHome) ?? new Set<string>();

--- a/apps/main-1.0/src/core/session-source-delete.ts
+++ b/apps/main-1.0/src/core/session-source-delete.ts
@@ -90,26 +90,28 @@ export function deleteLocalSessionSources(targets: readonly SessionSourceDeleteT
 }
 
 function deleteCodexAppStateRows(targets: readonly SessionSourceDeleteTarget[]): void {
-  const idsByDatabase = new Map<string, Set<string>>();
+  const idsByCodexHome = new Map<string, Set<string>>();
   for (const target of targets) {
     if (!CODEX_APP_SESSION_SOURCES.has(target.source) || !target.rawId) continue;
     const codexHome = codexHomeForRollout(target.filePath);
     if (!codexHome) continue;
-    for (const entry of listCodexStateDatabases(codexHome)) {
-      const ids = idsByDatabase.get(entry) ?? new Set<string>();
-      ids.add(target.rawId);
-      idsByDatabase.set(entry, ids);
-    }
+    const ids = idsByCodexHome.get(codexHome) ?? new Set<string>();
+    ids.add(target.rawId);
+    idsByCodexHome.set(codexHome, ids);
   }
 
-  for (const [databasePath, ids] of idsByDatabase) {
-    const database = openCodexStateDatabase(databasePath);
-    if (!database) continue;
-    try {
-      deleteCodexThreadRows(database, [...ids]);
-    } finally {
-      database.close();
+  for (const [codexHome, ids] of idsByCodexHome) {
+    const familyIds = new Set(ids);
+    for (const databasePath of listCodexStateDatabases(codexHome)) {
+      const database = openCodexStateDatabase(databasePath);
+      if (!database) continue;
+      try {
+        for (const id of deleteCodexThreadRows(database, [...familyIds])) familyIds.add(id);
+      } finally {
+        database.close();
+      }
     }
+    deleteCodexSessionIndexRows(codexHome, [...familyIds]);
   }
 }
 
@@ -146,21 +148,83 @@ function openCodexStateDatabase(databasePath: string): DatabaseSyncType | null {
   }
 }
 
-function deleteCodexThreadRows(database: DatabaseSyncType, sessionIds: string[]): void {
+function deleteCodexThreadRows(database: DatabaseSyncType, sessionIds: string[]): string[] {
   const ids = [...new Set(sessionIds.filter(Boolean))];
-  if (ids.length === 0 || !sqliteTableHasColumns(database, "threads", ["id"])) return;
-  const placeholders = ids.map(() => "?").join(", ");
+  if (ids.length === 0 || !sqliteTableHasColumns(database, "threads", ["id"])) return ids;
+  const familyIds = expandCodexThreadIds(database, ids);
+  const placeholders = familyIds.map(() => "?").join(", ");
   database.exec("BEGIN IMMEDIATE");
   try {
     if (sqliteTableHasColumns(database, "thread_spawn_edges", ["parent_thread_id", "child_thread_id"])) {
       database.prepare(
         `DELETE FROM thread_spawn_edges WHERE parent_thread_id IN (${placeholders}) OR child_thread_id IN (${placeholders})`,
-      ).run(...ids, ...ids);
+      ).run(...familyIds, ...familyIds);
     }
-    database.prepare(`DELETE FROM threads WHERE id IN (${placeholders})`).run(...ids);
+    if (sqliteTableHasColumns(database, "thread_dynamic_tools", ["thread_id"])) {
+      database.prepare(`DELETE FROM thread_dynamic_tools WHERE thread_id IN (${placeholders})`).run(...familyIds);
+    }
+    database.prepare(`DELETE FROM threads WHERE id IN (${placeholders})`).run(...familyIds);
     database.exec("COMMIT");
   } catch (error) {
     try { database.exec("ROLLBACK"); } catch { /* preserve the original error */ }
+    throw error;
+  }
+  return familyIds;
+}
+
+function expandCodexThreadIds(database: DatabaseSyncType, sessionIds: string[]): string[] {
+  if (!sqliteTableHasColumns(database, "thread_spawn_edges", ["parent_thread_id", "child_thread_id"])) {
+    return sessionIds;
+  }
+  const placeholders = sessionIds.map(() => "?").join(", ");
+  const rows = database.prepare(`
+    WITH RECURSIVE family(id) AS (
+      SELECT id FROM threads WHERE id IN (${placeholders})
+      UNION
+      SELECT edge.child_thread_id
+      FROM family
+      INNER JOIN thread_spawn_edges edge ON edge.parent_thread_id = family.id
+    )
+    SELECT DISTINCT id FROM family
+  `).all(...sessionIds) as Array<{ id?: unknown }>;
+  return [...new Set([
+    ...sessionIds,
+    ...rows.map((row) => typeof row.id === "string" ? row.id : "").filter(Boolean),
+  ])];
+}
+
+function deleteCodexSessionIndexRows(codexHome: string, sessionIds: string[]): void {
+  const indexPath = path.join(codexHome, "session_index.jsonl");
+  let content: string;
+  try {
+    content = fs.readFileSync(indexPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+  const ids = new Set(sessionIds);
+  const lines = content.split(/\r?\n/u);
+  let changed = false;
+  const kept = lines.filter((line) => {
+    if (!line.trim()) return true;
+    try {
+      const parsed = JSON.parse(line) as { id?: unknown };
+      if (typeof parsed.id === "string" && ids.has(parsed.id)) {
+        changed = true;
+        return false;
+      }
+    } catch {
+      // Preserve unrelated malformed rows; the normal Codex indexer will report them.
+    }
+    return true;
+  });
+  if (!changed) return;
+  const tempPath = `${indexPath}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    fs.writeFileSync(tempPath, kept.join("\n"), "utf8");
+    fs.renameSync(tempPath, indexPath);
+  } catch (error) {
+    try { fs.rmSync(tempPath, { force: true }); } catch { /* preserve the original error */ }
     throw error;
   }
 }

--- a/apps/main-1.0/src/core/session-source-delete.ts
+++ b/apps/main-1.0/src/core/session-source-delete.ts
@@ -102,16 +102,29 @@ function deleteCodexAppStateRows(targets: readonly SessionSourceDeleteTarget[]):
 
   for (const [codexHome, ids] of idsByCodexHome) {
     const familyIds = new Set(ids);
-    for (const databasePath of listCodexStateDatabases(codexHome)) {
-      const database = openCodexStateDatabase(databasePath);
-      if (!database) continue;
+    let databasePaths: string[] = [];
+    try {
+      databasePaths = listCodexStateDatabases(codexHome);
+    } catch {
+      // Codex state is auxiliary; an unavailable home must not block deletion.
+    }
+    for (const databasePath of databasePaths) {
+      let database: DatabaseSyncType | null = null;
       try {
+        database = openCodexStateDatabase(databasePath);
+        if (!database) continue;
         for (const id of deleteCodexThreadRows(database, [...familyIds])) familyIds.add(id);
+      } catch {
+        // Codex may hold a write lock while the app is running. State cleanup is best-effort.
       } finally {
-        database.close();
+        try { database?.close(); } catch { /* preserve the best-effort boundary */ }
       }
     }
-    deleteCodexSessionIndexRows(codexHome, [...familyIds]);
+    try {
+      deleteCodexSessionIndexRows(codexHome, [...familyIds]);
+    } catch {
+      // A stale native index must never turn a successful source deletion into a failure.
+    }
   }
 }
 

--- a/apps/main-1.0/src/core/store/sessions.ts
+++ b/apps/main-1.0/src/core/store/sessions.ts
@@ -763,7 +763,11 @@ export class SessionsStore {
       throw new Error("Cannot delete shared CodeWiz source database.");
     }
 
-    if (row.sourceAvailable) deleteLocalSessionSources(targets.filter((target) => target.sourceAvailable));
+    if (row.source === "codex-app") {
+      deleteLocalSessionSources(targets);
+    } else if (row.sourceAvailable) {
+      deleteLocalSessionSources(targets.filter((target) => target.sourceAvailable));
+    }
     return this.deleteSessionRecords(targets.map((target) => target.sessionKey), false).includes(sessionKey);
   }
 

--- a/apps/main-1.0/src/main/services/session-bulk-delete-service.ts
+++ b/apps/main-1.0/src/main/services/session-bulk-delete-service.ts
@@ -281,6 +281,12 @@ async function deleteTargetFamily(
 ): Promise<void> {
   const cascadeRoot = targets.find((target) => target.sessionKey === target.cascadeRootSessionKey);
   if (!cascadeRoot) throw new Error("Session deletion family is missing its cascade root.");
+  const staleCodexAppTargets = targets.filter((target) =>
+    target.source === "codex-app"
+    && !target.sourceAvailable
+    && target.environmentKind === "local",
+  );
+  if (staleCodexAppTargets.length > 0) deleteLocalSessionSources(staleCodexAppTargets);
   if (!cascadeRoot.sourceAvailable && !cascadeRoot.orphanedParentSessionId) return;
   const availableTargets = targets.filter((target) => target.sourceAvailable);
   if (availableTargets.length === 0) return;

--- a/apps/main-2.0/src/core/session-source-delete.test.ts
+++ b/apps/main-2.0/src/core/session-source-delete.test.ts
@@ -1,8 +1,12 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { createRequire } from "node:module";
 import { describe, expect, it } from "vitest";
 import { deleteLocalSessionSources, sessionSourceDeletionPaths } from "./session-source-delete";
+
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require("node:sqlite") as { DatabaseSync: typeof import("node:sqlite").DatabaseSync };
 
 describe("session source deletion", () => {
   it("rejects relative source paths before deleting anything", () => {
@@ -145,6 +149,42 @@ describe("session source deletion", () => {
       expect(fs.existsSync(parentFile)).toBe(true);
       expect(fs.existsSync(childFile)).toBe(true);
       expect(fs.existsSync(subagentsDirectory)).toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("removes stale Codex App state rows when the rollout file is already missing", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-codex-app-state-delete-"));
+    const codexHome = path.join(root, ".codex");
+    const rolloutPath = path.join(codexHome, "sessions", "2026", "08", "18", "rollout-stale.jsonl");
+    const statePath = path.join(codexHome, "state_1.sqlite");
+    const sessionId = "550e8400-e29b-41d4-a716-446655440000";
+    fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+    const db = new DatabaseSync(statePath);
+    db.exec(`
+      CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT NOT NULL);
+      CREATE TABLE thread_spawn_edges (parent_thread_id TEXT NOT NULL, child_thread_id TEXT NOT NULL PRIMARY KEY);
+    `);
+    db.prepare("INSERT INTO threads (id, rollout_path) VALUES (?, ?)").run(sessionId, rolloutPath);
+    db.prepare("INSERT INTO thread_spawn_edges (parent_thread_id, child_thread_id) VALUES (?, ?)").run(sessionId, "child");
+    db.close();
+
+    try {
+      deleteLocalSessionSources([{
+        source: "codex-app",
+        rawId: sessionId,
+        filePath: rolloutPath,
+        isSubagent: false,
+      }]);
+
+      const verify = new DatabaseSync(statePath);
+      try {
+        expect(verify.prepare("SELECT id FROM threads WHERE id = ?").get(sessionId)).toBeUndefined();
+        expect(verify.prepare("SELECT child_thread_id FROM thread_spawn_edges WHERE parent_thread_id = ?").get(sessionId)).toBeUndefined();
+      } finally {
+        verify.close();
+      }
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }

--- a/apps/main-2.0/src/core/session-source-delete.test.ts
+++ b/apps/main-2.0/src/core/session-source-delete.test.ts
@@ -199,4 +199,42 @@ describe("session source deletion", () => {
       fs.rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("does not fail source deletion when Codex state cleanup is unavailable", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-codex-app-state-best-effort-"));
+    const codexHome = path.join(root, ".codex");
+    const rolloutPath = path.join(codexHome, "sessions", "2026", "08", "19", "rollout-busy.jsonl");
+    const statePath = path.join(codexHome, "state_1.sqlite");
+    const sessionId = "750e8400-e29b-41d4-a716-446655440000";
+    fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+    fs.writeFileSync(rolloutPath, "fixture", "utf8");
+    fs.writeFileSync(
+      path.join(codexHome, "session_index.jsonl"),
+      `${JSON.stringify({ id: sessionId, thread_name: "busy" })}\n`,
+    );
+    const db = new DatabaseSync(statePath);
+    db.exec(`
+      CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT NOT NULL);
+      CREATE TRIGGER block_thread_delete
+      BEFORE DELETE ON threads
+      BEGIN
+        SELECT RAISE(ABORT, 'state cleanup blocked');
+      END;
+    `);
+    db.prepare("INSERT INTO threads (id, rollout_path) VALUES (?, ?)").run(sessionId, rolloutPath);
+    db.close();
+
+    try {
+      expect(() => deleteLocalSessionSources([{
+        source: "codex-app",
+        rawId: sessionId,
+        filePath: rolloutPath,
+        isSubagent: false,
+      }])).not.toThrow();
+      expect(fs.existsSync(rolloutPath)).toBe(false);
+      expect(fs.readFileSync(path.join(codexHome, "session_index.jsonl"), "utf8")).toBe("");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/apps/main-2.0/src/core/session-source-delete.test.ts
+++ b/apps/main-2.0/src/core/session-source-delete.test.ts
@@ -160,14 +160,20 @@ describe("session source deletion", () => {
     const rolloutPath = path.join(codexHome, "sessions", "2026", "08", "18", "rollout-stale.jsonl");
     const statePath = path.join(codexHome, "state_1.sqlite");
     const sessionId = "550e8400-e29b-41d4-a716-446655440000";
+    const childId = "650e8400-e29b-41d4-a716-446655440000";
     fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+    fs.writeFileSync(
+      path.join(codexHome, "session_index.jsonl"),
+      `${JSON.stringify({ id: sessionId, thread_name: "stale" })}\n${JSON.stringify({ id: "keep", thread_name: "keep" })}\n`,
+    );
     const db = new DatabaseSync(statePath);
     db.exec(`
       CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT NOT NULL);
       CREATE TABLE thread_spawn_edges (parent_thread_id TEXT NOT NULL, child_thread_id TEXT NOT NULL PRIMARY KEY);
     `);
     db.prepare("INSERT INTO threads (id, rollout_path) VALUES (?, ?)").run(sessionId, rolloutPath);
-    db.prepare("INSERT INTO thread_spawn_edges (parent_thread_id, child_thread_id) VALUES (?, ?)").run(sessionId, "child");
+    db.prepare("INSERT INTO threads (id, rollout_path) VALUES (?, ?)").run(childId, `${rolloutPath}.child`);
+    db.prepare("INSERT INTO thread_spawn_edges (parent_thread_id, child_thread_id) VALUES (?, ?)").run(sessionId, childId);
     db.close();
 
     try {
@@ -181,10 +187,14 @@ describe("session source deletion", () => {
       const verify = new DatabaseSync(statePath);
       try {
         expect(verify.prepare("SELECT id FROM threads WHERE id = ?").get(sessionId)).toBeUndefined();
+        expect(verify.prepare("SELECT id FROM threads WHERE id = ?").get(childId)).toBeUndefined();
         expect(verify.prepare("SELECT child_thread_id FROM thread_spawn_edges WHERE parent_thread_id = ?").get(sessionId)).toBeUndefined();
       } finally {
         verify.close();
       }
+      expect(fs.readFileSync(path.join(codexHome, "session_index.jsonl"), "utf8")).toBe(
+        `${JSON.stringify({ id: "keep", thread_name: "keep" })}\n`,
+      );
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }

--- a/apps/main-2.0/src/core/session-source-delete.ts
+++ b/apps/main-2.0/src/core/session-source-delete.ts
@@ -1,8 +1,14 @@
 import * as fs from "node:fs";
+import { createRequire } from "node:module";
 import * as path from "node:path";
+import type { DatabaseSync as DatabaseSyncType } from "node:sqlite";
 import type { SessionSource } from "./types";
 
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require("node:sqlite") as { DatabaseSync: typeof DatabaseSyncType };
+
 const CLAUDE_SESSION_FILE_SOURCES = new Set<SessionSource>(["claude-cli", "claude-app"]);
+const CODEX_APP_SESSION_SOURCES = new Set<SessionSource>(["codex-app"]);
 
 export interface SessionSourceDeleteTarget {
   source: SessionSource;
@@ -80,6 +86,95 @@ export function deleteLocalSessionSources(targets: readonly SessionSourceDeleteT
   for (const filePath of deletionPaths.files) deleteRegularFile(filePath);
   for (const directoryPath of deletionPaths.directories) deleteOwnedDirectory(directoryPath);
   for (const directoryPath of deletionPaths.emptyDirectories) removeEmptyDirectory(directoryPath);
+  deleteCodexAppStateRows(targets);
+}
+
+function deleteCodexAppStateRows(targets: readonly SessionSourceDeleteTarget[]): void {
+  const idsByDatabase = new Map<string, Set<string>>();
+  for (const target of targets) {
+    if (!CODEX_APP_SESSION_SOURCES.has(target.source) || !target.rawId) continue;
+    const codexHome = codexHomeForRollout(target.filePath);
+    if (!codexHome) continue;
+    for (const entry of listCodexStateDatabases(codexHome)) {
+      const ids = idsByDatabase.get(entry) ?? new Set<string>();
+      ids.add(target.rawId);
+      idsByDatabase.set(entry, ids);
+    }
+  }
+
+  for (const [databasePath, ids] of idsByDatabase) {
+    const database = openCodexStateDatabase(databasePath);
+    if (!database) continue;
+    try {
+      deleteCodexThreadRows(database, [...ids]);
+    } finally {
+      database.close();
+    }
+  }
+}
+
+function codexHomeForRollout(filePath: string): string | null {
+  let current = path.dirname(filePath);
+  for (;;) {
+    if (path.basename(current).toLowerCase() === "sessions") {
+      const codexHome = path.dirname(current);
+      return path.basename(codexHome).toLowerCase() === ".codex" ? codexHome : null;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function listCodexStateDatabases(codexHome: string): string[] {
+  try {
+    return fs.readdirSync(codexHome, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && /^state_\d+\.sqlite$/iu.test(entry.name))
+      .map((entry) => path.join(codexHome, entry.name));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+function openCodexStateDatabase(databasePath: string): DatabaseSyncType | null {
+  try {
+    return new DatabaseSync(databasePath, { timeout: 5_000 });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function deleteCodexThreadRows(database: DatabaseSyncType, sessionIds: string[]): void {
+  const ids = [...new Set(sessionIds.filter(Boolean))];
+  if (ids.length === 0 || !sqliteTableHasColumns(database, "threads", ["id"])) return;
+  const placeholders = ids.map(() => "?").join(", ");
+  database.exec("BEGIN IMMEDIATE");
+  try {
+    if (sqliteTableHasColumns(database, "thread_spawn_edges", ["parent_thread_id", "child_thread_id"])) {
+      database.prepare(
+        `DELETE FROM thread_spawn_edges WHERE parent_thread_id IN (${placeholders}) OR child_thread_id IN (${placeholders})`,
+      ).run(...ids, ...ids);
+    }
+    database.prepare(`DELETE FROM threads WHERE id IN (${placeholders})`).run(...ids);
+    database.exec("COMMIT");
+  } catch (error) {
+    try { database.exec("ROLLBACK"); } catch { /* preserve the original error */ }
+    throw error;
+  }
+}
+
+function sqliteTableHasColumns(database: DatabaseSyncType, table: string, columns: string[]): boolean {
+  const present = database.prepare(
+    "SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?",
+  ).get(table);
+  if (!present) return false;
+  const available = new Set(
+    (database.prepare(`PRAGMA table_info("${table.replaceAll('"', '""')}")`).all() as Array<{ name?: unknown }>)
+      .map((column) => typeof column.name === "string" ? column.name : ""),
+  );
+  return columns.every((column) => available.has(column));
 }
 
 function validateDeletionPaths(deletionPaths: SessionSourceDeletionPaths): void {

--- a/apps/main-2.0/src/core/session-source-delete.ts
+++ b/apps/main-2.0/src/core/session-source-delete.ts
@@ -8,7 +8,6 @@ const require = createRequire(import.meta.url);
 const { DatabaseSync } = require("node:sqlite") as { DatabaseSync: typeof DatabaseSyncType };
 
 const CLAUDE_SESSION_FILE_SOURCES = new Set<SessionSource>(["claude-cli", "claude-app"]);
-const CODEX_APP_SESSION_SOURCES = new Set<SessionSource>(["codex-app"]);
 
 export interface SessionSourceDeleteTarget {
   source: SessionSource;
@@ -92,7 +91,7 @@ export function deleteLocalSessionSources(targets: readonly SessionSourceDeleteT
 function deleteCodexAppStateRows(targets: readonly SessionSourceDeleteTarget[]): void {
   const idsByCodexHome = new Map<string, Set<string>>();
   for (const target of targets) {
-    if (!CODEX_APP_SESSION_SOURCES.has(target.source) || !target.rawId) continue;
+    if (target.source !== "codex-app" || !target.rawId) continue;
     const codexHome = codexHomeForRollout(target.filePath);
     if (!codexHome) continue;
     const ids = idsByCodexHome.get(codexHome) ?? new Set<string>();

--- a/apps/main-2.0/src/core/session-source-delete.ts
+++ b/apps/main-2.0/src/core/session-source-delete.ts
@@ -90,26 +90,28 @@ export function deleteLocalSessionSources(targets: readonly SessionSourceDeleteT
 }
 
 function deleteCodexAppStateRows(targets: readonly SessionSourceDeleteTarget[]): void {
-  const idsByDatabase = new Map<string, Set<string>>();
+  const idsByCodexHome = new Map<string, Set<string>>();
   for (const target of targets) {
     if (!CODEX_APP_SESSION_SOURCES.has(target.source) || !target.rawId) continue;
     const codexHome = codexHomeForRollout(target.filePath);
     if (!codexHome) continue;
-    for (const entry of listCodexStateDatabases(codexHome)) {
-      const ids = idsByDatabase.get(entry) ?? new Set<string>();
-      ids.add(target.rawId);
-      idsByDatabase.set(entry, ids);
-    }
+    const ids = idsByCodexHome.get(codexHome) ?? new Set<string>();
+    ids.add(target.rawId);
+    idsByCodexHome.set(codexHome, ids);
   }
 
-  for (const [databasePath, ids] of idsByDatabase) {
-    const database = openCodexStateDatabase(databasePath);
-    if (!database) continue;
-    try {
-      deleteCodexThreadRows(database, [...ids]);
-    } finally {
-      database.close();
+  for (const [codexHome, ids] of idsByCodexHome) {
+    const familyIds = new Set(ids);
+    for (const databasePath of listCodexStateDatabases(codexHome)) {
+      const database = openCodexStateDatabase(databasePath);
+      if (!database) continue;
+      try {
+        for (const id of deleteCodexThreadRows(database, [...familyIds])) familyIds.add(id);
+      } finally {
+        database.close();
+      }
     }
+    deleteCodexSessionIndexRows(codexHome, [...familyIds]);
   }
 }
 
@@ -146,21 +148,83 @@ function openCodexStateDatabase(databasePath: string): DatabaseSyncType | null {
   }
 }
 
-function deleteCodexThreadRows(database: DatabaseSyncType, sessionIds: string[]): void {
+function deleteCodexThreadRows(database: DatabaseSyncType, sessionIds: string[]): string[] {
   const ids = [...new Set(sessionIds.filter(Boolean))];
-  if (ids.length === 0 || !sqliteTableHasColumns(database, "threads", ["id"])) return;
-  const placeholders = ids.map(() => "?").join(", ");
+  if (ids.length === 0 || !sqliteTableHasColumns(database, "threads", ["id"])) return ids;
+  const familyIds = expandCodexThreadIds(database, ids);
+  const placeholders = familyIds.map(() => "?").join(", ");
   database.exec("BEGIN IMMEDIATE");
   try {
     if (sqliteTableHasColumns(database, "thread_spawn_edges", ["parent_thread_id", "child_thread_id"])) {
       database.prepare(
         `DELETE FROM thread_spawn_edges WHERE parent_thread_id IN (${placeholders}) OR child_thread_id IN (${placeholders})`,
-      ).run(...ids, ...ids);
+      ).run(...familyIds, ...familyIds);
     }
-    database.prepare(`DELETE FROM threads WHERE id IN (${placeholders})`).run(...ids);
+    if (sqliteTableHasColumns(database, "thread_dynamic_tools", ["thread_id"])) {
+      database.prepare(`DELETE FROM thread_dynamic_tools WHERE thread_id IN (${placeholders})`).run(...familyIds);
+    }
+    database.prepare(`DELETE FROM threads WHERE id IN (${placeholders})`).run(...familyIds);
     database.exec("COMMIT");
   } catch (error) {
     try { database.exec("ROLLBACK"); } catch { /* preserve the original error */ }
+    throw error;
+  }
+  return familyIds;
+}
+
+function expandCodexThreadIds(database: DatabaseSyncType, sessionIds: string[]): string[] {
+  if (!sqliteTableHasColumns(database, "thread_spawn_edges", ["parent_thread_id", "child_thread_id"])) {
+    return sessionIds;
+  }
+  const placeholders = sessionIds.map(() => "?").join(", ");
+  const rows = database.prepare(`
+    WITH RECURSIVE family(id) AS (
+      SELECT id FROM threads WHERE id IN (${placeholders})
+      UNION
+      SELECT edge.child_thread_id
+      FROM family
+      INNER JOIN thread_spawn_edges edge ON edge.parent_thread_id = family.id
+    )
+    SELECT DISTINCT id FROM family
+  `).all(...sessionIds) as Array<{ id?: unknown }>;
+  return [...new Set([
+    ...sessionIds,
+    ...rows.map((row) => typeof row.id === "string" ? row.id : "").filter(Boolean),
+  ])];
+}
+
+function deleteCodexSessionIndexRows(codexHome: string, sessionIds: string[]): void {
+  const indexPath = path.join(codexHome, "session_index.jsonl");
+  let content: string;
+  try {
+    content = fs.readFileSync(indexPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+  const ids = new Set(sessionIds);
+  const lines = content.split(/\r?\n/u);
+  let changed = false;
+  const kept = lines.filter((line) => {
+    if (!line.trim()) return true;
+    try {
+      const parsed = JSON.parse(line) as { id?: unknown };
+      if (typeof parsed.id === "string" && ids.has(parsed.id)) {
+        changed = true;
+        return false;
+      }
+    } catch {
+      // Preserve unrelated malformed rows; the normal Codex indexer will report them.
+    }
+    return true;
+  });
+  if (!changed) return;
+  const tempPath = `${indexPath}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    fs.writeFileSync(tempPath, kept.join("\n"), "utf8");
+    fs.renameSync(tempPath, indexPath);
+  } catch (error) {
+    try { fs.rmSync(tempPath, { force: true }); } catch { /* preserve the original error */ }
     throw error;
   }
 }

--- a/apps/main-2.0/src/core/session-source-delete.ts
+++ b/apps/main-2.0/src/core/session-source-delete.ts
@@ -102,16 +102,29 @@ function deleteCodexAppStateRows(targets: readonly SessionSourceDeleteTarget[]):
 
   for (const [codexHome, ids] of idsByCodexHome) {
     const familyIds = new Set(ids);
-    for (const databasePath of listCodexStateDatabases(codexHome)) {
-      const database = openCodexStateDatabase(databasePath);
-      if (!database) continue;
+    let databasePaths: string[] = [];
+    try {
+      databasePaths = listCodexStateDatabases(codexHome);
+    } catch {
+      // Codex state is auxiliary; an unavailable home must not block deletion.
+    }
+    for (const databasePath of databasePaths) {
+      let database: DatabaseSyncType | null = null;
       try {
+        database = openCodexStateDatabase(databasePath);
+        if (!database) continue;
         for (const id of deleteCodexThreadRows(database, [...familyIds])) familyIds.add(id);
+      } catch {
+        // Codex may hold a write lock while the app is running. State cleanup is best-effort.
       } finally {
-        database.close();
+        try { database?.close(); } catch { /* preserve the best-effort boundary */ }
       }
     }
-    deleteCodexSessionIndexRows(codexHome, [...familyIds]);
+    try {
+      deleteCodexSessionIndexRows(codexHome, [...familyIds]);
+    } catch {
+      // A stale native index must never turn a successful source deletion into a failure.
+    }
   }
 }
 

--- a/apps/main-2.0/src/core/session-store.ts
+++ b/apps/main-2.0/src/core/session-store.ts
@@ -317,7 +317,11 @@ export class SessionStore {
       }
       throw new Error("Cannot delete shared Cursor source database.");
     }
-    if (target.sourceAvailable) deleteLocalSessionSources(targets.filter((item) => item.sourceAvailable));
+    if (target.source === "codex-app") {
+      deleteLocalSessionSources(targets);
+    } else if (target.sourceAvailable) {
+      deleteLocalSessionSources(targets.filter((item) => item.sourceAvailable));
+    }
     return this.deleteSessionTargetRecords(targets, requestedSessionKey);
   }
 

--- a/apps/main-2.0/src/main/services/session-bulk-delete-service.ts
+++ b/apps/main-2.0/src/main/services/session-bulk-delete-service.ts
@@ -316,6 +316,12 @@ async function deleteTargetFamily(
 ): Promise<void> {
   const cascadeRoot = targets.find((target) => target.sessionKey === target.cascadeRootSessionKey);
   if (!cascadeRoot) throw new Error("Session deletion family is missing its cascade root.");
+  const staleCodexAppTargets = targets.filter((target) =>
+    target.source === "codex-app"
+    && !target.sourceAvailable
+    && target.environmentKind === "local",
+  );
+  if (staleCodexAppTargets.length > 0) deleteLocalSessionSources(staleCodexAppTargets);
   if (!cascadeRoot.sourceAvailable && !cascadeRoot.orphanedParentSessionId) return;
   const availableTargets = targets.filter((target) => target.sourceAvailable);
   if (availableTargets.length === 0) return;


### PR DESCRIPTION
## 变更\n- 删除 Codex App rollout 时同步清理对应 state_*.sqlite 的 threads 和 spawn edge 记录\n- 覆盖 V1/V2，并处理 rollout 文件已缺失但状态记录仍残留的情况\n\n## 验证\n- V1/V2 session-source-delete 与 session-bulk-delete-service 测试通过\n- V1 typecheck 通过\n- V2 typecheck 受仓库现有 yaml 依赖缺失阻断