### PR TITLE
fix: keep SSH Codex parent and child sessions distinct

### DIFF
--- a/.release-notes/fix-ssh-codex-session.md
+++ b/.release-notes/fix-ssh-codex-session.md
@@ -1,0 +1,6 @@
+# 修复 SSH Codex 父子会话记录
+<!-- release-target: both -->
+
+## Bug 修复
+
+- 修复 SSH 环境中的 Codex 子 Agent 会话携带父会话信息时，父会话可能被覆盖并从会话列表消失的问题。

--- a/apps/main-1.0/src/core/remote-sync.test.ts
+++ b/apps/main-1.0/src/core/remote-sync.test.ts
@@ -191,6 +191,91 @@ describe("remote sync", () => {
     }
   });
 
+  it("keeps a Codex child distinct when its rollout repeats inherited parent metadata", async () => {
+    const store = createInMemoryStore();
+    const environment = upsertSshEnvironment(store);
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-remote-inherited-meta-"));
+    const parentId = "codex-parent";
+    const childId = "codex-child";
+    const parentStartedAt = "2026-08-20T06:30:00Z";
+    const childStartedAt = "2026-08-20T06:31:00Z";
+    const inheritedAt = "2026-08-20T06:35:00Z";
+    const resumedAt = "2026-08-20T06:40:00Z";
+    const writeJsonl = (filePath: string, rows: unknown[]) => {
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, rows.map((row) => JSON.stringify(row)).join("\n"), "utf8");
+    };
+    const message = (text: string) => ({
+      type: "response_item",
+      payload: { type: "message", role: "user", content: [{ type: "input_text", text }] },
+    });
+    try {
+      writeJsonl(path.join(tempHome, ".codex", "sessions", "2026", "08", "20", "parent.jsonl"), [
+        {
+          type: "session_meta",
+          timestamp: parentStartedAt,
+          payload: { id: parentId, cwd: "/repo/parent", source: "vscode" },
+        },
+        message("parent question"),
+      ]);
+      writeJsonl(path.join(tempHome, ".codex", "sessions", "2026", "08", "20", "child.jsonl"), [
+        {
+          type: "session_meta",
+          timestamp: childStartedAt,
+          payload: {
+            id: childId,
+            session_id: parentId,
+            cwd: "/repo/child",
+            source: { subagent: { thread_spawn: { parent_thread_id: parentId, depth: 1 } } },
+            thread_source: "subagent",
+            parent_thread_id: parentId,
+          },
+        },
+        message("child task"),
+        {
+          type: "session_meta",
+          timestamp: inheritedAt,
+          payload: { id: parentId, cwd: "/repo/parent", source: "vscode" },
+        },
+        {
+          type: "session_meta",
+          timestamp: resumedAt,
+          payload: { id: parentId, cwd: "/repo/parent", source: "vscode" },
+        },
+      ]);
+
+      await syncRemoteEnvironment(store, environment, {
+        runSsh: async (_environment, remoteCommand) => execFileSync(
+          "python3",
+          ["-c", decodeCollectorScript(remoteCommand)],
+          { encoding: "utf8", env: { ...process.env, HOME: tempHome } },
+        ),
+      });
+
+      const sessions = store.searchSessions({ environmentId: environment.id, excludeSubagents: false });
+      expect(sessions).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          sessionKey: `ssh:ssh-devbox:codex-cli:${parentId}`,
+          rawId: parentId,
+          projectPath: "/repo/parent",
+          isSubagent: false,
+        }),
+        expect.objectContaining({
+          sessionKey: `ssh:ssh-devbox:codex-cli:${childId}`,
+          rawId: childId,
+          projectPath: "/repo/child",
+          timestamp: new Date(childStartedAt).getTime(),
+          isSubagent: true,
+          parentSessionId: parentId,
+        }),
+      ]));
+      expect(sessions).toHaveLength(2);
+    } finally {
+      store.close();
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
   it("indexes only the effective Codex and Claude branches from SSH summaries", async () => {
     const store = createInMemoryStore();
     const environment = upsertSshEnvironment(store);

--- a/apps/main-1.0/src/core/remote-sync.test.ts
+++ b/apps/main-1.0/src/core/remote-sync.test.ts
@@ -225,13 +225,18 @@ describe("remote sync", () => {
           payload: {
             id: childId,
             session_id: parentId,
-            cwd: "/repo/child",
+            cwd: "<local-workspace>",
             source: { subagent: { thread_spawn: { parent_thread_id: parentId, depth: 1 } } },
             thread_source: "subagent",
             parent_thread_id: parentId,
           },
         },
         message("child task"),
+        {
+          type: "session_meta",
+          timestamp: "2026-08-20T06:32:00Z",
+          payload: { id: childId, cwd: "/repo/child" },
+        },
         {
           type: "session_meta",
           timestamp: inheritedAt,

--- a/apps/main-1.0/src/core/remote-sync.test.ts
+++ b/apps/main-1.0/src/core/remote-sync.test.ts
@@ -248,6 +248,14 @@ describe("remote sync", () => {
           payload: { id: parentId, cwd: "/repo/parent", source: "vscode" },
         },
       ]);
+      writeJsonl(path.join(tempHome, ".codex", "sessions", "2026", "08", "20", "session-id-only.jsonl"), [
+        {
+          type: "session_meta",
+          timestamp: "2026-08-20T06:45:00Z",
+          payload: { session_id: "semantic-session-id", cwd: "/repo/legacy" },
+        },
+        message("legacy identity question"),
+      ]);
 
       await syncRemoteEnvironment(store, environment, {
         runSsh: async (_environment, remoteCommand) => execFileSync(
@@ -273,8 +281,14 @@ describe("remote sync", () => {
           isSubagent: true,
           parentSessionId: parentId,
         }),
+        expect.objectContaining({
+          sessionKey: "ssh:ssh-devbox:codex-cli:session-id-only",
+          rawId: "session-id-only",
+          projectPath: "/repo/legacy",
+        }),
       ]));
-      expect(sessions).toHaveLength(2);
+      expect(sessions).toHaveLength(3);
+      expect(store.getSession("ssh:ssh-devbox:codex-cli:semantic-session-id")).toBeNull();
     } finally {
       store.close();
       fs.rmSync(tempHome, { recursive: true, force: true });

--- a/apps/main-1.0/src/core/remote-sync.ts
+++ b/apps/main-1.0/src/core/remote-sync.ts
@@ -1225,34 +1225,34 @@ def emit_codex_summary(path, stat, titles, source):
         if row.get("type") == "session_meta":
           payload = row.get("payload")
           if isinstance(payload, dict):
-            session_id = payload.get("id")
-            if not isinstance(session_id, str) or not session_id:
-              session_id = payload.get("session_id")
-            if isinstance(session_id, str) and session_id:
+            meta_id = payload.get("id")
+            same_identity = not session_identity_found
+            if isinstance(meta_id, str) and meta_id:
               if not session_identity_found:
-                raw_id = session_id
+                raw_id = meta_id
                 session_identity_found = True
-              if session_id == raw_id:
-                candidate_project_path = payload.get("cwd")
-                if not usable_codex_project_path(project_path) and isinstance(candidate_project_path, str):
-                  project_path = candidate_project_path
-                git = payload.get("git")
-                if not git_branch and isinstance(git, dict) and isinstance(git.get("branch"), str):
-                  git_branch = git.get("branch")
-                structured_source = payload.get("source")
-                if isinstance(structured_source, dict):
-                  subagent = structured_source.get("subagent")
-                  thread_spawn = subagent.get("thread_spawn") if isinstance(subagent, dict) else None
-                  if isinstance(thread_spawn, dict) and isinstance(thread_spawn.get("parent_thread_id"), str):
-                    is_subagent = True
-                    parent_session_id = parent_session_id or thread_spawn.get("parent_thread_id")
-                if payload.get("thread_source") == "subagent" and isinstance(payload.get("parent_thread_id"), str):
+              same_identity = meta_id == raw_id
+            if same_identity:
+              candidate_project_path = payload.get("cwd")
+              if not usable_codex_project_path(project_path) and isinstance(candidate_project_path, str):
+                project_path = candidate_project_path
+              git = payload.get("git")
+              if not git_branch and isinstance(git, dict) and isinstance(git.get("branch"), str):
+                git_branch = git.get("branch")
+              structured_source = payload.get("source")
+              if isinstance(structured_source, dict):
+                subagent = structured_source.get("subagent")
+                thread_spawn = subagent.get("thread_spawn") if isinstance(subagent, dict) else None
+                if isinstance(thread_spawn, dict) and isinstance(thread_spawn.get("parent_thread_id"), str):
                   is_subagent = True
-                  parent_session_id = parent_session_id or payload.get("parent_thread_id")
-                parsed_timestamp = _iso_timestamp_ms(row.get("timestamp"))
-                if parsed_timestamp is not None and not session_timestamp_found:
-                  timestamp = parsed_timestamp
-                  session_timestamp_found = True
+                  parent_session_id = parent_session_id or thread_spawn.get("parent_thread_id")
+              if payload.get("thread_source") == "subagent" and isinstance(payload.get("parent_thread_id"), str):
+                is_subagent = True
+                parent_session_id = parent_session_id or payload.get("parent_thread_id")
+              parsed_timestamp = _iso_timestamp_ms(row.get("timestamp"))
+              if parsed_timestamp is not None and not session_timestamp_found:
+                timestamp = parsed_timestamp
+                session_timestamp_found = True
           continue
         if not row.get("type") and isinstance(row.get("id"), str) and isinstance(row.get("timestamp"), str):
           if not session_identity_found:

--- a/apps/main-1.0/src/core/remote-sync.ts
+++ b/apps/main-1.0/src/core/remote-sync.ts
@@ -1203,6 +1203,9 @@ def emit_codex_summary(path, stat, titles, source):
   git_branch = ""
   is_subagent = False
   parent_session_id = None
+  # Child rollouts may repeat inherited parent metadata; the first valid identity owns the file.
+  session_identity_seen = False
+  session_identity_timestamp_seen = False
   token_state = new_codex_token_state()
   rows = []
   try:
@@ -1218,35 +1221,51 @@ def emit_codex_summary(path, stat, titles, source):
         if row.get("type") == "session_meta":
           payload = row.get("payload")
           if isinstance(payload, dict):
-            raw_id = payload.get("id") if isinstance(payload.get("id"), str) else raw_id
-            project_path = payload.get("cwd") if isinstance(payload.get("cwd"), str) else project_path
-            git = payload.get("git")
-            if not git_branch and isinstance(git, dict) and isinstance(git.get("branch"), str):
-              git_branch = git.get("branch")
-            structured_source = payload.get("source")
-            if isinstance(structured_source, dict):
-              subagent = structured_source.get("subagent")
-              thread_spawn = subagent.get("thread_spawn") if isinstance(subagent, dict) else None
-              if isinstance(thread_spawn, dict) and isinstance(thread_spawn.get("parent_thread_id"), str):
+            meta_id = payload.get("id")
+            if not isinstance(meta_id, str) or not meta_id:
+              meta_id = payload.get("session_id")
+            if isinstance(meta_id, str) and meta_id:
+              same_identity = not session_identity_seen or meta_id == raw_id
+              if not session_identity_seen:
+                raw_id = meta_id
+              if same_identity and not project_path and isinstance(payload.get("cwd"), str):
+                project_path = payload.get("cwd")
+              git = payload.get("git")
+              if same_identity and not git_branch and isinstance(git, dict) and isinstance(git.get("branch"), str):
+                git_branch = git.get("branch")
+              structured_source = payload.get("source")
+              if same_identity and isinstance(structured_source, dict):
+                subagent = structured_source.get("subagent")
+                thread_spawn = subagent.get("thread_spawn") if isinstance(subagent, dict) else None
+                if isinstance(thread_spawn, dict) and isinstance(thread_spawn.get("parent_thread_id"), str):
+                  is_subagent = True
+                  if parent_session_id is None:
+                    parent_session_id = thread_spawn.get("parent_thread_id")
+              if same_identity and payload.get("thread_source") == "subagent" and isinstance(payload.get("parent_thread_id"), str):
                 is_subagent = True
-                parent_session_id = thread_spawn.get("parent_thread_id")
-            if payload.get("thread_source") == "subagent" and isinstance(payload.get("parent_thread_id"), str):
-              is_subagent = True
-              parent_session_id = payload.get("parent_thread_id")
-          parsed_timestamp = _iso_timestamp_ms(row.get("timestamp"))
-          if parsed_timestamp is not None:
-            timestamp = parsed_timestamp
+                if parent_session_id is None:
+                  parent_session_id = payload.get("parent_thread_id")
+              parsed_timestamp = _iso_timestamp_ms(row.get("timestamp"))
+              if same_identity and not session_identity_timestamp_seen and parsed_timestamp is not None:
+                timestamp = parsed_timestamp
+                session_identity_timestamp_seen = True
+              session_identity_seen = True
           continue
         if not row.get("type") and isinstance(row.get("id"), str) and isinstance(row.get("timestamp"), str):
-          raw_id = row.get("id")
+          same_identity = not session_identity_seen or row.get("id") == raw_id
+          if not session_identity_seen:
+            raw_id = row.get("id")
           git = row.get("git")
-          if isinstance(git, dict):
-            project_path = git.get("cwd") if isinstance(git.get("cwd"), str) else project_path
+          if same_identity and isinstance(git, dict):
+            if not project_path and isinstance(git.get("cwd"), str):
+              project_path = git.get("cwd")
             if not git_branch and isinstance(git.get("branch"), str):
               git_branch = git.get("branch")
           parsed_timestamp = _iso_timestamp_ms(row.get("timestamp"))
-          if parsed_timestamp is not None:
+          if same_identity and not session_identity_timestamp_seen and parsed_timestamp is not None:
             timestamp = parsed_timestamp
+            session_identity_timestamp_seen = True
+          session_identity_seen = True
           continue
         accumulate_codex_tokens(token_state, row)
   except Exception:

--- a/apps/main-1.0/src/core/remote-sync.ts
+++ b/apps/main-1.0/src/core/remote-sync.ts
@@ -1149,6 +1149,10 @@ def title_from(text):
   lines = [line.strip() for line in text.strip().splitlines() if line.strip()]
   return (lines[0] if lines else text.strip())[:120]
 
+def usable_codex_project_path(value):
+  normalized = value.strip() if isinstance(value, str) else ""
+  return bool(normalized) and re.fullmatch(r"<[^>]+>", normalized) is None
+
 def load_codex_titles(config_dir):
   titles = {}
   index_path = home / config_dir / "session_index.jsonl"
@@ -1197,15 +1201,15 @@ def emit_codex_summary(path, stat, titles, source):
   raw_id = path.stem
   project_path = ""
   timestamp = int(stat.st_mtime * 1000)
+  # Child rollouts may repeat inherited parent metadata; the first valid identity owns the file.
+  session_identity_found = False
+  session_timestamp_found = False
   first_question = ""
   message_count = 0
   message_events = []
   git_branch = ""
   is_subagent = False
   parent_session_id = None
-  # Child rollouts may repeat inherited parent metadata; the first valid identity owns the file.
-  session_identity_seen = False
-  session_identity_timestamp_seen = False
   token_state = new_codex_token_state()
   rows = []
   try:
@@ -1221,51 +1225,51 @@ def emit_codex_summary(path, stat, titles, source):
         if row.get("type") == "session_meta":
           payload = row.get("payload")
           if isinstance(payload, dict):
-            meta_id = payload.get("id")
-            if not isinstance(meta_id, str) or not meta_id:
-              meta_id = payload.get("session_id")
-            if isinstance(meta_id, str) and meta_id:
-              same_identity = not session_identity_seen or meta_id == raw_id
-              if not session_identity_seen:
-                raw_id = meta_id
-              if same_identity and not project_path and isinstance(payload.get("cwd"), str):
-                project_path = payload.get("cwd")
-              git = payload.get("git")
-              if same_identity and not git_branch and isinstance(git, dict) and isinstance(git.get("branch"), str):
-                git_branch = git.get("branch")
-              structured_source = payload.get("source")
-              if same_identity and isinstance(structured_source, dict):
-                subagent = structured_source.get("subagent")
-                thread_spawn = subagent.get("thread_spawn") if isinstance(subagent, dict) else None
-                if isinstance(thread_spawn, dict) and isinstance(thread_spawn.get("parent_thread_id"), str):
+            session_id = payload.get("id")
+            if not isinstance(session_id, str) or not session_id:
+              session_id = payload.get("session_id")
+            if isinstance(session_id, str) and session_id:
+              if not session_identity_found:
+                raw_id = session_id
+                session_identity_found = True
+              if session_id == raw_id:
+                candidate_project_path = payload.get("cwd")
+                if not usable_codex_project_path(project_path) and isinstance(candidate_project_path, str):
+                  project_path = candidate_project_path
+                git = payload.get("git")
+                if not git_branch and isinstance(git, dict) and isinstance(git.get("branch"), str):
+                  git_branch = git.get("branch")
+                structured_source = payload.get("source")
+                if isinstance(structured_source, dict):
+                  subagent = structured_source.get("subagent")
+                  thread_spawn = subagent.get("thread_spawn") if isinstance(subagent, dict) else None
+                  if isinstance(thread_spawn, dict) and isinstance(thread_spawn.get("parent_thread_id"), str):
+                    is_subagent = True
+                    parent_session_id = parent_session_id or thread_spawn.get("parent_thread_id")
+                if payload.get("thread_source") == "subagent" and isinstance(payload.get("parent_thread_id"), str):
                   is_subagent = True
-                  if parent_session_id is None:
-                    parent_session_id = thread_spawn.get("parent_thread_id")
-              if same_identity and payload.get("thread_source") == "subagent" and isinstance(payload.get("parent_thread_id"), str):
-                is_subagent = True
-                if parent_session_id is None:
-                  parent_session_id = payload.get("parent_thread_id")
-              parsed_timestamp = _iso_timestamp_ms(row.get("timestamp"))
-              if same_identity and not session_identity_timestamp_seen and parsed_timestamp is not None:
-                timestamp = parsed_timestamp
-                session_identity_timestamp_seen = True
-              session_identity_seen = True
+                  parent_session_id = parent_session_id or payload.get("parent_thread_id")
+                parsed_timestamp = _iso_timestamp_ms(row.get("timestamp"))
+                if parsed_timestamp is not None and not session_timestamp_found:
+                  timestamp = parsed_timestamp
+                  session_timestamp_found = True
           continue
         if not row.get("type") and isinstance(row.get("id"), str) and isinstance(row.get("timestamp"), str):
-          same_identity = not session_identity_seen or row.get("id") == raw_id
-          if not session_identity_seen:
+          if not session_identity_found:
             raw_id = row.get("id")
-          git = row.get("git")
-          if same_identity and isinstance(git, dict):
-            if not project_path and isinstance(git.get("cwd"), str):
-              project_path = git.get("cwd")
-            if not git_branch and isinstance(git.get("branch"), str):
-              git_branch = git.get("branch")
-          parsed_timestamp = _iso_timestamp_ms(row.get("timestamp"))
-          if same_identity and not session_identity_timestamp_seen and parsed_timestamp is not None:
-            timestamp = parsed_timestamp
-            session_identity_timestamp_seen = True
-          session_identity_seen = True
+            session_identity_found = True
+          if row.get("id") == raw_id:
+            git = row.get("git")
+            if isinstance(git, dict):
+              candidate_project_path = git.get("cwd")
+              if not usable_codex_project_path(project_path) and isinstance(candidate_project_path, str):
+                project_path = candidate_project_path
+              if not git_branch and isinstance(git.get("branch"), str):
+                git_branch = git.get("branch")
+            parsed_timestamp = _iso_timestamp_ms(row.get("timestamp"))
+            if parsed_timestamp is not None and not session_timestamp_found:
+              timestamp = parsed_timestamp
+              session_timestamp_found = True
           continue
         accumulate_codex_tokens(token_state, row)
   except Exception:

--- a/apps/main-2.0/src/core/remote-sync.test.ts
+++ b/apps/main-2.0/src/core/remote-sync.test.ts
@@ -20,6 +20,7 @@ describe("remote sync", () => {
     const childId = "child-session";
     const parentPath = path.join(tempHome, ".codex", "sessions", "2026", "08", "20", "parent.jsonl");
     const childPath = path.join(tempHome, ".codex", "sessions", "2026", "08", "20", "child.jsonl");
+    const sessionIdOnlyPath = path.join(tempHome, ".codex", "sessions", "2026", "08", "20", "session-id-only.jsonl");
     const writeJsonl = (filePath: string, rows: unknown[]) => {
       fs.mkdirSync(path.dirname(filePath), { recursive: true });
       fs.writeFileSync(filePath, rows.map((row) => JSON.stringify(row)).join("\n"), "utf8");
@@ -93,6 +94,25 @@ describe("remote sync", () => {
           },
         },
       ]);
+      writeJsonl(sessionIdOnlyPath, [
+        {
+          type: "session_meta",
+          timestamp: "2026-08-20T06:35:00.000Z",
+          payload: {
+            session_id: "semantic-session-id",
+            cwd: "/workspace/legacy",
+          },
+        },
+        {
+          type: "response_item",
+          timestamp: "2026-08-20T06:36:00.000Z",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "legacy identity question" }],
+          },
+        },
+      ]);
       fs.utimesSync(parentPath, new Date(2_000), new Date(2_000));
       fs.utimesSync(childPath, new Date(1_000), new Date(1_000));
 
@@ -129,12 +149,20 @@ describe("remote sync", () => {
         parentSessionId: parentId,
         timestamp: Date.parse("2026-08-20T06:33:00.000Z"),
       });
-      await expect(store.searchSessions({
+      await expect(store.getSession(`ssh:${environment.id}:codex-cli:session-id-only`)).resolves.toMatchObject({
+        rawId: "session-id-only",
+        projectPath: "/workspace/legacy",
+      });
+      await expect(store.getSession(`ssh:${environment.id}:codex-cli:semantic-session-id`)).resolves.toBeNull();
+      const rootSessions = await store.searchSessions({
         environmentId: environment.id,
         excludeSubagents: true,
-      })).resolves.toEqual([
+      });
+      expect(rootSessions).toEqual(expect.arrayContaining([
         expect.objectContaining({ rawId: parentId }),
-      ]);
+        expect.objectContaining({ rawId: "session-id-only" }),
+      ]));
+      expect(rootSessions).toHaveLength(2);
     } finally {
       await store.close();
       fs.rmSync(tempHome, { recursive: true, force: true });

--- a/apps/main-2.0/src/core/remote-sync.test.ts
+++ b/apps/main-2.0/src/core/remote-sync.test.ts
@@ -50,7 +50,7 @@ describe("remote sync", () => {
             id: childId,
             session_id: parentId,
             forked_from_id: parentId,
-            cwd: "/workspace/child",
+            cwd: "<local-workspace>",
             thread_source: "subagent",
             parent_thread_id: parentId,
             source: {
@@ -61,6 +61,15 @@ describe("remote sync", () => {
                 },
               },
             },
+          },
+        },
+        {
+          type: "session_meta",
+          timestamp: "2026-08-20T06:33:30.000Z",
+          payload: {
+            id: childId,
+            session_id: parentId,
+            cwd: "/workspace/child",
           },
         },
         {

--- a/apps/main-2.0/src/core/remote-sync.test.ts
+++ b/apps/main-2.0/src/core/remote-sync.test.ts
@@ -1,0 +1,134 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { inflateRawSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+import { createInMemoryStore } from "./postgres/test-session-store";
+import { syncRemoteEnvironment } from "./remote-sync";
+
+function decodeCollectorScript(command: string): string {
+  const encoded = command.match(/b64decode\("([^"]+)"\)/)?.[1] ?? "";
+  return inflateRawSync(Buffer.from(encoded, "base64")).toString("utf8");
+}
+
+describe("remote sync", () => {
+  it("keeps Codex parent and child sessions distinct when a child rollout contains inherited parent metadata", async () => {
+    const store = createInMemoryStore();
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-v2-remote-codex-"));
+    const parentId = "parent-session";
+    const childId = "child-session";
+    const parentPath = path.join(tempHome, ".codex", "sessions", "2026", "08", "20", "parent.jsonl");
+    const childPath = path.join(tempHome, ".codex", "sessions", "2026", "08", "20", "child.jsonl");
+    const writeJsonl = (filePath: string, rows: unknown[]) => {
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, rows.map((row) => JSON.stringify(row)).join("\n"), "utf8");
+    };
+
+    try {
+      writeJsonl(parentPath, [
+        {
+          type: "session_meta",
+          timestamp: "2026-08-20T06:31:06.970Z",
+          payload: { id: parentId, cwd: "/workspace/parent", source: "user" },
+        },
+        {
+          type: "response_item",
+          timestamp: "2026-08-20T06:32:00.000Z",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "parent question" }],
+          },
+        },
+      ]);
+      writeJsonl(childPath, [
+        {
+          type: "session_meta",
+          timestamp: "2026-08-20T06:33:00.000Z",
+          payload: {
+            id: childId,
+            session_id: parentId,
+            forked_from_id: parentId,
+            cwd: "/workspace/child",
+            thread_source: "subagent",
+            parent_thread_id: parentId,
+            source: {
+              subagent: {
+                thread_spawn: {
+                  parent_thread_id: parentId,
+                  depth: 1,
+                },
+              },
+            },
+          },
+        },
+        {
+          type: "session_meta",
+          timestamp: "2026-08-20T06:31:06.970Z",
+          payload: {
+            id: parentId,
+            session_id: parentId,
+            cwd: "/workspace/parent",
+            thread_source: "user",
+            source: "user",
+          },
+        },
+        {
+          type: "response_item",
+          timestamp: "2026-08-20T06:34:00.000Z",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "child task" }],
+          },
+        },
+      ]);
+      fs.utimesSync(parentPath, new Date(2_000), new Date(2_000));
+      fs.utimesSync(childPath, new Date(1_000), new Date(1_000));
+
+      const environment = await store.upsertEnvironment({
+        id: "ssh-devbox",
+        kind: "ssh",
+        label: "devbox",
+        hostAlias: "devbox",
+        host: "devbox.example.com",
+        authMode: "none",
+        enabled: true,
+      });
+      await syncRemoteEnvironment(store, environment, {
+        runSsh: async (_environment, command) => execFileSync(
+          process.platform === "win32" ? "python" : "python3",
+          ["-c", decodeCollectorScript(command)],
+          {
+            encoding: "utf8",
+            env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+          },
+        ),
+      });
+
+      await expect(store.getSession(`ssh:${environment.id}:codex-cli:${parentId}`)).resolves.toMatchObject({
+        rawId: parentId,
+        projectPath: "/workspace/parent",
+        isSubagent: false,
+        parentSessionId: null,
+      });
+      await expect(store.getSession(`ssh:${environment.id}:codex-cli:${childId}`)).resolves.toMatchObject({
+        rawId: childId,
+        projectPath: "/workspace/child",
+        isSubagent: true,
+        parentSessionId: parentId,
+        timestamp: Date.parse("2026-08-20T06:33:00.000Z"),
+      });
+      await expect(store.searchSessions({
+        environmentId: environment.id,
+        excludeSubagents: true,
+      })).resolves.toEqual([
+        expect.objectContaining({ rawId: parentId }),
+      ]);
+    } finally {
+      await store.close();
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    }
+  }, 20_000);
+});

--- a/apps/main-2.0/src/core/remote-sync.ts
+++ b/apps/main-2.0/src/core/remote-sync.ts
@@ -1161,6 +1161,10 @@ def title_from(text):
   lines = [line.strip() for line in text.strip().splitlines() if line.strip()]
   return (lines[0] if lines else text.strip())[:120]
 
+def usable_codex_project_path(value):
+  normalized = value.strip() if isinstance(value, str) else ""
+  return bool(normalized) and re.fullmatch(r"<[^>]+>", normalized) is None
+
 def load_codex_titles(config_dir):
   titles = {}
   index_path = home / config_dir / "session_index.jsonl"
@@ -1209,6 +1213,7 @@ def emit_codex_summary(path, stat, titles, source):
   raw_id = path.stem
   project_path = ""
   timestamp = int(stat.st_mtime * 1000)
+  # Child rollouts may repeat inherited parent metadata; the first valid identity owns the file.
   session_identity_found = False
   session_timestamp_found = False
   first_question = ""
@@ -1240,8 +1245,9 @@ def emit_codex_summary(path, stat, titles, source):
                 raw_id = session_id
                 session_identity_found = True
               if session_id == raw_id:
-                if not project_path and isinstance(payload.get("cwd"), str):
-                  project_path = payload.get("cwd")
+                candidate_project_path = payload.get("cwd")
+                if not usable_codex_project_path(project_path) and isinstance(candidate_project_path, str):
+                  project_path = candidate_project_path
                 git = payload.get("git")
                 if not git_branch and isinstance(git, dict) and isinstance(git.get("branch"), str):
                   git_branch = git.get("branch")
@@ -1267,8 +1273,9 @@ def emit_codex_summary(path, stat, titles, source):
           if row.get("id") == raw_id:
             git = row.get("git")
             if isinstance(git, dict):
-              if not project_path and isinstance(git.get("cwd"), str):
-                project_path = git.get("cwd")
+              candidate_project_path = git.get("cwd")
+              if not usable_codex_project_path(project_path) and isinstance(candidate_project_path, str):
+                project_path = candidate_project_path
               if not git_branch and isinstance(git.get("branch"), str):
                 git_branch = git.get("branch")
             parsed_timestamp = _iso_timestamp_ms(row.get("timestamp"))

--- a/apps/main-2.0/src/core/remote-sync.ts
+++ b/apps/main-2.0/src/core/remote-sync.ts
@@ -1209,6 +1209,8 @@ def emit_codex_summary(path, stat, titles, source):
   raw_id = path.stem
   project_path = ""
   timestamp = int(stat.st_mtime * 1000)
+  session_identity_found = False
+  session_timestamp_found = False
   first_question = ""
   message_count = 0
   message_events = []
@@ -1230,35 +1232,49 @@ def emit_codex_summary(path, stat, titles, source):
         if row.get("type") == "session_meta":
           payload = row.get("payload")
           if isinstance(payload, dict):
-            raw_id = payload.get("id") if isinstance(payload.get("id"), str) else raw_id
-            project_path = payload.get("cwd") if isinstance(payload.get("cwd"), str) else project_path
-            git = payload.get("git")
-            if not git_branch and isinstance(git, dict) and isinstance(git.get("branch"), str):
-              git_branch = git.get("branch")
-            structured_source = payload.get("source")
-            if isinstance(structured_source, dict):
-              subagent = structured_source.get("subagent")
-              thread_spawn = subagent.get("thread_spawn") if isinstance(subagent, dict) else None
-              if isinstance(thread_spawn, dict) and isinstance(thread_spawn.get("parent_thread_id"), str):
-                is_subagent = True
-                parent_session_id = thread_spawn.get("parent_thread_id")
-            if payload.get("thread_source") == "subagent" and isinstance(payload.get("parent_thread_id"), str):
-              is_subagent = True
-              parent_session_id = payload.get("parent_thread_id")
-          parsed_timestamp = _iso_timestamp_ms(row.get("timestamp"))
-          if parsed_timestamp is not None:
-            timestamp = parsed_timestamp
+            session_id = payload.get("id")
+            if not isinstance(session_id, str) or not session_id:
+              session_id = payload.get("session_id")
+            if isinstance(session_id, str) and session_id:
+              if not session_identity_found:
+                raw_id = session_id
+                session_identity_found = True
+              if session_id == raw_id:
+                if not project_path and isinstance(payload.get("cwd"), str):
+                  project_path = payload.get("cwd")
+                git = payload.get("git")
+                if not git_branch and isinstance(git, dict) and isinstance(git.get("branch"), str):
+                  git_branch = git.get("branch")
+                structured_source = payload.get("source")
+                if isinstance(structured_source, dict):
+                  subagent = structured_source.get("subagent")
+                  thread_spawn = subagent.get("thread_spawn") if isinstance(subagent, dict) else None
+                  if isinstance(thread_spawn, dict) and isinstance(thread_spawn.get("parent_thread_id"), str):
+                    is_subagent = True
+                    parent_session_id = parent_session_id or thread_spawn.get("parent_thread_id")
+                if payload.get("thread_source") == "subagent" and isinstance(payload.get("parent_thread_id"), str):
+                  is_subagent = True
+                  parent_session_id = parent_session_id or payload.get("parent_thread_id")
+                parsed_timestamp = _iso_timestamp_ms(row.get("timestamp"))
+                if parsed_timestamp is not None and not session_timestamp_found:
+                  timestamp = parsed_timestamp
+                  session_timestamp_found = True
           continue
         if not row.get("type") and isinstance(row.get("id"), str) and isinstance(row.get("timestamp"), str):
-          raw_id = row.get("id")
-          git = row.get("git")
-          if isinstance(git, dict):
-            project_path = git.get("cwd") if isinstance(git.get("cwd"), str) else project_path
-            if not git_branch and isinstance(git.get("branch"), str):
-              git_branch = git.get("branch")
-          parsed_timestamp = _iso_timestamp_ms(row.get("timestamp"))
-          if parsed_timestamp is not None:
-            timestamp = parsed_timestamp
+          if not session_identity_found:
+            raw_id = row.get("id")
+            session_identity_found = True
+          if row.get("id") == raw_id:
+            git = row.get("git")
+            if isinstance(git, dict):
+              if not project_path and isinstance(git.get("cwd"), str):
+                project_path = git.get("cwd")
+              if not git_branch and isinstance(git.get("branch"), str):
+                git_branch = git.get("branch")
+            parsed_timestamp = _iso_timestamp_ms(row.get("timestamp"))
+            if parsed_timestamp is not None and not session_timestamp_found:
+              timestamp = parsed_timestamp
+              session_timestamp_found = True
           continue
         accumulate_codex_tokens(token_state, row)
   except Exception:

--- a/apps/main-2.0/src/core/remote-sync.ts
+++ b/apps/main-2.0/src/core/remote-sync.ts
@@ -1237,34 +1237,34 @@ def emit_codex_summary(path, stat, titles, source):
         if row.get("type") == "session_meta":
           payload = row.get("payload")
           if isinstance(payload, dict):
-            session_id = payload.get("id")
-            if not isinstance(session_id, str) or not session_id:
-              session_id = payload.get("session_id")
-            if isinstance(session_id, str) and session_id:
+            meta_id = payload.get("id")
+            same_identity = not session_identity_found
+            if isinstance(meta_id, str) and meta_id:
               if not session_identity_found:
-                raw_id = session_id
+                raw_id = meta_id
                 session_identity_found = True
-              if session_id == raw_id:
-                candidate_project_path = payload.get("cwd")
-                if not usable_codex_project_path(project_path) and isinstance(candidate_project_path, str):
-                  project_path = candidate_project_path
-                git = payload.get("git")
-                if not git_branch and isinstance(git, dict) and isinstance(git.get("branch"), str):
-                  git_branch = git.get("branch")
-                structured_source = payload.get("source")
-                if isinstance(structured_source, dict):
-                  subagent = structured_source.get("subagent")
-                  thread_spawn = subagent.get("thread_spawn") if isinstance(subagent, dict) else None
-                  if isinstance(thread_spawn, dict) and isinstance(thread_spawn.get("parent_thread_id"), str):
-                    is_subagent = True
-                    parent_session_id = parent_session_id or thread_spawn.get("parent_thread_id")
-                if payload.get("thread_source") == "subagent" and isinstance(payload.get("parent_thread_id"), str):
+              same_identity = meta_id == raw_id
+            if same_identity:
+              candidate_project_path = payload.get("cwd")
+              if not usable_codex_project_path(project_path) and isinstance(candidate_project_path, str):
+                project_path = candidate_project_path
+              git = payload.get("git")
+              if not git_branch and isinstance(git, dict) and isinstance(git.get("branch"), str):
+                git_branch = git.get("branch")
+              structured_source = payload.get("source")
+              if isinstance(structured_source, dict):
+                subagent = structured_source.get("subagent")
+                thread_spawn = subagent.get("thread_spawn") if isinstance(subagent, dict) else None
+                if isinstance(thread_spawn, dict) and isinstance(thread_spawn.get("parent_thread_id"), str):
                   is_subagent = True
-                  parent_session_id = parent_session_id or payload.get("parent_thread_id")
-                parsed_timestamp = _iso_timestamp_ms(row.get("timestamp"))
-                if parsed_timestamp is not None and not session_timestamp_found:
-                  timestamp = parsed_timestamp
-                  session_timestamp_found = True
+                  parent_session_id = parent_session_id or thread_spawn.get("parent_thread_id")
+              if payload.get("thread_source") == "subagent" and isinstance(payload.get("parent_thread_id"), str):
+                is_subagent = True
+                parent_session_id = parent_session_id or payload.get("parent_thread_id")
+              parsed_timestamp = _iso_timestamp_ms(row.get("timestamp"))
+              if parsed_timestamp is not None and not session_timestamp_found:
+                timestamp = parsed_timestamp
+                session_timestamp_found = True
           continue
         if not row.get("type") and isinstance(row.get("id"), str) and isinstance(row.get("timestamp"), str):
           if not session_identity_found:


### PR DESCRIPTION
## Summary

- anchor each remote Codex rollout to its first valid session identity
- ignore inherited metadata from a different thread while allowing same-thread metadata to fill a placeholder project path
- cover the behavior in both V1 SQLite and V2 PostgreSQL session stores

## Verification

- V1 Vitest: 109 files, 1482 passed, 1 skipped
- V1 script tests: 79 passed
- V2 Vitest: 210 files, 1893 passed
- V2 Node 22 script tests: 165 passed
- V1 and V2 typecheck
- release-note check
- read-only remote collector verification keeps one visible parent and three correctly linked child sessions