### PR TITLE
fix: test Codex and Claude provider connections

### DIFF
--- a/.release-notes/provider-connection-test-ui.md
+++ b/.release-notes/provider-connection-test-ui.md
@@ -1,0 +1,6 @@
+# Provider 连接测试
+<!-- release-target: v2 -->
+
+## Bug 修复
+
+- Codex 和 Claude Code 的 Provider 配置现在可以直接测试连接，并清楚显示测试中、成功或失败状态。

--- a/.release-notes/provider-connection-test-ui.md
+++ b/.release-notes/provider-connection-test-ui.md
@@ -1,6 +1,0 @@
-# Provider 连接测试
-<!-- release-target: v2 -->
-
-## Bug 修复
-
-- Codex 和 Claude Code 的 Provider 配置现在可以直接测试连接，并清楚显示测试中、成功或失败状态。

--- a/.release-notes/provider-connection-test-v1-audit.md
+++ b/.release-notes/provider-connection-test-v1-audit.md
@@ -1,6 +1,0 @@
-# Provider 连接测试
-<!-- release-target: v1 -->
-
-## Bug 修复
-
-- Codex 和 Claude Code 供应商配置现在都可直接测试当前连接，并显示使用的凭据来源与耗时。

--- a/.release-notes/provider-connection-test-v1-audit.md
+++ b/.release-notes/provider-connection-test-v1-audit.md
@@ -1,0 +1,6 @@
+# Provider 连接测试
+<!-- release-target: v1 -->
+
+## Bug 修复
+
+- Codex 和 Claude Code 供应商配置现在都可直接测试当前连接，并显示使用的凭据来源与耗时。

--- a/.release-notes/provider-connection-test.md
+++ b/.release-notes/provider-connection-test.md
@@ -3,4 +3,4 @@
 
 ## Bug 修复
 
-- Codex 和 Claude Code 的 Provider 配置现在都可直接测试真实连接，并支持 CLI 外部凭据助手；API Key 未直接写在配置文件中时也能显示准确的成功或失败结果。
+- Codex 和 Claude Code 的 Provider 配置现在都可直接测试真实连接，并支持 CLI 外部凭据助手；API Key 未直接写在配置文件中时也能显示准确结果，切换或编辑服务地址时也不会误用其他地址保存的密钥。

--- a/.release-notes/provider-connection-test.md
+++ b/.release-notes/provider-connection-test.md
@@ -3,4 +3,4 @@
 
 ## Bug 修复
 
-- Codex 和 Claude Code 的 Provider 配置现在都可直接测试真实连接；即使凭据由 CLI 或配置文件之外的位置管理，也能显示准确的成功或失败结果。
+- Codex 和 Claude Code 的 Provider 配置现在都可直接测试真实连接，并支持 CLI 外部凭据助手；API Key 未直接写在配置文件中时也能显示准确的成功或失败结果。

--- a/.release-notes/provider-connection-test.md
+++ b/.release-notes/provider-connection-test.md
@@ -1,0 +1,6 @@
+# Provider 连接测试
+<!-- release-target: both -->
+
+## Bug 修复
+
+- Codex 和 Claude Code 的 Provider 配置现在都可直接测试真实连接；即使凭据由 CLI 或配置文件之外的位置管理，也能显示准确的成功或失败结果。

--- a/.release-notes/provider-credential-resolution.md
+++ b/.release-notes/provider-credential-resolution.md
@@ -1,0 +1,6 @@
+# Provider 连接可复用 CLI 动态凭据
+<!-- release-target: both -->
+
+## Bug 修复
+
+- Codex 与 Claude Provider 现在能识别并使用 CLI 配置的外部凭据助手，API Key 未直接写在配置文件中时也可完成模型探测与连接验证。

--- a/.release-notes/provider-credential-resolution.md
+++ b/.release-notes/provider-credential-resolution.md
@@ -1,6 +1,0 @@
-# Provider 连接可复用 CLI 动态凭据
-<!-- release-target: both -->
-
-## Bug 修复
-
-- Codex 与 Claude Provider 现在能识别并使用 CLI 配置的外部凭据助手，API Key 未直接写在配置文件中时也可完成模型探测与连接验证。

--- a/apps/main-1.0/src/core/claude-profile.test.ts
+++ b/apps/main-1.0/src/core/claude-profile.test.ts
@@ -11,6 +11,8 @@ import { applyClaudeApiConfig, loadClaudeApiConfigDefaults, loadClaudeConfigSnap
 
 async function withClaudeHome<T>(run: (claudeHome: string) => Promise<T>): Promise<T> {
   const claudeHome = await mkdtemp(path.join(tmpdir(), "agent-recall-claude-"));
+  vi.stubEnv("HOME", claudeHome);
+  vi.stubEnv("USERPROFILE", claudeHome);
   try {
     return await run(claudeHome);
   } finally {
@@ -148,6 +150,41 @@ describe("Claude Code provider switching", () => {
       const snapshot = await loadClaudeConfigSnapshot(claudeHome);
       expect(snapshot.exists).toBe(false);
       expect(snapshot.route).toEqual({});
+    });
+  });
+
+  it("detects apiKeyHelper without running its shell command during snapshots", async () => {
+    await withClaudeHome(async (claudeHome) => {
+      await writeFile(
+        path.join(claudeHome, "settings.json"),
+        JSON.stringify({
+          apiKeyHelper: "agent-recall-helper-must-not-run",
+          env: { ANTHROPIC_BASE_URL: "https://api.example.com/anthropic" },
+        }),
+      );
+
+      const snapshot = await loadClaudeConfigSnapshot(claudeHome);
+
+      expect(snapshot.hasApiKey).toBe(true);
+      expect(snapshot.credentialSource).toBe("settings.json apiKeyHelper");
+    });
+  });
+
+  it("does not treat Claude OAuth credentials as a reusable provider API key", async () => {
+    await withClaudeHome(async (claudeHome) => {
+      await writeFile(
+        path.join(claudeHome, "settings.json"),
+        JSON.stringify({ env: { ANTHROPIC_BASE_URL: "https://api.example.com/anthropic" } }),
+      );
+      await writeFile(
+        path.join(claudeHome, ".credentials.json"),
+        JSON.stringify({ claudeAiOauth: { accessToken: "synthetic-oauth-token" } }),
+      );
+
+      const snapshot = await loadClaudeConfigSnapshot(claudeHome);
+
+      expect(snapshot.hasApiKey).toBe(false);
+      expect(snapshot.credentialSource).toBeNull();
     });
   });
 
@@ -316,6 +353,37 @@ describe("Claude Code provider switching", () => {
       expect(result).toMatchObject({
         models: ["claude-sonnet-4.6"],
         credentialSource: "settings.json env.ANTHROPIC_API_KEY",
+      });
+    });
+  });
+
+  it("detects models with the auth value returned by apiKeyHelper", async () => {
+    await withClaudeHome(async (claudeHome) => {
+      await writeFile(
+        path.join(claudeHome, "settings.json"),
+        JSON.stringify({ apiKeyHelper: "echo helper-key" }),
+      );
+
+      const result = await probeClaudeModels(
+        {
+          claudeHome,
+          baseUrl: "https://api.example.com/anthropic",
+          apiKey: "",
+          apiFormat: "anthropic",
+          apiKeyField: "ANTHROPIC_API_KEY",
+        },
+        async (_url, init) => {
+          expect(init?.headers).toMatchObject({
+            Authorization: "Bearer helper-key",
+            "x-api-key": "helper-key",
+          });
+          return { ok: true, status: 200, async json() { return { models: ["claude-helper-model"] }; } };
+        },
+      );
+
+      expect(result).toMatchObject({
+        models: ["claude-helper-model"],
+        credentialSource: "settings.json apiKeyHelper",
       });
     });
   });

--- a/apps/main-1.0/src/core/claude-profile.test.ts
+++ b/apps/main-1.0/src/core/claude-profile.test.ts
@@ -329,7 +329,12 @@ describe("Claude Code provider switching", () => {
     await withClaudeHome(async (claudeHome) => {
       await writeFile(
         path.join(claudeHome, "settings.json"),
-        JSON.stringify({ env: { ANTHROPIC_API_KEY: "stored-key" } }),
+        JSON.stringify({
+          env: {
+            ANTHROPIC_BASE_URL: "https://api.example.com/anthropic",
+            ANTHROPIC_API_KEY: "stored-key",
+          },
+        }),
       );
 
       const result = await probeClaudeModels(
@@ -337,6 +342,7 @@ describe("Claude Code provider switching", () => {
           claudeHome,
           baseUrl: "https://api.example.com/anthropic",
           apiKey: "",
+          providerId: "custom",
           apiFormat: "anthropic",
           apiKeyField: "ANTHROPIC_API_KEY",
         },
@@ -361,7 +367,10 @@ describe("Claude Code provider switching", () => {
     await withClaudeHome(async (claudeHome) => {
       await writeFile(
         path.join(claudeHome, "settings.json"),
-        JSON.stringify({ apiKeyHelper: "echo helper-key" }),
+        JSON.stringify({
+          env: { ANTHROPIC_BASE_URL: "https://api.example.com/anthropic" },
+          apiKeyHelper: "echo helper-key",
+        }),
       );
 
       const result = await probeClaudeModels(
@@ -369,6 +378,7 @@ describe("Claude Code provider switching", () => {
           claudeHome,
           baseUrl: "https://api.example.com/anthropic",
           apiKey: "",
+          providerId: "custom",
           apiFormat: "anthropic",
           apiKeyField: "ANTHROPIC_API_KEY",
         },
@@ -388,11 +398,110 @@ describe("Claude Code provider switching", () => {
     });
   });
 
+  it("does not reuse settings credentials for a different Base URL", async () => {
+    await withClaudeHome(async (claudeHome) => {
+      await writeFile(
+        path.join(claudeHome, "settings.json"),
+        JSON.stringify({
+          env: { ANTHROPIC_BASE_URL: "https://old.example/anthropic" },
+          apiKeyHelper: "agent-recall-helper-must-not-run",
+        }),
+      );
+      const fetchImpl = vi.fn(async (_url: string, init?: { headers?: Record<string, string> }) => {
+        expect(init?.headers?.Authorization).toBe("Bearer explicit-key");
+        return { ok: true, status: 200, async json() { return { models: ["claude-explicit"] }; } };
+      });
+
+      await expect(probeClaudeModels({
+        claudeHome,
+        baseUrl: "https://new.example/anthropic",
+        apiKey: "",
+        providerId: "custom",
+        apiFormat: "anthropic",
+        apiKeyField: "ANTHROPIC_AUTH_TOKEN",
+      }, fetchImpl)).rejects.toThrow(/No API key was found/);
+      expect(fetchImpl).not.toHaveBeenCalled();
+
+      await expect(probeClaudeModels({
+        claudeHome,
+        baseUrl: "https://new.example/anthropic",
+        apiKey: "explicit-key",
+        providerId: "custom",
+        apiFormat: "anthropic",
+        apiKeyField: "ANTHROPIC_AUTH_TOKEN",
+      }, fetchImpl)).resolves.toMatchObject({ models: ["claude-explicit"] });
+      expect(fetchImpl).toHaveBeenCalled();
+    });
+  });
+
+  it("preserves apiKeyHelper when applying its matching route without persisting a token", async () => {
+    await withClaudeHome(async (claudeHome) => {
+      await writeFile(
+        path.join(claudeHome, "settings.json"),
+        JSON.stringify({
+          env: { ANTHROPIC_BASE_URL: "https://api.example.com/anthropic" },
+          apiKeyHelper: "agent-recall-helper-must-not-run",
+          hooks: { Stop: [] },
+        }),
+      );
+
+      const result = await applyClaudeApiConfig({
+        claudeHome,
+        apiConfig: {
+          activeProvider: "custom",
+          customProviderId: "internal-gateway",
+          customProviderName: "Internal Gateway",
+          customBaseUrl: "https://api.example.com/anthropic/",
+          customApiKey: "",
+          customModel: "claude-sonnet-4.6",
+          customHaikuModel: "claude-haiku-4.5",
+          customSonnetModel: "claude-sonnet-4.6",
+          customOpusModel: "claude-opus-4.6",
+          customApiFormat: "anthropic",
+          customApiKeyField: "ANTHROPIC_AUTH_TOKEN",
+        },
+      });
+
+      const settings = await readSettings(claudeHome);
+      expect(result.credentialSource).toBe("settings.json apiKeyHelper");
+      expect(settings.apiKeyHelper).toBe("agent-recall-helper-must-not-run");
+      expect(settings.env).toMatchObject({
+        ANTHROPIC_BASE_URL: "https://api.example.com/anthropic/",
+        ANTHROPIC_MODEL: "claude-sonnet-4.6",
+      });
+      expect(settings.env).not.toHaveProperty("ANTHROPIC_AUTH_TOKEN");
+      expect(settings.env).not.toHaveProperty("ANTHROPIC_API_KEY");
+      expect(settings.hooks).toEqual({ Stop: [] });
+      const appliedText = await readFile(path.join(claudeHome, "settings.json"), "utf8");
+
+      await expect(applyClaudeApiConfig({
+        claudeHome,
+        apiConfig: {
+          activeProvider: "custom",
+          customProviderId: "internal-gateway",
+          customProviderName: "Internal Gateway",
+          customBaseUrl: "https://other.example/anthropic",
+          customApiKey: "",
+          customModel: "claude-sonnet-4.6",
+          customApiFormat: "anthropic",
+          customApiKeyField: "ANTHROPIC_AUTH_TOKEN",
+        },
+      })).rejects.toThrow(/No API key was found/);
+      await expect(readFile(path.join(claudeHome, "settings.json"), "utf8")).resolves.toBe(appliedText);
+    });
+  });
+
   it("writes and verifies a custom route in the selected Claude config directory", async () => {
     await withClaudeHome(async (claudeHome) => {
       await writeFile(
         path.join(claudeHome, "settings.json"),
-        JSON.stringify({ env: { ANTHROPIC_AUTH_TOKEN: "stored-key" }, hooks: { Stop: [] } }),
+        JSON.stringify({
+          env: {
+            ANTHROPIC_BASE_URL: "https://api.example.com/anthropic",
+            ANTHROPIC_AUTH_TOKEN: "stored-key",
+          },
+          hooks: { Stop: [] },
+        }),
       );
 
       const result = await applyClaudeApiConfig({

--- a/apps/main-1.0/src/core/claude-profile.ts
+++ b/apps/main-1.0/src/core/claude-profile.ts
@@ -34,6 +34,7 @@ export interface ClaudeConfigSnapshot {
 export interface ClaudeModelProbeInput {
   baseUrl: string;
   apiKey: string;
+  providerId?: string;
   apiFormat: ClaudeApiConfig["customApiFormat"];
   apiKeyField: ClaudeApiConfig["customApiKeyField"];
   claudeHome?: string;
@@ -124,18 +125,38 @@ export async function probeClaudeModels(
 ): Promise<ClaudeModelProbeResult> {
   const claudeHome = resolveProviderConfigDirectory(input.claudeHome, ".claude");
   const explicitKey = input.apiKey.trim();
-  const credential = await resolveClaudeCredential({
-    claudeHome,
-    apiKeyField: input.apiKeyField,
-    explicitKey,
-    explicitSource: input.apiKeySource,
-  });
+  const requestedBaseUrl = normalizeBaseUrl(input.baseUrl);
+  const route = await loadClaudeApiConfigDefaults(claudeHome);
+  const routeMatches = route.activeProvider === "custom"
+    && (!requestedBaseUrl || normalizeBaseUrl(route.customBaseUrl || "") === requestedBaseUrl);
+  const baseUrl = requestedBaseUrl || (routeMatches ? normalizeBaseUrl(route.customBaseUrl || "") : "");
+  let credential: ResolvedClaudeCredential;
+  if (explicitKey) {
+    credential = await resolveClaudeCredential({
+      claudeHome,
+      apiKeyField: input.apiKeyField,
+      explicitKey,
+      explicitSource: input.apiKeySource,
+    });
+  } else {
+    credential = routeMatches
+      ? await resolveClaudeCredential({
+          claudeHome,
+          apiKeyField: input.apiKeyField,
+          executeCredentialHelper: true,
+        })
+      : { apiKey: "", source: null };
+  }
   const result = await probeProviderModels({
-    baseUrl: input.baseUrl,
+    baseUrl,
     apiKey: credential.apiKey,
     apiFormat: input.apiFormat,
   }, fetchImpl);
   return { ...result, credentialSource: credential.source || "resolved credential" };
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.trim().replace(/\/+$/, "");
 }
 
 export async function applyClaudeApiConfig(options: {
@@ -156,14 +177,24 @@ export async function applyClaudeApiConfig(options: {
 
   let credentialSource: string | null = null;
   if (apiConfig.activeProvider === "custom") {
-    const credential = await resolveClaudeCredential({
-      claudeHome,
-      apiKeyField: apiConfig.customApiKeyField,
-      explicitKey: apiConfig.customApiKey,
-      // Applying a route must never turn a short-lived helper value into a persisted API key.
-      executeCredentialHelper: false,
-    });
-    if (!credential.apiKey) throw new Error(`No API key was found for ${apiConfig.customProviderName}.`);
+    const explicitKey = apiConfig.customApiKey.trim();
+    const currentRoute = await loadClaudeApiConfigDefaults(claudeHome);
+    const currentRouteMatches = currentRoute.activeProvider === "custom"
+      && normalizeBaseUrl(currentRoute.customBaseUrl || "") === normalizeBaseUrl(apiConfig.customBaseUrl);
+    const credential: ResolvedClaudeCredential = explicitKey || currentRouteMatches
+      ? await resolveClaudeCredential({
+          claudeHome,
+          apiKeyField: apiConfig.customApiKeyField,
+          explicitKey,
+          // Applying a route must never turn a short-lived helper value into a persisted API key.
+          executeCredentialHelper: false,
+        })
+      : { apiKey: "", source: null };
+    const useApiKeyHelper = currentRouteMatches
+      && !explicitKey
+      && !credential.apiKey
+      && credential.configured === true;
+    if (!credential.apiKey && !useApiKeyHelper) throw new Error(`No API key was found for ${apiConfig.customProviderName}.`);
     credentialSource = credential.source;
     applyCustomClaudeEnv(settings, { ...apiConfig, customApiKey: credential.apiKey });
   } else {
@@ -215,13 +246,13 @@ function claudeApiConfigWithPresetDefaults(config: Partial<ClaudeApiConfig>): Cl
 }
 
 function applyCustomClaudeEnv(settings: Record<string, unknown>, apiConfig: ClaudeApiConfig): void {
-  if (!apiConfig.customApiKey) throw new Error(`API key is required to apply ${apiConfig.customProviderName}.`);
   if (!apiConfig.customBaseUrl) throw new Error(`Base URL is required to apply ${apiConfig.customProviderName}.`);
 
   const env = ensureEnv(settings);
   clearClaudeRouteEnv(settings);
   env.ANTHROPIC_BASE_URL = apiConfig.customBaseUrl;
-  env[apiConfig.customApiKeyField] = apiConfig.customApiKey;
+  // A matching apiKeyHelper stays authoritative without copying its short-lived value into env.
+  if (apiConfig.customApiKey) env[apiConfig.customApiKeyField] = apiConfig.customApiKey;
   // An empty model means "keep whatever the config file already selects", the same thing the
   // Default entry means in every model picker. Pinning the route without pinning the model is a
   // legitimate setup, so the model variables are simply left unset rather than rejected.
@@ -246,14 +277,28 @@ function applyCustomClaudeEnv(settings: Record<string, unknown>, apiConfig: Clau
  */
 export async function resolveClaudeProviderCredential(input: {
   claudeHome?: string;
+  providerId?: string;
+  /** When supplied, config-owned credentials must belong to this effective Claude Base URL. */
+  baseUrl?: string;
   apiKeyField?: ClaudeApiConfig["customApiKeyField"];
   apiKey?: string;
   apiKeySource?: string;
 }): Promise<{ apiKey: string; source: string | null }> {
+  const claudeHome = resolveProviderConfigDirectory(input.claudeHome, ".claude");
+  const explicitKey = input.apiKey?.trim() ?? "";
+  if (!explicitKey && input.baseUrl !== undefined) {
+    const route = await loadClaudeApiConfigDefaults(claudeHome);
+    if (
+      route.activeProvider !== "custom"
+      || normalizeBaseUrl(route.customBaseUrl || "") !== normalizeBaseUrl(input.baseUrl)
+    ) {
+      return { apiKey: "", source: null };
+    }
+  }
   return resolveClaudeCredential({
-    claudeHome: resolveProviderConfigDirectory(input.claudeHome, ".claude"),
+    claudeHome,
     apiKeyField: input.apiKeyField,
-    explicitKey: input.apiKey,
+    explicitKey,
     explicitSource: input.apiKeySource,
   });
 }

--- a/apps/main-1.0/src/core/claude-profile.ts
+++ b/apps/main-1.0/src/core/claude-profile.ts
@@ -10,6 +10,7 @@ import {
 import { writeVerifiedConfig } from "./atomic-config-write";
 import { probeProviderModels, type ProviderModelProbeResult, type ProviderModelsFetch } from "./provider-models";
 import { prepareProviderConfigDirectory, resolveProviderConfigDirectory } from "./provider-config-path";
+import { runProviderCredentialCommand } from "./provider-credential-helper";
 
 export interface ApplyClaudeProfileResult {
   profile: string;
@@ -41,6 +42,13 @@ export interface ClaudeModelProbeInput {
 
 export interface ClaudeModelProbeResult extends ProviderModelProbeResult {
   credentialSource: string;
+}
+
+interface ResolvedClaudeCredential {
+  apiKey: string;
+  source: string | null;
+  /** A helper can be configured without resolving its secret during config snapshots. */
+  configured?: boolean;
 }
 
 const CLAUDE_ROUTE_ENV_KEYS = [
@@ -95,14 +103,18 @@ export async function loadClaudeConfigSnapshot(configuredHome?: string): Promise
   const settingsPath = path.join(claudeHome, "settings.json");
   const text = await readOptionalFile(settingsPath);
   const route = await loadClaudeApiConfigDefaults(claudeHome);
-  const credential = await resolveClaudeCredential({ claudeHome, apiKeyField: route.customApiKeyField });
+  const credential = await resolveClaudeCredential({
+    claudeHome,
+    apiKeyField: route.customApiKeyField,
+    executeCredentialHelper: false,
+  });
   return {
     claudeHome,
     settingsPath,
     exists: Boolean(text?.trim()),
     route: Object.keys(route).length > 0 ? { ...route, customApiKey: "" } : route,
     credentialSource: credential.source,
-    hasApiKey: Boolean(credential.apiKey),
+    hasApiKey: Boolean(credential.apiKey) || credential.configured === true,
   };
 }
 
@@ -148,6 +160,8 @@ export async function applyClaudeApiConfig(options: {
       claudeHome,
       apiKeyField: apiConfig.customApiKeyField,
       explicitKey: apiConfig.customApiKey,
+      // Applying a route must never turn a short-lived helper value into a persisted API key.
+      executeCredentialHelper: false,
     });
     if (!credential.apiKey) throw new Error(`No API key was found for ${apiConfig.customProviderName}.`);
     credentialSource = credential.source;
@@ -226,9 +240,9 @@ function applyCustomClaudeEnv(settings: Record<string, unknown>, apiConfig: Clau
 
 /**
  * Resolves the credential the Claude CLI would use for a config directory, following the same
- * order it does: an explicitly typed key, then `settings.json`'s `env`, then the process
- * environment. Mirrors `resolveCodexProviderCredential` so callers that must work against either
- * agent — the AI summary panel, for one — can treat the two the same way.
+ * order it does: an explicitly typed key, process and settings environment values, then
+ * `apiKeyHelper`. Mirrors `resolveCodexProviderCredential` so callers that must work against
+ * either agent — the AI summary panel, for one — can treat the two the same way.
  */
 export async function resolveClaudeProviderCredential(input: {
   claudeHome?: string;
@@ -249,7 +263,9 @@ async function resolveClaudeCredential(options: {
   apiKeyField?: ClaudeApiConfig["customApiKeyField"];
   explicitKey?: string;
   explicitSource?: string;
-}): Promise<{ apiKey: string; source: string | null }> {
+  /** Config snapshots detect apiKeyHelper without executing a user-owned shell command. */
+  executeCredentialHelper?: boolean;
+}): Promise<ResolvedClaudeCredential> {
   const explicitKey = options.explicitKey?.trim() ?? "";
   if (explicitKey) return { apiKey: explicitKey, source: options.explicitSource || "API key field" };
   const settings = parseJsonObject(await readOptionalFile(path.join(options.claudeHome, "settings.json")));
@@ -262,6 +278,25 @@ async function resolveClaudeCredential(options: {
   for (const key of keys) {
     const value = readString(env[key]);
     if (value) return { apiKey: value, source: `settings.json env.${key}` };
+  }
+  const apiKeyHelper = readString(settings?.apiKeyHelper);
+  if (apiKeyHelper) {
+    const source = "settings.json apiKeyHelper";
+    if (options.executeCredentialHelper === false) return { apiKey: "", source, configured: true };
+    const helperEnv = { ...process.env };
+    for (const [key, value] of Object.entries(env)) {
+      if (typeof value === "string") helperEnv[key] = value;
+    }
+    const shell = process.platform === "win32"
+      ? process.env.ComSpec?.trim() || "cmd.exe"
+      : "/bin/sh";
+    const args = process.platform === "win32"
+      ? ["/d", "/s", "/c", apiKeyHelper]
+      : ["-c", apiKeyHelper];
+    return {
+      apiKey: await runProviderCredentialCommand({ command: shell, args, env: helperEnv }),
+      source,
+    };
   }
   return { apiKey: "", source: null };
 }

--- a/apps/main-1.0/src/core/codex-chat-proxy-lifecycle.test.ts
+++ b/apps/main-1.0/src/core/codex-chat-proxy-lifecycle.test.ts
@@ -1,0 +1,190 @@
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { CodexChatProxy } from "./codex-chat-proxy";
+
+const runningProxies: CodexChatProxy[] = [];
+
+afterEach(async () => {
+  await Promise.all(runningProxies.splice(0).map((proxy) => proxy.stop()));
+});
+
+describe("Codex Chat proxy upstream lifecycle", () => {
+  it("releases a completed upstream request before the proxy stops", async () => {
+    let upstreamSignal: AbortSignal | undefined;
+    const proxy = createProxy(async (_input, init) => {
+      upstreamSignal = init?.signal as AbortSignal;
+      return chatResponse("OK");
+    });
+    const status = await proxy.start();
+
+    const response = await requestCompletion(status.baseUrl);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('"delta":"OK"');
+    expect(upstreamSignal?.aborted).toBe(false);
+
+    await proxy.stop();
+    expect(upstreamSignal?.aborted).toBe(false);
+  });
+
+  it("releases failed upstream requests and redacts reflected credentials", async () => {
+    let upstreamSignal: AbortSignal | undefined;
+    const proxy = createProxy(async (_input, init) => {
+      upstreamSignal = init?.signal as AbortSignal;
+      return new Response("gateway rejected lifecycle-secret for tenant demo", { status: 401 });
+    });
+    const status = await proxy.start();
+
+    const response = await requestCompletion(status.baseUrl);
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      error: { message: "gateway rejected [REDACTED] for tenant demo" },
+    });
+
+    await proxy.stop();
+    expect(upstreamSignal?.aborted).toBe(false);
+  });
+
+  it("redacts credentials from thrown upstream transport errors", async () => {
+    const proxy = createProxy(async () => {
+      throw new Error("transport lifecycle-secret failed");
+    });
+    const status = await proxy.start();
+
+    const response = await requestCompletion(status.baseUrl);
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: { message: "transport [REDACTED] failed" },
+    });
+  });
+
+  it("aborts a hanging upstream request so stop can complete", async () => {
+    let upstreamSignal: AbortSignal | undefined;
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const proxy = createProxy((_input, init) => {
+      upstreamSignal = init?.signal as AbortSignal;
+      return new Promise<Response>((_resolve, reject) => {
+        upstreamSignal?.addEventListener("abort", () => reject(abortError()), { once: true });
+        markStarted();
+      });
+    });
+    const status = await proxy.start();
+    const clientRequest = requestCompletion(status.baseUrl).catch(() => null);
+    await started;
+
+    await expect(proxy.stop()).resolves.toBeUndefined();
+    expect(upstreamSignal?.aborted).toBe(true);
+    await clientRequest;
+  });
+
+  it("stops while a client is still uploading its request body", async () => {
+    let upstreamCalled = false;
+    const proxy = createProxy(async () => {
+      upstreamCalled = true;
+      return chatResponse("unexpected");
+    });
+    const status = await proxy.start();
+    const request = http.request(`${status.baseUrl}/responses`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": "1024",
+      },
+    });
+    request.on("error", () => undefined);
+    await new Promise<void>((resolve) => {
+      request.once("socket", (socket) => {
+        socket.once("connect", () => {
+          request.write('{"model":"test-model",');
+          setImmediate(resolve);
+        });
+      });
+    });
+
+    await expect(proxy.stop()).resolves.toBeUndefined();
+    expect(upstreamCalled).toBe(false);
+  });
+
+  it("aborts the matching upstream request when its client disconnects", async () => {
+    let upstreamSignal: AbortSignal | undefined;
+    let markStarted!: () => void;
+    let markAborted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const aborted = new Promise<void>((resolve) => {
+      markAborted = resolve;
+    });
+    const proxy = createProxy((_input, init) => {
+      upstreamSignal = init?.signal as AbortSignal;
+      return new Promise<Response>((_resolve, reject) => {
+        upstreamSignal?.addEventListener("abort", () => {
+          markAborted();
+          reject(abortError());
+        }, { once: true });
+        markStarted();
+      });
+    });
+    const status = await proxy.start();
+    const request = http.request(`${status.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+    });
+    request.on("error", () => undefined);
+    request.end(requestBody());
+    await started;
+
+    request.destroy();
+    await aborted;
+
+    expect(upstreamSignal?.aborted).toBe(true);
+    await expect(proxy.stop()).resolves.toBeUndefined();
+  });
+});
+
+function createProxy(
+  fetchImpl: (input: string | URL | Request, init?: RequestInit) => Promise<Response>,
+): CodexChatProxy {
+  const proxy = new CodexChatProxy({
+    upstreamBaseUrl: "https://upstream.invalid/v1",
+    apiKey: "lifecycle-secret",
+    model: "test-model",
+    fetchImpl: fetchImpl as typeof fetch,
+  });
+  runningProxies.push(proxy);
+  return proxy;
+}
+
+function requestCompletion(baseUrl: string): Promise<Response> {
+  return fetch(`${baseUrl}/responses`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: requestBody(),
+  });
+}
+
+function requestBody(): string {
+  return JSON.stringify({
+    model: "test-model",
+    input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "Reply OK." }] }],
+    stream: false,
+  });
+}
+
+function chatResponse(content: string): Response {
+  return new Response(JSON.stringify({
+    model: "test-model",
+    choices: [{ message: { content } }],
+  }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function abortError(): Error {
+  const error = new Error("upstream request aborted");
+  error.name = "AbortError";
+  return error;
+}

--- a/apps/main-1.0/src/core/codex-chat-proxy.ts
+++ b/apps/main-1.0/src/core/codex-chat-proxy.ts
@@ -6,6 +6,7 @@ export interface CodexChatProxyOptions {
   model: string;
   listenHost?: string;
   listenPort?: number;
+  fetchImpl?: typeof fetch;
 }
 
 export interface CodexChatProxyStatus {
@@ -20,6 +21,7 @@ export interface CodexChatProxyStatus {
 export class CodexChatProxy {
   private server: http.Server | null = null;
   private status: CodexChatProxyStatus | null = null;
+  private readonly activeUpstreamRequests = new Set<AbortController>();
 
   constructor(private readonly options: CodexChatProxyOptions) {}
 
@@ -51,10 +53,16 @@ export class CodexChatProxy {
     const server = this.server;
     this.server = null;
     this.status = null;
+    for (const controller of this.activeUpstreamRequests) controller.abort();
     if (!server) return;
-    await new Promise<void>((resolve, reject) => {
+    const closed = new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
     });
+    // `server.close()` waits for active clients, including one that never finishes uploading its
+    // request body. Force those sockets closed after initiating graceful shutdown so stop remains
+    // bounded; upstream requests have already received their abort signal above.
+    server.closeAllConnections();
+    await closed;
   }
 
   getStatus(): CodexChatProxyStatus {
@@ -89,38 +97,76 @@ export class CodexChatProxy {
       }
 
       const body = JSON.parse(await readRequestBody(req)) as Record<string, unknown>;
-      const upstreamResponse = await fetch(`${normalizeBaseUrl(this.options.upstreamBaseUrl)}/chat/completions`, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          authorization: `Bearer ${this.options.apiKey}`,
-        },
-        body: JSON.stringify(buildChatCompletionRequest(body, this.effectiveModel(body))),
-      });
+      const controller = new AbortController();
+      const abortUpstream = () => controller.abort();
+      const abortUpstreamIfResponseIncomplete = () => {
+        if (!res.writableEnded) abortUpstream();
+      };
+      req.once("aborted", abortUpstream);
+      res.once("close", abortUpstreamIfResponseIncomplete);
+      this.activeUpstreamRequests.add(controller);
+      try {
+        const upstreamResponse = await (this.options.fetchImpl ?? fetch)(
+          `${normalizeBaseUrl(this.options.upstreamBaseUrl)}/chat/completions`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              authorization: `Bearer ${this.options.apiKey}`,
+            },
+            body: JSON.stringify(buildChatCompletionRequest(body, this.effectiveModel(body))),
+            signal: controller.signal,
+          },
+        );
 
-      if (!upstreamResponse.ok || !upstreamResponse.body) {
-        const text = await upstreamResponse.text().catch(() => "");
-        writeJson(res, upstreamResponse.status || 502, {
-          error: { message: text || `Upstream request failed with status ${upstreamResponse.status}.` },
+        if (!upstreamResponse.ok || !upstreamResponse.body) {
+          const text = await upstreamResponse.text().catch(() => "");
+          if (res.destroyed || res.writableEnded) return;
+          writeJson(res, upstreamResponse.status || 502, {
+            error: {
+              message: redactSecret(
+                text || `Upstream request failed with status ${upstreamResponse.status}.`,
+                this.options.apiKey,
+              ),
+            },
+          });
+          return;
+        }
+
+        if (!upstreamResponse.headers.get("content-type")?.includes("text/event-stream")) {
+          if (res.destroyed || res.writableEnded) return;
+          await writeNonStreamingChatResponse(res, upstreamResponse);
+          return;
+        }
+
+        if (res.destroyed || res.writableEnded) return;
+        res.writeHead(200, {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
         });
-        return;
+        await pipeChatSseAsResponses(upstreamResponse.body, res, this.effectiveModel(body) || "chat-model");
+      } finally {
+        req.off("aborted", abortUpstream);
+        res.off("close", abortUpstreamIfResponseIncomplete);
+        this.activeUpstreamRequests.delete(controller);
       }
-
-      if (!upstreamResponse.headers.get("content-type")?.includes("text/event-stream")) {
-        await writeNonStreamingChatResponse(res, upstreamResponse);
-        return;
-      }
-
-      res.writeHead(200, {
-        "content-type": "text/event-stream",
-        "cache-control": "no-cache",
-        connection: "keep-alive",
-      });
-      await pipeChatSseAsResponses(upstreamResponse.body, res, this.effectiveModel(body) || "chat-model");
     } catch (error) {
+      if (isAbortError(error)) {
+        if (!res.destroyed && !res.writableEnded) res.destroy();
+        return;
+      }
+      if (res.destroyed || res.writableEnded) return;
       if (!res.headersSent) {
-        writeJson(res, 500, { error: { message: error instanceof Error ? error.message : String(error) } });
-      } else {
+        writeJson(res, 500, {
+          error: {
+            message: redactSecret(
+              error instanceof Error ? error.message : String(error),
+              this.options.apiKey,
+            ),
+          },
+        });
+      } else if (!res.writableEnded) {
         res.end();
       }
     }
@@ -527,6 +573,14 @@ function isResponsesPath(url: string): boolean {
 
 function normalizeBaseUrl(baseUrl: string): string {
   return baseUrl.trim().replace(/\/+$/, "");
+}
+
+function redactSecret(message: string, secret: string): string {
+  return secret ? message.split(secret).join("[REDACTED]") : message;
+}
+
+function isAbortError(error: unknown): boolean {
+  return Boolean(error && typeof error === "object" && "name" in error && error.name === "AbortError");
 }
 
 function readString(value: unknown): string {

--- a/apps/main-1.0/src/core/codex-profile.test.ts
+++ b/apps/main-1.0/src/core/codex-profile.test.ts
@@ -4,10 +4,12 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { API_PROVIDER_PRESETS, defaultApiConfig, mergeApiConfigWithProfileDefaults, normalizeApiConfig } from "./api-config";
-import { applyCodexApiConfig, codexProfileForApiConfig, loadActiveCodexSummaryEndpointDefaults, loadCodexConfigSnapshot, loadCodexProfileDefaults, probeCodexModels } from "./codex-profile";
+import { applyCodexApiConfig, codexProfileForApiConfig, loadActiveCodexSummaryEndpointDefaults, loadCodexConfigSnapshot, loadCodexProfileDefaults, probeCodexModels, resolveCodexProviderCredential } from "./codex-profile";
 
 async function withCodexHome<T>(run: (codexHome: string) => Promise<T>): Promise<T> {
   const codexHome = await mkdtemp(path.join(tmpdir(), "agent-recall-codex-"));
+  vi.stubEnv("HOME", codexHome);
+  vi.stubEnv("USERPROFILE", codexHome);
   try {
     return await run(codexHome);
   } finally {
@@ -318,6 +320,106 @@ describe("codex profile switching", () => {
       );
 
       expect(result.models).toEqual(["clawbot:gpt-5.5"]);
+    });
+  });
+
+  it("detects command-backed Codex auth without running the helper during snapshots", async () => {
+    await withCodexHome(async (codexHome) => {
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          'model_provider = "gateway"',
+          "",
+          "[model_providers.gateway]",
+          'base_url = "https://api.example/v1"',
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+        ].join("\n"),
+      );
+
+      await expect(loadCodexConfigSnapshot(codexHome)).resolves.toMatchObject({
+        hasApiKey: true,
+        credentialSource: "config.toml gateway.auth.command",
+        activeProvider: {
+          hasApiKey: true,
+          credentialSource: "config.toml gateway.auth.command",
+        },
+      });
+    });
+  });
+
+  it("probes with the bearer token returned by a Codex auth command", async () => {
+    await withCodexHome(async (codexHome) => {
+      await writeFile(path.join(codexHome, "command-token.txt"), "command-key\n");
+      const helperArgs = [
+        "-e",
+        'process.stdout.write(require("node:fs").readFileSync("command-token.txt", "utf8"))',
+      ];
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          'model_provider = "gateway"',
+          "",
+          "[model_providers.gateway]",
+          'base_url = "https://api.example/v1"',
+          "",
+          "[model_providers.gateway.auth]",
+          `command = ${JSON.stringify(process.execPath)}`,
+          `args = ${JSON.stringify(helperArgs)}`,
+          `cwd = ${JSON.stringify(codexHome)}`,
+          "timeout_ms = 5000",
+        ].join("\n"),
+      );
+
+      await expect(resolveCodexProviderCredential({
+        codexHome,
+        providerId: "gateway",
+        executeCredentialHelper: true,
+      })).resolves.toEqual({
+        apiKey: "command-key",
+        source: "config.toml gateway.auth.command",
+      });
+
+      const result = await probeCodexModels(
+        { baseUrl: "", apiKey: "", providerId: "gateway", codexHome },
+        async (_url, init) => {
+          expect(init?.headers?.Authorization).toBe("Bearer command-key");
+          return { ok: true, status: 200, async json() { return { data: [{ id: "gateway-model" }] }; } };
+        },
+      );
+
+      expect(result).toMatchObject({
+        models: ["gateway-model"],
+        credentialSource: "config.toml gateway.auth.command",
+      });
+    });
+  });
+
+  it("prefers the configured provider env_key over an unrelated auth.json login", async () => {
+    vi.stubEnv("DMS_API_KEY", "provider-env-key");
+    await withCodexHome(async (codexHome) => {
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          'model_provider = "dms"',
+          "",
+          "[model_providers.dms]",
+          'base_url = "https://api.example/v1"',
+          'env_key = "DMS_API_KEY"',
+        ].join("\n"),
+      );
+      await writeFile(path.join(codexHome, "auth.json"), JSON.stringify({ OPENAI_API_KEY: "official-login-key" }));
+
+      const result = await probeCodexModels(
+        { baseUrl: "", apiKey: "", providerId: "dms", codexHome },
+        async (_url, init) => {
+          expect(init?.headers?.Authorization).toBe("Bearer provider-env-key");
+          return { ok: true, status: 200, async json() { return { data: [{ id: "dms-model" }] }; } };
+        },
+      );
+
+      expect(result.credentialSource).toBe("environment DMS_API_KEY");
     });
   });
 
@@ -746,6 +848,9 @@ describe("loadActiveCodexSummaryEndpointDefaults", () => {
   beforeEach(() => {
     vi.stubEnv("OPENAI_API_KEY", "");
     codexHome = mkdtempSync(path.join(tmpdir(), "codex-profile-test-"));
+    vi.stubEnv("HOME", codexHome);
+    vi.stubEnv("USERPROFILE", codexHome);
+    vi.stubEnv("CODEX_API_KEY", "");
   });
 
   afterEach(() => {

--- a/apps/main-1.0/src/core/codex-profile.test.ts
+++ b/apps/main-1.0/src/core/codex-profile.test.ts
@@ -349,6 +349,211 @@ describe("codex profile switching", () => {
     });
   });
 
+  it("keeps resolving readable credentials when command execution is disabled", async () => {
+    await withCodexHome(async (codexHome) => {
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          "[model_providers.gateway]",
+          'api_key = "inline-key"',
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+        ].join("\n"),
+      );
+
+      await expect(resolveCodexProviderCredential({
+        codexHome,
+        providerId: "gateway",
+        executeCredentialHelper: false,
+      })).resolves.toEqual({
+        apiKey: "inline-key",
+        source: "config.toml gateway.api_key",
+      });
+
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          "[model_providers.gateway]",
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+        ].join("\n"),
+      );
+      await writeFile(path.join(codexHome, "auth.json"), '{"OPENAI_API_KEY":"auth-file-key"}\n');
+
+      await expect(resolveCodexProviderCredential({
+        codexHome,
+        providerId: "gateway",
+        executeCredentialHelper: false,
+      })).resolves.toEqual({
+        apiKey: "auth-file-key",
+        source: "auth.json OPENAI_API_KEY",
+      });
+    });
+  });
+
+  it("does not borrow a sibling key for a provider with command auth", async () => {
+    await withCodexHome(async (codexHome) => {
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          "[model_providers.gateway]",
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+          "",
+          "[model_providers.sibling]",
+          'api_key = "sibling-key"',
+        ].join("\n"),
+      );
+
+      await expect(resolveCodexProviderCredential({
+        codexHome,
+        providerId: "gateway",
+        executeCredentialHelper: false,
+      })).resolves.toMatchObject({
+        apiKey: "",
+        source: "config.toml gateway.auth.command",
+      });
+    });
+  });
+
+  it("applies a command-backed provider without executing or replacing its helper", async () => {
+    await withCodexHome(async (codexHome) => {
+      const authJson = '{"OPENAI_API_KEY":"unrelated-login-key","tokens":{"keep":true}}\n';
+      await writeFile(path.join(codexHome, "auth.json"), authJson);
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          'model_provider = "gateway"',
+          'model = "old-model"',
+          "",
+          "[model_providers.gateway]",
+          'name = "Old Gateway"',
+          'base_url = "https://old.example/v1"',
+          'wire_api = "responses"',
+          "requires_openai_auth = true",
+          'env_key = "OPENAI_API_KEY"',
+          'experimental_bearer_token = "stale-inline-key"',
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+          'args = ["token", "--json"]',
+          `cwd = ${JSON.stringify(codexHome)}`,
+          "timeout_ms = 4321",
+          "",
+          "[mcp_servers.echo]",
+          'command = "echo"',
+        ].join("\n"),
+      );
+
+      const result = await applyCodexApiConfig({
+        codexHome,
+        apiConfig: {
+          activeProvider: "custom",
+          customProviderId: "gateway",
+          customProviderName: "Gateway",
+          customBaseUrl: "https://new.example/v1",
+          customApiKey: "",
+          customModel: "new-model",
+          customApiFormat: "openai_responses",
+        },
+      });
+
+      const config = await readFile(path.join(codexHome, "config.toml"), "utf8");
+      expect(config).toContain('model_provider = "gateway"');
+      expect(config).toContain('model = "new-model"');
+      expect(config).toContain('name = "Gateway"');
+      expect(config).toContain('base_url = "https://new.example/v1"');
+      expect(config).not.toContain("requires_openai_auth");
+      expect(config).not.toContain("env_key");
+      expect(config).not.toContain("experimental_bearer_token");
+      expect(config).toContain("[model_providers.gateway.auth]");
+      expect(config).toContain('command = "agent-recall-helper-must-not-run"');
+      expect(config).toContain('args = ["token", "--json"]');
+      expect(config).toContain(`cwd = ${JSON.stringify(codexHome)}`);
+      expect(config).toContain("timeout_ms = 4321");
+      expect(config).toContain("[mcp_servers.echo]");
+      await expect(readFile(path.join(codexHome, "auth.json"), "utf8")).resolves.toBe(authJson);
+      expect(result).toMatchObject({
+        profile: "gateway",
+        credentialSource: "config.toml gateway.auth.command",
+        verified: true,
+      });
+      expect(result.backupPaths).toHaveLength(1);
+    });
+  });
+
+  it("does not create auth.json from a generic environment key for command auth", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "unrelated-environment-key");
+    await withCodexHome(async (codexHome) => {
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          "[model_providers.gateway]",
+          'base_url = "https://old.example/v1"',
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+        ].join("\n"),
+      );
+
+      await applyCodexApiConfig({
+        codexHome,
+        apiConfig: {
+          activeProvider: "custom",
+          customProviderId: "gateway",
+          customProviderName: "Gateway",
+          customBaseUrl: "https://new.example/v1",
+          customApiKey: "",
+          customModel: "new-model",
+          customApiFormat: "openai_responses",
+        },
+      });
+
+      await expect(readFile(path.join(codexHome, "auth.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
+  it("removes command auth when the user explicitly replaces it with an API key", async () => {
+    await withCodexHome(async (codexHome) => {
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          "[model_providers.gateway]",
+          'base_url = "https://old.example/v1"',
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+          'args = ["token"]',
+        ].join("\n"),
+      );
+
+      await applyCodexApiConfig({
+        codexHome,
+        apiConfig: {
+          activeProvider: "custom",
+          customProviderId: "gateway",
+          customProviderName: "Gateway",
+          customBaseUrl: "https://new.example/v1",
+          customApiKey: "explicit-key",
+          customModel: "new-model",
+          customApiFormat: "openai_responses",
+        },
+      });
+
+      const config = await readFile(path.join(codexHome, "config.toml"), "utf8");
+      expect(config).not.toContain("[model_providers.gateway.auth]");
+      expect(config).not.toContain("agent-recall-helper-must-not-run");
+      expect(config).toContain("requires_openai_auth = true");
+      expect(config).toContain('experimental_bearer_token = "explicit-key"');
+      await expect(readFile(path.join(codexHome, "auth.json"), "utf8")).resolves.toContain(
+        '"OPENAI_API_KEY": "explicit-key"',
+      );
+    });
+  });
+
   it("probes with the bearer token returned by a Codex auth command", async () => {
     await withCodexHome(async (codexHome) => {
       await writeFile(path.join(codexHome, "command-token.txt"), "command-key\n");

--- a/apps/main-1.0/src/core/codex-profile.test.ts
+++ b/apps/main-1.0/src/core/codex-profile.test.ts
@@ -331,10 +331,10 @@ describe("codex profile switching", () => {
         [
           'model_provider = "gateway"',
           "",
-          "[model_providers.gateway]",
+          "[model_providers.gateway] # provider route",
           'base_url = "https://api.example/v1"',
           "",
-          "[model_providers.gateway.auth]",
+          "[model_providers.gateway.auth] # external credential helper",
           'command = "agent-recall-helper-must-not-run"',
         ].join("\n"),
       );
@@ -506,7 +506,7 @@ describe("codex profile switching", () => {
           'model_provider = "gateway"',
           'model = "old-model"',
           "",
-          "[model_providers.gateway]",
+          "[model_providers.gateway] # provider route",
           'name = "Old Gateway"',
           'base_url = "https://new.example/v1"',
           'wire_api = "responses"',
@@ -514,7 +514,7 @@ describe("codex profile switching", () => {
           'env_key = "OPENAI_API_KEY"',
           'experimental_bearer_token = "stale-inline-key"',
           "",
-          "[model_providers.gateway.auth]",
+          "[model_providers.gateway.auth] # external credential helper",
           'command = "agent-recall-helper-must-not-run"',
           'args = ["token", "--json"]',
           `cwd = ${JSON.stringify(codexHome)}`,
@@ -546,7 +546,8 @@ describe("codex profile switching", () => {
       expect(config).not.toContain("requires_openai_auth");
       expect(config).not.toContain("env_key");
       expect(config).not.toContain("experimental_bearer_token");
-      expect(config).toContain("[model_providers.gateway.auth]");
+      expect(config).toContain("[model_providers.gateway] # provider route");
+      expect(config).toContain("[model_providers.gateway.auth] # external credential helper");
       expect(config).toContain('command = "agent-recall-helper-must-not-run"');
       expect(config).toContain('args = ["token", "--json"]');
       expect(config).toContain(`cwd = ${JSON.stringify(codexHome)}`);
@@ -626,10 +627,10 @@ describe("codex profile switching", () => {
       await writeFile(
         path.join(codexHome, "config.toml"),
         [
-          "[model_providers.gateway]",
+          "[model_providers.gateway] # provider route",
           'base_url = "https://old.example/v1"',
           "",
-          "[model_providers.gateway.auth]",
+          "[model_providers.gateway.auth] # external credential helper",
           'command = "agent-recall-helper-must-not-run"',
           'args = ["token"]',
         ].join("\n"),
@@ -651,6 +652,8 @@ describe("codex profile switching", () => {
       const config = await readFile(path.join(codexHome, "config.toml"), "utf8");
       expect(config).not.toContain("[model_providers.gateway.auth]");
       expect(config).not.toContain("agent-recall-helper-must-not-run");
+      expect(config).toContain("[model_providers.gateway] # provider route");
+      expect(config.match(/\[model_providers\.gateway\]/g)).toHaveLength(1);
       expect(config).toContain("requires_openai_auth = true");
       expect(config).toContain('experimental_bearer_token = "explicit-key"');
       await expect(readFile(path.join(codexHome, "auth.json"), "utf8")).resolves.toContain(

--- a/apps/main-1.0/src/core/codex-profile.test.ts
+++ b/apps/main-1.0/src/core/codex-profile.test.ts
@@ -508,7 +508,7 @@ describe("codex profile switching", () => {
           "",
           "[model_providers.gateway]",
           'name = "Old Gateway"',
-          'base_url = "https://old.example/v1"',
+          'base_url = "https://new.example/v1"',
           'wire_api = "responses"',
           "requires_openai_auth = true",
           'env_key = "OPENAI_API_KEY"',
@@ -562,6 +562,34 @@ describe("codex profile switching", () => {
     });
   });
 
+  it("does not carry command auth to a changed Base URL without an explicit key", async () => {
+    await withCodexHome(async (codexHome) => {
+      const originalConfig = [
+        "[model_providers.gateway]",
+        'base_url = "https://old.example/v1"',
+        "",
+        "[model_providers.gateway.auth]",
+        'command = "agent-recall-helper-must-not-run"',
+      ].join("\n");
+      await writeFile(path.join(codexHome, "config.toml"), originalConfig);
+
+      await expect(applyCodexApiConfig({
+        codexHome,
+        apiConfig: {
+          activeProvider: "custom",
+          customProviderId: "gateway",
+          customProviderName: "Gateway",
+          customBaseUrl: "https://new.example/v1",
+          customApiKey: "",
+          customModel: "new-model",
+          customApiFormat: "openai_responses",
+        },
+      })).rejects.toThrow(/No API key was found/);
+
+      await expect(readFile(path.join(codexHome, "config.toml"), "utf8")).resolves.toBe(originalConfig);
+    });
+  });
+
   it("does not create auth.json from a generic environment key for command auth", async () => {
     vi.stubEnv("OPENAI_API_KEY", "unrelated-environment-key");
     await withCodexHome(async (codexHome) => {
@@ -569,7 +597,7 @@ describe("codex profile switching", () => {
         path.join(codexHome, "config.toml"),
         [
           "[model_providers.gateway]",
-          'base_url = "https://old.example/v1"',
+          'base_url = "https://new.example/v1"',
           "",
           "[model_providers.gateway.auth]",
           'command = "agent-recall-helper-must-not-run"',
@@ -678,6 +706,33 @@ describe("codex profile switching", () => {
     });
   });
 
+  it("does not execute command auth for a different Base URL", async () => {
+    await withCodexHome(async (codexHome) => {
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          "[model_providers.gateway]",
+          'base_url = "https://old.example/v1"',
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+        ].join("\n"),
+      );
+      const fetchImpl = vi.fn();
+
+      await expect(probeCodexModels(
+        {
+          baseUrl: "https://new.example/v1",
+          apiKey: "",
+          providerId: "gateway",
+          codexHome,
+        },
+        fetchImpl,
+      )).rejects.toThrow(/No API key was found/);
+      expect(fetchImpl).not.toHaveBeenCalled();
+    });
+  });
+
   it("uses an explicit probe key without executing the configured auth command", async () => {
     await withCodexHome(async (codexHome) => {
       const markerPath = path.join(codexHome, "probe-helper-ran");
@@ -702,14 +757,14 @@ describe("codex profile switching", () => {
 
       const result = await probeCodexModels(
         {
-          baseUrl: "",
+          baseUrl: "https://new.example/v1",
           apiKey: "explicit-key",
           apiKeySource: "API key field",
           providerId: "gateway",
           codexHome,
         },
         async (url, init) => {
-          expect(String(url)).toBe("https://api.example/v1/models");
+          expect(String(url)).toBe("https://new.example/v1/models");
           expect(init?.headers?.Authorization).toBe("Bearer explicit-key");
           return { ok: true, status: 200, async json() { return { data: [{ id: "gateway-model" }] }; } };
         },
@@ -813,10 +868,8 @@ describe("codex profile switching", () => {
     });
   });
 
-  it("finds a key for a manually typed Custom route that has no section of its own", async () => {
+  it("does not borrow a different provider's key for a manually typed route", async () => {
     await withCodexHome(async (codexHome) => {
-      // The user picked "Manual custom route", so providerId `custom` matches nothing in
-      // config.toml — the key still has to be found on the provider Codex is actually using.
       await writeFile(
         path.join(codexHome, "config.toml"),
         [
@@ -828,18 +881,12 @@ describe("codex profile switching", () => {
         ].join("\n"),
       );
 
-      const result = await probeCodexModels(
+      const fetchImpl = vi.fn();
+      await expect(probeCodexModels(
         { baseUrl: "https://api.example/v1", apiKey: "", providerId: "custom", codexHome },
-        async (_url, init) => {
-          expect(init?.headers?.Authorization).toBe("Bearer sk-inline-dms");
-          return { ok: true, status: 200, async json() { return { data: [{ id: "gh:gpt-5.5" }] }; } };
-        },
-      );
-
-      expect(result).toMatchObject({
-        models: ["gh:gpt-5.5"],
-        credentialSource: "config.toml dms.api_key (provider dms)",
-      });
+        fetchImpl,
+      )).rejects.toThrow(/No API key was found/);
+      expect(fetchImpl).not.toHaveBeenCalled();
     });
   });
 
@@ -865,7 +912,10 @@ describe("codex profile switching", () => {
 
   it("falls back to a .env file next to the Codex config", async () => {
     await withCodexHome(async (codexHome) => {
-      await writeFile(path.join(codexHome, "config.toml"), 'model_provider = "dms"\n\n[model_providers.dms]\n');
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        'model_provider = "dms"\n\n[model_providers.dms]\nbase_url = "https://api.example/v1"\n',
+      );
       await writeFile(path.join(codexHome, ".env"), "# comment\nexport CODEX_API_KEY='sk-dotenv'\n");
 
       const result = await probeCodexModels(

--- a/apps/main-1.0/src/core/codex-profile.test.ts
+++ b/apps/main-1.0/src/core/codex-profile.test.ts
@@ -601,6 +601,51 @@ describe("codex profile switching", () => {
     });
   });
 
+  it("uses an explicit probe key without executing the configured auth command", async () => {
+    await withCodexHome(async (codexHome) => {
+      const markerPath = path.join(codexHome, "probe-helper-ran");
+      const helperArgs = [
+        "-e",
+        `require("node:fs").writeFileSync(${JSON.stringify(markerPath)}, "ran"); process.stdout.write("command-key")`,
+      ];
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          'model_provider = "gateway"',
+          "",
+          "[model_providers.gateway]",
+          'base_url = "https://api.example/v1"',
+          "",
+          "[model_providers.gateway.auth]",
+          `command = ${JSON.stringify(process.execPath)}`,
+          `args = ${JSON.stringify(helperArgs)}`,
+          `cwd = ${JSON.stringify(codexHome)}`,
+        ].join("\n"),
+      );
+
+      const result = await probeCodexModels(
+        {
+          baseUrl: "",
+          apiKey: "explicit-key",
+          apiKeySource: "API key field",
+          providerId: "gateway",
+          codexHome,
+        },
+        async (url, init) => {
+          expect(String(url)).toBe("https://api.example/v1/models");
+          expect(init?.headers?.Authorization).toBe("Bearer explicit-key");
+          return { ok: true, status: 200, async json() { return { data: [{ id: "gateway-model" }] }; } };
+        },
+      );
+
+      expect(result).toMatchObject({
+        models: ["gateway-model"],
+        credentialSource: "API key field",
+      });
+      await expect(readFile(markerPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
   it("prefers the configured provider env_key over an unrelated auth.json login", async () => {
     vi.stubEnv("DMS_API_KEY", "provider-env-key");
     await withCodexHome(async (codexHome) => {

--- a/apps/main-1.0/src/core/codex-profile.test.ts
+++ b/apps/main-1.0/src/core/codex-profile.test.ts
@@ -325,6 +325,7 @@ describe("codex profile switching", () => {
 
   it("detects command-backed Codex auth without running the helper during snapshots", async () => {
     await withCodexHome(async (codexHome) => {
+      await writeFile(path.join(codexHome, "auth.json"), '{"OPENAI_API_KEY":"unrelated-login-key"}\n');
       await writeFile(
         path.join(codexHome, "config.toml"),
         [
@@ -389,6 +390,82 @@ describe("codex profile switching", () => {
       })).resolves.toEqual({
         apiKey: "auth-file-key",
         source: "auth.json OPENAI_API_KEY",
+      });
+    });
+  });
+
+  it("can keep configured command auth authoritative without executing it or borrowing past it", async () => {
+    await withCodexHome(async (codexHome) => {
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          "[model_providers.gateway]",
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+        ].join("\n"),
+      );
+      await writeFile(path.join(codexHome, "auth.json"), '{"OPENAI_API_KEY":"unrelated-login-key"}\n');
+
+      await expect(resolveCodexProviderCredential({
+        codexHome,
+        providerId: "gateway",
+        executeCredentialHelper: false,
+        preferConfiguredHelper: true,
+      })).resolves.toMatchObject({
+        apiKey: "",
+        source: "config.toml gateway.auth.command",
+      });
+
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          'model_provider = "gateway"',
+          "",
+          "[model_providers.gateway]",
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+          "",
+          "[model_providers.sibling]",
+          'api_key = "sibling-key"',
+        ].join("\n"),
+      );
+      await writeFile(path.join(codexHome, "auth.json"), "{}\n");
+
+      await expect(resolveCodexProviderCredential({
+        codexHome,
+        providerId: "manual-route",
+        executeCredentialHelper: false,
+        preferConfiguredHelper: true,
+      })).resolves.toEqual({
+        apiKey: "",
+        source: null,
+      });
+    });
+  });
+
+  it("does not report a sibling provider helper as official-route authentication", async () => {
+    await withCodexHome(async (codexHome) => {
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          'model_provider = "openai"',
+          "",
+          "[model_providers.gateway]",
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+          "",
+          "[model_providers.sibling]",
+          'api_key = "sibling-key"',
+        ].join("\n"),
+      );
+
+      await expect(loadCodexConfigSnapshot(codexHome)).resolves.toMatchObject({
+        activeProviderId: "openai",
+        hasApiKey: false,
+        credentialSource: null,
       });
     });
   });
@@ -1135,6 +1212,7 @@ describe("loadActiveCodexSummaryEndpointDefaults", () => {
         `cwd = ${JSON.stringify(codexHome)}`,
       ].join("\n"),
     );
+    writeFileSync(path.join(codexHome, "auth.json"), '{"OPENAI_API_KEY":"unrelated-login-key"}\n');
 
     await expect(loadActiveCodexSummaryEndpointDefaults(codexHome)).resolves.toBeNull();
     await expect(readFile(customMarker, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
@@ -1158,6 +1236,7 @@ describe("loadActiveCodexSummaryEndpointDefaults", () => {
         `cwd = ${JSON.stringify(codexHome)}`,
       ].join("\n"),
     );
+    writeFileSync(path.join(codexHome, "auth.json"), "{}\n");
 
     await expect(loadActiveCodexSummaryEndpointDefaults(codexHome)).resolves.toBeNull();
     await expect(readFile(borrowedMarker, "utf8")).rejects.toMatchObject({ code: "ENOENT" });

--- a/apps/main-1.0/src/core/codex-profile.test.ts
+++ b/apps/main-1.0/src/core/codex-profile.test.ts
@@ -864,6 +864,55 @@ describe("loadActiveCodexSummaryEndpointDefaults", () => {
     return expect(loadActiveCodexSummaryEndpointDefaults(codexHome)).resolves.toBeNull();
   });
 
+  it("does not execute credential helpers while loading background defaults", async () => {
+    const customMarker = path.join(codexHome, "custom-helper-ran");
+    const customHelperArgs = [
+      "-e",
+      `require("node:fs").writeFileSync(${JSON.stringify(customMarker)}, "ran"); process.stdout.write("custom-key")`,
+    ];
+    writeFileSync(
+      path.join(codexHome, "config.toml"),
+      [
+        'model = "provider-model"',
+        'model_provider = "gateway"',
+        "",
+        "[model_providers.gateway]",
+        'base_url = "https://gateway.example/v1"',
+        "",
+        "[model_providers.gateway.auth]",
+        `command = ${JSON.stringify(process.execPath)}`,
+        `args = ${JSON.stringify(customHelperArgs)}`,
+        `cwd = ${JSON.stringify(codexHome)}`,
+      ].join("\n"),
+    );
+
+    await expect(loadActiveCodexSummaryEndpointDefaults(codexHome)).resolves.toBeNull();
+    await expect(readFile(customMarker, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+
+    const borrowedMarker = path.join(codexHome, "borrowed-helper-ran");
+    const borrowedHelperArgs = [
+      "-e",
+      `require("node:fs").writeFileSync(${JSON.stringify(borrowedMarker)}, "ran"); process.stdout.write("borrowed-key")`,
+    ];
+    writeFileSync(
+      path.join(codexHome, "config.toml"),
+      [
+        'model = "gpt-5.5"',
+        "",
+        "[model_providers.gateway]",
+        'base_url = "https://gateway.example/v1"',
+        "",
+        "[model_providers.gateway.auth]",
+        `command = ${JSON.stringify(process.execPath)}`,
+        `args = ${JSON.stringify(borrowedHelperArgs)}`,
+        `cwd = ${JSON.stringify(codexHome)}`,
+      ].join("\n"),
+    );
+
+    await expect(loadActiveCodexSummaryEndpointDefaults(codexHome)).resolves.toBeNull();
+    await expect(readFile(borrowedMarker, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("falls back to OPENAI_API_KEY for the official provider", async () => {
     writeFileSync(path.join(codexHome, "config.toml"), 'model = "gpt-5.5"\n');
     writeFileSync(

--- a/apps/main-1.0/src/core/codex-profile.ts
+++ b/apps/main-1.0/src/core/codex-profile.ts
@@ -187,10 +187,14 @@ export async function loadCodexConfigSnapshot(configuredHome?: string): Promise<
 export async function probeCodexModels(input: CodexModelProbeInput, fetchImpl: ProviderModelsFetch = fetch): Promise<CodexModelProbeResult> {
   const providerId = input.providerId || await readActiveCodexProviderId(input.codexHome);
   const explicitKey = input.apiKey.trim();
-  // Always consult the Codex config: a manually typed Custom route has no section of
-  // its own, and the summary route falls back to whatever Codex is already using.
-  const configProvider = await readCodexConfigProviderSecret(providerId, input.codexHome, !explicitKey);
-  const baseUrl = normalizeBaseUrl(input.baseUrl || configProvider?.baseUrl || "");
+  const requestedBaseUrl = normalizeBaseUrl(input.baseUrl);
+  const configProvider = await readCodexConfigProviderSecret(
+    providerId,
+    requestedBaseUrl,
+    input.codexHome,
+    !explicitKey,
+  );
+  const baseUrl = requestedBaseUrl || normalizeBaseUrl(configProvider?.baseUrl || "");
   const apiKey = explicitKey || configProvider?.apiKey || "";
   const result = await probeProviderModels({ baseUrl, apiKey }, fetchImpl);
   return {
@@ -202,6 +206,8 @@ export async function probeCodexModels(input: CodexModelProbeInput, fetchImpl: P
 export async function resolveCodexProviderCredential(input: {
   codexHome?: string;
   providerId?: string;
+  /** When supplied, config-owned credentials must belong to this exact provider route. */
+  baseUrl?: string;
   apiKey?: string;
   apiKeySource?: string;
   /** Opt in only for an operation that may execute the provider's configured auth command. */
@@ -212,12 +218,24 @@ export async function resolveCodexProviderCredential(input: {
   const codexHome = resolveProviderConfigDirectory(input.codexHome, ".codex");
   const configText = await readOptionalFile(path.join(codexHome, "config.toml"));
   const providerId = input.providerId || readTopLevelTomlString(configText, "model_provider") || "";
+  const explicitKey = input.apiKey?.trim() ?? "";
+  if (!explicitKey && input.baseUrl !== undefined) {
+    const section = providerId ? readTomlSection(configText, modelProviderSection(providerId)) : "";
+    const configuredBaseUrl = readTomlString(section, "base_url") || "";
+    if (
+      !configuredBaseUrl
+      || normalizeBaseUrl(configuredBaseUrl) !== normalizeBaseUrl(input.baseUrl)
+    ) {
+      return { apiKey: "", source: null };
+    }
+  }
   return resolveCodexCredential({
     codexHome,
     configText,
     providerId,
     explicitKey: input.apiKey,
     explicitSource: input.apiKeySource,
+    allowOtherProviders: input.baseUrl === undefined,
     executeCredentialHelper: input.executeCredentialHelper ?? false,
     preferConfiguredHelper: input.preferConfiguredHelper ?? false,
   });
@@ -269,20 +287,27 @@ async function readActiveCodexProviderId(codexHome?: string): Promise<string> {
 
 async function readCodexConfigProviderSecret(
   providerId: string,
+  requestedBaseUrl: string,
   codexHome?: string,
-  executeCredentialHelper = false,
+  resolveCredential = true,
 ): Promise<{ baseUrl: string; apiKey: string; credentialSource: string | null } | null> {
+  if (!providerId) return null;
   const home = resolveProviderConfigDirectory(codexHome, ".codex");
   const text = await readOptionalFile(path.join(home, "config.toml"));
   const section = readTomlSection(text, modelProviderSection(providerId));
   const baseUrl = readTomlString(section, "base_url") || "";
+  // Config-owned credentials belong to the route that declares them. Resolve (and potentially
+  // execute) them only after both the provider id and destination are known to match.
+  if (!baseUrl || (requestedBaseUrl && normalizeBaseUrl(baseUrl) !== requestedBaseUrl)) return null;
+  if (!resolveCredential) return { baseUrl, apiKey: "", credentialSource: null };
   const envKey = readTomlString(section, "env_key") || "";
   const credential = await resolveCodexCredential({
     codexHome: home,
     configText: text,
     providerId,
     envKey,
-    executeCredentialHelper,
+    allowOtherProviders: false,
+    executeCredentialHelper: true,
   });
   return baseUrl || credential.apiKey ? { baseUrl, apiKey: credential.apiKey, credentialSource: credential.source } : null;
 }
@@ -550,24 +575,32 @@ async function applyGeneratedCodexProvider(options: {
   if (!apiConfig.customBaseUrl) throw new Error(`Base URL is required to apply ${apiConfig.customProviderName}.`);
 
   const activeConfigText = await readOptionalFile(configTarget);
-  const commandAuth = readCodexCommandAuth(activeConfigText, providerId);
+  const currentProviderSection = readTomlSection(activeConfigText, modelProviderSection(providerId));
+  const currentBaseUrl = readTomlString(currentProviderSection, "base_url") || "";
+  const currentRouteMatches = Boolean(currentBaseUrl)
+    && normalizeBaseUrl(currentBaseUrl) === normalizeBaseUrl(apiConfig.customBaseUrl);
+  const commandAuth = currentRouteMatches ? readCodexCommandAuth(activeConfigText, providerId) : null;
   // An existing helper remains authoritative unless the user explicitly enters a replacement
   // key. In particular, never persist a generic environment/auth.json fallback for this route.
   const useCommandAuth = Boolean(commandAuth && !apiConfig.customApiKey.trim());
+  const explicitKey = apiConfig.customApiKey.trim();
   const credential: ResolvedCodexCredential = useCommandAuth
     ? {
         apiKey: "",
         source: `config.toml ${providerId}.auth.command`,
         configured: true,
       }
-    : await resolveCodexCredential({
-        codexHome,
-        configText: activeConfigText,
-        providerId,
-        explicitKey: apiConfig.customApiKey,
-        // Applying a route must never turn a short-lived helper token into a persisted API key.
-        executeCredentialHelper: false,
-      });
+    : explicitKey || currentRouteMatches
+      ? await resolveCodexCredential({
+          codexHome,
+          configText: activeConfigText,
+          providerId,
+          explicitKey,
+          allowOtherProviders: false,
+          // Applying a route must never turn a short-lived helper token into a persisted API key.
+          executeCredentialHelper: false,
+        })
+      : { apiKey: "", source: null };
   if (!useCommandAuth && !credential.apiKey) throw new Error(`No API key was found for ${apiConfig.customProviderName}.`);
   const effectiveConfig = { ...apiConfig, customApiKey: credential.apiKey };
   const baseConfigText = activeConfigText.trim() ? activeConfigText : generatedCodexConfig(effectiveConfig, providerId);

--- a/apps/main-1.0/src/core/codex-profile.ts
+++ b/apps/main-1.0/src/core/codex-profile.ts
@@ -146,6 +146,7 @@ export async function loadCodexConfigSnapshot(configuredHome?: string): Promise<
       providerId: provider.id,
       allowOtherProviders: false,
       executeCredentialHelper: false,
+      preferConfiguredHelper: true,
     });
     return {
       ...provider,
@@ -167,6 +168,7 @@ export async function loadCodexConfigSnapshot(configuredHome?: string): Promise<
     configText: text,
     providerId: activeProviderId,
     executeCredentialHelper: false,
+    preferConfiguredHelper: true,
   });
   return {
     codexHome,
@@ -204,6 +206,8 @@ export async function resolveCodexProviderCredential(input: {
   apiKeySource?: string;
   /** Opt in only for an operation that may execute the provider's configured auth command. */
   executeCredentialHelper?: boolean;
+  /** Keep configured command auth authoritative instead of resolving generic fallback keys. */
+  preferConfiguredHelper?: boolean;
 }): Promise<CodexCredentialResolution> {
   const codexHome = resolveProviderConfigDirectory(input.codexHome, ".codex");
   const configText = await readOptionalFile(path.join(codexHome, "config.toml"));
@@ -215,6 +219,7 @@ export async function resolveCodexProviderCredential(input: {
     explicitKey: input.apiKey,
     explicitSource: input.apiKeySource,
     executeCredentialHelper: input.executeCredentialHelper ?? false,
+    preferConfiguredHelper: input.preferConfiguredHelper ?? false,
   });
 }
 
@@ -228,6 +233,7 @@ export async function loadActiveCodexSummaryEndpointDefaults(codexHome?: string)
       codexHome: home,
       configText: text,
       executeCredentialHelper: false,
+      preferConfiguredHelper: true,
     });
     return credential.apiKey
       ? { baseUrl: "", model, apiKey: credential.apiKey, apiFormat: "openai_responses" }
@@ -244,6 +250,7 @@ export async function loadActiveCodexSummaryEndpointDefaults(codexHome?: string)
     providerId,
     envKey,
     executeCredentialHelper: false,
+    preferConfiguredHelper: true,
   });
   const apiKey = credential.apiKey;
   if (!baseUrl || !model || !apiKey) return null;
@@ -294,6 +301,8 @@ async function resolveCodexCredential(options: {
   allowOtherProviders?: boolean;
   /** Provider-owned commands run only when the caller explicitly opts in. */
   executeCredentialHelper?: boolean;
+  /** Do not let readable fallback credentials hide a configured provider helper. */
+  preferConfiguredHelper?: boolean;
 }): Promise<ResolvedCodexCredential> {
   const explicitKey = options.explicitKey?.trim() ?? "";
   if (explicitKey) return { apiKey: explicitKey, source: options.explicitSource || "API key field" };
@@ -304,6 +313,9 @@ async function resolveCodexCredential(options: {
     const source = `config.toml ${options.providerId}.auth.command`;
     if (options.executeCredentialHelper !== true) {
       configuredCommandSource = source;
+      if (options.preferConfiguredHelper) {
+        return { apiKey: "", source, configured: true };
+      }
     } else {
       return {
         apiKey: await runProviderCredentialCommand(commandAuth),
@@ -367,6 +379,7 @@ async function borrowCodexCredentialFromOtherProviders(options: {
   configText: string;
   providerId?: string;
   executeCredentialHelper?: boolean;
+  preferConfiguredHelper?: boolean;
 }): Promise<ResolvedCodexCredential> {
   const activeProviderId = readTopLevelTomlString(options.configText, "model_provider") || "";
   const candidates = [
@@ -382,8 +395,12 @@ async function borrowCodexCredentialFromOtherProviders(options: {
       providerId: candidate,
       allowOtherProviders: false,
       executeCredentialHelper: options.executeCredentialHelper,
+      preferConfiguredHelper: options.preferConfiguredHelper,
     });
     if (credential.apiKey) return { apiKey: credential.apiKey, source: `${credential.source} (provider ${candidate})` };
+    // A helper is scoped to its own provider. It blocks borrowing credentials from
+    // providers behind it, but must not make the requested route look authenticated.
+    if (credential.configured) return { apiKey: "", source: null };
   }
   return { apiKey: "", source: null };
 }

--- a/apps/main-1.0/src/core/codex-profile.ts
+++ b/apps/main-1.0/src/core/codex-profile.ts
@@ -184,11 +184,11 @@ export async function loadCodexConfigSnapshot(configuredHome?: string): Promise<
 
 export async function probeCodexModels(input: CodexModelProbeInput, fetchImpl: ProviderModelsFetch = fetch): Promise<CodexModelProbeResult> {
   const providerId = input.providerId || await readActiveCodexProviderId(input.codexHome);
+  const explicitKey = input.apiKey.trim();
   // Always consult the Codex config: a manually typed Custom route has no section of
   // its own, and the summary route falls back to whatever Codex is already using.
-  const configProvider = await readCodexConfigProviderSecret(providerId, input.codexHome, true);
+  const configProvider = await readCodexConfigProviderSecret(providerId, input.codexHome, !explicitKey);
   const baseUrl = normalizeBaseUrl(input.baseUrl || configProvider?.baseUrl || "");
-  const explicitKey = input.apiKey.trim();
   const apiKey = explicitKey || configProvider?.apiKey || "";
   const result = await probeProviderModels({ baseUrl, apiKey }, fetchImpl);
   return {

--- a/apps/main-1.0/src/core/codex-profile.ts
+++ b/apps/main-1.0/src/core/codex-profile.ts
@@ -754,7 +754,7 @@ function normalizeBaseUrl(baseUrl: string | null): string {
 
 function readCodexModelProviders(text: string): CodexConfigProviderEntry[] {
   const providers: CodexConfigProviderEntry[] = [];
-  const sectionPattern = /^\s*\[model_providers\.([A-Za-z0-9_-]+|"(?:\\.|[^"\\])+")\]\s*$/;
+  const sectionPattern = /^\s*\[model_providers\.([A-Za-z0-9_-]+|"(?:\\.|[^"\\])+")\]\s*(?:#.*)?$/;
   const lines = text.split(/\r?\n/);
   for (let index = 0; index < lines.length; index += 1) {
     const match = lines[index].match(sectionPattern);
@@ -855,7 +855,7 @@ function removeTopLevelTomlKey(text: string, key: string): string {
 
 function removeTomlSectionKey(text: string, sectionHeader: string, key: string): string {
   const lines = text.split(/\r?\n/);
-  const sectionStart = lines.findIndex((line) => line.trim() === sectionHeader);
+  const sectionStart = lines.findIndex((line) => isTomlSectionHeader(line, sectionHeader));
   if (sectionStart < 0) return text;
   let sectionEnd = lines.findIndex((line, index) => index > sectionStart && /^\s*\[/.test(line));
   if (sectionEnd < 0) sectionEnd = lines.length;
@@ -868,7 +868,7 @@ function removeTomlSectionKey(text: string, sectionHeader: string, key: string):
 
 function removeTomlSection(text: string, sectionHeader: string): string {
   const lines = text.split(/\r?\n/);
-  const sectionStart = lines.findIndex((line) => line.trim() === sectionHeader);
+  const sectionStart = lines.findIndex((line) => isTomlSectionHeader(line, sectionHeader));
   if (sectionStart < 0) return text;
   let sectionEnd = lines.findIndex((line, index) => index > sectionStart && /^\s*\[/.test(line));
   if (sectionEnd < 0) sectionEnd = lines.length;
@@ -882,7 +882,7 @@ function replaceOrInsertSectionString(text: string, sectionHeader: string, key: 
 
 function replaceOrInsertSectionLiteral(text: string, sectionHeader: string, key: string, value: string): string {
   const lines = text.split(/\r?\n/);
-  let sectionStart = lines.findIndex((line) => line.trim() === sectionHeader);
+  let sectionStart = lines.findIndex((line) => isTomlSectionHeader(line, sectionHeader));
   if (sectionStart < 0) {
     lines.push("", sectionHeader);
     sectionStart = lines.length - 1;
@@ -926,7 +926,7 @@ async function readOptionalFile(filePath: string): Promise<string> {
 
 function readTomlSection(text: string, sectionHeader: string): string {
   const lines = text.split(/\r?\n/);
-  const start = lines.findIndex((line) => line.trim() === sectionHeader);
+  const start = lines.findIndex((line) => isTomlSectionHeader(line, sectionHeader));
   if (start < 0) return "";
   const sectionLines: string[] = [];
   for (let i = start + 1; i < lines.length; i += 1) {
@@ -934,6 +934,13 @@ function readTomlSection(text: string, sectionHeader: string): string {
     sectionLines.push(lines[i]);
   }
   return sectionLines.join("\n");
+}
+
+function isTomlSectionHeader(line: string, sectionHeader: string): boolean {
+  const trimmed = line.trimStart();
+  if (!trimmed.startsWith(sectionHeader)) return false;
+  const suffix = trimmed.slice(sectionHeader.length).trimStart();
+  return suffix.length === 0 || suffix.startsWith("#");
 }
 
 function readTomlString(text: string, key: string): string | null {

--- a/apps/main-1.0/src/core/codex-profile.ts
+++ b/apps/main-1.0/src/core/codex-profile.ts
@@ -299,13 +299,17 @@ async function resolveCodexCredential(options: {
   if (explicitKey) return { apiKey: explicitKey, source: options.explicitSource || "API key field" };
 
   const commandAuth = options.providerId ? readCodexCommandAuth(options.configText, options.providerId) : null;
+  let configuredCommandSource: string | null = null;
   if (commandAuth) {
     const source = `config.toml ${options.providerId}.auth.command`;
-    if (options.executeCredentialHelper !== true) return { apiKey: "", source, configured: true };
-    return {
-      apiKey: await runProviderCredentialCommand(commandAuth),
-      source,
-    };
+    if (options.executeCredentialHelper !== true) {
+      configuredCommandSource = source;
+    } else {
+      return {
+        apiKey: await runProviderCredentialCommand(commandAuth),
+        source,
+      };
+    }
   }
 
   const section = options.providerId ? readTomlSection(options.configText, modelProviderSection(options.providerId)) : "";
@@ -346,6 +350,9 @@ async function resolveCodexCredential(options: {
     if (dotEnv[key]) return { apiKey: dotEnv[key], source: `.env ${key}` };
   }
 
+  // A configured helper belongs to this provider. Report it before considering sibling
+  // providers, but only after checking readable credentials owned by this provider.
+  if (configuredCommandSource) return { apiKey: "", source: configuredCommandSource, configured: true };
   if (options.allowOtherProviders === false) return { apiKey: "", source: null };
   return borrowCodexCredentialFromOtherProviders(options);
 }
@@ -525,44 +532,57 @@ async function applyGeneratedCodexProvider(options: {
 
   if (!apiConfig.customBaseUrl) throw new Error(`Base URL is required to apply ${apiConfig.customProviderName}.`);
 
-  await mkdir(backupDir, { recursive: true });
-  const backupPaths = await backupExistingTargets([
-    { target: authTarget, backup: path.join(backupDir, `auth.json.before-${providerId}-${stamp}`) },
-    { target: configTarget, backup: path.join(backupDir, `config.toml.before-${providerId}-${stamp}`) },
-  ]);
-
   const activeConfigText = await readOptionalFile(configTarget);
-  const credential = await resolveCodexCredential({
-    codexHome,
-    configText: activeConfigText,
-    providerId,
-    explicitKey: apiConfig.customApiKey,
-    // Applying a route must never turn a short-lived helper token into a persisted API key.
-    executeCredentialHelper: false,
-  });
-  if (!credential.apiKey) throw new Error(`No API key was found for ${apiConfig.customProviderName}.`);
+  const commandAuth = readCodexCommandAuth(activeConfigText, providerId);
+  // An existing helper remains authoritative unless the user explicitly enters a replacement
+  // key. In particular, never persist a generic environment/auth.json fallback for this route.
+  const useCommandAuth = Boolean(commandAuth && !apiConfig.customApiKey.trim());
+  const credential: ResolvedCodexCredential = useCommandAuth
+    ? {
+        apiKey: "",
+        source: `config.toml ${providerId}.auth.command`,
+        configured: true,
+      }
+    : await resolveCodexCredential({
+        codexHome,
+        configText: activeConfigText,
+        providerId,
+        explicitKey: apiConfig.customApiKey,
+        // Applying a route must never turn a short-lived helper token into a persisted API key.
+        executeCredentialHelper: false,
+      });
+  if (!useCommandAuth && !credential.apiKey) throw new Error(`No API key was found for ${apiConfig.customProviderName}.`);
   const effectiveConfig = { ...apiConfig, customApiKey: credential.apiKey };
   const baseConfigText = activeConfigText.trim() ? activeConfigText : generatedCodexConfig(effectiveConfig, providerId);
   const expectedBaseUrl = apiConfig.customApiFormat === "openai_chat" && options.chatProxyBaseUrl
     ? options.chatProxyBaseUrl
     : apiConfig.customBaseUrl;
 
-  // A `requires_openai_auth` provider reads its bearer token from auth.json, so writing
-  // config.toml alone leaves Codex itself without a usable credential.
-  const previousAuthText = await readOptionalFile(authTarget);
-  await writeVerifiedConfig({
-    targetPath: authTarget,
-    contents: codexAuthJson(previousAuthText, credential.apiKey),
-    verify: async () => {
-      const written = readCodexAuthKeys(await readOptionalFile(authTarget));
-      if (written[OFFICIAL_CODEX_AUTH_ENV_KEY] !== credential.apiKey) throw new Error("auth.json credential was not written");
-    },
-  });
+  await mkdir(backupDir, { recursive: true });
+  const backupPaths = await backupExistingTargets([
+    ...(!useCommandAuth ? [{ target: authTarget, backup: path.join(backupDir, `auth.json.before-${providerId}-${stamp}`) }] : []),
+    { target: configTarget, backup: path.join(backupDir, `config.toml.before-${providerId}-${stamp}`) },
+  ]);
+
+  let previousAuthText = "";
+  if (!useCommandAuth) {
+    // A `requires_openai_auth` provider reads its bearer token from auth.json, so writing
+    // config.toml alone leaves Codex itself without a usable credential.
+    previousAuthText = await readOptionalFile(authTarget);
+    await writeVerifiedConfig({
+      targetPath: authTarget,
+      contents: codexAuthJson(previousAuthText, credential.apiKey),
+      verify: async () => {
+        const written = readCodexAuthKeys(await readOptionalFile(authTarget));
+        if (written[OFFICIAL_CODEX_AUTH_ENV_KEY] !== credential.apiKey) throw new Error("auth.json credential was not written");
+      },
+    });
+  }
 
   try {
     await writeVerifiedConfig({
       targetPath: configTarget,
-      contents: applyCodexProviderConfig(baseConfigText, effectiveConfig, providerId, options.chatProxyBaseUrl),
+      contents: applyCodexProviderConfig(baseConfigText, effectiveConfig, providerId, options.chatProxyBaseUrl, useCommandAuth),
       verify: async () => {
         const snapshot = await loadCodexConfigSnapshot(codexHome);
         const provider = snapshot.providers.find((item) => item.id === providerId);
@@ -577,11 +597,13 @@ async function applyGeneratedCodexProvider(options: {
       },
     });
   } catch (error) {
-    if (previousAuthText) await writeFile(authTarget, previousAuthText, { mode: 0o600 });
-    else await rm(authTarget, { force: true });
+    if (!useCommandAuth) {
+      if (previousAuthText) await writeFile(authTarget, previousAuthText, { mode: 0o600 });
+      else await rm(authTarget, { force: true });
+    }
     throw error;
   }
-  await chmodIfExists(authTarget, 0o600);
+  if (!useCommandAuth) await chmodIfExists(authTarget, 0o600);
   await chmod(configTarget, 0o600);
 
   return {
@@ -629,7 +651,13 @@ function applyCodexOfficialConfigOverrides(text: string): string {
   return next.endsWith("\n") ? next : `${next}\n`;
 }
 
-function applyCodexProviderConfig(text: string, apiConfig: ApiConfig, providerId: string, chatProxyBaseUrl?: string): string {
+function applyCodexProviderConfig(
+  text: string,
+  apiConfig: ApiConfig,
+  providerId: string,
+  chatProxyBaseUrl?: string,
+  useCommandAuth = false,
+): string {
   const baseUrl = apiConfig.customApiFormat === "openai_chat" && chatProxyBaseUrl ? chatProxyBaseUrl : apiConfig.customBaseUrl;
   let next = removeTopLevelTomlKey(text, "experimental_bearer_token");
   next = replaceTopLevelString(next, "model_provider", providerId);
@@ -638,9 +666,17 @@ function applyCodexProviderConfig(text: string, apiConfig: ApiConfig, providerId
   next = replaceOrInsertSectionString(next, sectionHeader, "name", apiConfig.customProviderName);
   if (baseUrl) next = replaceOrInsertSectionString(next, sectionHeader, "base_url", baseUrl);
   next = replaceOrInsertSectionString(next, sectionHeader, "wire_api", "responses");
-  next = replaceOrInsertSectionLiteral(next, sectionHeader, "requires_openai_auth", "true");
-  if (apiConfig.customApiKey) {
-    next = replaceOrInsertSectionString(next, sectionHeader, "experimental_bearer_token", apiConfig.customApiKey);
+  const authSectionHeader = `${sectionHeader.slice(0, -1)}.auth]`;
+  if (useCommandAuth) {
+    for (const key of ["requires_openai_auth", "env_key", "experimental_bearer_token"]) {
+      next = removeTomlSectionKey(next, sectionHeader, key);
+    }
+  } else {
+    next = removeTomlSection(next, authSectionHeader);
+    next = replaceOrInsertSectionLiteral(next, sectionHeader, "requires_openai_auth", "true");
+    if (apiConfig.customApiKey) {
+      next = replaceOrInsertSectionString(next, sectionHeader, "experimental_bearer_token", apiConfig.customApiKey);
+    }
   }
   return next.endsWith("\n") ? next : `${next}\n`;
 }
@@ -765,6 +801,29 @@ function removeTopLevelTomlKey(text: string, key: string): string {
       return !(inTopLevel && pattern.test(line));
     })
     .join("\n");
+}
+
+function removeTomlSectionKey(text: string, sectionHeader: string, key: string): string {
+  const lines = text.split(/\r?\n/);
+  const sectionStart = lines.findIndex((line) => line.trim() === sectionHeader);
+  if (sectionStart < 0) return text;
+  let sectionEnd = lines.findIndex((line, index) => index > sectionStart && /^\s*\[/.test(line));
+  if (sectionEnd < 0) sectionEnd = lines.length;
+  const pattern = new RegExp(`^\\s*${escapeRegExp(key)}\\s*=`);
+  for (let index = sectionEnd - 1; index > sectionStart; index -= 1) {
+    if (pattern.test(lines[index])) lines.splice(index, 1);
+  }
+  return lines.join("\n");
+}
+
+function removeTomlSection(text: string, sectionHeader: string): string {
+  const lines = text.split(/\r?\n/);
+  const sectionStart = lines.findIndex((line) => line.trim() === sectionHeader);
+  if (sectionStart < 0) return text;
+  let sectionEnd = lines.findIndex((line, index) => index > sectionStart && /^\s*\[/.test(line));
+  if (sectionEnd < 0) sectionEnd = lines.length;
+  lines.splice(sectionStart, sectionEnd - sectionStart);
+  return lines.join("\n");
 }
 
 function replaceOrInsertSectionString(text: string, sectionHeader: string, key: string, value: string): string {

--- a/apps/main-1.0/src/core/codex-profile.ts
+++ b/apps/main-1.0/src/core/codex-profile.ts
@@ -186,7 +186,7 @@ export async function probeCodexModels(input: CodexModelProbeInput, fetchImpl: P
   const providerId = input.providerId || await readActiveCodexProviderId(input.codexHome);
   // Always consult the Codex config: a manually typed Custom route has no section of
   // its own, and the summary route falls back to whatever Codex is already using.
-  const configProvider = await readCodexConfigProviderSecret(providerId, input.codexHome);
+  const configProvider = await readCodexConfigProviderSecret(providerId, input.codexHome, true);
   const baseUrl = normalizeBaseUrl(input.baseUrl || configProvider?.baseUrl || "");
   const explicitKey = input.apiKey.trim();
   const apiKey = explicitKey || configProvider?.apiKey || "";
@@ -224,7 +224,11 @@ export async function loadActiveCodexSummaryEndpointDefaults(codexHome?: string)
   const providerId = readTopLevelTomlString(text, "model_provider");
   const model = readTopLevelTomlString(text, "model") || "";
   if (!providerId || providerId === OFFICIAL_CODEX_PROVIDER_ID) {
-    const credential = await resolveCodexCredential({ codexHome: home, configText: text });
+    const credential = await resolveCodexCredential({
+      codexHome: home,
+      configText: text,
+      executeCredentialHelper: false,
+    });
     return credential.apiKey
       ? { baseUrl: "", model, apiKey: credential.apiKey, apiFormat: "openai_responses" }
       : null;
@@ -234,7 +238,13 @@ export async function loadActiveCodexSummaryEndpointDefaults(codexHome?: string)
   const baseUrl = readTomlString(section, "base_url") || "";
   const wireApi = readTomlString(section, "wire_api") || "";
   const envKey = readTomlString(section, "env_key") || "";
-  const credential = await resolveCodexCredential({ codexHome: home, configText: text, providerId, envKey });
+  const credential = await resolveCodexCredential({
+    codexHome: home,
+    configText: text,
+    providerId,
+    envKey,
+    executeCredentialHelper: false,
+  });
   const apiKey = credential.apiKey;
   if (!baseUrl || !model || !apiKey) return null;
   return {
@@ -250,13 +260,23 @@ async function readActiveCodexProviderId(codexHome?: string): Promise<string> {
   return readTopLevelTomlString(text, "model_provider") || "";
 }
 
-async function readCodexConfigProviderSecret(providerId: string, codexHome?: string): Promise<{ baseUrl: string; apiKey: string; credentialSource: string | null } | null> {
+async function readCodexConfigProviderSecret(
+  providerId: string,
+  codexHome?: string,
+  executeCredentialHelper = false,
+): Promise<{ baseUrl: string; apiKey: string; credentialSource: string | null } | null> {
   const home = resolveProviderConfigDirectory(codexHome, ".codex");
   const text = await readOptionalFile(path.join(home, "config.toml"));
   const section = readTomlSection(text, modelProviderSection(providerId));
   const baseUrl = readTomlString(section, "base_url") || "";
   const envKey = readTomlString(section, "env_key") || "";
-  const credential = await resolveCodexCredential({ codexHome: home, configText: text, providerId, envKey });
+  const credential = await resolveCodexCredential({
+    codexHome: home,
+    configText: text,
+    providerId,
+    envKey,
+    executeCredentialHelper,
+  });
   return baseUrl || credential.apiKey ? { baseUrl, apiKey: credential.apiKey, credentialSource: credential.source } : null;
 }
 
@@ -272,7 +292,7 @@ async function resolveCodexCredential(options: {
   explicitSource?: string;
   /** Set to false when a caller must not borrow another provider's credential. */
   allowOtherProviders?: boolean;
-  /** Config snapshots detect helper-backed auth without executing provider-owned commands. */
+  /** Provider-owned commands run only when the caller explicitly opts in. */
   executeCredentialHelper?: boolean;
 }): Promise<ResolvedCodexCredential> {
   const explicitKey = options.explicitKey?.trim() ?? "";
@@ -281,7 +301,7 @@ async function resolveCodexCredential(options: {
   const commandAuth = options.providerId ? readCodexCommandAuth(options.configText, options.providerId) : null;
   if (commandAuth) {
     const source = `config.toml ${options.providerId}.auth.command`;
-    if (options.executeCredentialHelper === false) return { apiKey: "", source, configured: true };
+    if (options.executeCredentialHelper !== true) return { apiKey: "", source, configured: true };
     return {
       apiKey: await runProviderCredentialCommand(commandAuth),
       source,

--- a/apps/main-1.0/src/core/codex-profile.ts
+++ b/apps/main-1.0/src/core/codex-profile.ts
@@ -4,6 +4,7 @@ import { API_PROVIDER_PRESETS, normalizeApiConfig, type ApiConfig, type ApiProvi
 import { writeVerifiedConfig } from "./atomic-config-write";
 import { probeProviderModels, type ProviderModelsFetch } from "./provider-models";
 import { prepareProviderConfigDirectory, resolveProviderConfigDirectory } from "./provider-config-path";
+import { runProviderCredentialCommand } from "./provider-credential-helper";
 
 export type CodexProfileName = "codex" | "codexzh";
 export type CodexApplyProfileName = CodexProfileName | "generated";
@@ -49,9 +50,10 @@ export interface CodexConfigSnapshot {
   providers: CodexConfigProviderEntry[];
   /**
    * Credential the active route would actually use, resolved the same way `codex` resolves it:
-   * inline in `config.toml`, then `auth.json`, `.env`, and the environment. The per-provider
-   * entries deliberately refuse to borrow a sibling's key, so an official route — which has no
-   * `[model_providers.*]` section at all — has no other way to report that a key exists.
+   * command-backed auth or inline config, then the provider's environment key and compatible
+   * local stores. The per-provider entries deliberately refuse to borrow a sibling's key, so an
+   * official route — which has no `[model_providers.*]` section at all — has no other way to
+   * report that a key exists.
    */
   credentialSource: string | null;
   hasApiKey: boolean;
@@ -81,6 +83,11 @@ export interface CodexSummaryEndpointDefaults {
 export interface CodexCredentialResolution {
   apiKey: string;
   source: string | null;
+}
+
+interface ResolvedCodexCredential extends CodexCredentialResolution {
+  /** A helper-backed credential can be configured without resolving its secret during snapshots. */
+  configured?: boolean;
 }
 
 const OFFICIAL_CODEX_PROVIDER_ID = "openai";
@@ -133,10 +140,16 @@ export async function loadCodexConfigSnapshot(configuredHome?: string): Promise<
   const activeModel = readTopLevelTomlString(text, "model") || "";
   const providers = await Promise.all(readCodexModelProviders(text).map(async (provider) => {
     // Per-provider display must not borrow a sibling provider's key.
-    const credential = await resolveCodexCredential({ codexHome, configText: text, providerId: provider.id, allowOtherProviders: false });
+    const credential = await resolveCodexCredential({
+      codexHome,
+      configText: text,
+      providerId: provider.id,
+      allowOtherProviders: false,
+      executeCredentialHelper: false,
+    });
     return {
       ...provider,
-      hasApiKey: Boolean(credential.apiKey),
+      hasApiKey: Boolean(credential.apiKey) || credential.configured === true,
       credentialSource: credential.source,
     };
   }));
@@ -149,7 +162,12 @@ export async function loadCodexConfigSnapshot(configuredHome?: string): Promise<
   } catch {
     cachedModels = [];
   }
-  const activeCredential = await resolveCodexCredential({ codexHome, configText: text, providerId: activeProviderId });
+  const activeCredential = await resolveCodexCredential({
+    codexHome,
+    configText: text,
+    providerId: activeProviderId,
+    executeCredentialHelper: false,
+  });
   return {
     codexHome,
     configPath,
@@ -160,7 +178,7 @@ export async function loadCodexConfigSnapshot(configuredHome?: string): Promise<
     activeProvider: providers.find((provider) => provider.id === activeProviderId) ?? null,
     providers,
     credentialSource: activeCredential.source,
-    hasApiKey: Boolean(activeCredential.apiKey),
+    hasApiKey: Boolean(activeCredential.apiKey) || activeCredential.configured === true,
   };
 }
 
@@ -184,6 +202,8 @@ export async function resolveCodexProviderCredential(input: {
   providerId?: string;
   apiKey?: string;
   apiKeySource?: string;
+  /** Opt in only for an operation that may execute the provider's configured auth command. */
+  executeCredentialHelper?: boolean;
 }): Promise<CodexCredentialResolution> {
   const codexHome = resolveProviderConfigDirectory(input.codexHome, ".codex");
   const configText = await readOptionalFile(path.join(codexHome, "config.toml"));
@@ -194,6 +214,7 @@ export async function resolveCodexProviderCredential(input: {
     providerId,
     explicitKey: input.apiKey,
     explicitSource: input.apiKeySource,
+    executeCredentialHelper: input.executeCredentialHelper ?? false,
   });
 }
 
@@ -251,9 +272,21 @@ async function resolveCodexCredential(options: {
   explicitSource?: string;
   /** Set to false when a caller must not borrow another provider's credential. */
   allowOtherProviders?: boolean;
-}): Promise<{ apiKey: string; source: string | null }> {
+  /** Config snapshots detect helper-backed auth without executing provider-owned commands. */
+  executeCredentialHelper?: boolean;
+}): Promise<ResolvedCodexCredential> {
   const explicitKey = options.explicitKey?.trim() ?? "";
   if (explicitKey) return { apiKey: explicitKey, source: options.explicitSource || "API key field" };
+
+  const commandAuth = options.providerId ? readCodexCommandAuth(options.configText, options.providerId) : null;
+  if (commandAuth) {
+    const source = `config.toml ${options.providerId}.auth.command`;
+    if (options.executeCredentialHelper === false) return { apiKey: "", source, configured: true };
+    return {
+      apiKey: await runProviderCredentialCommand(commandAuth),
+      source,
+    };
+  }
 
   const section = options.providerId ? readTomlSection(options.configText, modelProviderSection(options.providerId)) : "";
   const inline = readInlineCodexKey(section);
@@ -282,24 +315,15 @@ async function resolveCodexCredential(options: {
   const configuredEnvKey = options.envKey || readTomlString(section, "env_key") || "";
   const envKeys = [...new Set([configuredEnvKey, OFFICIAL_CODEX_AUTH_ENV_KEY, ...CODEX_FALLBACK_ENV_KEYS].filter(Boolean))];
   const policy = readTomlSection(options.configText, "[shell_environment_policy.set]");
-  for (const key of envKeys) {
-    const value = readTomlString(policy, key);
-    if (value) return { apiKey: value, source: `config.toml shell_environment_policy.set.${key}` };
-  }
-
   const authFile = readCodexAuthKeys(await readOptionalFile(path.join(options.codexHome, "auth.json")));
-  for (const key of envKeys) {
-    if (authFile[key]) return { apiKey: authFile[key], source: `auth.json ${key}` };
-  }
-
   const dotEnv = parseDotEnv(await readOptionalFile(path.join(options.codexHome, ".env")));
-  for (const key of envKeys) {
-    if (dotEnv[key]) return { apiKey: dotEnv[key], source: `.env ${key}` };
-  }
-
   for (const key of envKeys) {
     const value = process.env[key]?.trim();
     if (value) return { apiKey: value, source: `environment ${key}` };
+    const configured = readTomlString(policy, key);
+    if (configured) return { apiKey: configured, source: `config.toml shell_environment_policy.set.${key}` };
+    if (authFile[key]) return { apiKey: authFile[key], source: `auth.json ${key}` };
+    if (dotEnv[key]) return { apiKey: dotEnv[key], source: `.env ${key}` };
   }
 
   if (options.allowOtherProviders === false) return { apiKey: "", source: null };
@@ -315,7 +339,8 @@ async function borrowCodexCredentialFromOtherProviders(options: {
   codexHome: string;
   configText: string;
   providerId?: string;
-}): Promise<{ apiKey: string; source: string | null }> {
+  executeCredentialHelper?: boolean;
+}): Promise<ResolvedCodexCredential> {
   const activeProviderId = readTopLevelTomlString(options.configText, "model_provider") || "";
   const candidates = [
     ...(activeProviderId && activeProviderId !== options.providerId ? [activeProviderId] : []),
@@ -329,6 +354,7 @@ async function borrowCodexCredentialFromOtherProviders(options: {
       configText: options.configText,
       providerId: candidate,
       allowOtherProviders: false,
+      executeCredentialHelper: options.executeCredentialHelper,
     });
     if (credential.apiKey) return { apiKey: credential.apiKey, source: `${credential.source} (provider ${candidate})` };
   }
@@ -491,6 +517,8 @@ async function applyGeneratedCodexProvider(options: {
     configText: activeConfigText,
     providerId,
     explicitKey: apiConfig.customApiKey,
+    // Applying a route must never turn a short-lived helper token into a persisted API key.
+    executeCredentialHelper: false,
   });
   if (!credential.apiKey) throw new Error(`No API key was found for ${apiConfig.customProviderName}.`);
   const effectiveConfig = { ...apiConfig, customApiKey: credential.apiKey };
@@ -682,6 +710,24 @@ function modelProviderSection(providerId: string): string {
     : `[model_providers.${tomlString(providerId)}]`;
 }
 
+function readCodexCommandAuth(text: string, providerId: string): {
+  command: string;
+  args: string[];
+  timeoutMs?: number;
+  cwd?: string;
+} | null {
+  const parentSection = modelProviderSection(providerId);
+  const authSection = readTomlSection(text, `${parentSection.slice(0, -1)}.auth]`);
+  const command = readTomlString(authSection, "command");
+  if (!command) return null;
+  return {
+    command,
+    args: readTomlStringArray(authSection, "args") ?? [],
+    timeoutMs: readTomlNumber(authSection, "timeout_ms") ?? undefined,
+    cwd: readTomlString(authSection, "cwd") ?? undefined,
+  };
+}
+
 function replaceTopLevelString(text: string, key: string, value: string): string {
   const line = `${key} = ${tomlString(value)}`;
   const pattern = new RegExp(`^${escapeRegExp(key)}\\s*=.*$`, "m");
@@ -766,6 +812,23 @@ function readTomlString(text: string, key: string): string | null {
   const rawValue = text.match(pattern)?.[1];
   if (!rawValue) return null;
   return parseTomlString(rawValue);
+}
+
+function readTomlStringArray(text: string, key: string): string[] | null {
+  const pattern = new RegExp(`^\\s*${escapeRegExp(key)}\\s*=\\s*\\[([\\s\\S]*?)\\]`, "m");
+  const body = text.match(pattern)?.[1];
+  if (body === undefined) return null;
+  return splitTomlCommaList(body)
+    .map((item) => parseTomlString(item))
+    .filter((item): item is string => item !== null);
+}
+
+function readTomlNumber(text: string, key: string): number | null {
+  const pattern = new RegExp(`^\\s*${escapeRegExp(key)}\\s*=\\s*(\\d+)\\s*$`, "m");
+  const value = text.match(pattern)?.[1];
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
 }
 
 function readTomlInlineTable(text: string, key: string): Record<string, string> {

--- a/apps/main-1.0/src/core/provider-credential-helper.ts
+++ b/apps/main-1.0/src/core/provider-credential-helper.ts
@@ -14,8 +14,8 @@ export interface ProviderCredentialCommand {
 
 /**
  * Runs a provider-owned credential helper without stdin and keeps its output out of errors.
- * Credential commands are only invoked from explicit probe/apply actions, never while rendering
- * a config snapshot.
+ * Credential commands are only invoked from explicit connection probes, never while rendering
+ * a config snapshot or applying a route.
  */
 export function runProviderCredentialCommand(spec: ProviderCredentialCommand): Promise<string> {
   const command = spec.command.trim();

--- a/apps/main-1.0/src/core/provider-credential-helper.ts
+++ b/apps/main-1.0/src/core/provider-credential-helper.ts
@@ -1,0 +1,74 @@
+import { spawn } from "node:child_process";
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+const MAX_TIMEOUT_MS = 30_000;
+const MAX_OUTPUT_BYTES = 64 * 1024;
+
+export interface ProviderCredentialCommand {
+  command: string;
+  args?: string[];
+  timeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+  cwd?: string;
+}
+
+/**
+ * Runs a provider-owned credential helper without stdin and keeps its output out of errors.
+ * Credential commands are only invoked from explicit probe/apply actions, never while rendering
+ * a config snapshot.
+ */
+export function runProviderCredentialCommand(spec: ProviderCredentialCommand): Promise<string> {
+  const command = spec.command.trim();
+  if (!command) return Promise.reject(new Error("Credential helper command is empty."));
+  const timeoutMs = Math.min(MAX_TIMEOUT_MS, Math.max(1, spec.timeoutMs ?? DEFAULT_TIMEOUT_MS));
+
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let settled = false;
+    let timer: NodeJS.Timeout | undefined;
+    const child = spawn(command, spec.args ?? [], {
+      env: spec.env ?? process.env,
+      cwd: spec.cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+
+    const finish = (error?: Error, value?: string) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      if (error) reject(error);
+      else resolve(value ?? "");
+    };
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+      if (Buffer.byteLength(stdout, "utf8") <= MAX_OUTPUT_BYTES) return;
+      child.kill();
+      finish(new Error("Credential helper output exceeded the allowed size."));
+    });
+    // Drain stderr without retaining it: helper diagnostics can accidentally contain credentials.
+    child.stderr.resume();
+    child.once("error", () => finish(new Error("Credential helper could not be started.")));
+    child.once("close", (code, signal) => {
+      if (settled) return;
+      if (code !== 0) {
+        finish(new Error(signal ? "Credential helper was terminated." : "Credential helper failed."));
+        return;
+      }
+      const value = stdout.trim();
+      if (!value) {
+        finish(new Error("Credential helper returned an empty value."));
+        return;
+      }
+      finish(undefined, value);
+    });
+
+    timer = setTimeout(() => {
+      child.kill();
+      finish(new Error("Credential helper timed out."));
+    }, timeoutMs);
+    timer.unref();
+  });
+}

--- a/apps/main-1.0/src/core/session-summarizer.test.ts
+++ b/apps/main-1.0/src/core/session-summarizer.test.ts
@@ -363,6 +363,7 @@ describe("summarizeSession", () => {
         apiFormat: "codex_exec",
         command: fake.executable,
         cwd: path.dirname(fake.executable),
+        cliArgs: ["-c", 'model_provider="connection-test"'],
         onTemporarySession: (sessionKey) => temporarySessions.push(sessionKey),
       },
       requestSummaryCompletion,
@@ -374,7 +375,14 @@ describe("summarizeSession", () => {
       .map((line) => JSON.parse(line) as { args: string[]; input: string });
     expect(result.summary).toBe("Summarized with current Codex config.");
     expect(temporarySessions).toEqual(["codex:thread-summary-1"]);
-    expect(calls[0].args).toEqual(expect.arrayContaining(["exec", "--ephemeral", "--json", "--skip-git-repo-check"]));
+    expect(calls[0].args).toEqual(expect.arrayContaining([
+      "exec",
+      "--ephemeral",
+      "--json",
+      "--skip-git-repo-check",
+      "-c",
+      'model_provider="connection-test"',
+    ]));
     expect(calls[0].args).not.toContain(expect.stringContaining("summarize using official codex"));
     expect(calls[0].input).toContain("summarize using official codex");
     expect(calls[0].input.length).toBeGreaterThan(20_000);
@@ -412,6 +420,7 @@ describe("summarizeSession", () => {
         apiFormat: "claude_exec",
         command: fake.executable,
         cwd: path.dirname(fake.executable),
+        cliArgs: ["--settings", '{"env":{"ANTHROPIC_BASE_URL":""}}'],
         onTemporarySession: (sessionKey) => temporarySessions.push(sessionKey),
       },
       requestSummaryCompletion,
@@ -423,7 +432,13 @@ describe("summarizeSession", () => {
       .map((line) => JSON.parse(line) as { args: string[]; input: string });
     expect(result.summary).toBe("Summarized with current Claude Code settings.");
     expect(temporarySessions).toEqual(["claude:claude-summary-1"]);
-    expect(calls[0].args).toEqual(expect.arrayContaining(["--print", "--output-format", "stream-json"]));
+    expect(calls[0].args).toEqual(expect.arrayContaining([
+      "--print",
+      "--output-format",
+      "stream-json",
+      "--settings",
+      '{"env":{"ANTHROPIC_BASE_URL":""}}',
+    ]));
     expect(calls[0].args).not.toContain(expect.stringContaining("summarize using official claude"));
     expect(calls[0].input).toContain("summarize using official claude");
     expect(calls[0].input.length).toBeGreaterThan(20_000);

--- a/apps/main-1.0/src/core/session-summarizer.ts
+++ b/apps/main-1.0/src/core/session-summarizer.ts
@@ -21,6 +21,8 @@ export interface SummaryEndpoint {
   command?: string;
   cwd?: string;
   modelArg?: string;
+  /** Extra read-only CLI flags used to test a draft without writing user configuration. */
+  cliArgs?: string[];
   reasoningEffort?: string;
   /**
    * Extra environment for CLI-backed endpoints. This is how a summary source points `codex` /
@@ -448,6 +450,7 @@ async function codexExecCompletion(endpoint: SummaryEndpoint, messages: ChatMess
       ...(endpoint.reasoningEffort
         ? ["--config", `model_reasoning_effort=\"${endpoint.reasoningEffort}\"`]
         : []),
+      ...(endpoint.cliArgs ?? []),
     ], {
       cwd,
       signal: mergedSignal,
@@ -544,6 +547,7 @@ async function claudeExecCompletion(endpoint: SummaryEndpoint, messages: ChatMes
     "--permission-mode",
     "bypassPermissions",
     ...(endpoint.modelArg ? ["--model", endpoint.modelArg] : []),
+    ...(endpoint.cliArgs ?? []),
   ];
 
   return new Promise<string>((resolve, reject) => {

--- a/apps/main-1.0/src/main/ipc/providers.ts
+++ b/apps/main-1.0/src/main/ipc/providers.ts
@@ -11,6 +11,8 @@ import {
   type ClaudeModelProbeRequest,
   type CodexModelProbeRequest,
   type ConfigSnapshotRequest,
+  type ProviderConnectionRequest,
+  type ProviderConnectionResult,
   type ProviderKeyTarget,
   type SummaryProviderConnectionRequest,
   type SummaryProviderConnectionResult,
@@ -22,6 +24,7 @@ export interface ProvidersIpcService {
   getClaudeConfig(input: ConfigSnapshotRequest): Promise<ClaudeConfigSnapshot>;
   probeCodexModels(input: CodexModelProbeRequest): Promise<CodexModelProbeResult>;
   probeClaudeModels(input: ClaudeModelProbeRequest): Promise<ClaudeModelProbeResult>;
+  testProviderConnection(input: ProviderConnectionRequest): Promise<ProviderConnectionResult>;
   testSummaryProviderConnection(input: SummaryProviderConnectionRequest): Promise<SummaryProviderConnectionResult>;
   applyCodexProfile(apiConfig: Partial<ApiConfig>): Promise<ApplyCodexProfileResult>;
   applyClaudeProfile(apiConfig: Partial<ClaudeApiConfig>): Promise<ApplyClaudeProfileResult>;
@@ -45,6 +48,8 @@ export function registerProvidersIpc(
     registerIpcHandler(ipc, PROVIDERS_IPC.getClaudeConfig, (_event, input) => service.getClaudeConfig(input)),
     registerIpcHandler(ipc, PROVIDERS_IPC.probeCodexModels, (_event, input) => service.probeCodexModels(input)),
     registerIpcHandler(ipc, PROVIDERS_IPC.probeClaudeModels, (_event, input) => service.probeClaudeModels(input)),
+    registerIpcHandler(ipc, PROVIDERS_IPC.testProviderConnection, (_event, input) =>
+      service.testProviderConnection(input)),
     registerIpcHandler(ipc, PROVIDERS_IPC.pickConfigDirectory, (_event, target, defaultPath) => {
       if (!pickConfigDirectory) throw new Error("Config directory picker is unavailable.");
       return pickConfigDirectory(target, defaultPath);

--- a/apps/main-1.0/src/main/services/provider-service.test.ts
+++ b/apps/main-1.0/src/main/services/provider-service.test.ts
@@ -956,6 +956,29 @@ describe("summary connection tests", () => {
 });
 
 describe("ProviderService Codex Chat proxy lifecycle", () => {
+  it("keeps helper-backed apply from promoting a generic resolver fallback into the API key field", async () => {
+    const harness = createHarness();
+    vi.mocked(harness.operations.resolveCodexProviderCredential).mockImplementation(async (input) => (
+      input.preferConfiguredHelper
+        ? { apiKey: "", source: "config.toml deepseek.auth.command" }
+        : { apiKey: "unrelated-login-key", source: "auth.json OPENAI_API_KEY" }
+    ));
+
+    await harness.service.applyCodexProfile(customCodexConfig({
+      customApiKey: "",
+      customApiFormat: "openai_responses",
+    }));
+
+    expect(harness.operations.resolveCodexProviderCredential).toHaveBeenCalledWith({
+      codexHome: undefined,
+      providerId: "deepseek",
+      preferConfiguredHelper: true,
+    });
+    expect(harness.operations.applyCodexApiConfig).toHaveBeenCalledWith({
+      apiConfig: expect.objectContaining({ customApiKey: "" }),
+    });
+  });
+
   it("reuses an identical proxy and replaces it only when its effective config changes", async () => {
     const harness = createHarness();
     const config = customCodexConfig();

--- a/apps/main-1.0/src/main/services/provider-service.test.ts
+++ b/apps/main-1.0/src/main/services/provider-service.test.ts
@@ -51,6 +51,9 @@ function proxyStatus(options: CodexChatProxyOptions): CodexChatProxyStatus {
 
 function createHarness(settings: AppSettings = cloneSettings()) {
   const keys = new Map<string, string>();
+  const getKey = vi.fn((target: "codex" | "claude", providerId: string) => (
+    keys.get(`${target}:${providerId}`) ?? ""
+  ));
   const savedSettings = new Map<string, unknown>();
   const settingsWrites: Array<{ path: string; value: unknown }> = [];
   const proxies: Array<CodexChatProxyPort & { start: ReturnType<typeof vi.fn>; stop: ReturnType<typeof vi.fn> }> = [];
@@ -115,7 +118,7 @@ function createHarness(settings: AppSettings = cloneSettings()) {
   const service = new ProviderService({
     getSettings: () => settings,
     keys: {
-      get: (target, providerId) => keys.get(`${target}:${providerId}`) ?? "",
+      get: getKey,
       set: (target, providerId, apiKey) => keys.set(`${target}:${providerId}`, apiKey),
     },
     settings: {
@@ -129,7 +132,7 @@ function createHarness(settings: AppSettings = cloneSettings()) {
     logError,
     operations,
   });
-  return { service, settings, keys, savedSettings, settingsWrites, operations, proxies, logError };
+  return { service, settings, keys, getKey, savedSettings, settingsWrites, operations, proxies, logError };
 }
 
 function customCodexConfig(overrides: Partial<ApiConfig> = {}): ApiConfig {
@@ -182,6 +185,8 @@ describe("ProviderService settings and keys", () => {
       customModel: "saved-claude-model",
     };
     const harness = createHarness(settings);
+    harness.keys.set("codex:custom", "stale-codex-key");
+    harness.keys.set("claude:custom", "stale-claude-key");
     for (const [path, value] of [
       ["apiConfig.customProviderName", settings.apiConfig.customProviderName],
       ["apiConfig.customBaseUrl", settings.apiConfig.customBaseUrl],
@@ -212,11 +217,13 @@ describe("ProviderService settings and keys", () => {
     expect(hydrated.apiConfig).toMatchObject({
       customProviderName: "Local Codex",
       customBaseUrl: "https://local.example/v1",
+      customApiKey: "",
       customModel: "local-codex-model",
     });
     expect(hydrated.claudeApiConfig).toMatchObject({
       customProviderName: "Local Claude",
       customBaseUrl: "https://local.example/anthropic",
+      customApiKey: "",
       customModel: "local-claude-model",
     });
   });
@@ -228,6 +235,7 @@ describe("ProviderService settings and keys", () => {
       ...settings.claudeApiConfig,
       activeProvider: "custom",
       customProviderId: "deepseek",
+      customBaseUrl: "https://api.deepseek.com/anthropic",
       customApiKey: "",
     };
     const harness = createHarness(settings);
@@ -574,9 +582,9 @@ describe("Provider connection tests", () => {
     await expect(access(testCwd)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("tests an unsaved Codex route with read-only CLI overrides and a stored key", async () => {
+  it("tests an unsaved Codex route only with the explicitly authorized draft key", async () => {
     const harness = createHarness();
-    harness.keys.set("codex:gateway", "stored-key");
+    harness.keys.set("codex:gateway", "stored-key-must-not-be-used");
 
     const result = await harness.service.testProviderConnection({
       target: "codex",
@@ -586,7 +594,7 @@ describe("Provider connection tests", () => {
         customConfigDir: "/tmp/provider-codex",
         customProviderName: "Gateway",
         customBaseUrl: "https://gateway.example/v1/",
-        customApiKey: "",
+        customApiKey: "typed-key",
         customModel: "gpt-test",
         customApiFormat: "openai_responses",
       },
@@ -599,7 +607,7 @@ describe("Provider connection tests", () => {
       modelArg: "gpt-test",
       env: {
         CODEX_HOME: endpoint.cwd,
-        OPENAI_API_KEY: "stored-key",
+        OPENAI_API_KEY: "typed-key",
       },
       cliArgs: expect.arrayContaining([
         "--ignore-user-config",
@@ -611,12 +619,92 @@ describe("Provider connection tests", () => {
         "model_providers.agent-recall-connection-test.env_key=\"OPENAI_API_KEY\"",
       ]),
     }));
-    expect(endpoint.cliArgs?.join(" ")).not.toContain("stored-key");
-    expect(result.credentialSource).toBe("AgentRecall codex key store");
+    expect(endpoint.cliArgs?.join(" ")).not.toContain("typed-key");
+    expect(harness.getKey).not.toHaveBeenCalled();
+    expect(result.credentialSource).toBe("API key field");
+  });
+
+  it("does not authorize stored keys when the connection-test draft key is empty", async () => {
+    const harness = createHarness();
+    harness.keys.set("codex:gateway", "stored-codex-key");
+    harness.keys.set("claude:gateway", "stored-claude-key");
+
+    await expect(harness.service.testProviderConnection({
+      target: "codex",
+      apiConfig: {
+        activeProvider: "custom",
+        customProviderId: "gateway",
+        customProviderName: "Gateway",
+        customBaseUrl: "https://gateway.example/v1",
+        customApiKey: "",
+        customModel: "gpt-test",
+        customApiFormat: "openai_responses",
+      },
+    })).rejects.toThrow(/Write this route to Codex config/);
+    await expect(harness.service.testProviderConnection({
+      target: "claude",
+      apiConfig: {
+        activeProvider: "custom",
+        customProviderId: "gateway",
+        customProviderName: "Gateway",
+        customBaseUrl: "https://gateway.example/anthropic",
+        customApiKey: "",
+        customModel: "claude-test",
+        customApiFormat: "anthropic",
+        customApiKeyField: "ANTHROPIC_AUTH_TOKEN",
+      },
+    })).rejects.toThrow(/Write this route to Claude Code settings/);
+
+    expect(harness.getKey).not.toHaveBeenCalled();
+    expect(harness.operations.requestSummaryCompletion).not.toHaveBeenCalled();
+  });
+
+  it("requires a readable draft key for the local Codex Chat proxy even when the disk route matches", async () => {
+    const harness = createHarness();
+    harness.keys.set("codex:gateway", "stored-key-must-not-be-used");
+    vi.mocked(harness.operations.loadCodexConfigSnapshot).mockResolvedValue({
+      codexHome: "/tmp/provider-codex",
+      configPath: "/tmp/provider-codex/config.toml",
+      exists: true,
+      activeProviderId: "gateway",
+      activeModel: "gpt-test",
+      activeProvider: null,
+      providers: [{
+        id: "gateway",
+        name: "Gateway",
+        baseUrl: "https://gateway.example/v1",
+        wireApi: "chat",
+        envKey: "",
+        requiresOpenaiAuth: false,
+        hasApiKey: true,
+        credentialSource: "config.toml gateway.auth",
+      }],
+      credentialSource: "config.toml gateway.auth",
+      hasApiKey: true,
+    });
+
+    await expect(harness.service.testProviderConnection({
+      target: "codex",
+      apiConfig: {
+        activeProvider: "custom",
+        customProviderId: "gateway",
+        customConfigDir: "/tmp/provider-codex",
+        customProviderName: "Gateway",
+        customBaseUrl: "https://gateway.example/v1",
+        customApiKey: "",
+        customModel: "gpt-test",
+        customApiFormat: "openai_chat",
+      },
+    })).rejects.toThrow(/uses the local Codex Chat proxy, but no API key was readable/);
+
+    expect(harness.getKey).not.toHaveBeenCalled();
+    expect(harness.operations.loadCodexConfigSnapshot).not.toHaveBeenCalled();
+    expect(harness.operations.requestSummaryCompletion).not.toHaveBeenCalled();
   });
 
   it("preserves an existing Codex provider's CLI-managed authentication", async () => {
     const harness = createHarness();
+    harness.keys.set("codex:gateway", "stored-key-must-not-be-used");
     vi.mocked(harness.operations.loadCodexConfigSnapshot).mockResolvedValue({
       codexHome: "/tmp/provider-codex",
       configPath: "/tmp/provider-codex/config.toml",
@@ -674,6 +762,7 @@ describe("Provider connection tests", () => {
     );
     const endpoint = vi.mocked(harness.operations.requestSummaryCompletion).mock.calls[0][0];
     expect(endpoint.cliArgs).not.toContain("--ignore-user-config");
+    expect(harness.getKey).not.toHaveBeenCalled();
     expect(harness.operations.resolveCodexProviderCredential).not.toHaveBeenCalled();
     expect(result.credentialSource).toBe("config.toml gateway.auth");
   });
@@ -701,8 +790,9 @@ describe("Provider connection tests", () => {
     expect(harness.operations.requestSummaryCompletion).not.toHaveBeenCalled();
   });
 
-  it("lets Claude Code resolve credentials that are not readable from its settings file", async () => {
+  it("lets an exact Claude disk route resolve credentials that are not readable from its settings file", async () => {
     const harness = createHarness();
+    harness.keys.set("claude:gateway", "stored-key-must-not-be-used");
     vi.mocked(harness.operations.loadClaudeConfigSnapshot).mockResolvedValue({
       claudeHome: "/tmp/provider-claude",
       settingsPath: "/tmp/provider-claude/settings.json",
@@ -740,13 +830,14 @@ describe("Provider connection tests", () => {
       expect.anything(),
       expect.anything(),
     );
+    expect(harness.getKey).not.toHaveBeenCalled();
     expect(harness.operations.resolveClaudeProviderCredential).not.toHaveBeenCalled();
     expect(result.credentialSource).toBe("settings.json apiKeyHelper");
   });
 
-  it("isolates a stored Claude key from user settings, helpers, OAuth, and process arguments", async () => {
+  it("isolates an explicitly authorized Claude draft key from user settings, helpers, OAuth, and arguments", async () => {
     const harness = createHarness();
-    harness.keys.set("claude:gateway", "stored-key");
+    harness.keys.set("claude:gateway", "stored-key-must-not-be-used");
 
     const result = await harness.service.testProviderConnection({
       target: "claude",
@@ -756,7 +847,7 @@ describe("Provider connection tests", () => {
         customConfigDir: "/tmp/provider-claude",
         customProviderName: "Gateway",
         customBaseUrl: "https://gateway.example/anthropic/",
-        customApiKey: "",
+        customApiKey: "typed-key",
         customModel: "claude-test",
         customApiFormat: "anthropic",
         customApiKeyField: "ANTHROPIC_AUTH_TOKEN",
@@ -767,14 +858,15 @@ describe("Provider connection tests", () => {
     expect(endpoint.env).toEqual({
       CLAUDE_CONFIG_DIR: endpoint.cwd,
       ANTHROPIC_BASE_URL: "https://gateway.example/anthropic",
-      ANTHROPIC_AUTH_TOKEN: "stored-key",
+      ANTHROPIC_AUTH_TOKEN: "typed-key",
       ANTHROPIC_API_KEY: "",
       CLAUDE_CODE_OAUTH_TOKEN: "",
     });
     expect(endpoint.cliArgs).toEqual(["--safe-mode", "--tools", "", "--no-session-persistence"]);
-    expect(endpoint.cliArgs?.join(" ")).not.toContain("stored-key");
+    expect(endpoint.cliArgs?.join(" ")).not.toContain("typed-key");
+    expect(harness.getKey).not.toHaveBeenCalled();
     expect(harness.operations.resolveClaudeProviderCredential).not.toHaveBeenCalled();
-    expect(result.credentialSource).toBe("AgentRecall claude key store");
+    expect(result.credentialSource).toBe("API key field");
   });
 
   it("does not treat an OAuth-only Claude login as a third-party API key", async () => {

--- a/apps/main-1.0/src/main/services/provider-service.test.ts
+++ b/apps/main-1.0/src/main/services/provider-service.test.ts
@@ -480,6 +480,204 @@ describe("ProviderService settings and keys", () => {
   });
 });
 
+describe("Provider connection tests", () => {
+  it("uses each official CLI without requiring AgentRecall to read an API key", async () => {
+    const settings = cloneSettings();
+    settings.codexBinary = "custom-codex";
+    settings.claudeBinary = "custom-claude";
+    const harness = createHarness(settings);
+
+    const codex = await harness.service.testProviderConnection({
+      target: "codex",
+      apiConfig: { activeProvider: "official", customConfigDir: "/tmp/provider-codex" },
+    });
+    const claude = await harness.service.testProviderConnection({
+      target: "claude",
+      apiConfig: { activeProvider: "official", customConfigDir: "/tmp/provider-claude" },
+    });
+
+    expect(harness.operations.resolveCodexProviderCredential).not.toHaveBeenCalled();
+    expect(harness.operations.resolveClaudeProviderCredential).not.toHaveBeenCalled();
+    expect(harness.operations.requestSummaryCompletion).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        apiFormat: "codex_exec",
+        command: "custom-codex",
+        env: { CODEX_HOME: "/tmp/provider-codex" },
+        cliArgs: ["--ignore-user-config"],
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(harness.operations.requestSummaryCompletion).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        apiFormat: "claude_exec",
+        command: "custom-claude",
+        env: expect.objectContaining({ CLAUDE_CONFIG_DIR: "/tmp/provider-claude", ANTHROPIC_BASE_URL: "" }),
+        cliArgs: expect.arrayContaining(["--settings"]),
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(codex.credentialSource).toBe("Codex CLI authentication");
+    expect(claude.credentialSource).toBe("Claude Code CLI authentication");
+  });
+
+  it("tests an unsaved Codex route with read-only CLI overrides and a stored key", async () => {
+    const harness = createHarness();
+    harness.keys.set("codex:gateway", "stored-key");
+    vi.mocked(harness.operations.resolveCodexProviderCredential).mockResolvedValue({
+      apiKey: "stored-key",
+      source: "AgentRecall codex key store",
+    });
+
+    const result = await harness.service.testProviderConnection({
+      target: "codex",
+      apiConfig: {
+        activeProvider: "custom",
+        customProviderId: "gateway",
+        customConfigDir: "/tmp/provider-codex",
+        customProviderName: "Gateway",
+        customBaseUrl: "https://gateway.example/v1/",
+        customApiKey: "",
+        customModel: "gpt-test",
+        customApiFormat: "openai_responses",
+      },
+    });
+
+    expect(harness.operations.resolveCodexProviderCredential).toHaveBeenCalledWith(expect.objectContaining({
+      apiKey: "stored-key",
+      apiKeySource: "AgentRecall codex key store",
+      codexHome: "/tmp/provider-codex",
+    }));
+    expect(harness.operations.requestSummaryCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiFormat: "codex_exec",
+        modelArg: "gpt-test",
+        env: {
+          CODEX_HOME: "/tmp/provider-codex",
+          OPENAI_API_KEY: "stored-key",
+        },
+        cliArgs: expect.arrayContaining([
+          "model_provider=\"gateway\"",
+          "model_providers.gateway.base_url=\"https://gateway.example/v1\"",
+        ]),
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(result.credentialSource).toBe("AgentRecall codex key store");
+  });
+
+  it("preserves an existing Codex provider's CLI-managed authentication", async () => {
+    const harness = createHarness();
+    vi.mocked(harness.operations.loadCodexConfigSnapshot).mockResolvedValue({
+      codexHome: "/tmp/provider-codex",
+      configPath: "/tmp/provider-codex/config.toml",
+      exists: true,
+      activeProviderId: "gateway",
+      activeModel: "gpt-test",
+      activeProvider: null,
+      providers: [{
+        id: "gateway",
+        name: "Gateway",
+        baseUrl: "https://gateway.example/v1",
+        wireApi: "responses",
+        envKey: "",
+        requiresOpenaiAuth: false,
+        hasApiKey: true,
+        credentialSource: "config.toml gateway.auth",
+      }],
+      credentialSource: "config.toml gateway.auth",
+      hasApiKey: true,
+    });
+
+    const result = await harness.service.testProviderConnection({
+      target: "codex",
+      apiConfig: {
+        activeProvider: "custom",
+        customProviderId: "gateway",
+        customConfigDir: "/tmp/provider-codex",
+        customProviderName: "Gateway",
+        customBaseUrl: "https://gateway.example/v1",
+        customApiKey: "",
+        customModel: "gpt-test",
+        customApiFormat: "openai_responses",
+      },
+    });
+
+    expect(harness.operations.requestSummaryCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: { CODEX_HOME: "/tmp/provider-codex" },
+        cliArgs: ["-c", 'model_provider="gateway"'],
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(result.credentialSource).toBe("config.toml gateway.auth");
+  });
+
+  it("does not send official CLI authentication to a new third-party route", async () => {
+    const harness = createHarness();
+
+    await expect(harness.service.testProviderConnection({
+      target: "codex",
+      apiConfig: {
+        activeProvider: "custom",
+        customProviderId: "unwritten",
+        customProviderName: "Unwritten",
+        customBaseUrl: "https://unwritten.example/v1",
+        customApiKey: "",
+        customModel: "gpt-test",
+        customApiFormat: "openai_responses",
+      },
+    })).rejects.toThrow(/Write this route to Codex config/);
+    expect(harness.operations.requestSummaryCompletion).not.toHaveBeenCalled();
+  });
+
+  it("lets Claude Code resolve credentials that are not readable from its settings file", async () => {
+    const harness = createHarness();
+    vi.mocked(harness.operations.loadClaudeConfigSnapshot).mockResolvedValue({
+      claudeHome: "/tmp/provider-claude",
+      settingsPath: "/tmp/provider-claude/settings.json",
+      exists: true,
+      route: {
+        activeProvider: "custom",
+        customBaseUrl: "https://gateway.example/anthropic",
+      },
+      credentialSource: "settings.json apiKeyHelper",
+      hasApiKey: true,
+    });
+
+    const result = await harness.service.testProviderConnection({
+      target: "claude",
+      apiConfig: {
+        activeProvider: "custom",
+        customProviderId: "gateway",
+        customConfigDir: "/tmp/provider-claude",
+        customProviderName: "Gateway",
+        customBaseUrl: "https://gateway.example/anthropic/",
+        customApiKey: "",
+        customModel: "claude-test",
+        customApiFormat: "anthropic",
+        customApiKeyField: "ANTHROPIC_AUTH_TOKEN",
+      },
+    });
+
+    expect(harness.operations.requestSummaryCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiFormat: "claude_exec",
+        modelArg: "claude-test",
+        env: { CLAUDE_CONFIG_DIR: "/tmp/provider-claude" },
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(result.credentialSource).toBe("settings.json apiKeyHelper");
+  });
+});
+
 describe("summary connection tests", () => {
   it("tests the Codex source through the same CLI path as real summaries", async () => {
     const settings = cloneSettings();

--- a/apps/main-1.0/src/main/services/provider-service.test.ts
+++ b/apps/main-1.0/src/main/services/provider-service.test.ts
@@ -560,8 +560,8 @@ describe("Provider connection tests", () => {
           OPENAI_API_KEY: "stored-key",
         },
         cliArgs: expect.arrayContaining([
-          "model_provider=\"gateway\"",
-          "model_providers.gateway.base_url=\"https://gateway.example/v1\"",
+          "model_provider=\"agent-recall-connection-test\"",
+          "model_providers.agent-recall-connection-test.base_url=\"https://gateway.example/v1\"",
         ]),
       }),
       expect.anything(),

--- a/apps/main-1.0/src/main/services/provider-service.test.ts
+++ b/apps/main-1.0/src/main/services/provider-service.test.ts
@@ -345,37 +345,102 @@ describe("ProviderService settings and keys", () => {
     ]);
   });
 
-  it("uses the selected saved key for model probing unless an explicit key is supplied", async () => {
+  it("uses a saved Codex key only for its exact route while allowing an explicit key", async () => {
     const settings = cloneSettings();
-    settings.apiConfig = customCodexConfig({ customProviderId: "deepseek" });
+    settings.apiConfig = customCodexConfig({
+      customProviderId: "deepseek",
+      customBaseUrl: "https://api.example/v1",
+    });
     const harness = createHarness(settings);
     harness.keys.set("codex:deepseek", "saved-key");
 
     await harness.service.probeCodexModels({
-      baseUrl: "https://api.example/v1",
+      baseUrl: "https://api.example/v1/",
       apiKey: "",
       providerId: "deepseek",
     });
     await harness.service.probeCodexModels({
-      baseUrl: "https://api.example/v1",
+      baseUrl: "https://other.example/v1",
+      apiKey: "",
+      providerId: "deepseek",
+    });
+    await harness.service.probeCodexModels({
+      baseUrl: "https://other.example/v1",
       apiKey: "explicit-key",
       providerId: "deepseek",
     });
 
     expect(harness.operations.probeCodexModels).toHaveBeenNthCalledWith(1, {
-      baseUrl: "https://api.example/v1",
+      baseUrl: "https://api.example/v1/",
       apiKey: "saved-key",
       providerId: "deepseek",
       codexHome: undefined,
       apiKeySource: "AgentRecall codex key store",
     });
     expect(harness.operations.probeCodexModels).toHaveBeenNthCalledWith(2, {
-      baseUrl: "https://api.example/v1",
+      baseUrl: "https://other.example/v1",
+      apiKey: "",
+      providerId: "deepseek",
+      codexHome: undefined,
+      apiKeySource: undefined,
+    });
+    expect(harness.operations.probeCodexModels).toHaveBeenNthCalledWith(3, {
+      baseUrl: "https://other.example/v1",
       apiKey: "explicit-key",
       providerId: "deepseek",
       codexHome: undefined,
       apiKeySource: "API key field",
     });
+  });
+
+  it("uses a saved Claude key only for its exact route while allowing an explicit key", async () => {
+    const settings = cloneSettings();
+    settings.claudeApiConfig = {
+      ...settings.claudeApiConfig,
+      activeProvider: "custom",
+      customProviderId: "gateway",
+      customBaseUrl: "https://api.example/anthropic",
+    };
+    const harness = createHarness(settings);
+    harness.keys.set("claude:gateway", "saved-key");
+
+    await harness.service.probeClaudeModels({
+      baseUrl: "https://api.example/anthropic/",
+      apiKey: "",
+      providerId: "gateway",
+      apiFormat: "anthropic",
+      apiKeyField: "ANTHROPIC_AUTH_TOKEN",
+    });
+    await harness.service.probeClaudeModels({
+      baseUrl: "https://other.example/anthropic",
+      apiKey: "",
+      providerId: "gateway",
+      apiFormat: "anthropic",
+      apiKeyField: "ANTHROPIC_AUTH_TOKEN",
+    });
+    await harness.service.probeClaudeModels({
+      baseUrl: "https://other.example/anthropic",
+      apiKey: "explicit-key",
+      providerId: "gateway",
+      apiFormat: "anthropic",
+      apiKeyField: "ANTHROPIC_AUTH_TOKEN",
+    });
+
+    expect(harness.operations.probeClaudeModels).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      apiKey: "saved-key",
+      providerId: "gateway",
+      apiKeySource: "AgentRecall claude key store",
+    }));
+    expect(harness.operations.probeClaudeModels).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      apiKey: "",
+      providerId: "gateway",
+      apiKeySource: undefined,
+    }));
+    expect(harness.operations.probeClaudeModels).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      apiKey: "explicit-key",
+      providerId: "gateway",
+      apiKeySource: "API key field",
+    }));
   });
 
   it("loads defaults and snapshots from each saved custom config directory", async () => {
@@ -396,8 +461,16 @@ describe("ProviderService settings and keys", () => {
 
   it("keeps inherited and independent summary credentials isolated", async () => {
     const settings = cloneSettings();
-    settings.apiConfig = customCodexConfig({ customProviderId: "dms", customApiKey: "" });
-    settings.summaryApiConfig = customCodexConfig({ customProviderId: "dms", customApiKey: "" });
+    settings.apiConfig = customCodexConfig({
+      customProviderId: "dms",
+      customBaseUrl: "https://api.example/v1",
+      customApiKey: "",
+    });
+    settings.summaryApiConfig = customCodexConfig({
+      customProviderId: "dms",
+      customBaseUrl: "https://api.example/v1",
+      customApiKey: "",
+    });
     const harness = createHarness(settings);
     harness.keys.set("codex:dms", "codex-key");
     harness.keys.set("summary:dms", "summary-key");
@@ -431,11 +504,18 @@ describe("ProviderService settings and keys", () => {
     const settings = cloneSettings();
     settings.claudeApiConfig = {
       ...settings.claudeApiConfig,
+      activeProvider: "custom",
       customProviderId: "claude-tab-provider",
       customConfigDir: "/tmp/claude-tab",
+      customBaseUrl: "https://claude.example",
     };
     settings.summaryClaudeConfigDir = "/tmp/summary-claude";
-    settings.summaryApiConfig = { ...settings.summaryApiConfig, customProviderId: "summary-provider" };
+    settings.summaryApiConfig = {
+      ...settings.summaryApiConfig,
+      activeProvider: "custom",
+      customProviderId: "summary-provider",
+      customBaseUrl: "https://summary.example",
+    };
     const harness = createHarness(settings);
     harness.keys.set("claude:claude-tab-provider", "claude-tab-key");
     harness.keys.set("summary:summary-provider", "summary-key");
@@ -953,6 +1033,28 @@ describe("summary connection tests", () => {
     );
     expect(result.credentialSource).toBe("Codex CLI");
   });
+
+  it("does not reuse a summary key after the Base URL changes", async () => {
+    const settings = cloneSettings();
+    settings.summaryApiConfig = {
+      ...settings.summaryApiConfig,
+      activeProvider: "custom",
+      customProviderId: "custom",
+      customBaseUrl: "https://old.example/v1",
+    };
+    const harness = createHarness(settings);
+    harness.keys.set("summary:custom", "old-route-key");
+
+    await expect(harness.service.testSummaryProviderConnection({
+      source: "custom",
+      baseUrl: "https://new.example/v1",
+      apiKey: "",
+      model: "summary-model",
+      providerId: "custom",
+      apiFormat: "openai_chat",
+    })).rejects.toThrow(/API key is required/);
+    expect(harness.operations.requestSummaryCompletion).not.toHaveBeenCalled();
+  });
 });
 
 describe("ProviderService Codex Chat proxy lifecycle", () => {
@@ -972,6 +1074,7 @@ describe("ProviderService Codex Chat proxy lifecycle", () => {
     expect(harness.operations.resolveCodexProviderCredential).toHaveBeenCalledWith({
       codexHome: undefined,
       providerId: "deepseek",
+      baseUrl: "https://api.deepseek.com",
       preferConfiguredHelper: true,
     });
     expect(harness.operations.applyCodexApiConfig).toHaveBeenCalledWith({
@@ -1028,14 +1131,44 @@ describe("ProviderService Codex Chat proxy lifecycle", () => {
   });
 
   it("starts the chat proxy with a securely stored key when the form is blank", async () => {
-    const harness = createHarness();
+    const settings = cloneSettings();
+    settings.apiConfig = customCodexConfig({ customApiKey: "" });
+    const harness = createHarness(settings);
     harness.keys.set("codex:deepseek", "stored-key");
 
-    await harness.service.applyCodexProfile(customCodexConfig({ customApiKey: "" }));
+    await harness.service.applyCodexProfile(settings.apiConfig);
 
     expect(harness.operations.createCodexChatProxy).toHaveBeenCalledWith(expect.objectContaining({ apiKey: "stored-key" }));
     expect(harness.operations.applyCodexApiConfig).toHaveBeenCalledWith(expect.objectContaining({
       apiConfig: expect.objectContaining({ customApiKey: "stored-key" }),
+    }));
+  });
+
+  it("does not inject a stored Codex key after the route Base URL changes", async () => {
+    const settings = cloneSettings();
+    settings.apiConfig = customCodexConfig({
+      customProviderId: "custom",
+      customBaseUrl: "https://old.example/v1",
+      customApiKey: "",
+      customApiFormat: "openai_responses",
+    });
+    const harness = createHarness(settings);
+    harness.keys.set("codex:custom", "old-route-key");
+
+    await harness.service.applyCodexProfile({
+      ...settings.apiConfig,
+      customBaseUrl: "https://new.example/v1",
+    });
+
+    expect(harness.operations.applyCodexApiConfig).toHaveBeenCalledWith({
+      apiConfig: expect.objectContaining({
+        customBaseUrl: "https://new.example/v1",
+        customApiKey: "",
+      }),
+    });
+    expect(harness.operations.resolveCodexProviderCredential).toHaveBeenCalledWith(expect.objectContaining({
+      providerId: "custom",
+      baseUrl: "https://new.example/v1",
     }));
   });
 });
@@ -1064,6 +1197,7 @@ describe("ProviderService Claude profile", () => {
       ...settings.claudeApiConfig,
       activeProvider: "custom",
       customProviderId: "dms",
+      customBaseUrl: "https://dms.example/anthropic",
       customApiKey: "",
     };
     const harness = createHarness(settings);
@@ -1073,6 +1207,31 @@ describe("ProviderService Claude profile", () => {
 
     expect(harness.operations.applyClaudeApiConfig).toHaveBeenCalledWith({
       apiConfig: expect.objectContaining({ customApiKey: "claude-key" }),
+    });
+  });
+
+  it("does not inject a stored Claude key after the route Base URL changes", async () => {
+    const settings = cloneSettings();
+    settings.claudeApiConfig = {
+      ...settings.claudeApiConfig,
+      activeProvider: "custom",
+      customProviderId: "custom",
+      customBaseUrl: "https://old.example/anthropic",
+      customApiKey: "",
+    };
+    const harness = createHarness(settings);
+    harness.keys.set("claude:custom", "old-route-key");
+
+    await harness.service.applyClaudeProfile({
+      ...settings.claudeApiConfig,
+      customBaseUrl: "https://new.example/anthropic",
+    });
+
+    expect(harness.operations.applyClaudeApiConfig).toHaveBeenCalledWith({
+      apiConfig: expect.objectContaining({
+        customBaseUrl: "https://new.example/anthropic",
+        customApiKey: "",
+      }),
     });
   });
 });

--- a/apps/main-1.0/src/main/services/provider-service.test.ts
+++ b/apps/main-1.0/src/main/services/provider-service.test.ts
@@ -1,3 +1,4 @@
+import { access, readdir } from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
 import type { ApiConfig, ClaudeApiConfig } from "../../core/api-config";
 import type { CodexChatProxyOptions, CodexChatProxyStatus } from "../../core/codex-chat-proxy";
@@ -481,11 +482,18 @@ describe("ProviderService settings and keys", () => {
 });
 
 describe("Provider connection tests", () => {
-  it("uses each official CLI without requiring AgentRecall to read an API key", async () => {
+  it("uses each official CLI in an empty, tool-free probe without reading an API key", async () => {
     const settings = cloneSettings();
     settings.codexBinary = "custom-codex";
     settings.claudeBinary = "custom-claude";
     const harness = createHarness(settings);
+    const testCwds: string[] = [];
+    vi.mocked(harness.operations.requestSummaryCompletion).mockImplementation(async (endpoint) => {
+      expect(endpoint.cwd).toContain("agent-recall-provider-test-");
+      expect(await readdir(endpoint.cwd!)).toEqual([]);
+      testCwds.push(endpoint.cwd!);
+      return "OK";
+    });
 
     const codex = await harness.service.testProviderConnection({
       target: "codex",
@@ -504,7 +512,19 @@ describe("Provider connection tests", () => {
         apiFormat: "codex_exec",
         command: "custom-codex",
         env: { CODEX_HOME: "/tmp/provider-codex" },
-        cliArgs: ["--ignore-user-config"],
+        cliArgs: expect.arrayContaining([
+          "--ignore-user-config",
+          "features.shell_tool=false",
+          "features.unified_exec=false",
+          "features.apps=false",
+          "features.remote_plugin=false",
+          "features.multi_agent=false",
+          "features.hooks=false",
+          'web_search="disabled"',
+          "tools.view_image=false",
+          "mcp_servers={}",
+          "project_doc_max_bytes=0",
+        ]),
       }),
       expect.anything(),
       expect.anything(),
@@ -515,22 +535,48 @@ describe("Provider connection tests", () => {
         apiFormat: "claude_exec",
         command: "custom-claude",
         env: expect.objectContaining({ CLAUDE_CONFIG_DIR: "/tmp/provider-claude", ANTHROPIC_BASE_URL: "" }),
-        cliArgs: expect.arrayContaining(["--settings"]),
+        cliArgs: expect.arrayContaining(["--safe-mode", "--tools", "", "--no-session-persistence", "--settings"]),
       }),
       expect.anything(),
       expect.anything(),
     );
     expect(codex.credentialSource).toBe("Codex CLI authentication");
     expect(claude.credentialSource).toBe("Claude Code CLI authentication");
+    const claudeEndpoint = vi.mocked(harness.operations.requestSummaryCompletion).mock.calls[1]?.[0];
+    expect(claudeEndpoint?.cliArgs?.slice(0, 4)).toEqual([
+      "--safe-mode",
+      "--tools",
+      "",
+      "--no-session-persistence",
+    ]);
+    const settingsIndex = claudeEndpoint?.cliArgs?.indexOf("--settings") ?? -1;
+    const settingsOverride = JSON.parse(claudeEndpoint?.cliArgs?.[settingsIndex + 1] ?? "{}") as Record<string, unknown>;
+    expect(settingsOverride).not.toHaveProperty("apiKeyHelper");
+    for (const testCwd of testCwds) {
+      await expect(access(testCwd)).rejects.toMatchObject({ code: "ENOENT" });
+    }
+  });
+
+  it("removes the isolated probe directory when a CLI request fails", async () => {
+    const harness = createHarness();
+    let testCwd = "";
+    vi.mocked(harness.operations.requestSummaryCompletion).mockImplementation(async (endpoint) => {
+      testCwd = endpoint.cwd!;
+      throw new Error("probe failed");
+    });
+
+    await expect(harness.service.testProviderConnection({
+      target: "codex",
+      apiConfig: { activeProvider: "official" },
+    })).rejects.toThrow("probe failed");
+
+    expect(testCwd).toContain("agent-recall-provider-test-");
+    await expect(access(testCwd)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("tests an unsaved Codex route with read-only CLI overrides and a stored key", async () => {
     const harness = createHarness();
     harness.keys.set("codex:gateway", "stored-key");
-    vi.mocked(harness.operations.resolveCodexProviderCredential).mockResolvedValue({
-      apiKey: "stored-key",
-      source: "AgentRecall codex key store",
-    });
 
     const result = await harness.service.testProviderConnection({
       target: "codex",
@@ -546,27 +592,26 @@ describe("Provider connection tests", () => {
       },
     });
 
-    expect(harness.operations.resolveCodexProviderCredential).toHaveBeenCalledWith(expect.objectContaining({
-      apiKey: "stored-key",
-      apiKeySource: "AgentRecall codex key store",
-      codexHome: "/tmp/provider-codex",
+    expect(harness.operations.resolveCodexProviderCredential).not.toHaveBeenCalled();
+    const endpoint = vi.mocked(harness.operations.requestSummaryCompletion).mock.calls[0][0];
+    expect(endpoint).toEqual(expect.objectContaining({
+      apiFormat: "codex_exec",
+      modelArg: "gpt-test",
+      env: {
+        CODEX_HOME: endpoint.cwd,
+        OPENAI_API_KEY: "stored-key",
+      },
+      cliArgs: expect.arrayContaining([
+        "--ignore-user-config",
+        "features.shell_tool=false",
+        "features.unified_exec=false",
+        "model_provider=\"agent-recall-connection-test\"",
+        "model_providers.agent-recall-connection-test.base_url=\"https://gateway.example/v1\"",
+        "model_providers.agent-recall-connection-test.requires_openai_auth=false",
+        "model_providers.agent-recall-connection-test.env_key=\"OPENAI_API_KEY\"",
+      ]),
     }));
-    expect(harness.operations.requestSummaryCompletion).toHaveBeenCalledWith(
-      expect.objectContaining({
-        apiFormat: "codex_exec",
-        modelArg: "gpt-test",
-        env: {
-          CODEX_HOME: "/tmp/provider-codex",
-          OPENAI_API_KEY: "stored-key",
-        },
-        cliArgs: expect.arrayContaining([
-          "model_provider=\"agent-recall-connection-test\"",
-          "model_providers.agent-recall-connection-test.base_url=\"https://gateway.example/v1\"",
-        ]),
-      }),
-      expect.anything(),
-      expect.anything(),
-    );
+    expect(endpoint.cliArgs?.join(" ")).not.toContain("stored-key");
     expect(result.credentialSource).toBe("AgentRecall codex key store");
   });
 
@@ -610,16 +655,35 @@ describe("Provider connection tests", () => {
     expect(harness.operations.requestSummaryCompletion).toHaveBeenCalledWith(
       expect.objectContaining({
         env: { CODEX_HOME: "/tmp/provider-codex" },
-        cliArgs: ["-c", 'model_provider="gateway"'],
+        cliArgs: expect.arrayContaining([
+          "features.shell_tool=false",
+          "features.unified_exec=false",
+          "features.apps=false",
+          "features.remote_plugin=false",
+          "features.multi_agent=false",
+          "features.hooks=false",
+          'web_search="disabled"',
+          "tools.view_image=false",
+          "mcp_servers={}",
+          "project_doc_max_bytes=0",
+          'model_provider="gateway"',
+        ]),
       }),
       expect.anything(),
       expect.anything(),
     );
+    const endpoint = vi.mocked(harness.operations.requestSummaryCompletion).mock.calls[0][0];
+    expect(endpoint.cliArgs).not.toContain("--ignore-user-config");
+    expect(harness.operations.resolveCodexProviderCredential).not.toHaveBeenCalled();
     expect(result.credentialSource).toBe("config.toml gateway.auth");
   });
 
   it("does not send official CLI authentication to a new third-party route", async () => {
     const harness = createHarness();
+    vi.mocked(harness.operations.resolveCodexProviderCredential).mockResolvedValue({
+      apiKey: "unrelated-key",
+      source: "auth.json OPENAI_API_KEY",
+    });
 
     await expect(harness.service.testProviderConnection({
       target: "codex",
@@ -633,6 +697,7 @@ describe("Provider connection tests", () => {
         customApiFormat: "openai_responses",
       },
     })).rejects.toThrow(/Write this route to Codex config/);
+    expect(harness.operations.resolveCodexProviderCredential).not.toHaveBeenCalled();
     expect(harness.operations.requestSummaryCompletion).not.toHaveBeenCalled();
   });
 
@@ -670,11 +735,101 @@ describe("Provider connection tests", () => {
         apiFormat: "claude_exec",
         modelArg: "claude-test",
         env: { CLAUDE_CONFIG_DIR: "/tmp/provider-claude" },
+        cliArgs: ["--safe-mode", "--tools", "", "--no-session-persistence"],
       }),
       expect.anything(),
       expect.anything(),
     );
+    expect(harness.operations.resolveClaudeProviderCredential).not.toHaveBeenCalled();
     expect(result.credentialSource).toBe("settings.json apiKeyHelper");
+  });
+
+  it("isolates a stored Claude key from user settings, helpers, OAuth, and process arguments", async () => {
+    const harness = createHarness();
+    harness.keys.set("claude:gateway", "stored-key");
+
+    const result = await harness.service.testProviderConnection({
+      target: "claude",
+      apiConfig: {
+        activeProvider: "custom",
+        customProviderId: "gateway",
+        customConfigDir: "/tmp/provider-claude",
+        customProviderName: "Gateway",
+        customBaseUrl: "https://gateway.example/anthropic/",
+        customApiKey: "",
+        customModel: "claude-test",
+        customApiFormat: "anthropic",
+        customApiKeyField: "ANTHROPIC_AUTH_TOKEN",
+      },
+    });
+
+    const endpoint = vi.mocked(harness.operations.requestSummaryCompletion).mock.calls[0][0];
+    expect(endpoint.env).toEqual({
+      CLAUDE_CONFIG_DIR: endpoint.cwd,
+      ANTHROPIC_BASE_URL: "https://gateway.example/anthropic",
+      ANTHROPIC_AUTH_TOKEN: "stored-key",
+      ANTHROPIC_API_KEY: "",
+      CLAUDE_CODE_OAUTH_TOKEN: "",
+    });
+    expect(endpoint.cliArgs).toEqual(["--safe-mode", "--tools", "", "--no-session-persistence"]);
+    expect(endpoint.cliArgs?.join(" ")).not.toContain("stored-key");
+    expect(harness.operations.resolveClaudeProviderCredential).not.toHaveBeenCalled();
+    expect(result.credentialSource).toBe("AgentRecall claude key store");
+  });
+
+  it("does not treat an OAuth-only Claude login as a third-party API key", async () => {
+    const harness = createHarness();
+    vi.mocked(harness.operations.loadClaudeConfigSnapshot).mockResolvedValue({
+      claudeHome: "/tmp/provider-claude",
+      settingsPath: "/tmp/provider-claude/settings.json",
+      exists: true,
+      route: {
+        activeProvider: "custom",
+        customBaseUrl: "https://gateway.example/anthropic",
+      },
+      credentialSource: null,
+      hasApiKey: false,
+    });
+
+    await expect(harness.service.testProviderConnection({
+      target: "claude",
+      apiConfig: {
+        activeProvider: "custom",
+        customProviderId: "gateway",
+        customConfigDir: "/tmp/provider-claude",
+        customProviderName: "Gateway",
+        customBaseUrl: "https://gateway.example/anthropic",
+        customApiKey: "",
+        customModel: "claude-test",
+        customApiFormat: "anthropic",
+        customApiKeyField: "ANTHROPIC_AUTH_TOKEN",
+      },
+    })).rejects.toThrow(/No readable API key/);
+    expect(harness.operations.requestSummaryCompletion).not.toHaveBeenCalled();
+  });
+
+  it("does not inject an unrelated Claude resolver key into an unwritten route", async () => {
+    const harness = createHarness();
+    vi.mocked(harness.operations.resolveClaudeProviderCredential).mockResolvedValue({
+      apiKey: "unrelated-key",
+      source: "environment ANTHROPIC_API_KEY",
+    });
+
+    await expect(harness.service.testProviderConnection({
+      target: "claude",
+      apiConfig: {
+        activeProvider: "custom",
+        customProviderId: "unwritten",
+        customProviderName: "Unwritten",
+        customBaseUrl: "https://unwritten.example/anthropic",
+        customApiKey: "",
+        customModel: "claude-test",
+        customApiFormat: "anthropic",
+        customApiKeyField: "ANTHROPIC_API_KEY",
+      },
+    })).rejects.toThrow(/Write this route to Claude Code settings/);
+    expect(harness.operations.resolveClaudeProviderCredential).not.toHaveBeenCalled();
+    expect(harness.operations.requestSummaryCompletion).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/main-1.0/src/main/services/provider-service.ts
+++ b/apps/main-1.0/src/main/services/provider-service.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import {
   API_PROVIDER_PRESETS,
   CLAUDE_API_PROVIDER_PRESETS,
@@ -112,6 +115,26 @@ function summaryConnectionApiFormat(
   }
   return apiFormat;
 }
+
+const CLAUDE_CONNECTION_TEST_ARGS = [
+  "--safe-mode",
+  "--tools",
+  "",
+  "--no-session-persistence",
+] as const;
+
+const CODEX_CONNECTION_TEST_ARGS = [
+  "-c", "features.shell_tool=false",
+  "-c", "features.unified_exec=false",
+  "-c", "features.apps=false",
+  "-c", "features.remote_plugin=false",
+  "-c", "features.multi_agent=false",
+  "-c", "features.hooks=false",
+  "-c", 'web_search="disabled"',
+  "-c", "tools.view_image=false",
+  "-c", "mcp_servers={}",
+  "-c", "project_doc_max_bytes=0",
+] as const;
 
 const defaultOperations: ProviderServiceOperations = {
   providerConfigDirectoryExists,
@@ -339,7 +362,9 @@ export class ProviderService {
         summaryClaudeModel: apiConfig.activeProvider === "custom" ? apiConfig.customModel : "",
         summaryClaudeConfigDir: apiConfig.customConfigDir,
       });
+      endpoint.cliArgs = [...CLAUDE_CONNECTION_TEST_ARGS];
       let credentialSource = "Claude Code CLI authentication";
+      let isolateConfigHome = false;
       if (apiConfig.activeProvider === "official") {
         const officialEnv = {
           ANTHROPIC_BASE_URL: "",
@@ -354,38 +379,38 @@ export class ProviderService {
           ANTHROPIC_DEFAULT_OPUS_MODEL_NAME: "",
         };
         endpoint.env = { ...endpoint.env, ...officialEnv };
-        endpoint.cliArgs = ["--settings", JSON.stringify({ env: officialEnv })];
+        endpoint.cliArgs.push("--settings", JSON.stringify({ env: officialEnv }));
       } else {
         if (!apiConfig.customBaseUrl.trim()) {
           throw new Error(`Base URL is required to test ${apiConfig.customProviderName}.`);
         }
+        const requestedBaseUrl = apiConfig.customBaseUrl.trim().replace(/\/+$/, "");
         const typedKey = apiConfig.customApiKey.trim();
-        const storedKey = typedKey
+        const storedKey = (typedKey
           ? ""
-          : this.dependencies.keys.get("claude", apiConfig.customProviderId);
-        const credential = await this.operations.resolveClaudeProviderCredential({
-          claudeHome: apiConfig.customConfigDir || undefined,
-          apiKeyField: apiConfig.customApiKeyField,
-          apiKey: typedKey || storedKey,
-          apiKeySource: typedKey
-            ? "API key field"
-            : storedKey
-              ? "AgentRecall claude key store"
-              : undefined,
-        });
-        if (credential.apiKey) {
+          : this.dependencies.keys.get("claude", apiConfig.customProviderId)).trim();
+        const providerKey = typedKey || storedKey;
+        if (providerKey) {
+          const authEnv = {
+            ANTHROPIC_BASE_URL: requestedBaseUrl,
+            ANTHROPIC_AUTH_TOKEN: "",
+            ANTHROPIC_API_KEY: "",
+            CLAUDE_CODE_OAUTH_TOKEN: "",
+            [apiConfig.customApiKeyField]: providerKey,
+          };
           endpoint.env = {
             ...endpoint.env,
-            ANTHROPIC_BASE_URL: apiConfig.customBaseUrl.trim().replace(/\/+$/, ""),
-            [apiConfig.customApiKeyField]: credential.apiKey,
+            ...authEnv,
           };
-          credentialSource = credential.source || credentialSource;
+          isolateConfigHome = true;
+          credentialSource = typedKey ? "API key field" : "AgentRecall claude key store";
         } else {
           const snapshot = await this.operations.loadClaudeConfigSnapshot(apiConfig.customConfigDir || undefined);
           const configuredBaseUrl = snapshot.route.customBaseUrl?.trim().replace(/\/+$/, "") ?? "";
           if (
             snapshot.route.activeProvider !== "custom"
-            || configuredBaseUrl !== apiConfig.customBaseUrl.trim().replace(/\/+$/, "")
+            || configuredBaseUrl !== requestedBaseUrl
+            || !snapshot.hasApiKey
           ) {
             throw new Error(
               `No readable API key was found for ${apiConfig.customProviderName}. Write this route to Claude Code settings before testing CLI-managed credentials.`,
@@ -394,15 +419,22 @@ export class ProviderService {
           credentialSource = snapshot.credentialSource || credentialSource;
         }
       }
-      await this.operations.requestSummaryCompletion(
-        endpoint,
-        prompt,
-        AbortSignal.timeout(30_000),
-      );
-      return {
-        elapsedMs: Math.max(0, Date.now() - startedAt),
-        credentialSource,
-      };
+      const testCwd = await mkdtemp(path.join(tmpdir(), "agent-recall-provider-test-"));
+      endpoint.cwd = testCwd;
+      if (isolateConfigHome) endpoint.env = { ...endpoint.env, CLAUDE_CONFIG_DIR: testCwd };
+      try {
+        await this.operations.requestSummaryCompletion(
+          endpoint,
+          prompt,
+          AbortSignal.timeout(30_000),
+        );
+        return {
+          elapsedMs: Math.max(0, Date.now() - startedAt),
+          credentialSource,
+        };
+      } finally {
+        await rm(testCwd, { recursive: true, force: true });
+      }
     }
 
     const apiConfig = this.withPresetDefaults(input.apiConfig);
@@ -413,31 +445,27 @@ export class ProviderService {
     });
     let credentialSource = "Codex CLI authentication";
     let testProxy: CodexChatProxyPort | null = null;
+    let isolateConfigHome = false;
     try {
       if (apiConfig.activeProvider === "official") {
         // Authentication still comes from CODEX_HOME, while routing/model/plugin config is ignored.
-        endpoint.cliArgs = ["--ignore-user-config"];
+        endpoint.cliArgs = ["--ignore-user-config", ...CODEX_CONNECTION_TEST_ARGS];
       } else {
         if (!apiConfig.customBaseUrl.trim()) {
           throw new Error(`Base URL is required to test ${apiConfig.customProviderName}.`);
         }
         const typedKey = apiConfig.customApiKey.trim();
-        const storedKey = typedKey
+        const storedKey = (typedKey
           ? ""
-          : this.dependencies.keys.get("codex", apiConfig.customProviderId);
-        const credential = await this.operations.resolveCodexProviderCredential({
-          codexHome: apiConfig.customConfigDir || undefined,
-          providerId: apiConfig.customProviderId,
-          apiKey: typedKey || storedKey,
-          apiKeySource: typedKey
-            ? "API key field"
-            : storedKey
-              ? "AgentRecall codex key store"
-              : undefined,
-        });
-        credentialSource = credential.source || credentialSource;
+          : this.dependencies.keys.get("codex", apiConfig.customProviderId)).trim();
+        const providerKey = typedKey || storedKey;
+        credentialSource = typedKey
+          ? "API key field"
+          : storedKey
+            ? "AgentRecall codex key store"
+            : credentialSource;
         const requestedBaseUrl = apiConfig.customBaseUrl.trim().replace(/\/+$/, "");
-        if (!credential.apiKey) {
+        if (!providerKey) {
           if (apiConfig.customApiFormat === "openai_chat") {
             throw new Error(
               `${apiConfig.customProviderName} uses the local Codex Chat proxy, but no API key was readable by AgentRecall.`,
@@ -456,7 +484,10 @@ export class ProviderService {
             );
           }
           credentialSource = configuredProvider.credentialSource || credentialSource;
-          endpoint.cliArgs = ["-c", `model_provider=${JSON.stringify(apiConfig.customProviderId)}`];
+          endpoint.cliArgs = [
+            ...CODEX_CONNECTION_TEST_ARGS,
+            "-c", `model_provider=${JSON.stringify(apiConfig.customProviderId)}`,
+          ];
         } else {
           // A reserved one-shot provider prevents an existing provider's mutually exclusive
           // `auth` block from being combined with the env-key authentication below.
@@ -465,7 +496,7 @@ export class ProviderService {
           if (apiConfig.customApiFormat === "openai_chat") {
             testProxy = this.operations.createCodexChatProxy({
               upstreamBaseUrl: baseUrl,
-              apiKey: credential.apiKey,
+              apiKey: providerKey,
               model: apiConfig.customModel,
               listenHost: "127.0.0.1",
               listenPort: 0,
@@ -474,25 +505,35 @@ export class ProviderService {
           }
           const prefix = `model_providers.${providerId}`;
           endpoint.cliArgs = [
+            "--ignore-user-config",
+            ...CODEX_CONNECTION_TEST_ARGS,
             "-c", `model_provider=${JSON.stringify(providerId)}`,
             "-c", `${prefix}.name=${JSON.stringify(apiConfig.customProviderName || providerId)}`,
             "-c", `${prefix}.base_url=${JSON.stringify(baseUrl)}`,
             "-c", `${prefix}.wire_api="responses"`,
-            "-c", `${prefix}.requires_openai_auth=true`,
+            "-c", `${prefix}.requires_openai_auth=false`,
             "-c", `${prefix}.env_key="OPENAI_API_KEY"`,
           ];
-          endpoint.env = { ...endpoint.env, OPENAI_API_KEY: credential.apiKey };
+          endpoint.env = { ...endpoint.env, OPENAI_API_KEY: providerKey };
+          isolateConfigHome = true;
         }
       }
-      await this.operations.requestSummaryCompletion(
-        endpoint,
-        prompt,
-        AbortSignal.timeout(30_000),
-      );
-      return {
-        elapsedMs: Math.max(0, Date.now() - startedAt),
-        credentialSource,
-      };
+      const testCwd = await mkdtemp(path.join(tmpdir(), "agent-recall-provider-test-"));
+      endpoint.cwd = testCwd;
+      if (isolateConfigHome) endpoint.env = { ...endpoint.env, CODEX_HOME: testCwd };
+      try {
+        await this.operations.requestSummaryCompletion(
+          endpoint,
+          prompt,
+          AbortSignal.timeout(30_000),
+        );
+        return {
+          elapsedMs: Math.max(0, Date.now() - startedAt),
+          credentialSource,
+        };
+      } finally {
+        await rm(testCwd, { recursive: true, force: true });
+      }
     } finally {
       await testProxy?.stop();
     }

--- a/apps/main-1.0/src/main/services/provider-service.ts
+++ b/apps/main-1.0/src/main/services/provider-service.ts
@@ -1,5 +1,6 @@
 import {
   API_PROVIDER_PRESETS,
+  CLAUDE_API_PROVIDER_PRESETS,
   mergeApiConfigWithProfileDefaults,
   mergeClaudeApiConfigWithProfileDefaults,
   normalizeApiConfig,
@@ -31,11 +32,13 @@ import {
 import type { AppSettings, AppSettingsUpdate } from "../../core/platform";
 import { providerConfigDirectoryExists } from "../../core/provider-config-path";
 import { requestSummaryCompletion } from "../../core/session-summarizer";
-import { buildCodexExecEndpoint } from "../../core/summary-endpoint";
+import { buildClaudeExecEndpoint, buildCodexExecEndpoint } from "../../core/summary-endpoint";
 import type {
   ClaudeModelProbeRequest,
   CodexModelProbeRequest,
   ConfigSnapshotRequest,
+  ProviderConnectionRequest,
+  ProviderConnectionResult,
   ProviderKeyTarget,
   SummaryProviderConnectionRequest,
   SummaryProviderConnectionResult,
@@ -313,6 +316,187 @@ export class ProviderService {
           ? `AgentRecall ${keyTarget} key store`
           : undefined,
     });
+  }
+
+  async testProviderConnection(input: ProviderConnectionRequest): Promise<ProviderConnectionResult> {
+    const startedAt = Date.now();
+    const settings = this.dependencies.getSettings();
+    const prompt = [{ role: "user" as const, content: "Reply with exactly OK." }];
+
+    if (input.target === "claude") {
+      const normalized = normalizeClaudeApiConfig(input.apiConfig);
+      const preset = CLAUDE_API_PROVIDER_PRESETS.find((item) => item.id === normalized.customProviderId);
+      const apiConfig = normalizeClaudeApiConfig({
+        ...normalized,
+        customProviderName: input.apiConfig.customProviderName?.trim() || preset?.providerName || normalized.customProviderId,
+        customBaseUrl: input.apiConfig.customBaseUrl?.trim() || preset?.baseUrl || "",
+        customModel: input.apiConfig.customModel?.trim() || preset?.model || "",
+        customApiFormat: input.apiConfig.customApiFormat ?? preset?.apiFormat ?? "anthropic",
+        customApiKeyField: input.apiConfig.customApiKeyField ?? preset?.apiKeyField ?? "ANTHROPIC_AUTH_TOKEN",
+      });
+      const endpoint = buildClaudeExecEndpoint({
+        ...settings,
+        summaryClaudeModel: apiConfig.activeProvider === "custom" ? apiConfig.customModel : "",
+        summaryClaudeConfigDir: apiConfig.customConfigDir,
+      });
+      let credentialSource = "Claude Code CLI authentication";
+      if (apiConfig.activeProvider === "official") {
+        const officialEnv = {
+          ANTHROPIC_BASE_URL: "",
+          ANTHROPIC_AUTH_TOKEN: "",
+          ANTHROPIC_API_KEY: "",
+          ANTHROPIC_MODEL: "",
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: "",
+          ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME: "",
+          ANTHROPIC_DEFAULT_SONNET_MODEL: "",
+          ANTHROPIC_DEFAULT_SONNET_MODEL_NAME: "",
+          ANTHROPIC_DEFAULT_OPUS_MODEL: "",
+          ANTHROPIC_DEFAULT_OPUS_MODEL_NAME: "",
+        };
+        endpoint.env = { ...endpoint.env, ...officialEnv };
+        endpoint.cliArgs = ["--settings", JSON.stringify({ env: officialEnv })];
+      } else {
+        if (!apiConfig.customBaseUrl.trim()) {
+          throw new Error(`Base URL is required to test ${apiConfig.customProviderName}.`);
+        }
+        const typedKey = apiConfig.customApiKey.trim();
+        const storedKey = typedKey
+          ? ""
+          : this.dependencies.keys.get("claude", apiConfig.customProviderId);
+        const credential = await this.operations.resolveClaudeProviderCredential({
+          claudeHome: apiConfig.customConfigDir || undefined,
+          apiKeyField: apiConfig.customApiKeyField,
+          apiKey: typedKey || storedKey,
+          apiKeySource: typedKey
+            ? "API key field"
+            : storedKey
+              ? "AgentRecall claude key store"
+              : undefined,
+        });
+        if (credential.apiKey) {
+          endpoint.env = {
+            ...endpoint.env,
+            ANTHROPIC_BASE_URL: apiConfig.customBaseUrl.trim().replace(/\/+$/, ""),
+            [apiConfig.customApiKeyField]: credential.apiKey,
+          };
+          credentialSource = credential.source || credentialSource;
+        } else {
+          const snapshot = await this.operations.loadClaudeConfigSnapshot(apiConfig.customConfigDir || undefined);
+          const configuredBaseUrl = snapshot.route.customBaseUrl?.trim().replace(/\/+$/, "") ?? "";
+          if (
+            snapshot.route.activeProvider !== "custom"
+            || configuredBaseUrl !== apiConfig.customBaseUrl.trim().replace(/\/+$/, "")
+          ) {
+            throw new Error(
+              `No readable API key was found for ${apiConfig.customProviderName}. Write this route to Claude Code settings before testing CLI-managed credentials.`,
+            );
+          }
+          credentialSource = snapshot.credentialSource || credentialSource;
+        }
+      }
+      await this.operations.requestSummaryCompletion(
+        endpoint,
+        prompt,
+        AbortSignal.timeout(30_000),
+      );
+      return {
+        elapsedMs: Math.max(0, Date.now() - startedAt),
+        credentialSource,
+      };
+    }
+
+    const apiConfig = this.withPresetDefaults(input.apiConfig);
+    const endpoint = buildCodexExecEndpoint({
+      ...settings,
+      summaryCodexModel: apiConfig.activeProvider === "custom" ? apiConfig.customModel : "",
+      summaryCodexConfigDir: apiConfig.customConfigDir,
+    });
+    let credentialSource = "Codex CLI authentication";
+    let testProxy: CodexChatProxyPort | null = null;
+    try {
+      if (apiConfig.activeProvider === "official") {
+        // Authentication still comes from CODEX_HOME, while routing/model/plugin config is ignored.
+        endpoint.cliArgs = ["--ignore-user-config"];
+      } else {
+        if (!apiConfig.customBaseUrl.trim()) {
+          throw new Error(`Base URL is required to test ${apiConfig.customProviderName}.`);
+        }
+        const typedKey = apiConfig.customApiKey.trim();
+        const storedKey = typedKey
+          ? ""
+          : this.dependencies.keys.get("codex", apiConfig.customProviderId);
+        const credential = await this.operations.resolveCodexProviderCredential({
+          codexHome: apiConfig.customConfigDir || undefined,
+          providerId: apiConfig.customProviderId,
+          apiKey: typedKey || storedKey,
+          apiKeySource: typedKey
+            ? "API key field"
+            : storedKey
+              ? "AgentRecall codex key store"
+              : undefined,
+        });
+        credentialSource = credential.source || credentialSource;
+        const requestedBaseUrl = apiConfig.customBaseUrl.trim().replace(/\/+$/, "");
+        const providerId = apiConfig.customProviderId === "custom"
+          ? "agent-recall-connection-test"
+          : apiConfig.customProviderId;
+        const providerKey = /^[A-Za-z0-9_-]+$/.test(providerId)
+          ? providerId
+          : JSON.stringify(providerId);
+        if (!credential.apiKey) {
+          if (apiConfig.customApiFormat === "openai_chat") {
+            throw new Error(
+              `${apiConfig.customProviderName} uses the local Codex Chat proxy, but no API key was readable by AgentRecall.`,
+            );
+          }
+          const snapshot = await this.operations.loadCodexConfigSnapshot(apiConfig.customConfigDir || undefined);
+          const configuredProvider = snapshot.providers.find((provider) => provider.id === providerId);
+          if (
+            !configuredProvider
+            || configuredProvider.baseUrl.trim().replace(/\/+$/, "") !== requestedBaseUrl
+          ) {
+            throw new Error(
+              `No readable API key was found for ${apiConfig.customProviderName}. Write this route to Codex config before testing CLI-managed credentials.`,
+            );
+          }
+          credentialSource = configuredProvider.credentialSource || credentialSource;
+          endpoint.cliArgs = ["-c", `model_provider=${JSON.stringify(providerId)}`];
+        } else {
+          let baseUrl = requestedBaseUrl;
+          if (apiConfig.customApiFormat === "openai_chat") {
+            testProxy = this.operations.createCodexChatProxy({
+              upstreamBaseUrl: baseUrl,
+              apiKey: credential.apiKey,
+              model: apiConfig.customModel,
+              listenHost: "127.0.0.1",
+              listenPort: 0,
+            });
+            baseUrl = (await testProxy.start()).baseUrl;
+          }
+          const prefix = `model_providers.${providerKey}`;
+          endpoint.cliArgs = [
+            "-c", `model_provider=${JSON.stringify(providerId)}`,
+            "-c", `${prefix}.name=${JSON.stringify(apiConfig.customProviderName || providerId)}`,
+            "-c", `${prefix}.base_url=${JSON.stringify(baseUrl)}`,
+            "-c", `${prefix}.wire_api="responses"`,
+            "-c", `${prefix}.requires_openai_auth=true`,
+            "-c", `${prefix}.env_key="OPENAI_API_KEY"`,
+          ];
+          endpoint.env = { ...endpoint.env, OPENAI_API_KEY: credential.apiKey };
+        }
+      }
+      await this.operations.requestSummaryCompletion(
+        endpoint,
+        prompt,
+        AbortSignal.timeout(30_000),
+      );
+      return {
+        elapsedMs: Math.max(0, Date.now() - startedAt),
+        credentialSource,
+      };
+    } finally {
+      await testProxy?.stop();
+    }
   }
 
   async testSummaryProviderConnection(

--- a/apps/main-1.0/src/main/services/provider-service.ts
+++ b/apps/main-1.0/src/main/services/provider-service.ts
@@ -731,6 +731,7 @@ export class ProviderService {
     const credential = await this.operations.resolveCodexProviderCredential({
       codexHome: apiConfig.customConfigDir || undefined,
       providerId: apiConfig.customProviderId,
+      preferConfiguredHelper: true,
     });
     return credential.apiKey ? { ...apiConfig, customApiKey: credential.apiKey } : apiConfig;
   }

--- a/apps/main-1.0/src/main/services/provider-service.ts
+++ b/apps/main-1.0/src/main/services/provider-service.ts
@@ -116,6 +116,18 @@ function storedKeyCanHydrateTarget(
     && normalizedProviderBaseUrl(savedTarget.customBaseUrl) === targetBaseUrl;
 }
 
+function providerRouteMatches(
+  target: ProviderKeyTargetConfig,
+  providerId: string,
+  baseUrl: string,
+): boolean {
+  const normalizedBaseUrl = normalizedProviderBaseUrl(baseUrl);
+  return Boolean(normalizedBaseUrl)
+    && target.activeProvider === "custom"
+    && target.customProviderId === providerId
+    && normalizedProviderBaseUrl(target.customBaseUrl) === normalizedBaseUrl;
+}
+
 /** Human-readable provenance for the credential the connection test ended up using. */
 function summaryKeySource(typedKey: string, resolvedKey: string, store: ProviderKeyTarget): string | undefined {
   if (typedKey) return "API key field";
@@ -335,12 +347,15 @@ export class ProviderService {
     const settings = this.dependencies.getSettings();
     const keyTarget = input.keyTarget ?? "codex";
     const targetConfig = keyTarget === "summary" ? settings.summaryApiConfig : settings.apiConfig;
-    const savedKey = (input.providerId ? this.dependencies.keys.get(keyTarget, input.providerId) : "")
-      || this.dependencies.keys.get(keyTarget, targetConfig.customProviderId);
+    const providerId = input.providerId || targetConfig.customProviderId;
+    const explicitKey = input.apiKey.trim();
+    const savedKey = !explicitKey && providerRouteMatches(targetConfig, providerId, input.baseUrl)
+      ? this.dependencies.keys.get(keyTarget, providerId)
+      : "";
     return this.operations.probeCodexModels({
       baseUrl: input.baseUrl,
-      apiKey: input.apiKey || savedKey,
-      providerId: input.providerId,
+      apiKey: explicitKey || savedKey,
+      providerId,
       // The renderer always sends the directory it means, so these fallbacks only cover a probe
       // that omitted one. A summary probe must not fall through to the Codex tab's directory:
       // they are independent routes, and an empty summary directory means the machine's `~/.codex`.
@@ -349,7 +364,7 @@ export class ProviderService {
           ? settings.summaryApiConfig.customConfigDir || settings.summaryCodexConfigDir
           : settings.apiConfig.customConfigDir)
         || undefined,
-      apiKeySource: input.apiKey
+      apiKeySource: explicitKey
         ? "API key field"
         : savedKey
           ? `AgentRecall ${keyTarget} key store`
@@ -362,16 +377,20 @@ export class ProviderService {
     const keyTarget = input.keyTarget ?? "claude";
     const targetConfig = keyTarget === "summary" ? settings.summaryApiConfig : settings.claudeApiConfig;
     const providerId = input.providerId || targetConfig.customProviderId;
-    const savedKey = this.dependencies.keys.get(keyTarget, providerId);
+    const explicitKey = input.apiKey.trim();
+    const savedKey = !explicitKey && providerRouteMatches(targetConfig, providerId, input.baseUrl)
+      ? this.dependencies.keys.get(keyTarget, providerId)
+      : "";
     return this.operations.probeClaudeModels({
       baseUrl: input.baseUrl,
-      apiKey: input.apiKey || savedKey,
+      apiKey: explicitKey || savedKey,
+      providerId,
       apiFormat: input.apiFormat,
       apiKeyField: input.apiKeyField,
       claudeHome: input.claudeHome
         || (keyTarget === "summary" ? settings.summaryClaudeConfigDir : settings.claudeApiConfig.customConfigDir)
         || undefined,
-      apiKeySource: input.apiKey
+      apiKeySource: explicitKey
         ? "API key field"
         : savedKey
           ? `AgentRecall ${keyTarget} key store`
@@ -616,9 +635,16 @@ export class ProviderService {
     const typedKey = input.apiKey.trim();
 
     if (input.source === "claude") {
-      const apiKey = typedKey || this.summaryStoredKey(input.providerId);
+      const id = input.providerId?.trim() || "";
+      const apiKey = typedKey || (
+        id && providerRouteMatches(settings.summaryApiConfig, id, input.baseUrl)
+          ? this.dependencies.keys.get("summary", id)
+          : ""
+      );
       return this.operations.resolveClaudeProviderCredential({
         claudeHome: input.configDir || settings.summaryClaudeConfigDir || undefined,
+        providerId: input.providerId,
+        baseUrl: input.baseUrl,
         apiKeyField: input.apiKeyField,
         apiKey,
         apiKeySource: summaryKeySource(typedKey, apiKey, "summary"),
@@ -626,32 +652,38 @@ export class ProviderService {
     }
 
     if (input.source === "codex") {
-      const apiKey = typedKey || this.summaryStoredKey(input.providerId);
+      const id = input.providerId?.trim() || "";
+      const apiKey = typedKey || (
+        id && providerRouteMatches(settings.summaryApiConfig, id, input.baseUrl)
+          ? this.dependencies.keys.get("summary", id)
+          : ""
+      );
       return this.operations.resolveCodexProviderCredential({
         codexHome: input.configDir || settings.summaryCodexConfigDir || undefined,
         providerId: input.providerId,
+        baseUrl: input.baseUrl,
         apiKey,
         apiKeySource: summaryKeySource(typedKey, apiKey, "summary"),
       });
     }
 
     const keyTarget = input.inherit ? "codex" : "summary";
-    const apiKey = typedKey || this.dependencies.keys.get(keyTarget, input.providerId);
+    const targetConfig = input.inherit ? settings.apiConfig : settings.summaryApiConfig;
+    const apiKey = typedKey || (
+      providerRouteMatches(targetConfig, input.providerId, input.baseUrl)
+        ? this.dependencies.keys.get(keyTarget, input.providerId)
+        : ""
+    );
     if (!input.inherit) {
       return Promise.resolve({ apiKey, source: summaryKeySource(typedKey, apiKey, "summary") ?? null });
     }
     return this.operations.resolveCodexProviderCredential({
       codexHome: input.codexHome || settings.apiConfig.customConfigDir || undefined,
       providerId: input.providerId,
+      baseUrl: input.baseUrl,
       apiKey,
       apiKeySource: summaryKeySource(typedKey, apiKey, "codex"),
     });
-  }
-
-  /** The Codex and Claude summary sources may have no provider id at all when the route is official. */
-  private summaryStoredKey(providerId: string | undefined): string {
-    const id = providerId?.trim();
-    return id ? this.dependencies.keys.get("summary", id) : "";
   }
 
   async applyCodexProfile(apiConfigInput: Partial<ApiConfig>): Promise<ApplyCodexProfileResult> {
@@ -667,8 +699,12 @@ export class ProviderService {
   applyClaudeProfile(apiConfigInput: Partial<ClaudeApiConfig>): Promise<ApplyClaudeProfileResult> {
     const apiConfig = { ...apiConfigInput };
     if (apiConfig.activeProvider === "custom" && !apiConfig.customApiKey?.trim()) {
-      const providerId = normalizeClaudeApiConfig({ customProviderId: apiConfig.customProviderId }).customProviderId;
-      apiConfig.customApiKey = this.dependencies.keys.get("claude", providerId);
+      const normalized = normalizeClaudeApiConfig(apiConfig);
+      const preset = CLAUDE_API_PROVIDER_PRESETS.find((item) => item.id === normalized.customProviderId);
+      const baseUrl = apiConfig.customBaseUrl?.trim() || preset?.baseUrl || "";
+      if (providerRouteMatches(this.dependencies.getSettings().claudeApiConfig, normalized.customProviderId, baseUrl)) {
+        apiConfig.customApiKey = this.dependencies.keys.get("claude", normalized.customProviderId);
+      }
     }
     return this.operations.applyClaudeApiConfig({ apiConfig });
   }
@@ -726,11 +762,18 @@ export class ProviderService {
 
   private async withCodexCredential(apiConfig: ApiConfig): Promise<ApiConfig> {
     if (apiConfig.activeProvider !== "custom" || apiConfig.customApiKey) return apiConfig;
-    const storedKey = this.dependencies.keys.get("codex", apiConfig.customProviderId);
+    const storedKey = providerRouteMatches(
+      this.dependencies.getSettings().apiConfig,
+      apiConfig.customProviderId,
+      apiConfig.customBaseUrl,
+    )
+      ? this.dependencies.keys.get("codex", apiConfig.customProviderId)
+      : "";
     if (storedKey) return { ...apiConfig, customApiKey: storedKey };
     const credential = await this.operations.resolveCodexProviderCredential({
       codexHome: apiConfig.customConfigDir || undefined,
       providerId: apiConfig.customProviderId,
+      baseUrl: apiConfig.customBaseUrl,
       preferConfiguredHelper: true,
     });
     return credential.apiKey ? { ...apiConfig, customApiKey: credential.apiKey } : apiConfig;

--- a/apps/main-1.0/src/main/services/provider-service.ts
+++ b/apps/main-1.0/src/main/services/provider-service.ts
@@ -96,6 +96,26 @@ function carriesApiKey(update: { customApiKey?: string } | undefined): boolean {
   return Boolean(update) && typeof update?.customApiKey === "string";
 }
 
+type ProviderKeyTargetConfig = Pick<ApiConfig | ClaudeApiConfig, "activeProvider" | "customProviderId" | "customBaseUrl">;
+
+function normalizedProviderBaseUrl(baseUrl: string): string {
+  return baseUrl.trim().replace(/\/+$/, "");
+}
+
+function storedKeyCanHydrateTarget(
+  target: ProviderKeyTargetConfig,
+  savedTarget: ProviderKeyTargetConfig,
+  presets: ReadonlyArray<{ id: string; baseUrl: string }>,
+): boolean {
+  const targetBaseUrl = normalizedProviderBaseUrl(target.customBaseUrl);
+  const fixedPreset = presets.find((preset) => preset.id !== "custom" && preset.id === target.customProviderId);
+  if (fixedPreset && normalizedProviderBaseUrl(fixedPreset.baseUrl) === targetBaseUrl) return true;
+  return Boolean(targetBaseUrl)
+    && savedTarget.activeProvider === "custom"
+    && savedTarget.customProviderId === target.customProviderId
+    && normalizedProviderBaseUrl(savedTarget.customBaseUrl) === targetBaseUrl;
+}
+
 /** Human-readable provenance for the credential the connection test ended up using. */
 function summaryKeySource(typedKey: string, resolvedKey: string, store: ProviderKeyTarget): string | undefined {
   if (typedKey) return "API key field";
@@ -206,21 +226,39 @@ export class ProviderService {
         this.getSavedSummaryConfigPatch(),
         undefined,
       ),
+    }, {
+      codex: currentSettings.apiConfig,
+      claude: currentSettings.claudeApiConfig,
     });
   }
 
-  addStoredKeys(settings: AppSettings): AppSettings {
+  addStoredKeys(
+    settings: AppSettings,
+    savedTargets?: { codex: ApiConfig; claude: ClaudeApiConfig },
+  ): AppSettings {
     const next = { ...settings };
     if (next.apiConfig.activeProvider === "custom") {
       next.apiConfig = {
         ...next.apiConfig,
-        customApiKey: this.dependencies.keys.get("codex", next.apiConfig.customProviderId),
+        customApiKey: !savedTargets || storedKeyCanHydrateTarget(
+          next.apiConfig,
+          savedTargets.codex,
+          API_PROVIDER_PRESETS,
+        )
+          ? this.dependencies.keys.get("codex", next.apiConfig.customProviderId)
+          : "",
       };
     }
     if (next.claudeApiConfig.activeProvider === "custom") {
       next.claudeApiConfig = {
         ...next.claudeApiConfig,
-        customApiKey: this.dependencies.keys.get("claude", next.claudeApiConfig.customProviderId),
+        customApiKey: !savedTargets || storedKeyCanHydrateTarget(
+          next.claudeApiConfig,
+          savedTargets.claude,
+          CLAUDE_API_PROVIDER_PRESETS,
+        )
+          ? this.dependencies.keys.get("claude", next.claudeApiConfig.customProviderId)
+          : "",
       };
     }
     if (next.summaryApiConfigMode === "custom" && next.summaryApiConfig.activeProvider === "custom") {
@@ -385,11 +423,7 @@ export class ProviderService {
           throw new Error(`Base URL is required to test ${apiConfig.customProviderName}.`);
         }
         const requestedBaseUrl = apiConfig.customBaseUrl.trim().replace(/\/+$/, "");
-        const typedKey = apiConfig.customApiKey.trim();
-        const storedKey = (typedKey
-          ? ""
-          : this.dependencies.keys.get("claude", apiConfig.customProviderId)).trim();
-        const providerKey = typedKey || storedKey;
+        const providerKey = apiConfig.customApiKey.trim();
         if (providerKey) {
           const authEnv = {
             ANTHROPIC_BASE_URL: requestedBaseUrl,
@@ -403,7 +437,7 @@ export class ProviderService {
             ...authEnv,
           };
           isolateConfigHome = true;
-          credentialSource = typedKey ? "API key field" : "AgentRecall claude key store";
+          credentialSource = "API key field";
         } else {
           const snapshot = await this.operations.loadClaudeConfigSnapshot(apiConfig.customConfigDir || undefined);
           const configuredBaseUrl = snapshot.route.customBaseUrl?.trim().replace(/\/+$/, "") ?? "";
@@ -454,16 +488,8 @@ export class ProviderService {
         if (!apiConfig.customBaseUrl.trim()) {
           throw new Error(`Base URL is required to test ${apiConfig.customProviderName}.`);
         }
-        const typedKey = apiConfig.customApiKey.trim();
-        const storedKey = (typedKey
-          ? ""
-          : this.dependencies.keys.get("codex", apiConfig.customProviderId)).trim();
-        const providerKey = typedKey || storedKey;
-        credentialSource = typedKey
-          ? "API key field"
-          : storedKey
-            ? "AgentRecall codex key store"
-            : credentialSource;
+        const providerKey = apiConfig.customApiKey.trim();
+        if (providerKey) credentialSource = "API key field";
         const requestedBaseUrl = apiConfig.customBaseUrl.trim().replace(/\/+$/, "");
         if (!providerKey) {
           if (apiConfig.customApiFormat === "openai_chat") {

--- a/apps/main-1.0/src/main/services/provider-service.ts
+++ b/apps/main-1.0/src/main/services/provider-service.ts
@@ -437,12 +437,6 @@ export class ProviderService {
         });
         credentialSource = credential.source || credentialSource;
         const requestedBaseUrl = apiConfig.customBaseUrl.trim().replace(/\/+$/, "");
-        const providerId = apiConfig.customProviderId === "custom"
-          ? "agent-recall-connection-test"
-          : apiConfig.customProviderId;
-        const providerKey = /^[A-Za-z0-9_-]+$/.test(providerId)
-          ? providerId
-          : JSON.stringify(providerId);
         if (!credential.apiKey) {
           if (apiConfig.customApiFormat === "openai_chat") {
             throw new Error(
@@ -450,7 +444,9 @@ export class ProviderService {
             );
           }
           const snapshot = await this.operations.loadCodexConfigSnapshot(apiConfig.customConfigDir || undefined);
-          const configuredProvider = snapshot.providers.find((provider) => provider.id === providerId);
+          const configuredProvider = snapshot.providers.find(
+            (provider) => provider.id === apiConfig.customProviderId,
+          );
           if (
             !configuredProvider
             || configuredProvider.baseUrl.trim().replace(/\/+$/, "") !== requestedBaseUrl
@@ -460,8 +456,11 @@ export class ProviderService {
             );
           }
           credentialSource = configuredProvider.credentialSource || credentialSource;
-          endpoint.cliArgs = ["-c", `model_provider=${JSON.stringify(providerId)}`];
+          endpoint.cliArgs = ["-c", `model_provider=${JSON.stringify(apiConfig.customProviderId)}`];
         } else {
+          // A reserved one-shot provider prevents an existing provider's mutually exclusive
+          // `auth` block from being combined with the env-key authentication below.
+          const providerId = "agent-recall-connection-test";
           let baseUrl = requestedBaseUrl;
           if (apiConfig.customApiFormat === "openai_chat") {
             testProxy = this.operations.createCodexChatProxy({
@@ -473,7 +472,7 @@ export class ProviderService {
             });
             baseUrl = (await testProxy.start()).baseUrl;
           }
-          const prefix = `model_providers.${providerKey}`;
+          const prefix = `model_providers.${providerId}`;
           endpoint.cliArgs = [
             "-c", `model_provider=${JSON.stringify(providerId)}`,
             "-c", `${prefix}.name=${JSON.stringify(apiConfig.customProviderName || providerId)}`,

--- a/apps/main-1.0/src/preload/providers.ts
+++ b/apps/main-1.0/src/preload/providers.ts
@@ -12,6 +12,8 @@ import {
   type ClaudeModelProbeRequest,
   type CodexModelProbeRequest,
   type ConfigSnapshotRequest,
+  type ProviderConnectionRequest,
+  type ProviderConnectionResult,
   type ProviderKeyTarget,
   type SummaryProviderConnectionRequest,
   type SummaryProviderConnectionResult,
@@ -29,6 +31,10 @@ export function createProvidersApi(ipc: ProvidersIpcRenderer) {
       ipc.invoke(PROVIDERS_IPC.probeCodexModels.channel, input),
     probeClaudeModels: (input: ClaudeModelProbeRequest): Promise<ClaudeModelProbeResult> =>
       ipc.invoke(PROVIDERS_IPC.probeClaudeModels.channel, input),
+    testProviderConnection: (
+      input: ProviderConnectionRequest,
+    ): Promise<ProviderConnectionResult> =>
+      ipc.invoke(PROVIDERS_IPC.testProviderConnection.channel, input),
     pickConfigDirectory: (target: ProviderKeyTarget, defaultPath?: string): Promise<string | null> =>
       ipc.invoke(PROVIDERS_IPC.pickConfigDirectory.channel, target, defaultPath),
     testSummaryProviderConnection: (

--- a/apps/main-1.0/src/renderer/src/features/providers/api-config-dialog.test.tsx
+++ b/apps/main-1.0/src/renderer/src/features/providers/api-config-dialog.test.tsx
@@ -231,6 +231,74 @@ describe("AI summary source pane", () => {
     expect(button?.disabled).toBe(false);
   });
 
+  it("clears hydrated Codex and Claude keys when their manual Base URLs change", async () => {
+    const settings = structuredClone(defaultSettings);
+    settings.apiConfig = {
+      ...settings.apiConfig,
+      activeProvider: "custom",
+      customProviderId: "custom",
+      customProviderName: "Custom Codex",
+      customBaseUrl: "https://old-codex.example/v1",
+      customApiKey: "hydrated-codex-key",
+      customModel: "gpt-test",
+    };
+    settings.claudeApiConfig = {
+      ...settings.claudeApiConfig,
+      activeProvider: "custom",
+      customProviderId: "custom",
+      customProviderName: "Custom Claude",
+      customBaseUrl: "https://old-claude.example/anthropic",
+      customApiKey: "hydrated-claude-key",
+      customModel: "claude-test",
+    };
+    await mountDialog(settings);
+
+    const codexFields = [...container.querySelectorAll<HTMLElement>(".settings-field")];
+    const codexBaseUrl = codexFields
+      .find((row) => row.querySelector(".settings-field-title")?.textContent === "Base URL")
+      ?.querySelector<HTMLInputElement>("input");
+    const codexKey = codexFields
+      .find((row) => row.querySelector(".settings-field-title")?.textContent === "API Key")
+      ?.querySelector<HTMLInputElement>("input");
+    expect(codexKey?.value).toBe("hydrated-codex-key");
+
+    await typeInto(codexBaseUrl!, "https://new-codex.example/v1");
+
+    expect(codexKey?.value).toBe("");
+    const codexTest = container.querySelector<HTMLButtonElement>('[data-provider-connection-test="codex"]');
+    await act(async () => codexTest?.click());
+    expect(testProviderConnection).toHaveBeenLastCalledWith({
+      target: "codex",
+      apiConfig: expect.objectContaining({
+        customBaseUrl: "https://new-codex.example/v1",
+        customApiKey: "",
+      }),
+    });
+
+    await selectTarget("Claude Code");
+    const claudeFields = [...container.querySelectorAll<HTMLElement>(".settings-field")];
+    const claudeBaseUrl = claudeFields
+      .find((row) => row.querySelector(".settings-field-title")?.textContent === "Base URL")
+      ?.querySelector<HTMLInputElement>("input");
+    const claudeKey = claudeFields
+      .find((row) => row.querySelector(".settings-field-title")?.textContent === "API Key")
+      ?.querySelector<HTMLInputElement>("input");
+    expect(claudeKey?.value).toBe("hydrated-claude-key");
+
+    await typeInto(claudeBaseUrl!, "https://new-claude.example/anthropic");
+
+    expect(claudeKey?.value).toBe("");
+    const claudeTest = container.querySelector<HTMLButtonElement>('[data-provider-connection-test="claude"]');
+    await act(async () => claudeTest?.click());
+    expect(testProviderConnection).toHaveBeenLastCalledWith({
+      target: "claude",
+      apiConfig: expect.objectContaining({
+        customBaseUrl: "https://new-claude.example/anthropic",
+        customApiKey: "",
+      }),
+    });
+  });
+
   it("renders the same eight rows in the same order for every source", async () => {
     await mountSummaryPane();
 

--- a/apps/main-1.0/src/renderer/src/features/providers/api-config-dialog.test.tsx
+++ b/apps/main-1.0/src/renderer/src/features/providers/api-config-dialog.test.tsx
@@ -49,12 +49,14 @@ function claudeSnapshot() {
 describe("AI summary source pane", () => {
   let container: HTMLDivElement;
   let root: Root;
+  let testProviderConnection: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
     container = document.createElement("div");
     document.body.append(container);
     root = createRoot(container);
+    testProviderConnection = vi.fn(async () => ({ elapsedMs: 1, credentialSource: "runtime" }));
     Object.defineProperty(window, "sessionSearch", {
       configurable: true,
       value: {
@@ -64,6 +66,7 @@ describe("AI summary source pane", () => {
         pickConfigDirectory: vi.fn(async () => ""),
         probeCodexModels: vi.fn(async () => ({ models: [], endpoint: "", endpoints: [], credentialSource: "" })),
         probeClaudeModels: vi.fn(async () => ({ models: [], endpoint: "", endpoints: [], credentialSource: "" })),
+        testProviderConnection,
         testSummaryProviderConnection: vi.fn(async () => ({ elapsedMs: 1, credentialSource: "" })),
       },
     });
@@ -75,9 +78,9 @@ describe("AI summary source pane", () => {
     vi.restoreAllMocks();
   });
 
-  async function mountSummaryPane(): Promise<void> {
+  async function mountDialog(settings = structuredClone(defaultSettings)): Promise<void> {
     await act(async () => root.render(createElement(ApiConfigDialog, {
-      settings: structuredClone(defaultSettings),
+      settings,
       language: "en" as const,
       feedback: null,
       onSettingsChange: vi.fn(),
@@ -85,6 +88,17 @@ describe("AI summary source pane", () => {
       onApplyToClaude: vi.fn(),
       onClose: vi.fn(),
     })));
+  }
+
+  async function selectTarget(label: string): Promise<void> {
+    const target = [...container.querySelectorAll<HTMLButtonElement>(".api-target-tabs button")]
+      .find((button) => button.textContent?.includes(label));
+    if (!target) throw new Error(`${label} tab not rendered`);
+    await act(async () => target.click());
+  }
+
+  async function mountSummaryPane(): Promise<void> {
+    await mountDialog();
     const summaryTab = [...container.querySelectorAll<HTMLButtonElement>(".api-target-tabs button")]
       .find((button) => button.textContent?.includes("AI Summary"));
     if (!summaryTab) throw new Error("AI summary tab not rendered");
@@ -115,6 +129,107 @@ describe("AI summary source pane", () => {
     return [...container.querySelectorAll("[data-summary-row]")]
       .map((element) => element.getAttribute("data-summary-row") ?? "");
   }
+
+  it("tests the official Codex and Claude runtimes with independent status", async () => {
+    await mountDialog();
+
+    const codexTest = container.querySelector<HTMLButtonElement>('[data-provider-connection-test="codex"]');
+    expect(codexTest).toBeTruthy();
+    testProviderConnection.mockResolvedValueOnce({ elapsedMs: 17, credentialSource: "Codex CLI" });
+    await act(async () => codexTest!.click());
+    expect(testProviderConnection).toHaveBeenLastCalledWith({
+      target: "codex",
+      apiConfig: defaultSettings.apiConfig,
+    });
+    expect(container.textContent).toContain("Codex connection succeeded in 17 ms using Codex CLI.");
+
+    await selectTarget("Claude Code");
+    const claudeTest = container.querySelector<HTMLButtonElement>('[data-provider-connection-test="claude"]');
+    expect(claudeTest).toBeTruthy();
+    testProviderConnection.mockRejectedValueOnce(new Error("Claude CLI is not installed."));
+    await act(async () => claudeTest!.click());
+    expect(testProviderConnection).toHaveBeenLastCalledWith({
+      target: "claude",
+      apiConfig: defaultSettings.claudeApiConfig,
+    });
+    expect(container.textContent).toContain("Claude CLI is not installed.");
+
+    await selectTarget("Codex");
+    expect(container.textContent).toContain("Codex connection succeeded in 17 ms using Codex CLI.");
+  });
+
+  it("keeps connection testing available for custom Codex and Claude drafts", async () => {
+    await mountDialog();
+
+    const codexPreset = [...container.querySelectorAll<HTMLButtonElement>(".codex-provider-switch button")]
+      .find((button) => button.querySelector("strong")?.textContent === "DeepSeek");
+    if (!codexPreset) throw new Error("Codex DeepSeek preset not rendered");
+    await act(async () => {
+      codexPreset.click();
+      await Promise.resolve();
+    });
+    const codexTest = container.querySelector<HTMLButtonElement>('[data-provider-connection-test="codex"]');
+    await act(async () => codexTest!.click());
+    expect(testProviderConnection).toHaveBeenLastCalledWith({
+      target: "codex",
+      apiConfig: expect.objectContaining({
+        activeProvider: "custom",
+        customProviderId: "deepseek",
+        customBaseUrl: "https://api.deepseek.com",
+      }),
+    });
+
+    await selectTarget("Claude Code");
+    const claudePreset = [...container.querySelectorAll<HTMLButtonElement>(".api-provider-switch--compact button")]
+      .find((button) => button.querySelector("strong")?.textContent === "DeepSeek");
+    if (!claudePreset) throw new Error("Claude DeepSeek preset not rendered");
+    await act(async () => {
+      claudePreset.click();
+      await Promise.resolve();
+    });
+    const claudeTest = container.querySelector<HTMLButtonElement>('[data-provider-connection-test="claude"]');
+    await act(async () => claudeTest!.click());
+    expect(testProviderConnection).toHaveBeenLastCalledWith({
+      target: "claude",
+      apiConfig: expect.objectContaining({
+        activeProvider: "custom",
+        customProviderId: "deepseek",
+        customBaseUrl: "https://api.deepseek.com/anthropic",
+      }),
+    });
+  });
+
+  it("discards a connection result when the tested draft changes", async () => {
+    let resolveConnection: ((result: { elapsedMs: number; credentialSource: string }) => void) | undefined;
+    testProviderConnection.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveConnection = resolve;
+    }));
+    const settings = structuredClone(defaultSettings);
+    settings.claudeApiConfig = {
+      ...settings.claudeApiConfig,
+      activeProvider: "custom",
+      customProviderId: "custom",
+      customProviderName: "Custom Claude",
+      customBaseUrl: "https://old.example/anthropic",
+      customModel: "claude-test",
+    };
+    await mountDialog(settings);
+    await selectTarget("Claude Code");
+
+    const button = container.querySelector<HTMLButtonElement>('[data-provider-connection-test="claude"]');
+    await act(async () => button!.click());
+    expect(container.textContent).toContain("Testing Claude Code connection...");
+    expect(button?.disabled).toBe(true);
+
+    const baseUrlRow = [...container.querySelectorAll<HTMLElement>(".settings-field")]
+      .find((row) => row.querySelector(".settings-field-title")?.textContent === "Base URL");
+    const baseUrlInput = baseUrlRow?.querySelector<HTMLInputElement>("input");
+    await typeInto(baseUrlInput!, "https://new.example/anthropic");
+    await act(async () => resolveConnection?.({ elapsedMs: 12, credentialSource: "stale credential" }));
+
+    expect(container.textContent).not.toContain("stale credential");
+    expect(button?.disabled).toBe(false);
+  });
 
   it("renders the same eight rows in the same order for every source", async () => {
     await mountSummaryPane();

--- a/apps/main-1.0/src/renderer/src/features/providers/api-config-dialog.test.tsx
+++ b/apps/main-1.0/src/renderer/src/features/providers/api-config-dialog.test.tsx
@@ -265,6 +265,13 @@ describe("AI summary source pane", () => {
     await typeInto(codexBaseUrl!, "https://new-codex.example/v1");
 
     expect(codexKey?.value).toBe("");
+    const codexDetect = container.querySelector<HTMLButtonElement>(".codex-model-detect-button");
+    await act(async () => codexDetect?.click());
+    expect(window.sessionSearch.probeCodexModels).toHaveBeenLastCalledWith(expect.objectContaining({
+      baseUrl: "https://new-codex.example/v1",
+      apiKey: "",
+      providerId: "custom",
+    }));
     const codexTest = container.querySelector<HTMLButtonElement>('[data-provider-connection-test="codex"]');
     await act(async () => codexTest?.click());
     expect(testProviderConnection).toHaveBeenLastCalledWith({
@@ -288,6 +295,13 @@ describe("AI summary source pane", () => {
     await typeInto(claudeBaseUrl!, "https://new-claude.example/anthropic");
 
     expect(claudeKey?.value).toBe("");
+    const claudeDetect = container.querySelector<HTMLButtonElement>(".codex-model-detect-button");
+    await act(async () => claudeDetect?.click());
+    expect(window.sessionSearch.probeClaudeModels).toHaveBeenLastCalledWith(expect.objectContaining({
+      baseUrl: "https://new-claude.example/anthropic",
+      apiKey: "",
+      providerId: "custom",
+    }));
     const claudeTest = container.querySelector<HTMLButtonElement>('[data-provider-connection-test="claude"]');
     await act(async () => claudeTest?.click());
     expect(testProviderConnection).toHaveBeenLastCalledWith({

--- a/apps/main-1.0/src/renderer/src/features/providers/api-config-dialog.tsx
+++ b/apps/main-1.0/src/renderer/src/features/providers/api-config-dialog.tsx
@@ -341,10 +341,16 @@ export function ApiConfigDialog({
   const detectCodexModels = async () => {
     setCodexModelProbeStatus({ kind: "running", message: l("Detecting models...", "正在探测模型...") });
     try {
+      const configuredProviderId = selectedCodexConfigProviderId || codexConfig?.activeProviderId;
+      const configuredProvider = codexConfig?.providers.find((provider) => provider.id === configuredProviderId);
+      const providerId = configuredProvider
+        && normalizeProviderBaseUrl(configuredProvider.baseUrl) === normalizeProviderBaseUrl(draftApiConfig.customBaseUrl)
+        ? configuredProvider.id
+        : draftApiConfig.customProviderId;
       const result = await window.sessionSearch.probeCodexModels({
         baseUrl: draftApiConfig.customBaseUrl,
         apiKey: draftApiConfig.customApiKey,
-        providerId: selectedCodexConfigProviderId || codexConfig?.activeProviderId,
+        providerId,
         codexHome: draftApiConfig.customConfigDir || undefined,
         keyTarget: "codex",
       });
@@ -1721,7 +1727,11 @@ export function ApiConfigDialog({
                   value={summaryView.baseUrl}
                   disabled={!settings || saving || !summaryView.baseUrlEditable}
                   placeholder={summaryView.baseUrlPlaceholder}
-                  onChange={(event) => updateDraftSummaryApiConfig({ customBaseUrl: event.currentTarget.value })}
+                  onChange={(event) => updateDraftSummaryApiConfig({
+                    customProviderId: "custom",
+                    customBaseUrl: event.currentTarget.value,
+                    customApiKey: "",
+                  })}
                 />
               </label>
               <div className="settings-field" data-summary-row="model">

--- a/apps/main-1.0/src/renderer/src/features/providers/api-config-dialog.tsx
+++ b/apps/main-1.0/src/renderer/src/features/providers/api-config-dialog.tsx
@@ -19,6 +19,15 @@ import type { SummaryProviderConnectionRequest } from "../../../../shared/ipc/pr
 import type { SettingsFeedback } from "../../app-types";
 import { localize, type LanguageMode } from "../../language";
 
+type ProviderConnectionRequest =
+  | { target: "codex"; apiConfig: ApiConfig }
+  | { target: "claude"; apiConfig: ClaudeApiConfig };
+
+interface ProviderConnectionResult {
+  elapsedMs: number;
+  credentialSource: string;
+}
+
 // The summary route is a plain OpenAI-compatible route just like the Codex one, so it
 // offers the same presets; only the stored credential differs.
 const SUMMARY_API_PROVIDER_PRESETS = API_PROVIDER_PRESETS;
@@ -89,9 +98,11 @@ export function ApiConfigDialog({
   const [codexModelOptions, setCodexModelOptions] = useState<string[]>([]);
   const [codexModelMenuOpen, setCodexModelMenuOpen] = useState(false);
   const [codexModelProbeStatus, setCodexModelProbeStatus] = useState<SettingsFeedback>(null);
+  const [codexConnectionStatus, setCodexConnectionStatus] = useState<SettingsFeedback>(null);
   const [claudeModelOptions, setClaudeModelOptions] = useState<string[]>([]);
   const [claudeModelMenuOpen, setClaudeModelMenuOpen] = useState(false);
   const [claudeModelProbeStatus, setClaudeModelProbeStatus] = useState<SettingsFeedback>(null);
+  const [claudeConnectionStatus, setClaudeConnectionStatus] = useState<SettingsFeedback>(null);
   const [summaryModelOptions, setSummaryModelOptions] = useState<string[]>([]);
   const [summaryModelMenuOpen, setSummaryModelMenuOpen] = useState(false);
   const [summaryModelProbeStatus, setSummaryModelProbeStatus] = useState<SettingsFeedback>(null);
@@ -106,8 +117,19 @@ export function ApiConfigDialog({
   const summaryApiPresetSelectionRef = useRef(0);
   const codexConfigHydrationRef = useRef("");
   const claudeConfigHydrationRef = useRef("");
+  const codexConnectionTestIdRef = useRef(0);
+  const claudeConnectionTestIdRef = useRef(0);
   const updateDraftApiConfig = (next: Partial<ApiConfig>) => setDraftApiConfig((current) => ({ ...current, ...next }));
   const updateDraftClaudeApiConfig = (next: Partial<ClaudeApiConfig>) => setDraftClaudeApiConfig((current) => ({ ...current, ...next }));
+  const codexConnectionSignature = JSON.stringify(draftApiConfig);
+  const claudeConnectionSignature = JSON.stringify(draftClaudeApiConfig);
+  const codexConnectionSignatureRef = useRef(codexConnectionSignature);
+  const claudeConnectionSignatureRef = useRef(claudeConnectionSignature);
+  codexConnectionSignatureRef.current = codexConnectionSignature;
+  claudeConnectionSignatureRef.current = claudeConnectionSignature;
+  const providerConnectionApi = window.sessionSearch as typeof window.sessionSearch & {
+    testProviderConnection(input: ProviderConnectionRequest): Promise<ProviderConnectionResult>;
+  };
   const updateDraftSummaryApiConfig = (next: Partial<ApiConfig>) => setDraftSummaryApiConfig((current) => ({ ...current, ...next }));
   const selectedPreset = API_PROVIDER_PRESETS.find((preset) => preset.id === draftApiConfig.customProviderId);
   const customName = selectedPreset?.label ?? (draftApiConfig.customProviderName || "Custom");
@@ -329,6 +351,64 @@ export function ApiConfigDialog({
       });
     } catch (error) {
       setClaudeModelProbeStatus({ kind: "error", message: error instanceof Error ? error.message : String(error) });
+    }
+  };
+
+  const testCodexConnection = async () => {
+    const testId = ++codexConnectionTestIdRef.current;
+    const testedSignature = codexConnectionSignature;
+    setCodexConnectionStatus({ kind: "running", message: l("Testing Codex connection...", "正在测试 Codex 连接...") });
+    try {
+      const result = await providerConnectionApi.testProviderConnection({
+        target: "codex",
+        apiConfig: { ...draftApiConfig },
+      });
+      if (
+        testId !== codexConnectionTestIdRef.current
+        || testedSignature !== codexConnectionSignatureRef.current
+      ) return;
+      setCodexConnectionStatus({
+        kind: "success",
+        message: l(
+          `Codex connection succeeded in ${result.elapsedMs} ms using ${result.credentialSource}.`,
+          `Codex 连接成功，使用 ${result.credentialSource}，耗时 ${result.elapsedMs} 毫秒。`,
+        ),
+      });
+    } catch (error) {
+      if (
+        testId !== codexConnectionTestIdRef.current
+        || testedSignature !== codexConnectionSignatureRef.current
+      ) return;
+      setCodexConnectionStatus({ kind: "error", message: error instanceof Error ? error.message : String(error) });
+    }
+  };
+
+  const testClaudeConnection = async () => {
+    const testId = ++claudeConnectionTestIdRef.current;
+    const testedSignature = claudeConnectionSignature;
+    setClaudeConnectionStatus({ kind: "running", message: l("Testing Claude Code connection...", "正在测试 Claude Code 连接...") });
+    try {
+      const result = await providerConnectionApi.testProviderConnection({
+        target: "claude",
+        apiConfig: { ...draftClaudeApiConfig },
+      });
+      if (
+        testId !== claudeConnectionTestIdRef.current
+        || testedSignature !== claudeConnectionSignatureRef.current
+      ) return;
+      setClaudeConnectionStatus({
+        kind: "success",
+        message: l(
+          `Claude Code connection succeeded in ${result.elapsedMs} ms using ${result.credentialSource}.`,
+          `Claude Code 连接成功，使用 ${result.credentialSource}，耗时 ${result.elapsedMs} 毫秒。`,
+        ),
+      });
+    } catch (error) {
+      if (
+        testId !== claudeConnectionTestIdRef.current
+        || testedSignature !== claudeConnectionSignatureRef.current
+      ) return;
+      setClaudeConnectionStatus({ kind: "error", message: error instanceof Error ? error.message : String(error) });
     }
   };
 
@@ -784,7 +864,6 @@ export function ApiConfigDialog({
     settings?.summarySource,
     settings?.summaryReasoningEffort,
   ]);
-
   useEffect(() => {
     setDraftApiConfig(settings?.apiConfig ?? { ...defaultApiConfig });
     setDraftClaudeApiConfig(settings?.claudeApiConfig ?? { ...defaultClaudeApiConfig });
@@ -798,6 +877,16 @@ export function ApiConfigDialog({
     setDraftSummaryReasoningEffort(settings?.summaryReasoningEffort ?? "medium");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [settingsSignature]);
+
+  useEffect(() => {
+    codexConnectionTestIdRef.current += 1;
+    setCodexConnectionStatus(null);
+  }, [codexConnectionSignature]);
+
+  useEffect(() => {
+    claudeConnectionTestIdRef.current += 1;
+    setClaudeConnectionStatus(null);
+  }, [claudeConnectionSignature]);
 
   useEffect(() => {
     // Re-read whenever the directory changes, otherwise the pane keeps showing the config
@@ -1752,9 +1841,38 @@ export function ApiConfigDialog({
           )}
         </div>
         <div className="dialog-actions api-config-actions">
-          <span className={`api-config-status ${feedback?.kind ?? ""}`} aria-live="polite">
-            {feedback?.message ?? ""}
-          </span>
+          <div className="api-config-feedback" aria-live="polite">
+            {feedback ? <span className={`api-config-status ${feedback.kind}`}>{feedback.message}</span> : null}
+            {apiTarget === "codex" && codexConnectionStatus ? (
+              <span className={`api-config-status ${codexConnectionStatus.kind}`}>{codexConnectionStatus.message}</span>
+            ) : null}
+            {apiTarget === "claude" && claudeConnectionStatus ? (
+              <span className={`api-config-status ${claudeConnectionStatus.kind}`}>{claudeConnectionStatus.message}</span>
+            ) : null}
+          </div>
+          {apiTarget === "codex" ? (
+            <button
+              type="button"
+              data-provider-connection-test="codex"
+              disabled={!settings || saving || codexConnectionStatus?.kind === "running"}
+              onClick={() => void testCodexConnection()}
+            >
+              {codexConnectionStatus?.kind === "running"
+                ? l("Testing connection...", "正在测试连接...")
+                : l("Test connection", "测试连接")}
+            </button>
+          ) : apiTarget === "claude" ? (
+            <button
+              type="button"
+              data-provider-connection-test="claude"
+              disabled={!settings || saving || claudeConnectionStatus?.kind === "running"}
+              onClick={() => void testClaudeConnection()}
+            >
+              {claudeConnectionStatus?.kind === "running"
+                ? l("Testing connection...", "正在测试连接...")
+                : l("Test connection", "测试连接")}
+            </button>
+          ) : null}
           <button type="button" className={apiTarget === "summary" ? "primary-action" : ""} disabled={!settings || saving} onClick={saveDraft}>
             {apiTarget === "summary"
               ? l("Save summary settings", "保存摘要设置")

--- a/apps/main-1.0/src/renderer/src/features/providers/api-config-dialog.tsx
+++ b/apps/main-1.0/src/renderer/src/features/providers/api-config-dialog.tsx
@@ -19,15 +19,6 @@ import type { SummaryProviderConnectionRequest } from "../../../../shared/ipc/pr
 import type { SettingsFeedback } from "../../app-types";
 import { localize, type LanguageMode } from "../../language";
 
-type ProviderConnectionRequest =
-  | { target: "codex"; apiConfig: ApiConfig }
-  | { target: "claude"; apiConfig: ClaudeApiConfig };
-
-interface ProviderConnectionResult {
-  elapsedMs: number;
-  credentialSource: string;
-}
-
 // The summary route is a plain OpenAI-compatible route just like the Codex one, so it
 // offers the same presets; only the stored credential differs.
 const SUMMARY_API_PROVIDER_PRESETS = API_PROVIDER_PRESETS;
@@ -127,9 +118,6 @@ export function ApiConfigDialog({
   const claudeConnectionSignatureRef = useRef(claudeConnectionSignature);
   codexConnectionSignatureRef.current = codexConnectionSignature;
   claudeConnectionSignatureRef.current = claudeConnectionSignature;
-  const providerConnectionApi = window.sessionSearch as typeof window.sessionSearch & {
-    testProviderConnection(input: ProviderConnectionRequest): Promise<ProviderConnectionResult>;
-  };
   const updateDraftSummaryApiConfig = (next: Partial<ApiConfig>) => setDraftSummaryApiConfig((current) => ({ ...current, ...next }));
   const selectedPreset = API_PROVIDER_PRESETS.find((preset) => preset.id === draftApiConfig.customProviderId);
   const customName = selectedPreset?.label ?? (draftApiConfig.customProviderName || "Custom");
@@ -359,7 +347,7 @@ export function ApiConfigDialog({
     const testedSignature = codexConnectionSignature;
     setCodexConnectionStatus({ kind: "running", message: l("Testing Codex connection...", "正在测试 Codex 连接...") });
     try {
-      const result = await providerConnectionApi.testProviderConnection({
+      const result = await window.sessionSearch.testProviderConnection({
         target: "codex",
         apiConfig: { ...draftApiConfig },
       });
@@ -388,7 +376,7 @@ export function ApiConfigDialog({
     const testedSignature = claudeConnectionSignature;
     setClaudeConnectionStatus({ kind: "running", message: l("Testing Claude Code connection...", "正在测试 Claude Code 连接...") });
     try {
-      const result = await providerConnectionApi.testProviderConnection({
+      const result = await window.sessionSearch.testProviderConnection({
         target: "claude",
         apiConfig: { ...draftClaudeApiConfig },
       });

--- a/apps/main-1.0/src/renderer/src/features/providers/api-config-dialog.tsx
+++ b/apps/main-1.0/src/renderer/src/features/providers/api-config-dialog.tsx
@@ -31,6 +31,16 @@ function hasSavedCustomRoute(
     && Boolean(config.customBaseUrl.trim() || config.customModel.trim() || config.customApiKey.trim());
 }
 
+function providerTargetMatches(
+  config: Pick<ApiConfig | ClaudeApiConfig, "activeProvider" | "customProviderId" | "customBaseUrl"> | null | undefined,
+  providerId: string,
+  baseUrl: string,
+): boolean {
+  return config?.activeProvider === "custom"
+    && config.customProviderId === providerId
+    && normalizeProviderBaseUrl(config.customBaseUrl) === normalizeProviderBaseUrl(baseUrl);
+}
+
 function buildSummaryDraftFromSettings(settings: AppSettings | null): ApiConfig {
   return settings?.summaryApiConfig ?? { ...defaultApiConfig };
 }
@@ -135,21 +145,26 @@ export function ApiConfigDialog({
     const activeProvider = snapshot.providers.find((provider) => provider.id === snapshot.activeProviderId);
     if (!activeProvider || snapshot.activeProviderId === "openai") {
       setSelectedCodexConfigProviderId("");
-      setDraftApiConfig((current) => ({ ...current, activeProvider: "official" }));
+      setDraftApiConfig((current) => ({ ...current, activeProvider: "official", customApiKey: "" }));
       return;
     }
     const preset = API_PROVIDER_PRESETS.find(
       (item) => item.id !== "custom" && (item.id === activeProvider.id || normalizeProviderBaseUrl(item.baseUrl) === normalizeProviderBaseUrl(activeProvider.baseUrl)),
     );
+    const nextProviderId = preset?.id ?? activeProvider.id;
+    const nextBaseUrl = activeProvider.baseUrl || preset?.baseUrl || "";
     setSelectedCodexConfigProviderId(preset ? "" : activeProvider.id);
     setDraftApiConfig((current) => ({
       ...current,
       activeProvider: "custom",
       // A preset match must keep the preset's own id, otherwise the preset button stops
       // looking selected and the stored key is looked up under the wrong name.
-      customProviderId: preset?.id ?? activeProvider.id,
+      customProviderId: nextProviderId,
       customProviderName: preset?.providerName ?? activeProvider.name ?? activeProvider.id,
-      customBaseUrl: activeProvider.baseUrl || preset?.baseUrl || current.customBaseUrl,
+      customBaseUrl: nextBaseUrl || current.customBaseUrl,
+      customApiKey: Boolean(nextBaseUrl) && providerTargetMatches(current, nextProviderId, nextBaseUrl)
+        ? current.customApiKey
+        : "",
       customModel: snapshot.activeModel || preset?.model || current.customModel,
       customApiFormat: activeProvider.wireApi === "chat" ? "openai_chat" : preset?.apiFormat ?? "openai_responses",
     }));
@@ -159,17 +174,21 @@ export function ApiConfigDialog({
     `${snapshot.configPath}:${snapshot.activeProviderId}:${snapshot.activeModel}:${snapshot.providers.map((provider) => `${provider.id}:${provider.baseUrl}`).join("|")}`;
 
   const claudeConfigHydrationKey = (snapshot: ClaudeConfigSnapshot) =>
-    `${snapshot.settingsPath}:${snapshot.route.activeProvider}:${snapshot.route.customBaseUrl}:${snapshot.route.customModel}`;
+    `${snapshot.settingsPath}:${snapshot.route.activeProvider}:${snapshot.route.customProviderId}:${snapshot.route.customBaseUrl}:${snapshot.route.customModel}`;
 
   const hydrateDraftFromClaudeConfig = (snapshot: ClaudeConfigSnapshot, configDir?: string) => {
     if (snapshot.route.activeProvider !== "custom") return;
     setSelectedClaudeConfigRoute("config");
-    setDraftClaudeApiConfig((current) => ({
-      ...current,
-      ...snapshot.route,
-      customConfigDir: configDir ?? current.customConfigDir,
-      customApiKey: current.customApiKey,
-    }));
+    setDraftClaudeApiConfig((current) => {
+      const nextProviderId = snapshot.route.customProviderId ?? current.customProviderId;
+      const nextBaseUrl = snapshot.route.customBaseUrl ?? current.customBaseUrl;
+      return {
+        ...current,
+        ...snapshot.route,
+        customConfigDir: configDir ?? current.customConfigDir,
+        customApiKey: providerTargetMatches(current, nextProviderId, nextBaseUrl) ? current.customApiKey : "",
+      };
+    });
   };
 
   const selectClaudeConfigRoute = (useConfigRoute: boolean) => {
@@ -187,21 +206,34 @@ export function ApiConfigDialog({
   const selectApiPreset = async (presetId: ApiProviderPresetId) => {
     const selectionId = ++apiPresetSelectionRef.current;
     const preset = API_PROVIDER_PRESETS.find((item) => item.id === presetId) ?? API_PROVIDER_PRESETS[0];
-    const apiKey = await window.sessionSearch.getApiProviderKey("codex", preset.id).catch(() => "");
+    const activeProvider = preset.id === "custom"
+      ? codexConfig?.providers.find((provider) => provider.id === codexConfig.activeProviderId)
+      : undefined;
+    const nextProviderId = activeProvider?.id ?? preset.id;
+    const apiKey = preset.id === "custom"
+      ? ""
+      : await window.sessionSearch.getApiProviderKey("codex", preset.id).catch(() => "");
     if (selectionId !== apiPresetSelectionRef.current) return;
     if (preset.id === "custom") {
-      const activeProvider = codexConfig?.providers.find((provider) => provider.id === codexConfig.activeProviderId);
       setSelectedCodexConfigProviderId(activeProvider?.id ?? "");
-      setDraftApiConfig((current) => ({
-        ...current,
-        activeProvider: "custom",
-        customProviderId: "custom",
-        customProviderName: activeProvider?.name || current.customProviderName || preset.providerName,
-        customBaseUrl: activeProvider?.baseUrl || current.customBaseUrl,
-        customApiKey: apiKey || current.customApiKey,
-        customModel: codexConfig?.activeModel || current.customModel,
-        customApiFormat: activeProvider?.wireApi === "chat" ? "openai_chat" : current.customApiFormat || preset.apiFormat,
-      }));
+      setDraftApiConfig((current) => {
+        const nextBaseUrl = activeProvider?.baseUrl || current.customBaseUrl;
+        const reusableKey = providerTargetMatches(current, nextProviderId, nextBaseUrl)
+          ? current.customApiKey
+          : providerTargetMatches(settings?.apiConfig, nextProviderId, nextBaseUrl)
+            ? settings?.apiConfig.customApiKey ?? ""
+            : "";
+        return {
+          ...current,
+          activeProvider: "custom",
+          customProviderId: nextProviderId,
+          customProviderName: activeProvider?.name || current.customProviderName || preset.providerName,
+          customBaseUrl: nextBaseUrl,
+          customApiKey: reusableKey,
+          customModel: codexConfig?.activeModel || current.customModel,
+          customApiFormat: activeProvider?.wireApi === "chat" ? "openai_chat" : current.customApiFormat || preset.apiFormat,
+        };
+      });
     } else {
       setSelectedCodexConfigProviderId("");
       setDraftApiConfig((current) => ({
@@ -282,21 +314,28 @@ export function ApiConfigDialog({
     // has typed, instead of snapping the select back to the previous provider.
     if (!providerId) {
       setSelectedCodexConfigProviderId("");
-      updateDraftApiConfig({ activeProvider: "custom", customProviderId: "custom" });
+      setDraftApiConfig((current) => ({
+        ...current,
+        activeProvider: "custom",
+        customProviderId: "custom",
+        customApiKey: providerTargetMatches(current, "custom", current.customBaseUrl) ? current.customApiKey : "",
+      }));
       return;
     }
     const provider = codexConfig?.providers.find((item) => item.id === providerId);
     if (!provider) return;
     setSelectedCodexConfigProviderId(provider.id);
-    updateDraftApiConfig({
+    setDraftApiConfig((current) => ({
+      ...current,
       activeProvider: "custom",
       // Keep the config's own id so the credential lookup and the applied config.toml
       // section both point at the provider the user just picked.
       customProviderId: provider.id,
       customProviderName: provider.name || provider.id,
       customBaseUrl: provider.baseUrl,
+      customApiKey: providerTargetMatches(current, provider.id, provider.baseUrl) ? current.customApiKey : "",
       customApiFormat: provider.wireApi === "chat" ? "openai_chat" : "openai_responses",
-    });
+    }));
   };
 
   const detectCodexModels = async () => {
@@ -758,20 +797,29 @@ export function ApiConfigDialog({
   const selectClaudeApiPreset = async (presetId: ClaudeApiProviderPresetId) => {
     const selectionId = ++claudeApiPresetSelectionRef.current;
     const preset = CLAUDE_API_PROVIDER_PRESETS.find((item) => item.id === presetId) ?? CLAUDE_API_PROVIDER_PRESETS[0];
-    const apiKey = await window.sessionSearch.getApiProviderKey("claude", preset.id).catch(() => "");
+    const apiKey = preset.id === "custom"
+      ? ""
+      : await window.sessionSearch.getApiProviderKey("claude", preset.id).catch(() => "");
     if (selectionId !== claudeApiPresetSelectionRef.current) return;
     setDraftClaudeApiConfig((current) => {
       if (preset.id === "custom") {
         // Seed empty fields from the manual route in ~/.claude/settings.json so a
         // hand-configured third-party provider becomes the Custom baseline.
         const route = claudeConfig?.route.activeProvider === "custom" ? claudeConfig.route : null;
+        const nextProviderId = route?.customProviderId ?? "custom";
+        const nextBaseUrl = current.customBaseUrl || route?.customBaseUrl || "";
+        const reusableKey = providerTargetMatches(current, nextProviderId, nextBaseUrl)
+          ? current.customApiKey
+          : providerTargetMatches(settings?.claudeApiConfig, nextProviderId, nextBaseUrl)
+            ? settings?.claudeApiConfig.customApiKey ?? ""
+            : "";
         return {
           ...current,
           activeProvider: "custom",
-          customProviderId: "custom",
+          customProviderId: nextProviderId,
           customProviderName: current.customProviderName || route?.customProviderName || preset.providerName,
-          customBaseUrl: current.customBaseUrl || route?.customBaseUrl || "",
-          customApiKey: apiKey || route?.customApiKey || current.customApiKey,
+          customBaseUrl: nextBaseUrl,
+          customApiKey: reusableKey,
           customModel: current.customModel || route?.customModel || "",
           customHaikuModel: current.customHaikuModel || route?.customHaikuModel || "",
           customSonnetModel: current.customSonnetModel || route?.customSonnetModel || "",
@@ -1102,7 +1150,14 @@ export function ApiConfigDialog({
                       value={draftApiConfig.customBaseUrl}
                       disabled={!settings || saving}
                       placeholder="https://api.example.com/v1"
-                      onChange={(event) => updateDraftApiConfig({ customBaseUrl: event.currentTarget.value })}
+                      onChange={(event) => {
+                        setSelectedCodexConfigProviderId("");
+                        updateDraftApiConfig({
+                          customProviderId: "custom",
+                          customBaseUrl: event.currentTarget.value,
+                          customApiKey: "",
+                        });
+                      }}
                     />
                   </label>
                   <label className="settings-field">
@@ -1380,7 +1435,14 @@ export function ApiConfigDialog({
                       value={draftClaudeApiConfig.customBaseUrl}
                       disabled={!settings || saving}
                       placeholder="https://api.example.com/anthropic"
-                      onChange={(event) => updateDraftClaudeApiConfig({ customBaseUrl: event.currentTarget.value })}
+                      onChange={(event) => {
+                        setSelectedClaudeConfigRoute("");
+                        updateDraftClaudeApiConfig({
+                          customProviderId: "custom",
+                          customBaseUrl: event.currentTarget.value,
+                          customApiKey: "",
+                        });
+                      }}
                     />
                   </label>
                   <label className="settings-field">

--- a/apps/main-1.0/src/renderer/src/styles.css
+++ b/apps/main-1.0/src/renderer/src/styles.css
@@ -6850,6 +6850,17 @@ select:focus-visible {
   box-shadow: 0 1px 2px var(--accent-ring, rgba(0, 0, 0, 0.12));
 }
 
+.api-config-feedback {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+  margin-right: auto;
+}
+
+.api-config-feedback .api-config-status {
+  margin-right: 0;
+}
+
 /* Save status sits on the left where Cancel used to be; the dialog closes via the top-right ✕. */
 .api-config-status {
   margin-right: auto;

--- a/apps/main-1.0/src/shared/ipc/providers.ts
+++ b/apps/main-1.0/src/shared/ipc/providers.ts
@@ -57,6 +57,17 @@ export const claudeModelProbeInput = z.object({
 
 export const providerKeyTarget = z.enum(["codex", "claude", "summary"]);
 
+export const providerConnectionInput = z.discriminatedUnion("target", [
+  z.object({
+    target: z.literal("codex"),
+    apiConfig: apiConfigInput,
+  }).strict(),
+  z.object({
+    target: z.literal("claude"),
+    apiConfig: claudeApiConfigInput,
+  }).strict(),
+]);
+
 const summaryConnectionFields = {
   baseUrl: boundedString(8_192).trim().min(1),
   apiKey: boundedString(65_536),
@@ -105,18 +116,25 @@ export type ProviderKeyTarget = z.infer<typeof providerKeyTarget>;
 export type ConfigSnapshotRequest = z.infer<typeof configSnapshotInput>;
 export type CodexModelProbeRequest = z.infer<typeof codexModelProbeInput>;
 export type ClaudeModelProbeRequest = z.infer<typeof claudeModelProbeInput>;
+export type ProviderConnectionRequest = z.infer<typeof providerConnectionInput>;
 export type SummaryProviderConnectionRequest = z.infer<typeof summaryProviderConnectionInput>;
 
-export interface SummaryProviderConnectionResult {
+export interface ProviderConnectionResult {
   elapsedMs: number;
   credentialSource: string;
 }
+
+export type SummaryProviderConnectionResult = ProviderConnectionResult;
 
 export const PROVIDERS_IPC = {
   getCodexConfig: defineIpcRequest("codex-config:get", z.tuple([configSnapshotInput])),
   getClaudeConfig: defineIpcRequest("claude-config:get", z.tuple([configSnapshotInput])),
   probeCodexModels: defineIpcRequest("codex-config:probe-models", z.tuple([codexModelProbeInput])),
   probeClaudeModels: defineIpcRequest("claude-config:probe-models", z.tuple([claudeModelProbeInput])),
+  testProviderConnection: defineIpcRequest(
+    "provider:test-connection",
+    z.tuple([providerConnectionInput]),
+  ),
   pickConfigDirectory: defineIpcRequest(
     "provider-config:pick-directory",
     z.tuple([providerKeyTarget, z.union([boundedString(8_192), z.undefined()])]),

--- a/apps/main-2.0/src/core/claude-profile.test.ts
+++ b/apps/main-2.0/src/core/claude-profile.test.ts
@@ -11,6 +11,8 @@ import { applyClaudeApiConfig, loadClaudeApiConfigDefaults, loadClaudeConfigSnap
 
 async function withClaudeHome<T>(run: (claudeHome: string) => Promise<T>): Promise<T> {
   const claudeHome = await mkdtemp(path.join(tmpdir(), "agent-recall-claude-"));
+  vi.stubEnv("HOME", claudeHome);
+  vi.stubEnv("USERPROFILE", claudeHome);
   try {
     return await run(claudeHome);
   } finally {
@@ -148,6 +150,41 @@ describe("Claude Code provider switching", () => {
       const snapshot = await loadClaudeConfigSnapshot(claudeHome);
       expect(snapshot.exists).toBe(false);
       expect(snapshot.route).toEqual({});
+    });
+  });
+
+  it("detects apiKeyHelper without running its shell command during snapshots", async () => {
+    await withClaudeHome(async (claudeHome) => {
+      await writeFile(
+        path.join(claudeHome, "settings.json"),
+        JSON.stringify({
+          apiKeyHelper: "agent-recall-helper-must-not-run",
+          env: { ANTHROPIC_BASE_URL: "https://api.example.com/anthropic" },
+        }),
+      );
+
+      const snapshot = await loadClaudeConfigSnapshot(claudeHome);
+
+      expect(snapshot.hasApiKey).toBe(true);
+      expect(snapshot.credentialSource).toBe("settings.json apiKeyHelper");
+    });
+  });
+
+  it("does not treat Claude OAuth credentials as a reusable provider API key", async () => {
+    await withClaudeHome(async (claudeHome) => {
+      await writeFile(
+        path.join(claudeHome, "settings.json"),
+        JSON.stringify({ env: { ANTHROPIC_BASE_URL: "https://api.example.com/anthropic" } }),
+      );
+      await writeFile(
+        path.join(claudeHome, ".credentials.json"),
+        JSON.stringify({ claudeAiOauth: { accessToken: "synthetic-oauth-token" } }),
+      );
+
+      const snapshot = await loadClaudeConfigSnapshot(claudeHome);
+
+      expect(snapshot.hasApiKey).toBe(false);
+      expect(snapshot.credentialSource).toBeNull();
     });
   });
 
@@ -316,6 +353,37 @@ describe("Claude Code provider switching", () => {
       expect(result).toMatchObject({
         models: ["claude-sonnet-4.6"],
         credentialSource: "settings.json env.ANTHROPIC_API_KEY",
+      });
+    });
+  });
+
+  it("detects models with the auth value returned by apiKeyHelper", async () => {
+    await withClaudeHome(async (claudeHome) => {
+      await writeFile(
+        path.join(claudeHome, "settings.json"),
+        JSON.stringify({ apiKeyHelper: "echo helper-key" }),
+      );
+
+      const result = await probeClaudeModels(
+        {
+          claudeHome,
+          baseUrl: "https://api.example.com/anthropic",
+          apiKey: "",
+          apiFormat: "anthropic",
+          apiKeyField: "ANTHROPIC_API_KEY",
+        },
+        async (_url, init) => {
+          expect(init?.headers).toMatchObject({
+            Authorization: "Bearer helper-key",
+            "x-api-key": "helper-key",
+          });
+          return { ok: true, status: 200, async json() { return { models: ["claude-helper-model"] }; } };
+        },
+      );
+
+      expect(result).toMatchObject({
+        models: ["claude-helper-model"],
+        credentialSource: "settings.json apiKeyHelper",
       });
     });
   });

--- a/apps/main-2.0/src/core/claude-profile.test.ts
+++ b/apps/main-2.0/src/core/claude-profile.test.ts
@@ -329,7 +329,12 @@ describe("Claude Code provider switching", () => {
     await withClaudeHome(async (claudeHome) => {
       await writeFile(
         path.join(claudeHome, "settings.json"),
-        JSON.stringify({ env: { ANTHROPIC_API_KEY: "stored-key" } }),
+        JSON.stringify({
+          env: {
+            ANTHROPIC_BASE_URL: "https://api.example.com/anthropic",
+            ANTHROPIC_API_KEY: "stored-key",
+          },
+        }),
       );
 
       const result = await probeClaudeModels(
@@ -337,6 +342,7 @@ describe("Claude Code provider switching", () => {
           claudeHome,
           baseUrl: "https://api.example.com/anthropic",
           apiKey: "",
+          providerId: "custom",
           apiFormat: "anthropic",
           apiKeyField: "ANTHROPIC_API_KEY",
         },
@@ -361,7 +367,10 @@ describe("Claude Code provider switching", () => {
     await withClaudeHome(async (claudeHome) => {
       await writeFile(
         path.join(claudeHome, "settings.json"),
-        JSON.stringify({ apiKeyHelper: "echo helper-key" }),
+        JSON.stringify({
+          env: { ANTHROPIC_BASE_URL: "https://api.example.com/anthropic" },
+          apiKeyHelper: "echo helper-key",
+        }),
       );
 
       const result = await probeClaudeModels(
@@ -369,6 +378,7 @@ describe("Claude Code provider switching", () => {
           claudeHome,
           baseUrl: "https://api.example.com/anthropic",
           apiKey: "",
+          providerId: "custom",
           apiFormat: "anthropic",
           apiKeyField: "ANTHROPIC_API_KEY",
         },
@@ -388,11 +398,110 @@ describe("Claude Code provider switching", () => {
     });
   });
 
+  it("does not reuse settings credentials for a different Base URL", async () => {
+    await withClaudeHome(async (claudeHome) => {
+      await writeFile(
+        path.join(claudeHome, "settings.json"),
+        JSON.stringify({
+          env: { ANTHROPIC_BASE_URL: "https://old.example/anthropic" },
+          apiKeyHelper: "agent-recall-helper-must-not-run",
+        }),
+      );
+      const fetchImpl = vi.fn(async (_url: string, init?: { headers?: Record<string, string> }) => {
+        expect(init?.headers?.Authorization).toBe("Bearer explicit-key");
+        return { ok: true, status: 200, async json() { return { models: ["claude-explicit"] }; } };
+      });
+
+      await expect(probeClaudeModels({
+        claudeHome,
+        baseUrl: "https://new.example/anthropic",
+        apiKey: "",
+        providerId: "custom",
+        apiFormat: "anthropic",
+        apiKeyField: "ANTHROPIC_AUTH_TOKEN",
+      }, fetchImpl)).rejects.toThrow(/No API key was found/);
+      expect(fetchImpl).not.toHaveBeenCalled();
+
+      await expect(probeClaudeModels({
+        claudeHome,
+        baseUrl: "https://new.example/anthropic",
+        apiKey: "explicit-key",
+        providerId: "custom",
+        apiFormat: "anthropic",
+        apiKeyField: "ANTHROPIC_AUTH_TOKEN",
+      }, fetchImpl)).resolves.toMatchObject({ models: ["claude-explicit"] });
+      expect(fetchImpl).toHaveBeenCalled();
+    });
+  });
+
+  it("preserves apiKeyHelper when applying its matching route without persisting a token", async () => {
+    await withClaudeHome(async (claudeHome) => {
+      await writeFile(
+        path.join(claudeHome, "settings.json"),
+        JSON.stringify({
+          env: { ANTHROPIC_BASE_URL: "https://api.example.com/anthropic" },
+          apiKeyHelper: "agent-recall-helper-must-not-run",
+          hooks: { Stop: [] },
+        }),
+      );
+
+      const result = await applyClaudeApiConfig({
+        claudeHome,
+        apiConfig: {
+          activeProvider: "custom",
+          customProviderId: "internal-gateway",
+          customProviderName: "Internal Gateway",
+          customBaseUrl: "https://api.example.com/anthropic/",
+          customApiKey: "",
+          customModel: "claude-sonnet-4.6",
+          customHaikuModel: "claude-haiku-4.5",
+          customSonnetModel: "claude-sonnet-4.6",
+          customOpusModel: "claude-opus-4.6",
+          customApiFormat: "anthropic",
+          customApiKeyField: "ANTHROPIC_AUTH_TOKEN",
+        },
+      });
+
+      const settings = await readSettings(claudeHome);
+      expect(result.credentialSource).toBe("settings.json apiKeyHelper");
+      expect(settings.apiKeyHelper).toBe("agent-recall-helper-must-not-run");
+      expect(settings.env).toMatchObject({
+        ANTHROPIC_BASE_URL: "https://api.example.com/anthropic/",
+        ANTHROPIC_MODEL: "claude-sonnet-4.6",
+      });
+      expect(settings.env).not.toHaveProperty("ANTHROPIC_AUTH_TOKEN");
+      expect(settings.env).not.toHaveProperty("ANTHROPIC_API_KEY");
+      expect(settings.hooks).toEqual({ Stop: [] });
+      const appliedText = await readFile(path.join(claudeHome, "settings.json"), "utf8");
+
+      await expect(applyClaudeApiConfig({
+        claudeHome,
+        apiConfig: {
+          activeProvider: "custom",
+          customProviderId: "internal-gateway",
+          customProviderName: "Internal Gateway",
+          customBaseUrl: "https://other.example/anthropic",
+          customApiKey: "",
+          customModel: "claude-sonnet-4.6",
+          customApiFormat: "anthropic",
+          customApiKeyField: "ANTHROPIC_AUTH_TOKEN",
+        },
+      })).rejects.toThrow(/No API key was found/);
+      await expect(readFile(path.join(claudeHome, "settings.json"), "utf8")).resolves.toBe(appliedText);
+    });
+  });
+
   it("writes and verifies a custom route in the selected Claude config directory", async () => {
     await withClaudeHome(async (claudeHome) => {
       await writeFile(
         path.join(claudeHome, "settings.json"),
-        JSON.stringify({ env: { ANTHROPIC_AUTH_TOKEN: "stored-key" }, hooks: { Stop: [] } }),
+        JSON.stringify({
+          env: {
+            ANTHROPIC_BASE_URL: "https://api.example.com/anthropic",
+            ANTHROPIC_AUTH_TOKEN: "stored-key",
+          },
+          hooks: { Stop: [] },
+        }),
       );
 
       const result = await applyClaudeApiConfig({

--- a/apps/main-2.0/src/core/claude-profile.ts
+++ b/apps/main-2.0/src/core/claude-profile.ts
@@ -34,6 +34,7 @@ export interface ClaudeConfigSnapshot {
 export interface ClaudeModelProbeInput {
   baseUrl: string;
   apiKey: string;
+  providerId?: string;
   apiFormat: ClaudeApiConfig["customApiFormat"];
   apiKeyField: ClaudeApiConfig["customApiKeyField"];
   claudeHome?: string;
@@ -124,18 +125,38 @@ export async function probeClaudeModels(
 ): Promise<ClaudeModelProbeResult> {
   const claudeHome = resolveProviderConfigDirectory(input.claudeHome, ".claude");
   const explicitKey = input.apiKey.trim();
-  const credential = await resolveClaudeCredential({
-    claudeHome,
-    apiKeyField: input.apiKeyField,
-    explicitKey,
-    explicitSource: input.apiKeySource,
-  });
+  const requestedBaseUrl = normalizeBaseUrl(input.baseUrl);
+  const route = await loadClaudeApiConfigDefaults(claudeHome);
+  const routeMatches = route.activeProvider === "custom"
+    && (!requestedBaseUrl || normalizeBaseUrl(route.customBaseUrl || "") === requestedBaseUrl);
+  const baseUrl = requestedBaseUrl || (routeMatches ? normalizeBaseUrl(route.customBaseUrl || "") : "");
+  let credential: ResolvedClaudeCredential;
+  if (explicitKey) {
+    credential = await resolveClaudeCredential({
+      claudeHome,
+      apiKeyField: input.apiKeyField,
+      explicitKey,
+      explicitSource: input.apiKeySource,
+    });
+  } else {
+    credential = routeMatches
+      ? await resolveClaudeCredential({
+          claudeHome,
+          apiKeyField: input.apiKeyField,
+          executeCredentialHelper: true,
+        })
+      : { apiKey: "", source: null };
+  }
   const result = await probeProviderModels({
-    baseUrl: input.baseUrl,
+    baseUrl,
     apiKey: credential.apiKey,
     apiFormat: input.apiFormat,
   }, fetchImpl);
   return { ...result, credentialSource: credential.source || "resolved credential" };
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.trim().replace(/\/+$/, "");
 }
 
 export async function applyClaudeApiConfig(options: {
@@ -156,14 +177,24 @@ export async function applyClaudeApiConfig(options: {
 
   let credentialSource: string | null = null;
   if (apiConfig.activeProvider === "custom") {
-    const credential = await resolveClaudeCredential({
-      claudeHome,
-      apiKeyField: apiConfig.customApiKeyField,
-      explicitKey: apiConfig.customApiKey,
-      // Applying a route must never turn a short-lived helper value into a persisted API key.
-      executeCredentialHelper: false,
-    });
-    if (!credential.apiKey) throw new Error(`No API key was found for ${apiConfig.customProviderName}.`);
+    const explicitKey = apiConfig.customApiKey.trim();
+    const currentRoute = await loadClaudeApiConfigDefaults(claudeHome);
+    const currentRouteMatches = currentRoute.activeProvider === "custom"
+      && normalizeBaseUrl(currentRoute.customBaseUrl || "") === normalizeBaseUrl(apiConfig.customBaseUrl);
+    const credential: ResolvedClaudeCredential = explicitKey || currentRouteMatches
+      ? await resolveClaudeCredential({
+          claudeHome,
+          apiKeyField: apiConfig.customApiKeyField,
+          explicitKey,
+          // Applying a route must never turn a short-lived helper value into a persisted API key.
+          executeCredentialHelper: false,
+        })
+      : { apiKey: "", source: null };
+    const useApiKeyHelper = currentRouteMatches
+      && !explicitKey
+      && !credential.apiKey
+      && credential.configured === true;
+    if (!credential.apiKey && !useApiKeyHelper) throw new Error(`No API key was found for ${apiConfig.customProviderName}.`);
     credentialSource = credential.source;
     applyCustomClaudeEnv(settings, { ...apiConfig, customApiKey: credential.apiKey });
   } else {
@@ -215,13 +246,13 @@ function claudeApiConfigWithPresetDefaults(config: Partial<ClaudeApiConfig>): Cl
 }
 
 function applyCustomClaudeEnv(settings: Record<string, unknown>, apiConfig: ClaudeApiConfig): void {
-  if (!apiConfig.customApiKey) throw new Error(`API key is required to apply ${apiConfig.customProviderName}.`);
   if (!apiConfig.customBaseUrl) throw new Error(`Base URL is required to apply ${apiConfig.customProviderName}.`);
 
   const env = ensureEnv(settings);
   clearClaudeRouteEnv(settings);
   env.ANTHROPIC_BASE_URL = apiConfig.customBaseUrl;
-  env[apiConfig.customApiKeyField] = apiConfig.customApiKey;
+  // A matching apiKeyHelper stays authoritative without copying its short-lived value into env.
+  if (apiConfig.customApiKey) env[apiConfig.customApiKeyField] = apiConfig.customApiKey;
   // An empty model means "keep whatever the config file already selects", the same thing the
   // Default entry means in every model picker. Pinning the route without pinning the model is a
   // legitimate setup, so the model variables are simply left unset rather than rejected.
@@ -246,14 +277,28 @@ function applyCustomClaudeEnv(settings: Record<string, unknown>, apiConfig: Clau
  */
 export async function resolveClaudeProviderCredential(input: {
   claudeHome?: string;
+  providerId?: string;
+  /** When supplied, config-owned credentials must belong to this effective Claude Base URL. */
+  baseUrl?: string;
   apiKeyField?: ClaudeApiConfig["customApiKeyField"];
   apiKey?: string;
   apiKeySource?: string;
 }): Promise<{ apiKey: string; source: string | null }> {
+  const claudeHome = resolveProviderConfigDirectory(input.claudeHome, ".claude");
+  const explicitKey = input.apiKey?.trim() ?? "";
+  if (!explicitKey && input.baseUrl !== undefined) {
+    const route = await loadClaudeApiConfigDefaults(claudeHome);
+    if (
+      route.activeProvider !== "custom"
+      || normalizeBaseUrl(route.customBaseUrl || "") !== normalizeBaseUrl(input.baseUrl)
+    ) {
+      return { apiKey: "", source: null };
+    }
+  }
   return resolveClaudeCredential({
-    claudeHome: resolveProviderConfigDirectory(input.claudeHome, ".claude"),
+    claudeHome,
     apiKeyField: input.apiKeyField,
-    explicitKey: input.apiKey,
+    explicitKey,
     explicitSource: input.apiKeySource,
   });
 }

--- a/apps/main-2.0/src/core/claude-profile.ts
+++ b/apps/main-2.0/src/core/claude-profile.ts
@@ -10,6 +10,7 @@ import {
 import { writeVerifiedConfig } from "./atomic-config-write";
 import { probeProviderModels, type ProviderModelProbeResult, type ProviderModelsFetch } from "./provider-models";
 import { prepareProviderConfigDirectory, resolveProviderConfigDirectory } from "./provider-config-path";
+import { runProviderCredentialCommand } from "./provider-credential-helper";
 
 export interface ApplyClaudeProfileResult {
   profile: string;
@@ -41,6 +42,13 @@ export interface ClaudeModelProbeInput {
 
 export interface ClaudeModelProbeResult extends ProviderModelProbeResult {
   credentialSource: string;
+}
+
+interface ResolvedClaudeCredential {
+  apiKey: string;
+  source: string | null;
+  /** A helper can be configured without resolving its secret during config snapshots. */
+  configured?: boolean;
 }
 
 const CLAUDE_ROUTE_ENV_KEYS = [
@@ -95,14 +103,18 @@ export async function loadClaudeConfigSnapshot(configuredHome?: string): Promise
   const settingsPath = path.join(claudeHome, "settings.json");
   const text = await readOptionalFile(settingsPath);
   const route = await loadClaudeApiConfigDefaults(claudeHome);
-  const credential = await resolveClaudeCredential({ claudeHome, apiKeyField: route.customApiKeyField });
+  const credential = await resolveClaudeCredential({
+    claudeHome,
+    apiKeyField: route.customApiKeyField,
+    executeCredentialHelper: false,
+  });
   return {
     claudeHome,
     settingsPath,
     exists: Boolean(text?.trim()),
     route: Object.keys(route).length > 0 ? { ...route, customApiKey: "" } : route,
     credentialSource: credential.source,
-    hasApiKey: Boolean(credential.apiKey),
+    hasApiKey: Boolean(credential.apiKey) || credential.configured === true,
   };
 }
 
@@ -148,6 +160,8 @@ export async function applyClaudeApiConfig(options: {
       claudeHome,
       apiKeyField: apiConfig.customApiKeyField,
       explicitKey: apiConfig.customApiKey,
+      // Applying a route must never turn a short-lived helper value into a persisted API key.
+      executeCredentialHelper: false,
     });
     if (!credential.apiKey) throw new Error(`No API key was found for ${apiConfig.customProviderName}.`);
     credentialSource = credential.source;
@@ -226,9 +240,9 @@ function applyCustomClaudeEnv(settings: Record<string, unknown>, apiConfig: Clau
 
 /**
  * Resolves the credential the Claude CLI would use for a config directory, following the same
- * order it does: an explicitly typed key, then `settings.json`'s `env`, then the process
- * environment. Mirrors `resolveCodexProviderCredential` so callers that must work against either
- * agent — the AI summary panel, for one — can treat the two the same way.
+ * order it does: an explicitly typed key, process and settings environment values, then
+ * `apiKeyHelper`. Mirrors `resolveCodexProviderCredential` so callers that must work against
+ * either agent — the AI summary panel, for one — can treat the two the same way.
  */
 export async function resolveClaudeProviderCredential(input: {
   claudeHome?: string;
@@ -249,7 +263,9 @@ async function resolveClaudeCredential(options: {
   apiKeyField?: ClaudeApiConfig["customApiKeyField"];
   explicitKey?: string;
   explicitSource?: string;
-}): Promise<{ apiKey: string; source: string | null }> {
+  /** Config snapshots detect apiKeyHelper without executing a user-owned shell command. */
+  executeCredentialHelper?: boolean;
+}): Promise<ResolvedClaudeCredential> {
   const explicitKey = options.explicitKey?.trim() ?? "";
   if (explicitKey) return { apiKey: explicitKey, source: options.explicitSource || "API key field" };
   const settings = parseJsonObject(await readOptionalFile(path.join(options.claudeHome, "settings.json")));
@@ -262,6 +278,25 @@ async function resolveClaudeCredential(options: {
   for (const key of keys) {
     const value = readString(env[key]);
     if (value) return { apiKey: value, source: `settings.json env.${key}` };
+  }
+  const apiKeyHelper = readString(settings?.apiKeyHelper);
+  if (apiKeyHelper) {
+    const source = "settings.json apiKeyHelper";
+    if (options.executeCredentialHelper === false) return { apiKey: "", source, configured: true };
+    const helperEnv = { ...process.env };
+    for (const [key, value] of Object.entries(env)) {
+      if (typeof value === "string") helperEnv[key] = value;
+    }
+    const shell = process.platform === "win32"
+      ? process.env.ComSpec?.trim() || "cmd.exe"
+      : "/bin/sh";
+    const args = process.platform === "win32"
+      ? ["/d", "/s", "/c", apiKeyHelper]
+      : ["-c", apiKeyHelper];
+    return {
+      apiKey: await runProviderCredentialCommand({ command: shell, args, env: helperEnv }),
+      source,
+    };
   }
   return { apiKey: "", source: null };
 }

--- a/apps/main-2.0/src/core/codex-chat-proxy-lifecycle.test.ts
+++ b/apps/main-2.0/src/core/codex-chat-proxy-lifecycle.test.ts
@@ -1,0 +1,190 @@
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { CodexChatProxy } from "./codex-chat-proxy";
+
+const runningProxies: CodexChatProxy[] = [];
+
+afterEach(async () => {
+  await Promise.all(runningProxies.splice(0).map((proxy) => proxy.stop()));
+});
+
+describe("Codex Chat proxy upstream lifecycle", () => {
+  it("releases a completed upstream request before the proxy stops", async () => {
+    let upstreamSignal: AbortSignal | undefined;
+    const proxy = createProxy(async (_input, init) => {
+      upstreamSignal = init?.signal as AbortSignal;
+      return chatResponse("OK");
+    });
+    const status = await proxy.start();
+
+    const response = await requestCompletion(status.baseUrl);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('"delta":"OK"');
+    expect(upstreamSignal?.aborted).toBe(false);
+
+    await proxy.stop();
+    expect(upstreamSignal?.aborted).toBe(false);
+  });
+
+  it("releases failed upstream requests and redacts reflected credentials", async () => {
+    let upstreamSignal: AbortSignal | undefined;
+    const proxy = createProxy(async (_input, init) => {
+      upstreamSignal = init?.signal as AbortSignal;
+      return new Response("gateway rejected lifecycle-secret for tenant demo", { status: 401 });
+    });
+    const status = await proxy.start();
+
+    const response = await requestCompletion(status.baseUrl);
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      error: { message: "gateway rejected [REDACTED] for tenant demo" },
+    });
+
+    await proxy.stop();
+    expect(upstreamSignal?.aborted).toBe(false);
+  });
+
+  it("redacts credentials from thrown upstream transport errors", async () => {
+    const proxy = createProxy(async () => {
+      throw new Error("transport lifecycle-secret failed");
+    });
+    const status = await proxy.start();
+
+    const response = await requestCompletion(status.baseUrl);
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: { message: "transport [REDACTED] failed" },
+    });
+  });
+
+  it("aborts a hanging upstream request so stop can complete", async () => {
+    let upstreamSignal: AbortSignal | undefined;
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const proxy = createProxy((_input, init) => {
+      upstreamSignal = init?.signal as AbortSignal;
+      return new Promise<Response>((_resolve, reject) => {
+        upstreamSignal?.addEventListener("abort", () => reject(abortError()), { once: true });
+        markStarted();
+      });
+    });
+    const status = await proxy.start();
+    const clientRequest = requestCompletion(status.baseUrl).catch(() => null);
+    await started;
+
+    await expect(proxy.stop()).resolves.toBeUndefined();
+    expect(upstreamSignal?.aborted).toBe(true);
+    await clientRequest;
+  });
+
+  it("stops while a client is still uploading its request body", async () => {
+    let upstreamCalled = false;
+    const proxy = createProxy(async () => {
+      upstreamCalled = true;
+      return chatResponse("unexpected");
+    });
+    const status = await proxy.start();
+    const request = http.request(`${status.baseUrl}/responses`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": "1024",
+      },
+    });
+    request.on("error", () => undefined);
+    await new Promise<void>((resolve) => {
+      request.once("socket", (socket) => {
+        socket.once("connect", () => {
+          request.write('{"model":"test-model",');
+          setImmediate(resolve);
+        });
+      });
+    });
+
+    await expect(proxy.stop()).resolves.toBeUndefined();
+    expect(upstreamCalled).toBe(false);
+  });
+
+  it("aborts the matching upstream request when its client disconnects", async () => {
+    let upstreamSignal: AbortSignal | undefined;
+    let markStarted!: () => void;
+    let markAborted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const aborted = new Promise<void>((resolve) => {
+      markAborted = resolve;
+    });
+    const proxy = createProxy((_input, init) => {
+      upstreamSignal = init?.signal as AbortSignal;
+      return new Promise<Response>((_resolve, reject) => {
+        upstreamSignal?.addEventListener("abort", () => {
+          markAborted();
+          reject(abortError());
+        }, { once: true });
+        markStarted();
+      });
+    });
+    const status = await proxy.start();
+    const request = http.request(`${status.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+    });
+    request.on("error", () => undefined);
+    request.end(requestBody());
+    await started;
+
+    request.destroy();
+    await aborted;
+
+    expect(upstreamSignal?.aborted).toBe(true);
+    await expect(proxy.stop()).resolves.toBeUndefined();
+  });
+});
+
+function createProxy(
+  fetchImpl: (input: string | URL | Request, init?: RequestInit) => Promise<Response>,
+): CodexChatProxy {
+  const proxy = new CodexChatProxy({
+    upstreamBaseUrl: "https://upstream.invalid/v1",
+    apiKey: "lifecycle-secret",
+    model: "test-model",
+    fetchImpl: fetchImpl as typeof fetch,
+  });
+  runningProxies.push(proxy);
+  return proxy;
+}
+
+function requestCompletion(baseUrl: string): Promise<Response> {
+  return fetch(`${baseUrl}/responses`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: requestBody(),
+  });
+}
+
+function requestBody(): string {
+  return JSON.stringify({
+    model: "test-model",
+    input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "Reply OK." }] }],
+    stream: false,
+  });
+}
+
+function chatResponse(content: string): Response {
+  return new Response(JSON.stringify({
+    model: "test-model",
+    choices: [{ message: { content } }],
+  }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function abortError(): Error {
+  const error = new Error("upstream request aborted");
+  error.name = "AbortError";
+  return error;
+}

--- a/apps/main-2.0/src/core/codex-chat-proxy.ts
+++ b/apps/main-2.0/src/core/codex-chat-proxy.ts
@@ -6,6 +6,7 @@ export interface CodexChatProxyOptions {
   model: string;
   listenHost?: string;
   listenPort?: number;
+  fetchImpl?: typeof fetch;
 }
 
 export interface CodexChatProxyStatus {
@@ -20,6 +21,7 @@ export interface CodexChatProxyStatus {
 export class CodexChatProxy {
   private server: http.Server | null = null;
   private status: CodexChatProxyStatus | null = null;
+  private readonly activeUpstreamRequests = new Set<AbortController>();
 
   constructor(private readonly options: CodexChatProxyOptions) {}
 
@@ -51,10 +53,16 @@ export class CodexChatProxy {
     const server = this.server;
     this.server = null;
     this.status = null;
+    for (const controller of this.activeUpstreamRequests) controller.abort();
     if (!server) return;
-    await new Promise<void>((resolve, reject) => {
+    const closed = new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
     });
+    // `server.close()` waits for active clients, including one that never finishes uploading its
+    // request body. Force those sockets closed after initiating graceful shutdown so stop remains
+    // bounded; upstream requests have already received their abort signal above.
+    server.closeAllConnections();
+    await closed;
   }
 
   getStatus(): CodexChatProxyStatus {
@@ -89,38 +97,76 @@ export class CodexChatProxy {
       }
 
       const body = JSON.parse(await readRequestBody(req)) as Record<string, unknown>;
-      const upstreamResponse = await fetch(`${normalizeBaseUrl(this.options.upstreamBaseUrl)}/chat/completions`, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          authorization: `Bearer ${this.options.apiKey}`,
-        },
-        body: JSON.stringify(buildChatCompletionRequest(body, this.effectiveModel(body))),
-      });
+      const controller = new AbortController();
+      const abortUpstream = () => controller.abort();
+      const abortUpstreamIfResponseIncomplete = () => {
+        if (!res.writableEnded) abortUpstream();
+      };
+      req.once("aborted", abortUpstream);
+      res.once("close", abortUpstreamIfResponseIncomplete);
+      this.activeUpstreamRequests.add(controller);
+      try {
+        const upstreamResponse = await (this.options.fetchImpl ?? fetch)(
+          `${normalizeBaseUrl(this.options.upstreamBaseUrl)}/chat/completions`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              authorization: `Bearer ${this.options.apiKey}`,
+            },
+            body: JSON.stringify(buildChatCompletionRequest(body, this.effectiveModel(body))),
+            signal: controller.signal,
+          },
+        );
 
-      if (!upstreamResponse.ok || !upstreamResponse.body) {
-        const text = await upstreamResponse.text().catch(() => "");
-        writeJson(res, upstreamResponse.status || 502, {
-          error: { message: text || `Upstream request failed with status ${upstreamResponse.status}.` },
+        if (!upstreamResponse.ok || !upstreamResponse.body) {
+          const text = await upstreamResponse.text().catch(() => "");
+          if (res.destroyed || res.writableEnded) return;
+          writeJson(res, upstreamResponse.status || 502, {
+            error: {
+              message: redactSecret(
+                text || `Upstream request failed with status ${upstreamResponse.status}.`,
+                this.options.apiKey,
+              ),
+            },
+          });
+          return;
+        }
+
+        if (!upstreamResponse.headers.get("content-type")?.includes("text/event-stream")) {
+          if (res.destroyed || res.writableEnded) return;
+          await writeNonStreamingChatResponse(res, upstreamResponse);
+          return;
+        }
+
+        if (res.destroyed || res.writableEnded) return;
+        res.writeHead(200, {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
         });
-        return;
+        await pipeChatSseAsResponses(upstreamResponse.body, res, this.effectiveModel(body) || "chat-model");
+      } finally {
+        req.off("aborted", abortUpstream);
+        res.off("close", abortUpstreamIfResponseIncomplete);
+        this.activeUpstreamRequests.delete(controller);
       }
-
-      if (!upstreamResponse.headers.get("content-type")?.includes("text/event-stream")) {
-        await writeNonStreamingChatResponse(res, upstreamResponse);
-        return;
-      }
-
-      res.writeHead(200, {
-        "content-type": "text/event-stream",
-        "cache-control": "no-cache",
-        connection: "keep-alive",
-      });
-      await pipeChatSseAsResponses(upstreamResponse.body, res, this.effectiveModel(body) || "chat-model");
     } catch (error) {
+      if (isAbortError(error)) {
+        if (!res.destroyed && !res.writableEnded) res.destroy();
+        return;
+      }
+      if (res.destroyed || res.writableEnded) return;
       if (!res.headersSent) {
-        writeJson(res, 500, { error: { message: error instanceof Error ? error.message : String(error) } });
-      } else {
+        writeJson(res, 500, {
+          error: {
+            message: redactSecret(
+              error instanceof Error ? error.message : String(error),
+              this.options.apiKey,
+            ),
+          },
+        });
+      } else if (!res.writableEnded) {
         res.end();
       }
     }
@@ -527,6 +573,14 @@ function isResponsesPath(url: string): boolean {
 
 function normalizeBaseUrl(baseUrl: string): string {
   return baseUrl.trim().replace(/\/+$/, "");
+}
+
+function redactSecret(message: string, secret: string): string {
+  return secret ? message.split(secret).join("[REDACTED]") : message;
+}
+
+function isAbortError(error: unknown): boolean {
+  return Boolean(error && typeof error === "object" && "name" in error && error.name === "AbortError");
 }
 
 function readString(value: unknown): string {

--- a/apps/main-2.0/src/core/codex-profile.test.ts
+++ b/apps/main-2.0/src/core/codex-profile.test.ts
@@ -4,10 +4,12 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { API_PROVIDER_PRESETS, defaultApiConfig, mergeApiConfigWithProfileDefaults, normalizeApiConfig } from "./api-config";
-import { applyCodexApiConfig, codexProfileForApiConfig, loadActiveCodexSummaryEndpointDefaults, loadCodexConfigSnapshot, loadCodexProfileDefaults, probeCodexModels } from "./codex-profile";
+import { applyCodexApiConfig, codexProfileForApiConfig, loadActiveCodexSummaryEndpointDefaults, loadCodexConfigSnapshot, loadCodexProfileDefaults, probeCodexModels, resolveCodexProviderCredential } from "./codex-profile";
 
 async function withCodexHome<T>(run: (codexHome: string) => Promise<T>): Promise<T> {
   const codexHome = await mkdtemp(path.join(tmpdir(), "agent-recall-codex-"));
+  vi.stubEnv("HOME", codexHome);
+  vi.stubEnv("USERPROFILE", codexHome);
   try {
     return await run(codexHome);
   } finally {
@@ -318,6 +320,106 @@ describe("codex profile switching", () => {
       );
 
       expect(result.models).toEqual(["clawbot:gpt-5.5"]);
+    });
+  });
+
+  it("detects command-backed Codex auth without running the helper during snapshots", async () => {
+    await withCodexHome(async (codexHome) => {
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          'model_provider = "gateway"',
+          "",
+          "[model_providers.gateway]",
+          'base_url = "https://api.example/v1"',
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+        ].join("\n"),
+      );
+
+      await expect(loadCodexConfigSnapshot(codexHome)).resolves.toMatchObject({
+        hasApiKey: true,
+        credentialSource: "config.toml gateway.auth.command",
+        activeProvider: {
+          hasApiKey: true,
+          credentialSource: "config.toml gateway.auth.command",
+        },
+      });
+    });
+  });
+
+  it("probes with the bearer token returned by a Codex auth command", async () => {
+    await withCodexHome(async (codexHome) => {
+      await writeFile(path.join(codexHome, "command-token.txt"), "command-key\n");
+      const helperArgs = [
+        "-e",
+        'process.stdout.write(require("node:fs").readFileSync("command-token.txt", "utf8"))',
+      ];
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          'model_provider = "gateway"',
+          "",
+          "[model_providers.gateway]",
+          'base_url = "https://api.example/v1"',
+          "",
+          "[model_providers.gateway.auth]",
+          `command = ${JSON.stringify(process.execPath)}`,
+          `args = ${JSON.stringify(helperArgs)}`,
+          `cwd = ${JSON.stringify(codexHome)}`,
+          "timeout_ms = 5000",
+        ].join("\n"),
+      );
+
+      await expect(resolveCodexProviderCredential({
+        codexHome,
+        providerId: "gateway",
+        executeCredentialHelper: true,
+      })).resolves.toEqual({
+        apiKey: "command-key",
+        source: "config.toml gateway.auth.command",
+      });
+
+      const result = await probeCodexModels(
+        { baseUrl: "", apiKey: "", providerId: "gateway", codexHome },
+        async (_url, init) => {
+          expect(init?.headers?.Authorization).toBe("Bearer command-key");
+          return { ok: true, status: 200, async json() { return { data: [{ id: "gateway-model" }] }; } };
+        },
+      );
+
+      expect(result).toMatchObject({
+        models: ["gateway-model"],
+        credentialSource: "config.toml gateway.auth.command",
+      });
+    });
+  });
+
+  it("prefers the configured provider env_key over an unrelated auth.json login", async () => {
+    vi.stubEnv("DMS_API_KEY", "provider-env-key");
+    await withCodexHome(async (codexHome) => {
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          'model_provider = "dms"',
+          "",
+          "[model_providers.dms]",
+          'base_url = "https://api.example/v1"',
+          'env_key = "DMS_API_KEY"',
+        ].join("\n"),
+      );
+      await writeFile(path.join(codexHome, "auth.json"), JSON.stringify({ OPENAI_API_KEY: "official-login-key" }));
+
+      const result = await probeCodexModels(
+        { baseUrl: "", apiKey: "", providerId: "dms", codexHome },
+        async (_url, init) => {
+          expect(init?.headers?.Authorization).toBe("Bearer provider-env-key");
+          return { ok: true, status: 200, async json() { return { data: [{ id: "dms-model" }] }; } };
+        },
+      );
+
+      expect(result.credentialSource).toBe("environment DMS_API_KEY");
     });
   });
 
@@ -746,6 +848,9 @@ describe("loadActiveCodexSummaryEndpointDefaults", () => {
   beforeEach(() => {
     vi.stubEnv("OPENAI_API_KEY", "");
     codexHome = mkdtempSync(path.join(tmpdir(), "codex-profile-test-"));
+    vi.stubEnv("HOME", codexHome);
+    vi.stubEnv("USERPROFILE", codexHome);
+    vi.stubEnv("CODEX_API_KEY", "");
   });
 
   afterEach(() => {

--- a/apps/main-2.0/src/core/codex-profile.test.ts
+++ b/apps/main-2.0/src/core/codex-profile.test.ts
@@ -349,6 +349,211 @@ describe("codex profile switching", () => {
     });
   });
 
+  it("keeps resolving readable credentials when command execution is disabled", async () => {
+    await withCodexHome(async (codexHome) => {
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          "[model_providers.gateway]",
+          'api_key = "inline-key"',
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+        ].join("\n"),
+      );
+
+      await expect(resolveCodexProviderCredential({
+        codexHome,
+        providerId: "gateway",
+        executeCredentialHelper: false,
+      })).resolves.toEqual({
+        apiKey: "inline-key",
+        source: "config.toml gateway.api_key",
+      });
+
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          "[model_providers.gateway]",
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+        ].join("\n"),
+      );
+      await writeFile(path.join(codexHome, "auth.json"), '{"OPENAI_API_KEY":"auth-file-key"}\n');
+
+      await expect(resolveCodexProviderCredential({
+        codexHome,
+        providerId: "gateway",
+        executeCredentialHelper: false,
+      })).resolves.toEqual({
+        apiKey: "auth-file-key",
+        source: "auth.json OPENAI_API_KEY",
+      });
+    });
+  });
+
+  it("does not borrow a sibling key for a provider with command auth", async () => {
+    await withCodexHome(async (codexHome) => {
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          "[model_providers.gateway]",
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+          "",
+          "[model_providers.sibling]",
+          'api_key = "sibling-key"',
+        ].join("\n"),
+      );
+
+      await expect(resolveCodexProviderCredential({
+        codexHome,
+        providerId: "gateway",
+        executeCredentialHelper: false,
+      })).resolves.toMatchObject({
+        apiKey: "",
+        source: "config.toml gateway.auth.command",
+      });
+    });
+  });
+
+  it("applies a command-backed provider without executing or replacing its helper", async () => {
+    await withCodexHome(async (codexHome) => {
+      const authJson = '{"OPENAI_API_KEY":"unrelated-login-key","tokens":{"keep":true}}\n';
+      await writeFile(path.join(codexHome, "auth.json"), authJson);
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          'model_provider = "gateway"',
+          'model = "old-model"',
+          "",
+          "[model_providers.gateway]",
+          'name = "Old Gateway"',
+          'base_url = "https://old.example/v1"',
+          'wire_api = "responses"',
+          "requires_openai_auth = true",
+          'env_key = "OPENAI_API_KEY"',
+          'experimental_bearer_token = "stale-inline-key"',
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+          'args = ["token", "--json"]',
+          `cwd = ${JSON.stringify(codexHome)}`,
+          "timeout_ms = 4321",
+          "",
+          "[mcp_servers.echo]",
+          'command = "echo"',
+        ].join("\n"),
+      );
+
+      const result = await applyCodexApiConfig({
+        codexHome,
+        apiConfig: {
+          activeProvider: "custom",
+          customProviderId: "gateway",
+          customProviderName: "Gateway",
+          customBaseUrl: "https://new.example/v1",
+          customApiKey: "",
+          customModel: "new-model",
+          customApiFormat: "openai_responses",
+        },
+      });
+
+      const config = await readFile(path.join(codexHome, "config.toml"), "utf8");
+      expect(config).toContain('model_provider = "gateway"');
+      expect(config).toContain('model = "new-model"');
+      expect(config).toContain('name = "Gateway"');
+      expect(config).toContain('base_url = "https://new.example/v1"');
+      expect(config).not.toContain("requires_openai_auth");
+      expect(config).not.toContain("env_key");
+      expect(config).not.toContain("experimental_bearer_token");
+      expect(config).toContain("[model_providers.gateway.auth]");
+      expect(config).toContain('command = "agent-recall-helper-must-not-run"');
+      expect(config).toContain('args = ["token", "--json"]');
+      expect(config).toContain(`cwd = ${JSON.stringify(codexHome)}`);
+      expect(config).toContain("timeout_ms = 4321");
+      expect(config).toContain("[mcp_servers.echo]");
+      await expect(readFile(path.join(codexHome, "auth.json"), "utf8")).resolves.toBe(authJson);
+      expect(result).toMatchObject({
+        profile: "gateway",
+        credentialSource: "config.toml gateway.auth.command",
+        verified: true,
+      });
+      expect(result.backupPaths).toHaveLength(1);
+    });
+  });
+
+  it("does not create auth.json from a generic environment key for command auth", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "unrelated-environment-key");
+    await withCodexHome(async (codexHome) => {
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          "[model_providers.gateway]",
+          'base_url = "https://old.example/v1"',
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+        ].join("\n"),
+      );
+
+      await applyCodexApiConfig({
+        codexHome,
+        apiConfig: {
+          activeProvider: "custom",
+          customProviderId: "gateway",
+          customProviderName: "Gateway",
+          customBaseUrl: "https://new.example/v1",
+          customApiKey: "",
+          customModel: "new-model",
+          customApiFormat: "openai_responses",
+        },
+      });
+
+      await expect(readFile(path.join(codexHome, "auth.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
+  it("removes command auth when the user explicitly replaces it with an API key", async () => {
+    await withCodexHome(async (codexHome) => {
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          "[model_providers.gateway]",
+          'base_url = "https://old.example/v1"',
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+          'args = ["token"]',
+        ].join("\n"),
+      );
+
+      await applyCodexApiConfig({
+        codexHome,
+        apiConfig: {
+          activeProvider: "custom",
+          customProviderId: "gateway",
+          customProviderName: "Gateway",
+          customBaseUrl: "https://new.example/v1",
+          customApiKey: "explicit-key",
+          customModel: "new-model",
+          customApiFormat: "openai_responses",
+        },
+      });
+
+      const config = await readFile(path.join(codexHome, "config.toml"), "utf8");
+      expect(config).not.toContain("[model_providers.gateway.auth]");
+      expect(config).not.toContain("agent-recall-helper-must-not-run");
+      expect(config).toContain("requires_openai_auth = true");
+      expect(config).toContain('experimental_bearer_token = "explicit-key"');
+      await expect(readFile(path.join(codexHome, "auth.json"), "utf8")).resolves.toContain(
+        '"OPENAI_API_KEY": "explicit-key"',
+      );
+    });
+  });
+
   it("probes with the bearer token returned by a Codex auth command", async () => {
     await withCodexHome(async (codexHome) => {
       await writeFile(path.join(codexHome, "command-token.txt"), "command-key\n");

--- a/apps/main-2.0/src/core/codex-profile.test.ts
+++ b/apps/main-2.0/src/core/codex-profile.test.ts
@@ -331,10 +331,10 @@ describe("codex profile switching", () => {
         [
           'model_provider = "gateway"',
           "",
-          "[model_providers.gateway]",
+          "[model_providers.gateway] # provider route",
           'base_url = "https://api.example/v1"',
           "",
-          "[model_providers.gateway.auth]",
+          "[model_providers.gateway.auth] # external credential helper",
           'command = "agent-recall-helper-must-not-run"',
         ].join("\n"),
       );
@@ -506,7 +506,7 @@ describe("codex profile switching", () => {
           'model_provider = "gateway"',
           'model = "old-model"',
           "",
-          "[model_providers.gateway]",
+          "[model_providers.gateway] # provider route",
           'name = "Old Gateway"',
           'base_url = "https://new.example/v1"',
           'wire_api = "responses"',
@@ -514,7 +514,7 @@ describe("codex profile switching", () => {
           'env_key = "OPENAI_API_KEY"',
           'experimental_bearer_token = "stale-inline-key"',
           "",
-          "[model_providers.gateway.auth]",
+          "[model_providers.gateway.auth] # external credential helper",
           'command = "agent-recall-helper-must-not-run"',
           'args = ["token", "--json"]',
           `cwd = ${JSON.stringify(codexHome)}`,
@@ -546,7 +546,8 @@ describe("codex profile switching", () => {
       expect(config).not.toContain("requires_openai_auth");
       expect(config).not.toContain("env_key");
       expect(config).not.toContain("experimental_bearer_token");
-      expect(config).toContain("[model_providers.gateway.auth]");
+      expect(config).toContain("[model_providers.gateway] # provider route");
+      expect(config).toContain("[model_providers.gateway.auth] # external credential helper");
       expect(config).toContain('command = "agent-recall-helper-must-not-run"');
       expect(config).toContain('args = ["token", "--json"]');
       expect(config).toContain(`cwd = ${JSON.stringify(codexHome)}`);
@@ -626,10 +627,10 @@ describe("codex profile switching", () => {
       await writeFile(
         path.join(codexHome, "config.toml"),
         [
-          "[model_providers.gateway]",
+          "[model_providers.gateway] # provider route",
           'base_url = "https://old.example/v1"',
           "",
-          "[model_providers.gateway.auth]",
+          "[model_providers.gateway.auth] # external credential helper",
           'command = "agent-recall-helper-must-not-run"',
           'args = ["token"]',
         ].join("\n"),
@@ -651,6 +652,8 @@ describe("codex profile switching", () => {
       const config = await readFile(path.join(codexHome, "config.toml"), "utf8");
       expect(config).not.toContain("[model_providers.gateway.auth]");
       expect(config).not.toContain("agent-recall-helper-must-not-run");
+      expect(config).toContain("[model_providers.gateway] # provider route");
+      expect(config.match(/\[model_providers\.gateway\]/g)).toHaveLength(1);
       expect(config).toContain("requires_openai_auth = true");
       expect(config).toContain('experimental_bearer_token = "explicit-key"');
       await expect(readFile(path.join(codexHome, "auth.json"), "utf8")).resolves.toContain(

--- a/apps/main-2.0/src/core/codex-profile.test.ts
+++ b/apps/main-2.0/src/core/codex-profile.test.ts
@@ -508,7 +508,7 @@ describe("codex profile switching", () => {
           "",
           "[model_providers.gateway]",
           'name = "Old Gateway"',
-          'base_url = "https://old.example/v1"',
+          'base_url = "https://new.example/v1"',
           'wire_api = "responses"',
           "requires_openai_auth = true",
           'env_key = "OPENAI_API_KEY"',
@@ -562,6 +562,34 @@ describe("codex profile switching", () => {
     });
   });
 
+  it("does not carry command auth to a changed Base URL without an explicit key", async () => {
+    await withCodexHome(async (codexHome) => {
+      const originalConfig = [
+        "[model_providers.gateway]",
+        'base_url = "https://old.example/v1"',
+        "",
+        "[model_providers.gateway.auth]",
+        'command = "agent-recall-helper-must-not-run"',
+      ].join("\n");
+      await writeFile(path.join(codexHome, "config.toml"), originalConfig);
+
+      await expect(applyCodexApiConfig({
+        codexHome,
+        apiConfig: {
+          activeProvider: "custom",
+          customProviderId: "gateway",
+          customProviderName: "Gateway",
+          customBaseUrl: "https://new.example/v1",
+          customApiKey: "",
+          customModel: "new-model",
+          customApiFormat: "openai_responses",
+        },
+      })).rejects.toThrow(/No API key was found/);
+
+      await expect(readFile(path.join(codexHome, "config.toml"), "utf8")).resolves.toBe(originalConfig);
+    });
+  });
+
   it("does not create auth.json from a generic environment key for command auth", async () => {
     vi.stubEnv("OPENAI_API_KEY", "unrelated-environment-key");
     await withCodexHome(async (codexHome) => {
@@ -569,7 +597,7 @@ describe("codex profile switching", () => {
         path.join(codexHome, "config.toml"),
         [
           "[model_providers.gateway]",
-          'base_url = "https://old.example/v1"',
+          'base_url = "https://new.example/v1"',
           "",
           "[model_providers.gateway.auth]",
           'command = "agent-recall-helper-must-not-run"',
@@ -678,6 +706,33 @@ describe("codex profile switching", () => {
     });
   });
 
+  it("does not execute command auth for a different Base URL", async () => {
+    await withCodexHome(async (codexHome) => {
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          "[model_providers.gateway]",
+          'base_url = "https://old.example/v1"',
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+        ].join("\n"),
+      );
+      const fetchImpl = vi.fn();
+
+      await expect(probeCodexModels(
+        {
+          baseUrl: "https://new.example/v1",
+          apiKey: "",
+          providerId: "gateway",
+          codexHome,
+        },
+        fetchImpl,
+      )).rejects.toThrow(/No API key was found/);
+      expect(fetchImpl).not.toHaveBeenCalled();
+    });
+  });
+
   it("uses an explicit probe key without executing the configured auth command", async () => {
     await withCodexHome(async (codexHome) => {
       const markerPath = path.join(codexHome, "probe-helper-ran");
@@ -702,14 +757,14 @@ describe("codex profile switching", () => {
 
       const result = await probeCodexModels(
         {
-          baseUrl: "",
+          baseUrl: "https://new.example/v1",
           apiKey: "explicit-key",
           apiKeySource: "API key field",
           providerId: "gateway",
           codexHome,
         },
         async (url, init) => {
-          expect(String(url)).toBe("https://api.example/v1/models");
+          expect(String(url)).toBe("https://new.example/v1/models");
           expect(init?.headers?.Authorization).toBe("Bearer explicit-key");
           return { ok: true, status: 200, async json() { return { data: [{ id: "gateway-model" }] }; } };
         },
@@ -813,10 +868,8 @@ describe("codex profile switching", () => {
     });
   });
 
-  it("finds a key for a manually typed Custom route that has no section of its own", async () => {
+  it("does not borrow a different provider's key for a manually typed route", async () => {
     await withCodexHome(async (codexHome) => {
-      // The user picked "Manual custom route", so providerId `custom` matches nothing in
-      // config.toml — the key still has to be found on the provider Codex is actually using.
       await writeFile(
         path.join(codexHome, "config.toml"),
         [
@@ -828,18 +881,12 @@ describe("codex profile switching", () => {
         ].join("\n"),
       );
 
-      const result = await probeCodexModels(
+      const fetchImpl = vi.fn();
+      await expect(probeCodexModels(
         { baseUrl: "https://api.example/v1", apiKey: "", providerId: "custom", codexHome },
-        async (_url, init) => {
-          expect(init?.headers?.Authorization).toBe("Bearer sk-inline-dms");
-          return { ok: true, status: 200, async json() { return { data: [{ id: "gh:gpt-5.5" }] }; } };
-        },
-      );
-
-      expect(result).toMatchObject({
-        models: ["gh:gpt-5.5"],
-        credentialSource: "config.toml dms.api_key (provider dms)",
-      });
+        fetchImpl,
+      )).rejects.toThrow(/No API key was found/);
+      expect(fetchImpl).not.toHaveBeenCalled();
     });
   });
 
@@ -865,7 +912,10 @@ describe("codex profile switching", () => {
 
   it("falls back to a .env file next to the Codex config", async () => {
     await withCodexHome(async (codexHome) => {
-      await writeFile(path.join(codexHome, "config.toml"), 'model_provider = "dms"\n\n[model_providers.dms]\n');
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        'model_provider = "dms"\n\n[model_providers.dms]\nbase_url = "https://api.example/v1"\n',
+      );
       await writeFile(path.join(codexHome, ".env"), "# comment\nexport CODEX_API_KEY='sk-dotenv'\n");
 
       const result = await probeCodexModels(

--- a/apps/main-2.0/src/core/codex-profile.test.ts
+++ b/apps/main-2.0/src/core/codex-profile.test.ts
@@ -601,6 +601,51 @@ describe("codex profile switching", () => {
     });
   });
 
+  it("uses an explicit probe key without executing the configured auth command", async () => {
+    await withCodexHome(async (codexHome) => {
+      const markerPath = path.join(codexHome, "probe-helper-ran");
+      const helperArgs = [
+        "-e",
+        `require("node:fs").writeFileSync(${JSON.stringify(markerPath)}, "ran"); process.stdout.write("command-key")`,
+      ];
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          'model_provider = "gateway"',
+          "",
+          "[model_providers.gateway]",
+          'base_url = "https://api.example/v1"',
+          "",
+          "[model_providers.gateway.auth]",
+          `command = ${JSON.stringify(process.execPath)}`,
+          `args = ${JSON.stringify(helperArgs)}`,
+          `cwd = ${JSON.stringify(codexHome)}`,
+        ].join("\n"),
+      );
+
+      const result = await probeCodexModels(
+        {
+          baseUrl: "",
+          apiKey: "explicit-key",
+          apiKeySource: "API key field",
+          providerId: "gateway",
+          codexHome,
+        },
+        async (url, init) => {
+          expect(String(url)).toBe("https://api.example/v1/models");
+          expect(init?.headers?.Authorization).toBe("Bearer explicit-key");
+          return { ok: true, status: 200, async json() { return { data: [{ id: "gateway-model" }] }; } };
+        },
+      );
+
+      expect(result).toMatchObject({
+        models: ["gateway-model"],
+        credentialSource: "API key field",
+      });
+      await expect(readFile(markerPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
   it("prefers the configured provider env_key over an unrelated auth.json login", async () => {
     vi.stubEnv("DMS_API_KEY", "provider-env-key");
     await withCodexHome(async (codexHome) => {

--- a/apps/main-2.0/src/core/codex-profile.test.ts
+++ b/apps/main-2.0/src/core/codex-profile.test.ts
@@ -325,6 +325,7 @@ describe("codex profile switching", () => {
 
   it("detects command-backed Codex auth without running the helper during snapshots", async () => {
     await withCodexHome(async (codexHome) => {
+      await writeFile(path.join(codexHome, "auth.json"), '{"OPENAI_API_KEY":"unrelated-login-key"}\n');
       await writeFile(
         path.join(codexHome, "config.toml"),
         [
@@ -389,6 +390,82 @@ describe("codex profile switching", () => {
       })).resolves.toEqual({
         apiKey: "auth-file-key",
         source: "auth.json OPENAI_API_KEY",
+      });
+    });
+  });
+
+  it("can keep configured command auth authoritative without executing it or borrowing past it", async () => {
+    await withCodexHome(async (codexHome) => {
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          "[model_providers.gateway]",
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+        ].join("\n"),
+      );
+      await writeFile(path.join(codexHome, "auth.json"), '{"OPENAI_API_KEY":"unrelated-login-key"}\n');
+
+      await expect(resolveCodexProviderCredential({
+        codexHome,
+        providerId: "gateway",
+        executeCredentialHelper: false,
+        preferConfiguredHelper: true,
+      })).resolves.toMatchObject({
+        apiKey: "",
+        source: "config.toml gateway.auth.command",
+      });
+
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          'model_provider = "gateway"',
+          "",
+          "[model_providers.gateway]",
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+          "",
+          "[model_providers.sibling]",
+          'api_key = "sibling-key"',
+        ].join("\n"),
+      );
+      await writeFile(path.join(codexHome, "auth.json"), "{}\n");
+
+      await expect(resolveCodexProviderCredential({
+        codexHome,
+        providerId: "manual-route",
+        executeCredentialHelper: false,
+        preferConfiguredHelper: true,
+      })).resolves.toEqual({
+        apiKey: "",
+        source: null,
+      });
+    });
+  });
+
+  it("does not report a sibling provider helper as official-route authentication", async () => {
+    await withCodexHome(async (codexHome) => {
+      await writeFile(
+        path.join(codexHome, "config.toml"),
+        [
+          'model_provider = "openai"',
+          "",
+          "[model_providers.gateway]",
+          "",
+          "[model_providers.gateway.auth]",
+          'command = "agent-recall-helper-must-not-run"',
+          "",
+          "[model_providers.sibling]",
+          'api_key = "sibling-key"',
+        ].join("\n"),
+      );
+
+      await expect(loadCodexConfigSnapshot(codexHome)).resolves.toMatchObject({
+        activeProviderId: "openai",
+        hasApiKey: false,
+        credentialSource: null,
       });
     });
   });
@@ -1135,6 +1212,7 @@ describe("loadActiveCodexSummaryEndpointDefaults", () => {
         `cwd = ${JSON.stringify(codexHome)}`,
       ].join("\n"),
     );
+    writeFileSync(path.join(codexHome, "auth.json"), '{"OPENAI_API_KEY":"unrelated-login-key"}\n');
 
     await expect(loadActiveCodexSummaryEndpointDefaults(codexHome)).resolves.toBeNull();
     await expect(readFile(customMarker, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
@@ -1158,6 +1236,7 @@ describe("loadActiveCodexSummaryEndpointDefaults", () => {
         `cwd = ${JSON.stringify(codexHome)}`,
       ].join("\n"),
     );
+    writeFileSync(path.join(codexHome, "auth.json"), "{}\n");
 
     await expect(loadActiveCodexSummaryEndpointDefaults(codexHome)).resolves.toBeNull();
     await expect(readFile(borrowedMarker, "utf8")).rejects.toMatchObject({ code: "ENOENT" });

--- a/apps/main-2.0/src/core/codex-profile.test.ts
+++ b/apps/main-2.0/src/core/codex-profile.test.ts
@@ -864,6 +864,55 @@ describe("loadActiveCodexSummaryEndpointDefaults", () => {
     return expect(loadActiveCodexSummaryEndpointDefaults(codexHome)).resolves.toBeNull();
   });
 
+  it("does not execute credential helpers while loading background defaults", async () => {
+    const customMarker = path.join(codexHome, "custom-helper-ran");
+    const customHelperArgs = [
+      "-e",
+      `require("node:fs").writeFileSync(${JSON.stringify(customMarker)}, "ran"); process.stdout.write("custom-key")`,
+    ];
+    writeFileSync(
+      path.join(codexHome, "config.toml"),
+      [
+        'model = "provider-model"',
+        'model_provider = "gateway"',
+        "",
+        "[model_providers.gateway]",
+        'base_url = "https://gateway.example/v1"',
+        "",
+        "[model_providers.gateway.auth]",
+        `command = ${JSON.stringify(process.execPath)}`,
+        `args = ${JSON.stringify(customHelperArgs)}`,
+        `cwd = ${JSON.stringify(codexHome)}`,
+      ].join("\n"),
+    );
+
+    await expect(loadActiveCodexSummaryEndpointDefaults(codexHome)).resolves.toBeNull();
+    await expect(readFile(customMarker, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+
+    const borrowedMarker = path.join(codexHome, "borrowed-helper-ran");
+    const borrowedHelperArgs = [
+      "-e",
+      `require("node:fs").writeFileSync(${JSON.stringify(borrowedMarker)}, "ran"); process.stdout.write("borrowed-key")`,
+    ];
+    writeFileSync(
+      path.join(codexHome, "config.toml"),
+      [
+        'model = "gpt-5.5"',
+        "",
+        "[model_providers.gateway]",
+        'base_url = "https://gateway.example/v1"',
+        "",
+        "[model_providers.gateway.auth]",
+        `command = ${JSON.stringify(process.execPath)}`,
+        `args = ${JSON.stringify(borrowedHelperArgs)}`,
+        `cwd = ${JSON.stringify(codexHome)}`,
+      ].join("\n"),
+    );
+
+    await expect(loadActiveCodexSummaryEndpointDefaults(codexHome)).resolves.toBeNull();
+    await expect(readFile(borrowedMarker, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("falls back to OPENAI_API_KEY for the official provider", async () => {
     writeFileSync(path.join(codexHome, "config.toml"), 'model = "gpt-5.5"\n');
     writeFileSync(

--- a/apps/main-2.0/src/core/codex-profile.ts
+++ b/apps/main-2.0/src/core/codex-profile.ts
@@ -187,10 +187,14 @@ export async function loadCodexConfigSnapshot(configuredHome?: string): Promise<
 export async function probeCodexModels(input: CodexModelProbeInput, fetchImpl: ProviderModelsFetch = fetch): Promise<CodexModelProbeResult> {
   const providerId = input.providerId || await readActiveCodexProviderId(input.codexHome);
   const explicitKey = input.apiKey.trim();
-  // Always consult the Codex config: a manually typed Custom route has no section of
-  // its own, and the summary route falls back to whatever Codex is already using.
-  const configProvider = await readCodexConfigProviderSecret(providerId, input.codexHome, !explicitKey);
-  const baseUrl = normalizeBaseUrl(input.baseUrl || configProvider?.baseUrl || "");
+  const requestedBaseUrl = normalizeBaseUrl(input.baseUrl);
+  const configProvider = await readCodexConfigProviderSecret(
+    providerId,
+    requestedBaseUrl,
+    input.codexHome,
+    !explicitKey,
+  );
+  const baseUrl = requestedBaseUrl || normalizeBaseUrl(configProvider?.baseUrl || "");
   const apiKey = explicitKey || configProvider?.apiKey || "";
   const result = await probeProviderModels({ baseUrl, apiKey }, fetchImpl);
   return {
@@ -202,6 +206,8 @@ export async function probeCodexModels(input: CodexModelProbeInput, fetchImpl: P
 export async function resolveCodexProviderCredential(input: {
   codexHome?: string;
   providerId?: string;
+  /** When supplied, config-owned credentials must belong to this exact provider route. */
+  baseUrl?: string;
   apiKey?: string;
   apiKeySource?: string;
   /** Opt in only for an operation that may execute the provider's configured auth command. */
@@ -212,12 +218,24 @@ export async function resolveCodexProviderCredential(input: {
   const codexHome = resolveProviderConfigDirectory(input.codexHome, ".codex");
   const configText = await readOptionalFile(path.join(codexHome, "config.toml"));
   const providerId = input.providerId || readTopLevelTomlString(configText, "model_provider") || "";
+  const explicitKey = input.apiKey?.trim() ?? "";
+  if (!explicitKey && input.baseUrl !== undefined) {
+    const section = providerId ? readTomlSection(configText, modelProviderSection(providerId)) : "";
+    const configuredBaseUrl = readTomlString(section, "base_url") || "";
+    if (
+      !configuredBaseUrl
+      || normalizeBaseUrl(configuredBaseUrl) !== normalizeBaseUrl(input.baseUrl)
+    ) {
+      return { apiKey: "", source: null };
+    }
+  }
   return resolveCodexCredential({
     codexHome,
     configText,
     providerId,
     explicitKey: input.apiKey,
     explicitSource: input.apiKeySource,
+    allowOtherProviders: input.baseUrl === undefined,
     executeCredentialHelper: input.executeCredentialHelper ?? false,
     preferConfiguredHelper: input.preferConfiguredHelper ?? false,
   });
@@ -269,20 +287,27 @@ async function readActiveCodexProviderId(codexHome?: string): Promise<string> {
 
 async function readCodexConfigProviderSecret(
   providerId: string,
+  requestedBaseUrl: string,
   codexHome?: string,
-  executeCredentialHelper = false,
+  resolveCredential = true,
 ): Promise<{ baseUrl: string; apiKey: string; credentialSource: string | null } | null> {
+  if (!providerId) return null;
   const home = resolveProviderConfigDirectory(codexHome, ".codex");
   const text = await readOptionalFile(path.join(home, "config.toml"));
   const section = readTomlSection(text, modelProviderSection(providerId));
   const baseUrl = readTomlString(section, "base_url") || "";
+  // Config-owned credentials belong to the route that declares them. Resolve (and potentially
+  // execute) them only after both the provider id and destination are known to match.
+  if (!baseUrl || (requestedBaseUrl && normalizeBaseUrl(baseUrl) !== requestedBaseUrl)) return null;
+  if (!resolveCredential) return { baseUrl, apiKey: "", credentialSource: null };
   const envKey = readTomlString(section, "env_key") || "";
   const credential = await resolveCodexCredential({
     codexHome: home,
     configText: text,
     providerId,
     envKey,
-    executeCredentialHelper,
+    allowOtherProviders: false,
+    executeCredentialHelper: true,
   });
   return baseUrl || credential.apiKey ? { baseUrl, apiKey: credential.apiKey, credentialSource: credential.source } : null;
 }
@@ -550,24 +575,32 @@ async function applyGeneratedCodexProvider(options: {
   if (!apiConfig.customBaseUrl) throw new Error(`Base URL is required to apply ${apiConfig.customProviderName}.`);
 
   const activeConfigText = await readOptionalFile(configTarget);
-  const commandAuth = readCodexCommandAuth(activeConfigText, providerId);
+  const currentProviderSection = readTomlSection(activeConfigText, modelProviderSection(providerId));
+  const currentBaseUrl = readTomlString(currentProviderSection, "base_url") || "";
+  const currentRouteMatches = Boolean(currentBaseUrl)
+    && normalizeBaseUrl(currentBaseUrl) === normalizeBaseUrl(apiConfig.customBaseUrl);
+  const commandAuth = currentRouteMatches ? readCodexCommandAuth(activeConfigText, providerId) : null;
   // An existing helper remains authoritative unless the user explicitly enters a replacement
   // key. In particular, never persist a generic environment/auth.json fallback for this route.
   const useCommandAuth = Boolean(commandAuth && !apiConfig.customApiKey.trim());
+  const explicitKey = apiConfig.customApiKey.trim();
   const credential: ResolvedCodexCredential = useCommandAuth
     ? {
         apiKey: "",
         source: `config.toml ${providerId}.auth.command`,
         configured: true,
       }
-    : await resolveCodexCredential({
-        codexHome,
-        configText: activeConfigText,
-        providerId,
-        explicitKey: apiConfig.customApiKey,
-        // Applying a route must never turn a short-lived helper token into a persisted API key.
-        executeCredentialHelper: false,
-      });
+    : explicitKey || currentRouteMatches
+      ? await resolveCodexCredential({
+          codexHome,
+          configText: activeConfigText,
+          providerId,
+          explicitKey,
+          allowOtherProviders: false,
+          // Applying a route must never turn a short-lived helper token into a persisted API key.
+          executeCredentialHelper: false,
+        })
+      : { apiKey: "", source: null };
   if (!useCommandAuth && !credential.apiKey) throw new Error(`No API key was found for ${apiConfig.customProviderName}.`);
   const effectiveConfig = { ...apiConfig, customApiKey: credential.apiKey };
   const baseConfigText = activeConfigText.trim() ? activeConfigText : generatedCodexConfig(effectiveConfig, providerId);

--- a/apps/main-2.0/src/core/codex-profile.ts
+++ b/apps/main-2.0/src/core/codex-profile.ts
@@ -146,6 +146,7 @@ export async function loadCodexConfigSnapshot(configuredHome?: string): Promise<
       providerId: provider.id,
       allowOtherProviders: false,
       executeCredentialHelper: false,
+      preferConfiguredHelper: true,
     });
     return {
       ...provider,
@@ -167,6 +168,7 @@ export async function loadCodexConfigSnapshot(configuredHome?: string): Promise<
     configText: text,
     providerId: activeProviderId,
     executeCredentialHelper: false,
+    preferConfiguredHelper: true,
   });
   return {
     codexHome,
@@ -204,6 +206,8 @@ export async function resolveCodexProviderCredential(input: {
   apiKeySource?: string;
   /** Opt in only for an operation that may execute the provider's configured auth command. */
   executeCredentialHelper?: boolean;
+  /** Keep configured command auth authoritative instead of resolving generic fallback keys. */
+  preferConfiguredHelper?: boolean;
 }): Promise<CodexCredentialResolution> {
   const codexHome = resolveProviderConfigDirectory(input.codexHome, ".codex");
   const configText = await readOptionalFile(path.join(codexHome, "config.toml"));
@@ -215,6 +219,7 @@ export async function resolveCodexProviderCredential(input: {
     explicitKey: input.apiKey,
     explicitSource: input.apiKeySource,
     executeCredentialHelper: input.executeCredentialHelper ?? false,
+    preferConfiguredHelper: input.preferConfiguredHelper ?? false,
   });
 }
 
@@ -228,6 +233,7 @@ export async function loadActiveCodexSummaryEndpointDefaults(codexHome?: string)
       codexHome: home,
       configText: text,
       executeCredentialHelper: false,
+      preferConfiguredHelper: true,
     });
     return credential.apiKey
       ? { baseUrl: "", model, apiKey: credential.apiKey, apiFormat: "openai_responses" }
@@ -244,6 +250,7 @@ export async function loadActiveCodexSummaryEndpointDefaults(codexHome?: string)
     providerId,
     envKey,
     executeCredentialHelper: false,
+    preferConfiguredHelper: true,
   });
   const apiKey = credential.apiKey;
   if (!baseUrl || !model || !apiKey) return null;
@@ -294,6 +301,8 @@ async function resolveCodexCredential(options: {
   allowOtherProviders?: boolean;
   /** Provider-owned commands run only when the caller explicitly opts in. */
   executeCredentialHelper?: boolean;
+  /** Do not let readable fallback credentials hide a configured provider helper. */
+  preferConfiguredHelper?: boolean;
 }): Promise<ResolvedCodexCredential> {
   const explicitKey = options.explicitKey?.trim() ?? "";
   if (explicitKey) return { apiKey: explicitKey, source: options.explicitSource || "API key field" };
@@ -304,6 +313,9 @@ async function resolveCodexCredential(options: {
     const source = `config.toml ${options.providerId}.auth.command`;
     if (options.executeCredentialHelper !== true) {
       configuredCommandSource = source;
+      if (options.preferConfiguredHelper) {
+        return { apiKey: "", source, configured: true };
+      }
     } else {
       return {
         apiKey: await runProviderCredentialCommand(commandAuth),
@@ -367,6 +379,7 @@ async function borrowCodexCredentialFromOtherProviders(options: {
   configText: string;
   providerId?: string;
   executeCredentialHelper?: boolean;
+  preferConfiguredHelper?: boolean;
 }): Promise<ResolvedCodexCredential> {
   const activeProviderId = readTopLevelTomlString(options.configText, "model_provider") || "";
   const candidates = [
@@ -382,8 +395,12 @@ async function borrowCodexCredentialFromOtherProviders(options: {
       providerId: candidate,
       allowOtherProviders: false,
       executeCredentialHelper: options.executeCredentialHelper,
+      preferConfiguredHelper: options.preferConfiguredHelper,
     });
     if (credential.apiKey) return { apiKey: credential.apiKey, source: `${credential.source} (provider ${candidate})` };
+    // A helper is scoped to its own provider. It blocks borrowing credentials from
+    // providers behind it, but must not make the requested route look authenticated.
+    if (credential.configured) return { apiKey: "", source: null };
   }
   return { apiKey: "", source: null };
 }

--- a/apps/main-2.0/src/core/codex-profile.ts
+++ b/apps/main-2.0/src/core/codex-profile.ts
@@ -184,11 +184,11 @@ export async function loadCodexConfigSnapshot(configuredHome?: string): Promise<
 
 export async function probeCodexModels(input: CodexModelProbeInput, fetchImpl: ProviderModelsFetch = fetch): Promise<CodexModelProbeResult> {
   const providerId = input.providerId || await readActiveCodexProviderId(input.codexHome);
+  const explicitKey = input.apiKey.trim();
   // Always consult the Codex config: a manually typed Custom route has no section of
   // its own, and the summary route falls back to whatever Codex is already using.
-  const configProvider = await readCodexConfigProviderSecret(providerId, input.codexHome, true);
+  const configProvider = await readCodexConfigProviderSecret(providerId, input.codexHome, !explicitKey);
   const baseUrl = normalizeBaseUrl(input.baseUrl || configProvider?.baseUrl || "");
-  const explicitKey = input.apiKey.trim();
   const apiKey = explicitKey || configProvider?.apiKey || "";
   const result = await probeProviderModels({ baseUrl, apiKey }, fetchImpl);
   return {

--- a/apps/main-2.0/src/core/codex-profile.ts
+++ b/apps/main-2.0/src/core/codex-profile.ts
@@ -754,7 +754,7 @@ function normalizeBaseUrl(baseUrl: string | null): string {
 
 function readCodexModelProviders(text: string): CodexConfigProviderEntry[] {
   const providers: CodexConfigProviderEntry[] = [];
-  const sectionPattern = /^\s*\[model_providers\.([A-Za-z0-9_-]+|"(?:\\.|[^"\\])+")\]\s*$/;
+  const sectionPattern = /^\s*\[model_providers\.([A-Za-z0-9_-]+|"(?:\\.|[^"\\])+")\]\s*(?:#.*)?$/;
   const lines = text.split(/\r?\n/);
   for (let index = 0; index < lines.length; index += 1) {
     const match = lines[index].match(sectionPattern);
@@ -855,7 +855,7 @@ function removeTopLevelTomlKey(text: string, key: string): string {
 
 function removeTomlSectionKey(text: string, sectionHeader: string, key: string): string {
   const lines = text.split(/\r?\n/);
-  const sectionStart = lines.findIndex((line) => line.trim() === sectionHeader);
+  const sectionStart = lines.findIndex((line) => isTomlSectionHeader(line, sectionHeader));
   if (sectionStart < 0) return text;
   let sectionEnd = lines.findIndex((line, index) => index > sectionStart && /^\s*\[/.test(line));
   if (sectionEnd < 0) sectionEnd = lines.length;
@@ -868,7 +868,7 @@ function removeTomlSectionKey(text: string, sectionHeader: string, key: string):
 
 function removeTomlSection(text: string, sectionHeader: string): string {
   const lines = text.split(/\r?\n/);
-  const sectionStart = lines.findIndex((line) => line.trim() === sectionHeader);
+  const sectionStart = lines.findIndex((line) => isTomlSectionHeader(line, sectionHeader));
   if (sectionStart < 0) return text;
   let sectionEnd = lines.findIndex((line, index) => index > sectionStart && /^\s*\[/.test(line));
   if (sectionEnd < 0) sectionEnd = lines.length;
@@ -882,7 +882,7 @@ function replaceOrInsertSectionString(text: string, sectionHeader: string, key: 
 
 function replaceOrInsertSectionLiteral(text: string, sectionHeader: string, key: string, value: string): string {
   const lines = text.split(/\r?\n/);
-  let sectionStart = lines.findIndex((line) => line.trim() === sectionHeader);
+  let sectionStart = lines.findIndex((line) => isTomlSectionHeader(line, sectionHeader));
   if (sectionStart < 0) {
     lines.push("", sectionHeader);
     sectionStart = lines.length - 1;
@@ -926,7 +926,7 @@ async function readOptionalFile(filePath: string): Promise<string> {
 
 function readTomlSection(text: string, sectionHeader: string): string {
   const lines = text.split(/\r?\n/);
-  const start = lines.findIndex((line) => line.trim() === sectionHeader);
+  const start = lines.findIndex((line) => isTomlSectionHeader(line, sectionHeader));
   if (start < 0) return "";
   const sectionLines: string[] = [];
   for (let i = start + 1; i < lines.length; i += 1) {
@@ -934,6 +934,13 @@ function readTomlSection(text: string, sectionHeader: string): string {
     sectionLines.push(lines[i]);
   }
   return sectionLines.join("\n");
+}
+
+function isTomlSectionHeader(line: string, sectionHeader: string): boolean {
+  const trimmed = line.trimStart();
+  if (!trimmed.startsWith(sectionHeader)) return false;
+  const suffix = trimmed.slice(sectionHeader.length).trimStart();
+  return suffix.length === 0 || suffix.startsWith("#");
 }
 
 function readTomlString(text: string, key: string): string | null {

--- a/apps/main-2.0/src/core/codex-profile.ts
+++ b/apps/main-2.0/src/core/codex-profile.ts
@@ -299,13 +299,17 @@ async function resolveCodexCredential(options: {
   if (explicitKey) return { apiKey: explicitKey, source: options.explicitSource || "API key field" };
 
   const commandAuth = options.providerId ? readCodexCommandAuth(options.configText, options.providerId) : null;
+  let configuredCommandSource: string | null = null;
   if (commandAuth) {
     const source = `config.toml ${options.providerId}.auth.command`;
-    if (options.executeCredentialHelper !== true) return { apiKey: "", source, configured: true };
-    return {
-      apiKey: await runProviderCredentialCommand(commandAuth),
-      source,
-    };
+    if (options.executeCredentialHelper !== true) {
+      configuredCommandSource = source;
+    } else {
+      return {
+        apiKey: await runProviderCredentialCommand(commandAuth),
+        source,
+      };
+    }
   }
 
   const section = options.providerId ? readTomlSection(options.configText, modelProviderSection(options.providerId)) : "";
@@ -346,6 +350,9 @@ async function resolveCodexCredential(options: {
     if (dotEnv[key]) return { apiKey: dotEnv[key], source: `.env ${key}` };
   }
 
+  // A configured helper belongs to this provider. Report it before considering sibling
+  // providers, but only after checking readable credentials owned by this provider.
+  if (configuredCommandSource) return { apiKey: "", source: configuredCommandSource, configured: true };
   if (options.allowOtherProviders === false) return { apiKey: "", source: null };
   return borrowCodexCredentialFromOtherProviders(options);
 }
@@ -525,44 +532,57 @@ async function applyGeneratedCodexProvider(options: {
 
   if (!apiConfig.customBaseUrl) throw new Error(`Base URL is required to apply ${apiConfig.customProviderName}.`);
 
-  await mkdir(backupDir, { recursive: true });
-  const backupPaths = await backupExistingTargets([
-    { target: authTarget, backup: path.join(backupDir, `auth.json.before-${providerId}-${stamp}`) },
-    { target: configTarget, backup: path.join(backupDir, `config.toml.before-${providerId}-${stamp}`) },
-  ]);
-
   const activeConfigText = await readOptionalFile(configTarget);
-  const credential = await resolveCodexCredential({
-    codexHome,
-    configText: activeConfigText,
-    providerId,
-    explicitKey: apiConfig.customApiKey,
-    // Applying a route must never turn a short-lived helper token into a persisted API key.
-    executeCredentialHelper: false,
-  });
-  if (!credential.apiKey) throw new Error(`No API key was found for ${apiConfig.customProviderName}.`);
+  const commandAuth = readCodexCommandAuth(activeConfigText, providerId);
+  // An existing helper remains authoritative unless the user explicitly enters a replacement
+  // key. In particular, never persist a generic environment/auth.json fallback for this route.
+  const useCommandAuth = Boolean(commandAuth && !apiConfig.customApiKey.trim());
+  const credential: ResolvedCodexCredential = useCommandAuth
+    ? {
+        apiKey: "",
+        source: `config.toml ${providerId}.auth.command`,
+        configured: true,
+      }
+    : await resolveCodexCredential({
+        codexHome,
+        configText: activeConfigText,
+        providerId,
+        explicitKey: apiConfig.customApiKey,
+        // Applying a route must never turn a short-lived helper token into a persisted API key.
+        executeCredentialHelper: false,
+      });
+  if (!useCommandAuth && !credential.apiKey) throw new Error(`No API key was found for ${apiConfig.customProviderName}.`);
   const effectiveConfig = { ...apiConfig, customApiKey: credential.apiKey };
   const baseConfigText = activeConfigText.trim() ? activeConfigText : generatedCodexConfig(effectiveConfig, providerId);
   const expectedBaseUrl = apiConfig.customApiFormat === "openai_chat" && options.chatProxyBaseUrl
     ? options.chatProxyBaseUrl
     : apiConfig.customBaseUrl;
 
-  // A `requires_openai_auth` provider reads its bearer token from auth.json, so writing
-  // config.toml alone leaves Codex itself without a usable credential.
-  const previousAuthText = await readOptionalFile(authTarget);
-  await writeVerifiedConfig({
-    targetPath: authTarget,
-    contents: codexAuthJson(previousAuthText, credential.apiKey),
-    verify: async () => {
-      const written = readCodexAuthKeys(await readOptionalFile(authTarget));
-      if (written[OFFICIAL_CODEX_AUTH_ENV_KEY] !== credential.apiKey) throw new Error("auth.json credential was not written");
-    },
-  });
+  await mkdir(backupDir, { recursive: true });
+  const backupPaths = await backupExistingTargets([
+    ...(!useCommandAuth ? [{ target: authTarget, backup: path.join(backupDir, `auth.json.before-${providerId}-${stamp}`) }] : []),
+    { target: configTarget, backup: path.join(backupDir, `config.toml.before-${providerId}-${stamp}`) },
+  ]);
+
+  let previousAuthText = "";
+  if (!useCommandAuth) {
+    // A `requires_openai_auth` provider reads its bearer token from auth.json, so writing
+    // config.toml alone leaves Codex itself without a usable credential.
+    previousAuthText = await readOptionalFile(authTarget);
+    await writeVerifiedConfig({
+      targetPath: authTarget,
+      contents: codexAuthJson(previousAuthText, credential.apiKey),
+      verify: async () => {
+        const written = readCodexAuthKeys(await readOptionalFile(authTarget));
+        if (written[OFFICIAL_CODEX_AUTH_ENV_KEY] !== credential.apiKey) throw new Error("auth.json credential was not written");
+      },
+    });
+  }
 
   try {
     await writeVerifiedConfig({
       targetPath: configTarget,
-      contents: applyCodexProviderConfig(baseConfigText, effectiveConfig, providerId, options.chatProxyBaseUrl),
+      contents: applyCodexProviderConfig(baseConfigText, effectiveConfig, providerId, options.chatProxyBaseUrl, useCommandAuth),
       verify: async () => {
         const snapshot = await loadCodexConfigSnapshot(codexHome);
         const provider = snapshot.providers.find((item) => item.id === providerId);
@@ -577,11 +597,13 @@ async function applyGeneratedCodexProvider(options: {
       },
     });
   } catch (error) {
-    if (previousAuthText) await writeFile(authTarget, previousAuthText, { mode: 0o600 });
-    else await rm(authTarget, { force: true });
+    if (!useCommandAuth) {
+      if (previousAuthText) await writeFile(authTarget, previousAuthText, { mode: 0o600 });
+      else await rm(authTarget, { force: true });
+    }
     throw error;
   }
-  await chmodIfExists(authTarget, 0o600);
+  if (!useCommandAuth) await chmodIfExists(authTarget, 0o600);
   await chmod(configTarget, 0o600);
 
   return {
@@ -629,7 +651,13 @@ function applyCodexOfficialConfigOverrides(text: string): string {
   return next.endsWith("\n") ? next : `${next}\n`;
 }
 
-function applyCodexProviderConfig(text: string, apiConfig: ApiConfig, providerId: string, chatProxyBaseUrl?: string): string {
+function applyCodexProviderConfig(
+  text: string,
+  apiConfig: ApiConfig,
+  providerId: string,
+  chatProxyBaseUrl?: string,
+  useCommandAuth = false,
+): string {
   const baseUrl = apiConfig.customApiFormat === "openai_chat" && chatProxyBaseUrl ? chatProxyBaseUrl : apiConfig.customBaseUrl;
   let next = removeTopLevelTomlKey(text, "experimental_bearer_token");
   next = replaceTopLevelString(next, "model_provider", providerId);
@@ -638,9 +666,17 @@ function applyCodexProviderConfig(text: string, apiConfig: ApiConfig, providerId
   next = replaceOrInsertSectionString(next, sectionHeader, "name", apiConfig.customProviderName);
   if (baseUrl) next = replaceOrInsertSectionString(next, sectionHeader, "base_url", baseUrl);
   next = replaceOrInsertSectionString(next, sectionHeader, "wire_api", "responses");
-  next = replaceOrInsertSectionLiteral(next, sectionHeader, "requires_openai_auth", "true");
-  if (apiConfig.customApiKey) {
-    next = replaceOrInsertSectionString(next, sectionHeader, "experimental_bearer_token", apiConfig.customApiKey);
+  const authSectionHeader = `${sectionHeader.slice(0, -1)}.auth]`;
+  if (useCommandAuth) {
+    for (const key of ["requires_openai_auth", "env_key", "experimental_bearer_token"]) {
+      next = removeTomlSectionKey(next, sectionHeader, key);
+    }
+  } else {
+    next = removeTomlSection(next, authSectionHeader);
+    next = replaceOrInsertSectionLiteral(next, sectionHeader, "requires_openai_auth", "true");
+    if (apiConfig.customApiKey) {
+      next = replaceOrInsertSectionString(next, sectionHeader, "experimental_bearer_token", apiConfig.customApiKey);
+    }
   }
   return next.endsWith("\n") ? next : `${next}\n`;
 }
@@ -765,6 +801,29 @@ function removeTopLevelTomlKey(text: string, key: string): string {
       return !(inTopLevel && pattern.test(line));
     })
     .join("\n");
+}
+
+function removeTomlSectionKey(text: string, sectionHeader: string, key: string): string {
+  const lines = text.split(/\r?\n/);
+  const sectionStart = lines.findIndex((line) => line.trim() === sectionHeader);
+  if (sectionStart < 0) return text;
+  let sectionEnd = lines.findIndex((line, index) => index > sectionStart && /^\s*\[/.test(line));
+  if (sectionEnd < 0) sectionEnd = lines.length;
+  const pattern = new RegExp(`^\\s*${escapeRegExp(key)}\\s*=`);
+  for (let index = sectionEnd - 1; index > sectionStart; index -= 1) {
+    if (pattern.test(lines[index])) lines.splice(index, 1);
+  }
+  return lines.join("\n");
+}
+
+function removeTomlSection(text: string, sectionHeader: string): string {
+  const lines = text.split(/\r?\n/);
+  const sectionStart = lines.findIndex((line) => line.trim() === sectionHeader);
+  if (sectionStart < 0) return text;
+  let sectionEnd = lines.findIndex((line, index) => index > sectionStart && /^\s*\[/.test(line));
+  if (sectionEnd < 0) sectionEnd = lines.length;
+  lines.splice(sectionStart, sectionEnd - sectionStart);
+  return lines.join("\n");
 }
 
 function replaceOrInsertSectionString(text: string, sectionHeader: string, key: string, value: string): string {

--- a/apps/main-2.0/src/core/codex-profile.ts
+++ b/apps/main-2.0/src/core/codex-profile.ts
@@ -186,7 +186,7 @@ export async function probeCodexModels(input: CodexModelProbeInput, fetchImpl: P
   const providerId = input.providerId || await readActiveCodexProviderId(input.codexHome);
   // Always consult the Codex config: a manually typed Custom route has no section of
   // its own, and the summary route falls back to whatever Codex is already using.
-  const configProvider = await readCodexConfigProviderSecret(providerId, input.codexHome);
+  const configProvider = await readCodexConfigProviderSecret(providerId, input.codexHome, true);
   const baseUrl = normalizeBaseUrl(input.baseUrl || configProvider?.baseUrl || "");
   const explicitKey = input.apiKey.trim();
   const apiKey = explicitKey || configProvider?.apiKey || "";
@@ -224,7 +224,11 @@ export async function loadActiveCodexSummaryEndpointDefaults(codexHome?: string)
   const providerId = readTopLevelTomlString(text, "model_provider");
   const model = readTopLevelTomlString(text, "model") || "";
   if (!providerId || providerId === OFFICIAL_CODEX_PROVIDER_ID) {
-    const credential = await resolveCodexCredential({ codexHome: home, configText: text });
+    const credential = await resolveCodexCredential({
+      codexHome: home,
+      configText: text,
+      executeCredentialHelper: false,
+    });
     return credential.apiKey
       ? { baseUrl: "", model, apiKey: credential.apiKey, apiFormat: "openai_responses" }
       : null;
@@ -234,7 +238,13 @@ export async function loadActiveCodexSummaryEndpointDefaults(codexHome?: string)
   const baseUrl = readTomlString(section, "base_url") || "";
   const wireApi = readTomlString(section, "wire_api") || "";
   const envKey = readTomlString(section, "env_key") || "";
-  const credential = await resolveCodexCredential({ codexHome: home, configText: text, providerId, envKey });
+  const credential = await resolveCodexCredential({
+    codexHome: home,
+    configText: text,
+    providerId,
+    envKey,
+    executeCredentialHelper: false,
+  });
   const apiKey = credential.apiKey;
   if (!baseUrl || !model || !apiKey) return null;
   return {
@@ -250,13 +260,23 @@ async function readActiveCodexProviderId(codexHome?: string): Promise<string> {
   return readTopLevelTomlString(text, "model_provider") || "";
 }
 
-async function readCodexConfigProviderSecret(providerId: string, codexHome?: string): Promise<{ baseUrl: string; apiKey: string; credentialSource: string | null } | null> {
+async function readCodexConfigProviderSecret(
+  providerId: string,
+  codexHome?: string,
+  executeCredentialHelper = false,
+): Promise<{ baseUrl: string; apiKey: string; credentialSource: string | null } | null> {
   const home = resolveProviderConfigDirectory(codexHome, ".codex");
   const text = await readOptionalFile(path.join(home, "config.toml"));
   const section = readTomlSection(text, modelProviderSection(providerId));
   const baseUrl = readTomlString(section, "base_url") || "";
   const envKey = readTomlString(section, "env_key") || "";
-  const credential = await resolveCodexCredential({ codexHome: home, configText: text, providerId, envKey });
+  const credential = await resolveCodexCredential({
+    codexHome: home,
+    configText: text,
+    providerId,
+    envKey,
+    executeCredentialHelper,
+  });
   return baseUrl || credential.apiKey ? { baseUrl, apiKey: credential.apiKey, credentialSource: credential.source } : null;
 }
 
@@ -272,7 +292,7 @@ async function resolveCodexCredential(options: {
   explicitSource?: string;
   /** Set to false when a caller must not borrow another provider's credential. */
   allowOtherProviders?: boolean;
-  /** Config snapshots detect helper-backed auth without executing provider-owned commands. */
+  /** Provider-owned commands run only when the caller explicitly opts in. */
   executeCredentialHelper?: boolean;
 }): Promise<ResolvedCodexCredential> {
   const explicitKey = options.explicitKey?.trim() ?? "";
@@ -281,7 +301,7 @@ async function resolveCodexCredential(options: {
   const commandAuth = options.providerId ? readCodexCommandAuth(options.configText, options.providerId) : null;
   if (commandAuth) {
     const source = `config.toml ${options.providerId}.auth.command`;
-    if (options.executeCredentialHelper === false) return { apiKey: "", source, configured: true };
+    if (options.executeCredentialHelper !== true) return { apiKey: "", source, configured: true };
     return {
       apiKey: await runProviderCredentialCommand(commandAuth),
       source,

--- a/apps/main-2.0/src/core/codex-profile.ts
+++ b/apps/main-2.0/src/core/codex-profile.ts
@@ -4,6 +4,7 @@ import { API_PROVIDER_PRESETS, normalizeApiConfig, type ApiConfig, type ApiProvi
 import { writeVerifiedConfig } from "./atomic-config-write";
 import { probeProviderModels, type ProviderModelsFetch } from "./provider-models";
 import { prepareProviderConfigDirectory, resolveProviderConfigDirectory } from "./provider-config-path";
+import { runProviderCredentialCommand } from "./provider-credential-helper";
 
 export type CodexProfileName = "codex" | "codexzh";
 export type CodexApplyProfileName = CodexProfileName | "generated";
@@ -49,9 +50,10 @@ export interface CodexConfigSnapshot {
   providers: CodexConfigProviderEntry[];
   /**
    * Credential the active route would actually use, resolved the same way `codex` resolves it:
-   * inline in `config.toml`, then `auth.json`, `.env`, and the environment. The per-provider
-   * entries deliberately refuse to borrow a sibling's key, so an official route — which has no
-   * `[model_providers.*]` section at all — has no other way to report that a key exists.
+   * command-backed auth or inline config, then the provider's environment key and compatible
+   * local stores. The per-provider entries deliberately refuse to borrow a sibling's key, so an
+   * official route — which has no `[model_providers.*]` section at all — has no other way to
+   * report that a key exists.
    */
   credentialSource: string | null;
   hasApiKey: boolean;
@@ -81,6 +83,11 @@ export interface CodexSummaryEndpointDefaults {
 export interface CodexCredentialResolution {
   apiKey: string;
   source: string | null;
+}
+
+interface ResolvedCodexCredential extends CodexCredentialResolution {
+  /** A helper-backed credential can be configured without resolving its secret during snapshots. */
+  configured?: boolean;
 }
 
 const OFFICIAL_CODEX_PROVIDER_ID = "openai";
@@ -133,10 +140,16 @@ export async function loadCodexConfigSnapshot(configuredHome?: string): Promise<
   const activeModel = readTopLevelTomlString(text, "model") || "";
   const providers = await Promise.all(readCodexModelProviders(text).map(async (provider) => {
     // Per-provider display must not borrow a sibling provider's key.
-    const credential = await resolveCodexCredential({ codexHome, configText: text, providerId: provider.id, allowOtherProviders: false });
+    const credential = await resolveCodexCredential({
+      codexHome,
+      configText: text,
+      providerId: provider.id,
+      allowOtherProviders: false,
+      executeCredentialHelper: false,
+    });
     return {
       ...provider,
-      hasApiKey: Boolean(credential.apiKey),
+      hasApiKey: Boolean(credential.apiKey) || credential.configured === true,
       credentialSource: credential.source,
     };
   }));
@@ -149,7 +162,12 @@ export async function loadCodexConfigSnapshot(configuredHome?: string): Promise<
   } catch {
     cachedModels = [];
   }
-  const activeCredential = await resolveCodexCredential({ codexHome, configText: text, providerId: activeProviderId });
+  const activeCredential = await resolveCodexCredential({
+    codexHome,
+    configText: text,
+    providerId: activeProviderId,
+    executeCredentialHelper: false,
+  });
   return {
     codexHome,
     configPath,
@@ -160,7 +178,7 @@ export async function loadCodexConfigSnapshot(configuredHome?: string): Promise<
     activeProvider: providers.find((provider) => provider.id === activeProviderId) ?? null,
     providers,
     credentialSource: activeCredential.source,
-    hasApiKey: Boolean(activeCredential.apiKey),
+    hasApiKey: Boolean(activeCredential.apiKey) || activeCredential.configured === true,
   };
 }
 
@@ -184,6 +202,8 @@ export async function resolveCodexProviderCredential(input: {
   providerId?: string;
   apiKey?: string;
   apiKeySource?: string;
+  /** Opt in only for an operation that may execute the provider's configured auth command. */
+  executeCredentialHelper?: boolean;
 }): Promise<CodexCredentialResolution> {
   const codexHome = resolveProviderConfigDirectory(input.codexHome, ".codex");
   const configText = await readOptionalFile(path.join(codexHome, "config.toml"));
@@ -194,6 +214,7 @@ export async function resolveCodexProviderCredential(input: {
     providerId,
     explicitKey: input.apiKey,
     explicitSource: input.apiKeySource,
+    executeCredentialHelper: input.executeCredentialHelper ?? false,
   });
 }
 
@@ -251,9 +272,21 @@ async function resolveCodexCredential(options: {
   explicitSource?: string;
   /** Set to false when a caller must not borrow another provider's credential. */
   allowOtherProviders?: boolean;
-}): Promise<{ apiKey: string; source: string | null }> {
+  /** Config snapshots detect helper-backed auth without executing provider-owned commands. */
+  executeCredentialHelper?: boolean;
+}): Promise<ResolvedCodexCredential> {
   const explicitKey = options.explicitKey?.trim() ?? "";
   if (explicitKey) return { apiKey: explicitKey, source: options.explicitSource || "API key field" };
+
+  const commandAuth = options.providerId ? readCodexCommandAuth(options.configText, options.providerId) : null;
+  if (commandAuth) {
+    const source = `config.toml ${options.providerId}.auth.command`;
+    if (options.executeCredentialHelper === false) return { apiKey: "", source, configured: true };
+    return {
+      apiKey: await runProviderCredentialCommand(commandAuth),
+      source,
+    };
+  }
 
   const section = options.providerId ? readTomlSection(options.configText, modelProviderSection(options.providerId)) : "";
   const inline = readInlineCodexKey(section);
@@ -282,24 +315,15 @@ async function resolveCodexCredential(options: {
   const configuredEnvKey = options.envKey || readTomlString(section, "env_key") || "";
   const envKeys = [...new Set([configuredEnvKey, OFFICIAL_CODEX_AUTH_ENV_KEY, ...CODEX_FALLBACK_ENV_KEYS].filter(Boolean))];
   const policy = readTomlSection(options.configText, "[shell_environment_policy.set]");
-  for (const key of envKeys) {
-    const value = readTomlString(policy, key);
-    if (value) return { apiKey: value, source: `config.toml shell_environment_policy.set.${key}` };
-  }
-
   const authFile = readCodexAuthKeys(await readOptionalFile(path.join(options.codexHome, "auth.json")));
-  for (const key of envKeys) {
-    if (authFile[key]) return { apiKey: authFile[key], source: `auth.json ${key}` };
-  }
-
   const dotEnv = parseDotEnv(await readOptionalFile(path.join(options.codexHome, ".env")));
-  for (const key of envKeys) {
-    if (dotEnv[key]) return { apiKey: dotEnv[key], source: `.env ${key}` };
-  }
-
   for (const key of envKeys) {
     const value = process.env[key]?.trim();
     if (value) return { apiKey: value, source: `environment ${key}` };
+    const configured = readTomlString(policy, key);
+    if (configured) return { apiKey: configured, source: `config.toml shell_environment_policy.set.${key}` };
+    if (authFile[key]) return { apiKey: authFile[key], source: `auth.json ${key}` };
+    if (dotEnv[key]) return { apiKey: dotEnv[key], source: `.env ${key}` };
   }
 
   if (options.allowOtherProviders === false) return { apiKey: "", source: null };
@@ -315,7 +339,8 @@ async function borrowCodexCredentialFromOtherProviders(options: {
   codexHome: string;
   configText: string;
   providerId?: string;
-}): Promise<{ apiKey: string; source: string | null }> {
+  executeCredentialHelper?: boolean;
+}): Promise<ResolvedCodexCredential> {
   const activeProviderId = readTopLevelTomlString(options.configText, "model_provider") || "";
   const candidates = [
     ...(activeProviderId && activeProviderId !== options.providerId ? [activeProviderId] : []),
@@ -329,6 +354,7 @@ async function borrowCodexCredentialFromOtherProviders(options: {
       configText: options.configText,
       providerId: candidate,
       allowOtherProviders: false,
+      executeCredentialHelper: options.executeCredentialHelper,
     });
     if (credential.apiKey) return { apiKey: credential.apiKey, source: `${credential.source} (provider ${candidate})` };
   }
@@ -491,6 +517,8 @@ async function applyGeneratedCodexProvider(options: {
     configText: activeConfigText,
     providerId,
     explicitKey: apiConfig.customApiKey,
+    // Applying a route must never turn a short-lived helper token into a persisted API key.
+    executeCredentialHelper: false,
   });
   if (!credential.apiKey) throw new Error(`No API key was found for ${apiConfig.customProviderName}.`);
   const effectiveConfig = { ...apiConfig, customApiKey: credential.apiKey };
@@ -682,6 +710,24 @@ function modelProviderSection(providerId: string): string {
     : `[model_providers.${tomlString(providerId)}]`;
 }
 
+function readCodexCommandAuth(text: string, providerId: string): {
+  command: string;
+  args: string[];
+  timeoutMs?: number;
+  cwd?: string;
+} | null {
+  const parentSection = modelProviderSection(providerId);
+  const authSection = readTomlSection(text, `${parentSection.slice(0, -1)}.auth]`);
+  const command = readTomlString(authSection, "command");
+  if (!command) return null;
+  return {
+    command,
+    args: readTomlStringArray(authSection, "args") ?? [],
+    timeoutMs: readTomlNumber(authSection, "timeout_ms") ?? undefined,
+    cwd: readTomlString(authSection, "cwd") ?? undefined,
+  };
+}
+
 function replaceTopLevelString(text: string, key: string, value: string): string {
   const line = `${key} = ${tomlString(value)}`;
   const pattern = new RegExp(`^${escapeRegExp(key)}\\s*=.*$`, "m");
@@ -766,6 +812,23 @@ function readTomlString(text: string, key: string): string | null {
   const rawValue = text.match(pattern)?.[1];
   if (!rawValue) return null;
   return parseTomlString(rawValue);
+}
+
+function readTomlStringArray(text: string, key: string): string[] | null {
+  const pattern = new RegExp(`^\\s*${escapeRegExp(key)}\\s*=\\s*\\[([\\s\\S]*?)\\]`, "m");
+  const body = text.match(pattern)?.[1];
+  if (body === undefined) return null;
+  return splitTomlCommaList(body)
+    .map((item) => parseTomlString(item))
+    .filter((item): item is string => item !== null);
+}
+
+function readTomlNumber(text: string, key: string): number | null {
+  const pattern = new RegExp(`^\\s*${escapeRegExp(key)}\\s*=\\s*(\\d+)\\s*$`, "m");
+  const value = text.match(pattern)?.[1];
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
 }
 
 function readTomlInlineTable(text: string, key: string): Record<string, string> {

--- a/apps/main-2.0/src/core/provider-credential-helper.ts
+++ b/apps/main-2.0/src/core/provider-credential-helper.ts
@@ -14,8 +14,8 @@ export interface ProviderCredentialCommand {
 
 /**
  * Runs a provider-owned credential helper without stdin and keeps its output out of errors.
- * Credential commands are only invoked from explicit probe/apply actions, never while rendering
- * a config snapshot.
+ * Credential commands are only invoked from explicit connection probes, never while rendering
+ * a config snapshot or applying a route.
  */
 export function runProviderCredentialCommand(spec: ProviderCredentialCommand): Promise<string> {
   const command = spec.command.trim();

--- a/apps/main-2.0/src/core/provider-credential-helper.ts
+++ b/apps/main-2.0/src/core/provider-credential-helper.ts
@@ -1,0 +1,74 @@
+import { spawn } from "node:child_process";
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+const MAX_TIMEOUT_MS = 30_000;
+const MAX_OUTPUT_BYTES = 64 * 1024;
+
+export interface ProviderCredentialCommand {
+  command: string;
+  args?: string[];
+  timeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+  cwd?: string;
+}
+
+/**
+ * Runs a provider-owned credential helper without stdin and keeps its output out of errors.
+ * Credential commands are only invoked from explicit probe/apply actions, never while rendering
+ * a config snapshot.
+ */
+export function runProviderCredentialCommand(spec: ProviderCredentialCommand): Promise<string> {
+  const command = spec.command.trim();
+  if (!command) return Promise.reject(new Error("Credential helper command is empty."));
+  const timeoutMs = Math.min(MAX_TIMEOUT_MS, Math.max(1, spec.timeoutMs ?? DEFAULT_TIMEOUT_MS));
+
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let settled = false;
+    let timer: NodeJS.Timeout | undefined;
+    const child = spawn(command, spec.args ?? [], {
+      env: spec.env ?? process.env,
+      cwd: spec.cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+
+    const finish = (error?: Error, value?: string) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      if (error) reject(error);
+      else resolve(value ?? "");
+    };
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+      if (Buffer.byteLength(stdout, "utf8") <= MAX_OUTPUT_BYTES) return;
+      child.kill();
+      finish(new Error("Credential helper output exceeded the allowed size."));
+    });
+    // Drain stderr without retaining it: helper diagnostics can accidentally contain credentials.
+    child.stderr.resume();
+    child.once("error", () => finish(new Error("Credential helper could not be started.")));
+    child.once("close", (code, signal) => {
+      if (settled) return;
+      if (code !== 0) {
+        finish(new Error(signal ? "Credential helper was terminated." : "Credential helper failed."));
+        return;
+      }
+      const value = stdout.trim();
+      if (!value) {
+        finish(new Error("Credential helper returned an empty value."));
+        return;
+      }
+      finish(undefined, value);
+    });
+
+    timer = setTimeout(() => {
+      child.kill();
+      finish(new Error("Credential helper timed out."));
+    }, timeoutMs);
+    timer.unref();
+  });
+}

--- a/apps/main-2.0/src/core/session-summarizer.test.ts
+++ b/apps/main-2.0/src/core/session-summarizer.test.ts
@@ -363,6 +363,7 @@ describe("summarizeSession", () => {
         apiFormat: "codex_exec",
         command: fake.executable,
         cwd: path.dirname(fake.executable),
+        cliArgs: ["-c", 'model_provider="connection-test"'],
         onTemporarySession: (sessionKey) => temporarySessions.push(sessionKey),
       },
       requestSummaryCompletion,
@@ -374,7 +375,14 @@ describe("summarizeSession", () => {
       .map((line) => JSON.parse(line) as { args: string[]; input: string });
     expect(result.summary).toBe("Summarized with current Codex config.");
     expect(temporarySessions).toEqual(["codex:thread-summary-1"]);
-    expect(calls[0].args).toEqual(expect.arrayContaining(["exec", "--ephemeral", "--json", "--skip-git-repo-check"]));
+    expect(calls[0].args).toEqual(expect.arrayContaining([
+      "exec",
+      "--ephemeral",
+      "--json",
+      "--skip-git-repo-check",
+      "-c",
+      'model_provider="connection-test"',
+    ]));
     expect(calls[0].args).not.toContain(expect.stringContaining("summarize using official codex"));
     expect(calls[0].input).toContain("summarize using official codex");
     expect(calls[0].input.length).toBeGreaterThan(20_000);
@@ -412,6 +420,7 @@ describe("summarizeSession", () => {
         apiFormat: "claude_exec",
         command: fake.executable,
         cwd: path.dirname(fake.executable),
+        cliArgs: ["--settings", '{"env":{"ANTHROPIC_BASE_URL":""}}'],
         onTemporarySession: (sessionKey) => temporarySessions.push(sessionKey),
       },
       requestSummaryCompletion,
@@ -423,7 +432,13 @@ describe("summarizeSession", () => {
       .map((line) => JSON.parse(line) as { args: string[]; input: string });
     expect(result.summary).toBe("Summarized with current Claude Code settings.");
     expect(temporarySessions).toEqual(["claude:claude-summary-1"]);
-    expect(calls[0].args).toEqual(expect.arrayContaining(["--print", "--output-format", "stream-json"]));
+    expect(calls[0].args).toEqual(expect.arrayContaining([
+      "--print",
+      "--output-format",
+      "stream-json",
+      "--settings",
+      '{"env":{"ANTHROPIC_BASE_URL":""}}',
+    ]));
     expect(calls[0].args).not.toContain(expect.stringContaining("summarize using official claude"));
     expect(calls[0].input).toContain("summarize using official claude");
     expect(calls[0].input.length).toBeGreaterThan(20_000);

--- a/apps/main-2.0/src/core/session-summarizer.ts
+++ b/apps/main-2.0/src/core/session-summarizer.ts
@@ -21,6 +21,8 @@ export interface SummaryEndpoint {
   command?: string;
   cwd?: string;
   modelArg?: string;
+  /** Extra read-only CLI flags used to test a draft without writing user configuration. */
+  cliArgs?: string[];
   reasoningEffort?: string;
   /**
    * Extra environment for CLI-backed endpoints. This is how a summary source points `codex` /
@@ -448,6 +450,7 @@ async function codexExecCompletion(endpoint: SummaryEndpoint, messages: ChatMess
       ...(endpoint.reasoningEffort
         ? ["--config", `model_reasoning_effort=\"${endpoint.reasoningEffort}\"`]
         : []),
+      ...(endpoint.cliArgs ?? []),
     ], {
       cwd,
       signal: mergedSignal,
@@ -544,6 +547,7 @@ async function claudeExecCompletion(endpoint: SummaryEndpoint, messages: ChatMes
     "--permission-mode",
     "bypassPermissions",
     ...(endpoint.modelArg ? ["--model", endpoint.modelArg] : []),
+    ...(endpoint.cliArgs ?? []),
   ];
 
   return new Promise<string>((resolve, reject) => {

--- a/apps/main-2.0/src/main/ipc/providers.ts
+++ b/apps/main-2.0/src/main/ipc/providers.ts
@@ -11,6 +11,8 @@ import {
   type ClaudeModelProbeRequest,
   type CodexModelProbeRequest,
   type ConfigSnapshotRequest,
+  type ProviderConnectionRequest,
+  type ProviderConnectionResult,
   type ProviderKeyTarget,
   type SummaryProviderConnectionRequest,
   type SummaryProviderConnectionResult,
@@ -22,6 +24,7 @@ export interface ProvidersIpcService {
   getClaudeConfig(input: ConfigSnapshotRequest): Promise<ClaudeConfigSnapshot>;
   probeCodexModels(input: CodexModelProbeRequest): Promise<CodexModelProbeResult>;
   probeClaudeModels(input: ClaudeModelProbeRequest): Promise<ClaudeModelProbeResult>;
+  testProviderConnection(input: ProviderConnectionRequest): Promise<ProviderConnectionResult>;
   testSummaryProviderConnection(
     input: SummaryProviderConnectionRequest,
   ): Promise<SummaryProviderConnectionResult>;
@@ -47,6 +50,8 @@ export function registerProvidersIpc(
     registerIpcHandler(ipc, PROVIDERS_IPC.getClaudeConfig, (_event, input) => service.getClaudeConfig(input)),
     registerIpcHandler(ipc, PROVIDERS_IPC.probeCodexModels, (_event, input) => service.probeCodexModels(input)),
     registerIpcHandler(ipc, PROVIDERS_IPC.probeClaudeModels, (_event, input) => service.probeClaudeModels(input)),
+    registerIpcHandler(ipc, PROVIDERS_IPC.testProviderConnection, (_event, input) =>
+      service.testProviderConnection(input)),
     registerIpcHandler(ipc, PROVIDERS_IPC.pickConfigDirectory, (_event, target, defaultPath) => {
       if (!pickConfigDirectory) throw new Error("Config directory picker is unavailable.");
       return pickConfigDirectory(target, defaultPath);

--- a/apps/main-2.0/src/main/services/provider-service.test.ts
+++ b/apps/main-2.0/src/main/services/provider-service.test.ts
@@ -68,6 +68,14 @@ function createHarness(settings: AppSettings = cloneSettings()) {
       credentialSource: "config.toml deepseek.auth.command",
       verified: true as const,
     })),
+    applyClaudeApiConfig: vi.fn(async () => ({
+      profile: "custom",
+      claudeHome: "/tmp/claude",
+      settingsPath: "/tmp/claude/settings.json",
+      backupPaths: [],
+      credentialSource: "API key field",
+      verified: true as const,
+    })),
   };
   const service = new ProviderService({
     getSettings: () => settings,
@@ -176,11 +184,18 @@ describe("summary Claude route isolation", () => {
     const settings = cloneSettings();
     settings.claudeApiConfig = {
       ...settings.claudeApiConfig,
+      activeProvider: "custom",
       customProviderId: "claude-tab-provider",
       customConfigDir: "/tmp/claude-tab",
+      customBaseUrl: "https://claude.example",
     };
     settings.summaryClaudeConfigDir = "/tmp/summary-claude";
-    settings.summaryApiConfig = { ...settings.summaryApiConfig, customProviderId: "summary-provider" };
+    settings.summaryApiConfig = {
+      ...settings.summaryApiConfig,
+      activeProvider: "custom",
+      customProviderId: "summary-provider",
+      customBaseUrl: "https://summary.example",
+    };
     const harness = createHarness(settings);
     harness.keys.set("claude:claude-tab-provider", "claude-tab-key");
     harness.keys.set("summary:summary-provider", "summary-key");
@@ -206,8 +221,10 @@ describe("summary Claude route isolation", () => {
     const settings = cloneSettings();
     settings.claudeApiConfig = {
       ...settings.claudeApiConfig,
+      activeProvider: "custom",
       customProviderId: "claude-tab-provider",
       customConfigDir: "/tmp/claude-tab",
+      customBaseUrl: "https://claude.example",
     };
     settings.summaryClaudeConfigDir = "/tmp/summary-claude";
     const harness = createHarness(settings);
@@ -262,6 +279,71 @@ describe("summary Claude route isolation", () => {
 
     expect(harness.operations.probeCodexModels).toHaveBeenCalledWith(expect.objectContaining({
       codexHome: "/tmp/summary-codex",
+    }));
+  });
+});
+
+describe("provider model probe credential routes", () => {
+  it("uses stored Codex and Claude keys only for exact routes", async () => {
+    const settings = cloneSettings();
+    settings.apiConfig = {
+      ...settings.apiConfig,
+      activeProvider: "custom",
+      customProviderId: "gateway",
+      customBaseUrl: "https://api.example/v1",
+    };
+    settings.claudeApiConfig = {
+      ...settings.claudeApiConfig,
+      activeProvider: "custom",
+      customProviderId: "gateway",
+      customBaseUrl: "https://api.example/anthropic",
+    };
+    const harness = createHarness(settings);
+    harness.keys.set("codex:gateway", "codex-key");
+    harness.keys.set("claude:gateway", "claude-key");
+
+    await harness.service.probeCodexModels({
+      baseUrl: "https://other.example/v1",
+      apiKey: "",
+      providerId: "gateway",
+    });
+    await harness.service.probeClaudeModels({
+      baseUrl: "https://other.example/anthropic",
+      apiKey: "",
+      providerId: "gateway",
+      apiFormat: "anthropic",
+      apiKeyField: "ANTHROPIC_AUTH_TOKEN",
+    });
+    await harness.service.probeCodexModels({
+      baseUrl: "https://other.example/v1",
+      apiKey: "explicit-codex",
+      providerId: "gateway",
+    });
+    await harness.service.probeClaudeModels({
+      baseUrl: "https://other.example/anthropic",
+      apiKey: "explicit-claude",
+      providerId: "gateway",
+      apiFormat: "anthropic",
+      apiKeyField: "ANTHROPIC_AUTH_TOKEN",
+    });
+
+    expect(harness.operations.probeCodexModels).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      apiKey: "",
+      providerId: "gateway",
+      apiKeySource: undefined,
+    }));
+    expect(harness.operations.probeClaudeModels).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      apiKey: "",
+      providerId: "gateway",
+      apiKeySource: undefined,
+    }));
+    expect(harness.operations.probeCodexModels).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      apiKey: "explicit-codex",
+      apiKeySource: "API key field",
+    }));
+    expect(harness.operations.probeClaudeModels).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      apiKey: "explicit-claude",
+      apiKeySource: "API key field",
     }));
   });
 });
@@ -725,10 +807,55 @@ describe("ProviderService Codex profile", () => {
     expect(harness.operations.resolveCodexProviderCredential).toHaveBeenCalledWith({
       codexHome: undefined,
       providerId: "deepseek",
+      baseUrl: "https://api.deepseek.com",
       preferConfiguredHelper: true,
     });
     expect(harness.operations.applyCodexApiConfig).toHaveBeenCalledWith({
       apiConfig: expect.objectContaining({ customApiKey: "" }),
+    });
+  });
+
+  it("does not inject stored keys into changed Codex or Claude routes", async () => {
+    const settings = cloneSettings();
+    settings.apiConfig = {
+      ...settings.apiConfig,
+      activeProvider: "custom",
+      customProviderId: "custom",
+      customBaseUrl: "https://old.example/v1",
+      customApiKey: "",
+      customApiFormat: "openai_responses",
+    };
+    settings.claudeApiConfig = {
+      ...settings.claudeApiConfig,
+      activeProvider: "custom",
+      customProviderId: "custom",
+      customBaseUrl: "https://old.example/anthropic",
+      customApiKey: "",
+    };
+    const harness = createHarness(settings);
+    harness.keys.set("codex:custom", "old-codex-key");
+    harness.keys.set("claude:custom", "old-claude-key");
+
+    await harness.service.applyCodexProfile({
+      ...settings.apiConfig,
+      customBaseUrl: "https://new.example/v1",
+    });
+    await harness.service.applyClaudeProfile({
+      ...settings.claudeApiConfig,
+      customBaseUrl: "https://new.example/anthropic",
+    });
+
+    expect(harness.operations.applyCodexApiConfig).toHaveBeenCalledWith({
+      apiConfig: expect.objectContaining({
+        customBaseUrl: "https://new.example/v1",
+        customApiKey: "",
+      }),
+    });
+    expect(harness.operations.applyClaudeApiConfig).toHaveBeenCalledWith({
+      apiConfig: expect.objectContaining({
+        customBaseUrl: "https://new.example/anthropic",
+        customApiKey: "",
+      }),
     });
   });
 });
@@ -766,6 +893,12 @@ describe("summary connection test credentials", () => {
     const settings = cloneSettings();
     settings.summaryClaudeConfigDir = "/tmp/summary-claude";
     settings.claudeApiConfig = { ...settings.claudeApiConfig, customConfigDir: "/tmp/claude-tab" };
+    settings.summaryApiConfig = {
+      ...settings.summaryApiConfig,
+      activeProvider: "custom",
+      customProviderId: "claude-provider",
+      customBaseUrl: "https://summary.example/v1",
+    };
     const harness = createHarness(settings);
     harness.keys.set("summary:claude-provider", "summary-key");
     vi.mocked(harness.operations.resolveClaudeProviderCredential!).mockResolvedValue({
@@ -792,7 +925,13 @@ describe("summary connection test credentials", () => {
 
   it("borrows the Codex tab's credential only when the custom source inherits", async () => {
     const settings = cloneSettings();
-    settings.apiConfig = { ...settings.apiConfig, customConfigDir: "/tmp/codex-tab" };
+    settings.apiConfig = {
+      ...settings.apiConfig,
+      activeProvider: "custom",
+      customProviderId: "shared-provider",
+      customBaseUrl: "https://summary.example/v1",
+      customConfigDir: "/tmp/codex-tab",
+    };
     const harness = createHarness(settings);
     harness.keys.set("codex:shared-provider", "codex-tab-key");
     harness.keys.set("summary:shared-provider", "summary-key");
@@ -818,7 +957,14 @@ describe("summary connection test credentials", () => {
   });
 
   it("uses the summary key slot for a custom source that does not inherit", async () => {
-    const harness = createHarness();
+    const settings = cloneSettings();
+    settings.summaryApiConfig = {
+      ...settings.summaryApiConfig,
+      activeProvider: "custom",
+      customProviderId: "shared-provider",
+      customBaseUrl: "https://summary.example/v1",
+    };
+    const harness = createHarness(settings);
     harness.keys.set("codex:shared-provider", "codex-tab-key");
     harness.keys.set("summary:shared-provider", "summary-key");
 
@@ -841,8 +987,37 @@ describe("summary connection test credentials", () => {
     );
   });
 
+  it("does not reuse a summary key after the Base URL changes", async () => {
+    const settings = cloneSettings();
+    settings.summaryApiConfig = {
+      ...settings.summaryApiConfig,
+      activeProvider: "custom",
+      customProviderId: "custom",
+      customBaseUrl: "https://old.example/v1",
+    };
+    const harness = createHarness(settings);
+    harness.keys.set("summary:custom", "old-route-key");
+
+    await expect(harness.service.testSummaryProviderConnection({
+      source: "custom",
+      baseUrl: "https://new.example/v1",
+      apiKey: "",
+      model: "summary-model",
+      providerId: "custom",
+      apiFormat: "openai_chat",
+    })).rejects.toThrow(/API key is required/);
+    expect(harness.operations.requestSummaryCompletion).not.toHaveBeenCalled();
+  });
+
   it("refuses the Gemini native format instead of testing a different one", async () => {
-    const harness = createHarness();
+    const settings = cloneSettings();
+    settings.summaryApiConfig = {
+      ...settings.summaryApiConfig,
+      activeProvider: "custom",
+      customProviderId: "gemini-provider",
+      customBaseUrl: "https://summary.example/v1",
+    };
+    const harness = createHarness(settings);
     harness.keys.set("summary:gemini-provider", "summary-key");
     vi.mocked(harness.operations.resolveClaudeProviderCredential!).mockResolvedValue({
       apiKey: "summary-key",

--- a/apps/main-2.0/src/main/services/provider-service.test.ts
+++ b/apps/main-2.0/src/main/services/provider-service.test.ts
@@ -327,8 +327,8 @@ describe("Provider connection tests", () => {
           OPENAI_API_KEY: "stored-key",
         },
         cliArgs: expect.arrayContaining([
-          "model_provider=\"gateway\"",
-          "model_providers.gateway.base_url=\"https://gateway.example/v1\"",
+          "model_provider=\"agent-recall-connection-test\"",
+          "model_providers.agent-recall-connection-test.base_url=\"https://gateway.example/v1\"",
         ]),
       }),
       expect.anything(),

--- a/apps/main-2.0/src/main/services/provider-service.test.ts
+++ b/apps/main-2.0/src/main/services/provider-service.test.ts
@@ -13,6 +13,25 @@ function createHarness(settings: AppSettings = cloneSettings()) {
     providerConfigDirectoryExists: vi.fn(async () => true),
     loadCodexProfileDefaults: vi.fn(async () => ({})),
     loadClaudeApiConfigDefaults: vi.fn(async () => ({})),
+    loadCodexConfigSnapshot: vi.fn(async () => ({
+      codexHome: "/tmp/codex",
+      configPath: "/tmp/codex/config.toml",
+      exists: false,
+      activeProviderId: "openai",
+      activeModel: "",
+      activeProvider: null,
+      providers: [],
+      credentialSource: null,
+      hasApiKey: false,
+    })),
+    loadClaudeConfigSnapshot: vi.fn(async () => ({
+      claudeHome: "/tmp/claude",
+      settingsPath: "/tmp/claude/settings.json",
+      exists: false,
+      route: {},
+      credentialSource: null,
+      hasApiKey: false,
+    })),
     probeCodexModels: vi.fn(async () => ({
       models: ["codex-model-a"],
       endpoint: "https://api.example/v1/models",
@@ -225,6 +244,204 @@ describe("summary Claude route isolation", () => {
     expect(harness.operations.probeCodexModels).toHaveBeenCalledWith(expect.objectContaining({
       codexHome: "/tmp/summary-codex",
     }));
+  });
+});
+
+describe("Provider connection tests", () => {
+  it("uses each official CLI without requiring AgentRecall to read an API key", async () => {
+    const settings = cloneSettings();
+    settings.codexBinary = "custom-codex";
+    settings.claudeBinary = "custom-claude";
+    const harness = createHarness(settings);
+
+    const codex = await harness.service.testProviderConnection({
+      target: "codex",
+      apiConfig: { activeProvider: "official", customConfigDir: "/tmp/provider-codex" },
+    });
+    const claude = await harness.service.testProviderConnection({
+      target: "claude",
+      apiConfig: { activeProvider: "official", customConfigDir: "/tmp/provider-claude" },
+    });
+
+    expect(harness.operations.resolveCodexProviderCredential).not.toHaveBeenCalled();
+    expect(harness.operations.resolveClaudeProviderCredential).not.toHaveBeenCalled();
+    expect(harness.operations.requestSummaryCompletion).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        apiFormat: "codex_exec",
+        command: "custom-codex",
+        env: { CODEX_HOME: "/tmp/provider-codex" },
+        cliArgs: ["--ignore-user-config"],
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(harness.operations.requestSummaryCompletion).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        apiFormat: "claude_exec",
+        command: "custom-claude",
+        env: expect.objectContaining({ CLAUDE_CONFIG_DIR: "/tmp/provider-claude", ANTHROPIC_BASE_URL: "" }),
+        cliArgs: expect.arrayContaining(["--settings"]),
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(codex.credentialSource).toBe("Codex CLI authentication");
+    expect(claude.credentialSource).toBe("Claude Code CLI authentication");
+  });
+
+  it("tests an unsaved Codex route with read-only CLI overrides and a stored key", async () => {
+    const harness = createHarness();
+    harness.keys.set("codex:gateway", "stored-key");
+    vi.mocked(harness.operations.resolveCodexProviderCredential!).mockResolvedValue({
+      apiKey: "stored-key",
+      source: "AgentRecall codex key store",
+    });
+
+    const result = await harness.service.testProviderConnection({
+      target: "codex",
+      apiConfig: {
+        activeProvider: "custom",
+        customProviderId: "gateway",
+        customConfigDir: "/tmp/provider-codex",
+        customProviderName: "Gateway",
+        customBaseUrl: "https://gateway.example/v1/",
+        customApiKey: "",
+        customModel: "gpt-test",
+        customApiFormat: "openai_responses",
+      },
+    });
+
+    expect(harness.operations.resolveCodexProviderCredential).toHaveBeenCalledWith(expect.objectContaining({
+      apiKey: "stored-key",
+      apiKeySource: "AgentRecall codex key store",
+      codexHome: "/tmp/provider-codex",
+    }));
+    expect(harness.operations.requestSummaryCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiFormat: "codex_exec",
+        modelArg: "gpt-test",
+        env: {
+          CODEX_HOME: "/tmp/provider-codex",
+          OPENAI_API_KEY: "stored-key",
+        },
+        cliArgs: expect.arrayContaining([
+          "model_provider=\"gateway\"",
+          "model_providers.gateway.base_url=\"https://gateway.example/v1\"",
+        ]),
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(result.credentialSource).toBe("AgentRecall codex key store");
+  });
+
+  it("preserves an existing Codex provider's CLI-managed authentication", async () => {
+    const harness = createHarness();
+    vi.mocked(harness.operations.loadCodexConfigSnapshot!).mockResolvedValue({
+      codexHome: "/tmp/provider-codex",
+      configPath: "/tmp/provider-codex/config.toml",
+      exists: true,
+      activeProviderId: "gateway",
+      activeModel: "gpt-test",
+      activeProvider: null,
+      providers: [{
+        id: "gateway",
+        name: "Gateway",
+        baseUrl: "https://gateway.example/v1",
+        wireApi: "responses",
+        envKey: "",
+        requiresOpenaiAuth: false,
+        hasApiKey: true,
+        credentialSource: "config.toml gateway.auth",
+      }],
+      credentialSource: "config.toml gateway.auth",
+      hasApiKey: true,
+    });
+
+    const result = await harness.service.testProviderConnection({
+      target: "codex",
+      apiConfig: {
+        activeProvider: "custom",
+        customProviderId: "gateway",
+        customConfigDir: "/tmp/provider-codex",
+        customProviderName: "Gateway",
+        customBaseUrl: "https://gateway.example/v1",
+        customApiKey: "",
+        customModel: "gpt-test",
+        customApiFormat: "openai_responses",
+      },
+    });
+
+    expect(harness.operations.requestSummaryCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: { CODEX_HOME: "/tmp/provider-codex" },
+        cliArgs: ["-c", 'model_provider="gateway"'],
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(result.credentialSource).toBe("config.toml gateway.auth");
+  });
+
+  it("does not send official CLI authentication to a new third-party route", async () => {
+    const harness = createHarness();
+
+    await expect(harness.service.testProviderConnection({
+      target: "codex",
+      apiConfig: {
+        activeProvider: "custom",
+        customProviderId: "unwritten",
+        customProviderName: "Unwritten",
+        customBaseUrl: "https://unwritten.example/v1",
+        customApiKey: "",
+        customModel: "gpt-test",
+        customApiFormat: "openai_responses",
+      },
+    })).rejects.toThrow(/Write this route to Codex config/);
+    expect(harness.operations.requestSummaryCompletion).not.toHaveBeenCalled();
+  });
+
+  it("lets Claude Code resolve credentials that are not readable from its settings file", async () => {
+    const harness = createHarness();
+    vi.mocked(harness.operations.loadClaudeConfigSnapshot!).mockResolvedValue({
+      claudeHome: "/tmp/provider-claude",
+      settingsPath: "/tmp/provider-claude/settings.json",
+      exists: true,
+      route: {
+        activeProvider: "custom",
+        customBaseUrl: "https://gateway.example/anthropic",
+      },
+      credentialSource: "settings.json apiKeyHelper",
+      hasApiKey: true,
+    });
+
+    const result = await harness.service.testProviderConnection({
+      target: "claude",
+      apiConfig: {
+        activeProvider: "custom",
+        customProviderId: "gateway",
+        customConfigDir: "/tmp/provider-claude",
+        customProviderName: "Gateway",
+        customBaseUrl: "https://gateway.example/anthropic/",
+        customApiKey: "",
+        customModel: "claude-test",
+        customApiFormat: "anthropic",
+        customApiKeyField: "ANTHROPIC_AUTH_TOKEN",
+      },
+    });
+
+    expect(harness.operations.requestSummaryCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiFormat: "claude_exec",
+        modelArg: "claude-test",
+        env: { CLAUDE_CONFIG_DIR: "/tmp/provider-claude" },
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(result.credentialSource).toBe("settings.json apiKeyHelper");
   });
 });
 

--- a/apps/main-2.0/src/main/services/provider-service.test.ts
+++ b/apps/main-2.0/src/main/services/provider-service.test.ts
@@ -9,6 +9,9 @@ function cloneSettings(): AppSettings {
 
 function createHarness(settings: AppSettings = cloneSettings()) {
   const keys = new Map<string, string>();
+  const getKey = vi.fn(async (target: "codex" | "claude", providerId: string) => (
+    keys.get(`${target}:${providerId}`) ?? ""
+  ));
   const savedSettings = new Map<string, unknown>();
   const operations: Partial<ProviderServiceOperations> = {
     providerConfigDirectoryExists: vi.fn(async () => true),
@@ -58,7 +61,7 @@ function createHarness(settings: AppSettings = cloneSettings()) {
   const service = new ProviderService({
     getSettings: () => settings,
     keys: {
-      get: async (target, providerId) => keys.get(`${target}:${providerId}`) ?? "",
+      get: getKey,
       set: async (target, providerId, apiKey) => {
         keys.set(`${target}:${providerId}`, apiKey);
       },
@@ -73,7 +76,7 @@ function createHarness(settings: AppSettings = cloneSettings()) {
     logError: vi.fn(),
     operations,
   });
-  return { service, settings, keys, savedSettings, operations };
+  return { service, settings, keys, getKey, savedSettings, operations };
 }
 
 describe("ProviderService local config directories", () => {
@@ -113,6 +116,8 @@ describe("ProviderService local config directories", () => {
       customModel: "saved-claude-model",
     };
     const harness = createHarness(settings);
+    harness.keys.set("codex:custom", "stale-codex-key");
+    harness.keys.set("claude:custom", "stale-claude-key");
     for (const [path, value] of [
       ["apiConfig.customProviderName", settings.apiConfig.customProviderName],
       ["apiConfig.customBaseUrl", settings.apiConfig.customBaseUrl],
@@ -143,11 +148,13 @@ describe("ProviderService local config directories", () => {
     expect(hydrated.apiConfig).toMatchObject({
       customProviderName: "Local Codex",
       customBaseUrl: "https://local.example/v1",
+      customApiKey: "",
       customModel: "local-codex-model",
     });
     expect(hydrated.claudeApiConfig).toMatchObject({
       customProviderName: "Local Claude",
       customBaseUrl: "https://local.example/anthropic",
+      customApiKey: "",
       customModel: "local-claude-model",
     });
   });
@@ -341,9 +348,9 @@ describe("Provider connection tests", () => {
     await expect(access(testCwd)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("tests an unsaved Codex route with read-only CLI overrides and a stored key", async () => {
+  it("tests an unsaved Codex route only with the explicitly authorized draft key", async () => {
     const harness = createHarness();
-    harness.keys.set("codex:gateway", "stored-key");
+    harness.keys.set("codex:gateway", "stored-key-must-not-be-used");
 
     const result = await harness.service.testProviderConnection({
       target: "codex",
@@ -353,7 +360,7 @@ describe("Provider connection tests", () => {
         customConfigDir: "/tmp/provider-codex",
         customProviderName: "Gateway",
         customBaseUrl: "https://gateway.example/v1/",
-        customApiKey: "",
+        customApiKey: "typed-key",
         customModel: "gpt-test",
         customApiFormat: "openai_responses",
       },
@@ -366,7 +373,7 @@ describe("Provider connection tests", () => {
       modelArg: "gpt-test",
       env: {
         CODEX_HOME: endpoint.cwd,
-        OPENAI_API_KEY: "stored-key",
+        OPENAI_API_KEY: "typed-key",
       },
       cliArgs: expect.arrayContaining([
         "--ignore-user-config",
@@ -378,12 +385,92 @@ describe("Provider connection tests", () => {
         "model_providers.agent-recall-connection-test.env_key=\"OPENAI_API_KEY\"",
       ]),
     }));
-    expect(endpoint.cliArgs?.join(" ")).not.toContain("stored-key");
-    expect(result.credentialSource).toBe("AgentRecall codex key store");
+    expect(endpoint.cliArgs?.join(" ")).not.toContain("typed-key");
+    expect(harness.getKey).not.toHaveBeenCalled();
+    expect(result.credentialSource).toBe("API key field");
+  });
+
+  it("does not authorize stored keys when the connection-test draft key is empty", async () => {
+    const harness = createHarness();
+    harness.keys.set("codex:gateway", "stored-codex-key");
+    harness.keys.set("claude:gateway", "stored-claude-key");
+
+    await expect(harness.service.testProviderConnection({
+      target: "codex",
+      apiConfig: {
+        activeProvider: "custom",
+        customProviderId: "gateway",
+        customProviderName: "Gateway",
+        customBaseUrl: "https://gateway.example/v1",
+        customApiKey: "",
+        customModel: "gpt-test",
+        customApiFormat: "openai_responses",
+      },
+    })).rejects.toThrow(/Write this route to Codex config/);
+    await expect(harness.service.testProviderConnection({
+      target: "claude",
+      apiConfig: {
+        activeProvider: "custom",
+        customProviderId: "gateway",
+        customProviderName: "Gateway",
+        customBaseUrl: "https://gateway.example/anthropic",
+        customApiKey: "",
+        customModel: "claude-test",
+        customApiFormat: "anthropic",
+        customApiKeyField: "ANTHROPIC_AUTH_TOKEN",
+      },
+    })).rejects.toThrow(/Write this route to Claude Code settings/);
+
+    expect(harness.getKey).not.toHaveBeenCalled();
+    expect(harness.operations.requestSummaryCompletion).not.toHaveBeenCalled();
+  });
+
+  it("requires a readable draft key for the local Codex Chat proxy even when the disk route matches", async () => {
+    const harness = createHarness();
+    harness.keys.set("codex:gateway", "stored-key-must-not-be-used");
+    vi.mocked(harness.operations.loadCodexConfigSnapshot!).mockResolvedValue({
+      codexHome: "/tmp/provider-codex",
+      configPath: "/tmp/provider-codex/config.toml",
+      exists: true,
+      activeProviderId: "gateway",
+      activeModel: "gpt-test",
+      activeProvider: null,
+      providers: [{
+        id: "gateway",
+        name: "Gateway",
+        baseUrl: "https://gateway.example/v1",
+        wireApi: "chat",
+        envKey: "",
+        requiresOpenaiAuth: false,
+        hasApiKey: true,
+        credentialSource: "config.toml gateway.auth",
+      }],
+      credentialSource: "config.toml gateway.auth",
+      hasApiKey: true,
+    });
+
+    await expect(harness.service.testProviderConnection({
+      target: "codex",
+      apiConfig: {
+        activeProvider: "custom",
+        customProviderId: "gateway",
+        customConfigDir: "/tmp/provider-codex",
+        customProviderName: "Gateway",
+        customBaseUrl: "https://gateway.example/v1",
+        customApiKey: "",
+        customModel: "gpt-test",
+        customApiFormat: "openai_chat",
+      },
+    })).rejects.toThrow(/uses the local Codex Chat proxy, but no API key was readable/);
+
+    expect(harness.getKey).not.toHaveBeenCalled();
+    expect(harness.operations.loadCodexConfigSnapshot).not.toHaveBeenCalled();
+    expect(harness.operations.requestSummaryCompletion).not.toHaveBeenCalled();
   });
 
   it("preserves an existing Codex provider's CLI-managed authentication", async () => {
     const harness = createHarness();
+    harness.keys.set("codex:gateway", "stored-key-must-not-be-used");
     vi.mocked(harness.operations.loadCodexConfigSnapshot!).mockResolvedValue({
       codexHome: "/tmp/provider-codex",
       configPath: "/tmp/provider-codex/config.toml",
@@ -441,6 +528,7 @@ describe("Provider connection tests", () => {
     );
     const endpoint = vi.mocked(harness.operations.requestSummaryCompletion!).mock.calls[0][0];
     expect(endpoint.cliArgs).not.toContain("--ignore-user-config");
+    expect(harness.getKey).not.toHaveBeenCalled();
     expect(harness.operations.resolveCodexProviderCredential).not.toHaveBeenCalled();
     expect(result.credentialSource).toBe("config.toml gateway.auth");
   });
@@ -468,8 +556,9 @@ describe("Provider connection tests", () => {
     expect(harness.operations.requestSummaryCompletion).not.toHaveBeenCalled();
   });
 
-  it("lets Claude Code resolve credentials that are not readable from its settings file", async () => {
+  it("lets an exact Claude disk route resolve credentials that are not readable from its settings file", async () => {
     const harness = createHarness();
+    harness.keys.set("claude:gateway", "stored-key-must-not-be-used");
     vi.mocked(harness.operations.loadClaudeConfigSnapshot!).mockResolvedValue({
       claudeHome: "/tmp/provider-claude",
       settingsPath: "/tmp/provider-claude/settings.json",
@@ -507,13 +596,14 @@ describe("Provider connection tests", () => {
       expect.anything(),
       expect.anything(),
     );
+    expect(harness.getKey).not.toHaveBeenCalled();
     expect(harness.operations.resolveClaudeProviderCredential).not.toHaveBeenCalled();
     expect(result.credentialSource).toBe("settings.json apiKeyHelper");
   });
 
-  it("isolates a stored Claude key from user settings, helpers, OAuth, and process arguments", async () => {
+  it("isolates an explicitly authorized Claude draft key from user settings, helpers, OAuth, and arguments", async () => {
     const harness = createHarness();
-    harness.keys.set("claude:gateway", "stored-key");
+    harness.keys.set("claude:gateway", "stored-key-must-not-be-used");
 
     const result = await harness.service.testProviderConnection({
       target: "claude",
@@ -523,7 +613,7 @@ describe("Provider connection tests", () => {
         customConfigDir: "/tmp/provider-claude",
         customProviderName: "Gateway",
         customBaseUrl: "https://gateway.example/anthropic/",
-        customApiKey: "",
+        customApiKey: "typed-key",
         customModel: "claude-test",
         customApiFormat: "anthropic",
         customApiKeyField: "ANTHROPIC_AUTH_TOKEN",
@@ -534,14 +624,15 @@ describe("Provider connection tests", () => {
     expect(endpoint.env).toEqual({
       CLAUDE_CONFIG_DIR: endpoint.cwd,
       ANTHROPIC_BASE_URL: "https://gateway.example/anthropic",
-      ANTHROPIC_AUTH_TOKEN: "stored-key",
+      ANTHROPIC_AUTH_TOKEN: "typed-key",
       ANTHROPIC_API_KEY: "",
       CLAUDE_CODE_OAUTH_TOKEN: "",
     });
     expect(endpoint.cliArgs).toEqual(["--safe-mode", "--tools", "", "--no-session-persistence"]);
-    expect(endpoint.cliArgs?.join(" ")).not.toContain("stored-key");
+    expect(endpoint.cliArgs?.join(" ")).not.toContain("typed-key");
+    expect(harness.getKey).not.toHaveBeenCalled();
     expect(harness.operations.resolveClaudeProviderCredential).not.toHaveBeenCalled();
-    expect(result.credentialSource).toBe("AgentRecall claude key store");
+    expect(result.credentialSource).toBe("API key field");
   });
 
   it("does not treat an OAuth-only Claude login as a third-party API key", async () => {

--- a/apps/main-2.0/src/main/services/provider-service.test.ts
+++ b/apps/main-2.0/src/main/services/provider-service.test.ts
@@ -1,3 +1,4 @@
+import { access, readdir } from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
 import { defaultSettings, type AppSettings } from "../../core/platform";
 import { ProviderService, type ProviderServiceOperations } from "./provider-service";
@@ -248,11 +249,18 @@ describe("summary Claude route isolation", () => {
 });
 
 describe("Provider connection tests", () => {
-  it("uses each official CLI without requiring AgentRecall to read an API key", async () => {
+  it("uses each official CLI in an empty, tool-free probe without reading an API key", async () => {
     const settings = cloneSettings();
     settings.codexBinary = "custom-codex";
     settings.claudeBinary = "custom-claude";
     const harness = createHarness(settings);
+    const testCwds: string[] = [];
+    vi.mocked(harness.operations.requestSummaryCompletion!).mockImplementation(async (endpoint) => {
+      expect(endpoint.cwd).toContain("agent-recall-provider-test-");
+      expect(await readdir(endpoint.cwd!)).toEqual([]);
+      testCwds.push(endpoint.cwd!);
+      return "OK";
+    });
 
     const codex = await harness.service.testProviderConnection({
       target: "codex",
@@ -271,7 +279,19 @@ describe("Provider connection tests", () => {
         apiFormat: "codex_exec",
         command: "custom-codex",
         env: { CODEX_HOME: "/tmp/provider-codex" },
-        cliArgs: ["--ignore-user-config"],
+        cliArgs: expect.arrayContaining([
+          "--ignore-user-config",
+          "features.shell_tool=false",
+          "features.unified_exec=false",
+          "features.apps=false",
+          "features.remote_plugin=false",
+          "features.multi_agent=false",
+          "features.hooks=false",
+          'web_search="disabled"',
+          "tools.view_image=false",
+          "mcp_servers={}",
+          "project_doc_max_bytes=0",
+        ]),
       }),
       expect.anything(),
       expect.anything(),
@@ -282,22 +302,48 @@ describe("Provider connection tests", () => {
         apiFormat: "claude_exec",
         command: "custom-claude",
         env: expect.objectContaining({ CLAUDE_CONFIG_DIR: "/tmp/provider-claude", ANTHROPIC_BASE_URL: "" }),
-        cliArgs: expect.arrayContaining(["--settings"]),
+        cliArgs: expect.arrayContaining(["--safe-mode", "--tools", "", "--no-session-persistence", "--settings"]),
       }),
       expect.anything(),
       expect.anything(),
     );
     expect(codex.credentialSource).toBe("Codex CLI authentication");
     expect(claude.credentialSource).toBe("Claude Code CLI authentication");
+    const claudeEndpoint = vi.mocked(harness.operations.requestSummaryCompletion!).mock.calls[1]?.[0];
+    expect(claudeEndpoint?.cliArgs?.slice(0, 4)).toEqual([
+      "--safe-mode",
+      "--tools",
+      "",
+      "--no-session-persistence",
+    ]);
+    const settingsIndex = claudeEndpoint?.cliArgs?.indexOf("--settings") ?? -1;
+    const settingsOverride = JSON.parse(claudeEndpoint?.cliArgs?.[settingsIndex + 1] ?? "{}") as Record<string, unknown>;
+    expect(settingsOverride).not.toHaveProperty("apiKeyHelper");
+    for (const testCwd of testCwds) {
+      await expect(access(testCwd)).rejects.toMatchObject({ code: "ENOENT" });
+    }
+  });
+
+  it("removes the isolated probe directory when a CLI request fails", async () => {
+    const harness = createHarness();
+    let testCwd = "";
+    vi.mocked(harness.operations.requestSummaryCompletion!).mockImplementation(async (endpoint) => {
+      testCwd = endpoint.cwd!;
+      throw new Error("probe failed");
+    });
+
+    await expect(harness.service.testProviderConnection({
+      target: "codex",
+      apiConfig: { activeProvider: "official" },
+    })).rejects.toThrow("probe failed");
+
+    expect(testCwd).toContain("agent-recall-provider-test-");
+    await expect(access(testCwd)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("tests an unsaved Codex route with read-only CLI overrides and a stored key", async () => {
     const harness = createHarness();
     harness.keys.set("codex:gateway", "stored-key");
-    vi.mocked(harness.operations.resolveCodexProviderCredential!).mockResolvedValue({
-      apiKey: "stored-key",
-      source: "AgentRecall codex key store",
-    });
 
     const result = await harness.service.testProviderConnection({
       target: "codex",
@@ -313,27 +359,26 @@ describe("Provider connection tests", () => {
       },
     });
 
-    expect(harness.operations.resolveCodexProviderCredential).toHaveBeenCalledWith(expect.objectContaining({
-      apiKey: "stored-key",
-      apiKeySource: "AgentRecall codex key store",
-      codexHome: "/tmp/provider-codex",
+    expect(harness.operations.resolveCodexProviderCredential).not.toHaveBeenCalled();
+    const endpoint = vi.mocked(harness.operations.requestSummaryCompletion!).mock.calls[0][0];
+    expect(endpoint).toEqual(expect.objectContaining({
+      apiFormat: "codex_exec",
+      modelArg: "gpt-test",
+      env: {
+        CODEX_HOME: endpoint.cwd,
+        OPENAI_API_KEY: "stored-key",
+      },
+      cliArgs: expect.arrayContaining([
+        "--ignore-user-config",
+        "features.shell_tool=false",
+        "features.unified_exec=false",
+        "model_provider=\"agent-recall-connection-test\"",
+        "model_providers.agent-recall-connection-test.base_url=\"https://gateway.example/v1\"",
+        "model_providers.agent-recall-connection-test.requires_openai_auth=false",
+        "model_providers.agent-recall-connection-test.env_key=\"OPENAI_API_KEY\"",
+      ]),
     }));
-    expect(harness.operations.requestSummaryCompletion).toHaveBeenCalledWith(
-      expect.objectContaining({
-        apiFormat: "codex_exec",
-        modelArg: "gpt-test",
-        env: {
-          CODEX_HOME: "/tmp/provider-codex",
-          OPENAI_API_KEY: "stored-key",
-        },
-        cliArgs: expect.arrayContaining([
-          "model_provider=\"agent-recall-connection-test\"",
-          "model_providers.agent-recall-connection-test.base_url=\"https://gateway.example/v1\"",
-        ]),
-      }),
-      expect.anything(),
-      expect.anything(),
-    );
+    expect(endpoint.cliArgs?.join(" ")).not.toContain("stored-key");
     expect(result.credentialSource).toBe("AgentRecall codex key store");
   });
 
@@ -377,16 +422,35 @@ describe("Provider connection tests", () => {
     expect(harness.operations.requestSummaryCompletion).toHaveBeenCalledWith(
       expect.objectContaining({
         env: { CODEX_HOME: "/tmp/provider-codex" },
-        cliArgs: ["-c", 'model_provider="gateway"'],
+        cliArgs: expect.arrayContaining([
+          "features.shell_tool=false",
+          "features.unified_exec=false",
+          "features.apps=false",
+          "features.remote_plugin=false",
+          "features.multi_agent=false",
+          "features.hooks=false",
+          'web_search="disabled"',
+          "tools.view_image=false",
+          "mcp_servers={}",
+          "project_doc_max_bytes=0",
+          'model_provider="gateway"',
+        ]),
       }),
       expect.anything(),
       expect.anything(),
     );
+    const endpoint = vi.mocked(harness.operations.requestSummaryCompletion!).mock.calls[0][0];
+    expect(endpoint.cliArgs).not.toContain("--ignore-user-config");
+    expect(harness.operations.resolveCodexProviderCredential).not.toHaveBeenCalled();
     expect(result.credentialSource).toBe("config.toml gateway.auth");
   });
 
   it("does not send official CLI authentication to a new third-party route", async () => {
     const harness = createHarness();
+    vi.mocked(harness.operations.resolveCodexProviderCredential!).mockResolvedValue({
+      apiKey: "unrelated-key",
+      source: "auth.json OPENAI_API_KEY",
+    });
 
     await expect(harness.service.testProviderConnection({
       target: "codex",
@@ -400,6 +464,7 @@ describe("Provider connection tests", () => {
         customApiFormat: "openai_responses",
       },
     })).rejects.toThrow(/Write this route to Codex config/);
+    expect(harness.operations.resolveCodexProviderCredential).not.toHaveBeenCalled();
     expect(harness.operations.requestSummaryCompletion).not.toHaveBeenCalled();
   });
 
@@ -437,11 +502,101 @@ describe("Provider connection tests", () => {
         apiFormat: "claude_exec",
         modelArg: "claude-test",
         env: { CLAUDE_CONFIG_DIR: "/tmp/provider-claude" },
+        cliArgs: ["--safe-mode", "--tools", "", "--no-session-persistence"],
       }),
       expect.anything(),
       expect.anything(),
     );
+    expect(harness.operations.resolveClaudeProviderCredential).not.toHaveBeenCalled();
     expect(result.credentialSource).toBe("settings.json apiKeyHelper");
+  });
+
+  it("isolates a stored Claude key from user settings, helpers, OAuth, and process arguments", async () => {
+    const harness = createHarness();
+    harness.keys.set("claude:gateway", "stored-key");
+
+    const result = await harness.service.testProviderConnection({
+      target: "claude",
+      apiConfig: {
+        activeProvider: "custom",
+        customProviderId: "gateway",
+        customConfigDir: "/tmp/provider-claude",
+        customProviderName: "Gateway",
+        customBaseUrl: "https://gateway.example/anthropic/",
+        customApiKey: "",
+        customModel: "claude-test",
+        customApiFormat: "anthropic",
+        customApiKeyField: "ANTHROPIC_AUTH_TOKEN",
+      },
+    });
+
+    const endpoint = vi.mocked(harness.operations.requestSummaryCompletion!).mock.calls[0][0];
+    expect(endpoint.env).toEqual({
+      CLAUDE_CONFIG_DIR: endpoint.cwd,
+      ANTHROPIC_BASE_URL: "https://gateway.example/anthropic",
+      ANTHROPIC_AUTH_TOKEN: "stored-key",
+      ANTHROPIC_API_KEY: "",
+      CLAUDE_CODE_OAUTH_TOKEN: "",
+    });
+    expect(endpoint.cliArgs).toEqual(["--safe-mode", "--tools", "", "--no-session-persistence"]);
+    expect(endpoint.cliArgs?.join(" ")).not.toContain("stored-key");
+    expect(harness.operations.resolveClaudeProviderCredential).not.toHaveBeenCalled();
+    expect(result.credentialSource).toBe("AgentRecall claude key store");
+  });
+
+  it("does not treat an OAuth-only Claude login as a third-party API key", async () => {
+    const harness = createHarness();
+    vi.mocked(harness.operations.loadClaudeConfigSnapshot!).mockResolvedValue({
+      claudeHome: "/tmp/provider-claude",
+      settingsPath: "/tmp/provider-claude/settings.json",
+      exists: true,
+      route: {
+        activeProvider: "custom",
+        customBaseUrl: "https://gateway.example/anthropic",
+      },
+      credentialSource: null,
+      hasApiKey: false,
+    });
+
+    await expect(harness.service.testProviderConnection({
+      target: "claude",
+      apiConfig: {
+        activeProvider: "custom",
+        customProviderId: "gateway",
+        customConfigDir: "/tmp/provider-claude",
+        customProviderName: "Gateway",
+        customBaseUrl: "https://gateway.example/anthropic",
+        customApiKey: "",
+        customModel: "claude-test",
+        customApiFormat: "anthropic",
+        customApiKeyField: "ANTHROPIC_AUTH_TOKEN",
+      },
+    })).rejects.toThrow(/No readable API key/);
+    expect(harness.operations.requestSummaryCompletion).not.toHaveBeenCalled();
+  });
+
+  it("does not inject an unrelated Claude resolver key into an unwritten route", async () => {
+    const harness = createHarness();
+    vi.mocked(harness.operations.resolveClaudeProviderCredential!).mockResolvedValue({
+      apiKey: "unrelated-key",
+      source: "environment ANTHROPIC_API_KEY",
+    });
+
+    await expect(harness.service.testProviderConnection({
+      target: "claude",
+      apiConfig: {
+        activeProvider: "custom",
+        customProviderId: "unwritten",
+        customProviderName: "Unwritten",
+        customBaseUrl: "https://unwritten.example/anthropic",
+        customApiKey: "",
+        customModel: "claude-test",
+        customApiFormat: "anthropic",
+        customApiKeyField: "ANTHROPIC_API_KEY",
+      },
+    })).rejects.toThrow(/Write this route to Claude Code settings/);
+    expect(harness.operations.resolveClaudeProviderCredential).not.toHaveBeenCalled();
+    expect(harness.operations.requestSummaryCompletion).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/main-2.0/src/main/services/provider-service.test.ts
+++ b/apps/main-2.0/src/main/services/provider-service.test.ts
@@ -57,6 +57,17 @@ function createHarness(settings: AppSettings = cloneSettings()) {
       source: apiKey ? "API key field" : null,
     })),
     requestSummaryCompletion: vi.fn(async () => "OK"),
+    applyCodexApiConfig: vi.fn(async () => ({
+      profile: "generated",
+      codexHome: "/tmp/codex",
+      authSource: null,
+      configSource: null,
+      authTarget: "/tmp/codex/auth.json",
+      configTarget: "/tmp/codex/config.toml",
+      backupPaths: [],
+      credentialSource: "config.toml deepseek.auth.command",
+      verified: true as const,
+    })),
   };
   const service = new ProviderService({
     getSettings: () => settings,
@@ -688,6 +699,37 @@ describe("Provider connection tests", () => {
     })).rejects.toThrow(/Write this route to Claude Code settings/);
     expect(harness.operations.resolveClaudeProviderCredential).not.toHaveBeenCalled();
     expect(harness.operations.requestSummaryCompletion).not.toHaveBeenCalled();
+  });
+});
+
+describe("ProviderService Codex profile", () => {
+  it("keeps helper-backed apply from promoting a generic resolver fallback into the API key field", async () => {
+    const harness = createHarness();
+    vi.mocked(harness.operations.resolveCodexProviderCredential!).mockImplementation(async (input) => (
+      input.preferConfiguredHelper
+        ? { apiKey: "", source: "config.toml deepseek.auth.command" }
+        : { apiKey: "unrelated-login-key", source: "auth.json OPENAI_API_KEY" }
+    ));
+
+    await harness.service.applyCodexProfile({
+      ...defaultSettings.apiConfig,
+      activeProvider: "custom",
+      customProviderId: "deepseek",
+      customProviderName: "DeepSeek",
+      customBaseUrl: "https://api.deepseek.com",
+      customApiKey: "",
+      customModel: "deepseek-v4-flash",
+      customApiFormat: "openai_responses",
+    });
+
+    expect(harness.operations.resolveCodexProviderCredential).toHaveBeenCalledWith({
+      codexHome: undefined,
+      providerId: "deepseek",
+      preferConfiguredHelper: true,
+    });
+    expect(harness.operations.applyCodexApiConfig).toHaveBeenCalledWith({
+      apiConfig: expect.objectContaining({ customApiKey: "" }),
+    });
   });
 });
 

--- a/apps/main-2.0/src/main/services/provider-service.ts
+++ b/apps/main-2.0/src/main/services/provider-service.ts
@@ -740,6 +740,7 @@ export class ProviderService {
     const credential = await this.operations.resolveCodexProviderCredential({
       codexHome: apiConfig.customConfigDir || undefined,
       providerId: apiConfig.customProviderId,
+      preferConfiguredHelper: true,
     });
     return credential.apiKey ? { ...apiConfig, customApiKey: credential.apiKey } : apiConfig;
   }

--- a/apps/main-2.0/src/main/services/provider-service.ts
+++ b/apps/main-2.0/src/main/services/provider-service.ts
@@ -98,6 +98,26 @@ function carriesApiKey(update: { customApiKey?: string } | undefined): boolean {
   return Boolean(update) && typeof update?.customApiKey === "string";
 }
 
+type ProviderKeyTargetConfig = Pick<ApiConfig | ClaudeApiConfig, "activeProvider" | "customProviderId" | "customBaseUrl">;
+
+function normalizedProviderBaseUrl(baseUrl: string): string {
+  return baseUrl.trim().replace(/\/+$/, "");
+}
+
+function storedKeyCanHydrateTarget(
+  target: ProviderKeyTargetConfig,
+  savedTarget: ProviderKeyTargetConfig,
+  presets: ReadonlyArray<{ id: string; baseUrl: string }>,
+): boolean {
+  const targetBaseUrl = normalizedProviderBaseUrl(target.customBaseUrl);
+  const fixedPreset = presets.find((preset) => preset.id !== "custom" && preset.id === target.customProviderId);
+  if (fixedPreset && normalizedProviderBaseUrl(fixedPreset.baseUrl) === targetBaseUrl) return true;
+  return Boolean(targetBaseUrl)
+    && savedTarget.activeProvider === "custom"
+    && savedTarget.customProviderId === target.customProviderId
+    && normalizedProviderBaseUrl(savedTarget.customBaseUrl) === targetBaseUrl;
+}
+
 /** Human-readable provenance for the credential the connection test ended up using. */
 function summaryKeySource(typedKey: string, resolvedKey: string, store: ProviderKeyTarget): string | undefined {
   if (typedKey) return "API key field";
@@ -208,21 +228,39 @@ export class ProviderService {
         this.getSavedSummaryConfigPatch(),
         undefined,
       ),
+    }, {
+      codex: currentSettings.apiConfig,
+      claude: currentSettings.claudeApiConfig,
     });
   }
 
-  async addStoredKeys(settings: AppSettings): Promise<AppSettings> {
+  async addStoredKeys(
+    settings: AppSettings,
+    savedTargets?: { codex: ApiConfig; claude: ClaudeApiConfig },
+  ): Promise<AppSettings> {
     const next = { ...settings };
     if (next.apiConfig.activeProvider === "custom") {
       next.apiConfig = {
         ...next.apiConfig,
-        customApiKey: await this.dependencies.keys.get("codex", next.apiConfig.customProviderId),
+        customApiKey: !savedTargets || storedKeyCanHydrateTarget(
+          next.apiConfig,
+          savedTargets.codex,
+          API_PROVIDER_PRESETS,
+        )
+          ? await this.dependencies.keys.get("codex", next.apiConfig.customProviderId)
+          : "",
       };
     }
     if (next.claudeApiConfig.activeProvider === "custom") {
       next.claudeApiConfig = {
         ...next.claudeApiConfig,
-        customApiKey: await this.dependencies.keys.get("claude", next.claudeApiConfig.customProviderId),
+        customApiKey: !savedTargets || storedKeyCanHydrateTarget(
+          next.claudeApiConfig,
+          savedTargets.claude,
+          CLAUDE_API_PROVIDER_PRESETS,
+        )
+          ? await this.dependencies.keys.get("claude", next.claudeApiConfig.customProviderId)
+          : "",
       };
     }
     if (next.summaryApiConfigMode === "custom" && next.summaryApiConfig.activeProvider === "custom") {
@@ -391,11 +429,7 @@ export class ProviderService {
           throw new Error(`Base URL is required to test ${apiConfig.customProviderName}.`);
         }
         const requestedBaseUrl = apiConfig.customBaseUrl.trim().replace(/\/+$/, "");
-        const typedKey = apiConfig.customApiKey.trim();
-        const storedKey = (typedKey
-          ? ""
-          : await this.dependencies.keys.get("claude", apiConfig.customProviderId)).trim();
-        const providerKey = typedKey || storedKey;
+        const providerKey = apiConfig.customApiKey.trim();
         if (providerKey) {
           const authEnv = {
             ANTHROPIC_BASE_URL: requestedBaseUrl,
@@ -409,7 +443,7 @@ export class ProviderService {
             ...authEnv,
           };
           isolateConfigHome = true;
-          credentialSource = typedKey ? "API key field" : "AgentRecall claude key store";
+          credentialSource = "API key field";
         } else {
           const snapshot = await this.operations.loadClaudeConfigSnapshot(apiConfig.customConfigDir || undefined);
           const configuredBaseUrl = snapshot.route.customBaseUrl?.trim().replace(/\/+$/, "") ?? "";
@@ -460,16 +494,8 @@ export class ProviderService {
         if (!apiConfig.customBaseUrl.trim()) {
           throw new Error(`Base URL is required to test ${apiConfig.customProviderName}.`);
         }
-        const typedKey = apiConfig.customApiKey.trim();
-        const storedKey = (typedKey
-          ? ""
-          : await this.dependencies.keys.get("codex", apiConfig.customProviderId)).trim();
-        const providerKey = typedKey || storedKey;
-        credentialSource = typedKey
-          ? "API key field"
-          : storedKey
-            ? "AgentRecall codex key store"
-            : credentialSource;
+        const providerKey = apiConfig.customApiKey.trim();
+        if (providerKey) credentialSource = "API key field";
         const requestedBaseUrl = apiConfig.customBaseUrl.trim().replace(/\/+$/, "");
         if (!providerKey) {
           if (apiConfig.customApiFormat === "openai_chat") {

--- a/apps/main-2.0/src/main/services/provider-service.ts
+++ b/apps/main-2.0/src/main/services/provider-service.ts
@@ -443,12 +443,6 @@ export class ProviderService {
         });
         credentialSource = credential.source || credentialSource;
         const requestedBaseUrl = apiConfig.customBaseUrl.trim().replace(/\/+$/, "");
-        const providerId = apiConfig.customProviderId === "custom"
-          ? "agent-recall-connection-test"
-          : apiConfig.customProviderId;
-        const providerKey = /^[A-Za-z0-9_-]+$/.test(providerId)
-          ? providerId
-          : JSON.stringify(providerId);
         if (!credential.apiKey) {
           if (apiConfig.customApiFormat === "openai_chat") {
             throw new Error(
@@ -456,7 +450,9 @@ export class ProviderService {
             );
           }
           const snapshot = await this.operations.loadCodexConfigSnapshot(apiConfig.customConfigDir || undefined);
-          const configuredProvider = snapshot.providers.find((provider) => provider.id === providerId);
+          const configuredProvider = snapshot.providers.find(
+            (provider) => provider.id === apiConfig.customProviderId,
+          );
           if (
             !configuredProvider
             || configuredProvider.baseUrl.trim().replace(/\/+$/, "") !== requestedBaseUrl
@@ -466,8 +462,11 @@ export class ProviderService {
             );
           }
           credentialSource = configuredProvider.credentialSource || credentialSource;
-          endpoint.cliArgs = ["-c", `model_provider=${JSON.stringify(providerId)}`];
+          endpoint.cliArgs = ["-c", `model_provider=${JSON.stringify(apiConfig.customProviderId)}`];
         } else {
+          // A reserved one-shot provider prevents an existing provider's mutually exclusive
+          // `auth` block from being combined with the env-key authentication below.
+          const providerId = "agent-recall-connection-test";
           let baseUrl = requestedBaseUrl;
           if (apiConfig.customApiFormat === "openai_chat") {
             testProxy = this.operations.createCodexChatProxy({
@@ -479,7 +478,7 @@ export class ProviderService {
             });
             baseUrl = (await testProxy.start()).baseUrl;
           }
-          const prefix = `model_providers.${providerKey}`;
+          const prefix = `model_providers.${providerId}`;
           endpoint.cliArgs = [
             "-c", `model_provider=${JSON.stringify(providerId)}`,
             "-c", `${prefix}.name=${JSON.stringify(apiConfig.customProviderName || providerId)}`,

--- a/apps/main-2.0/src/main/services/provider-service.ts
+++ b/apps/main-2.0/src/main/services/provider-service.ts
@@ -1,5 +1,6 @@
 import {
   API_PROVIDER_PRESETS,
+  CLAUDE_API_PROVIDER_PRESETS,
   mergeApiConfigWithProfileDefaults,
   mergeClaudeApiConfigWithProfileDefaults,
   normalizeApiConfig,
@@ -31,11 +32,13 @@ import {
 import type { AppSettings, AppSettingsUpdate } from "../../core/platform";
 import { providerConfigDirectoryExists } from "../../core/provider-config-path";
 import { requestSummaryCompletion } from "../../core/session-summarizer";
-import { buildCodexExecEndpoint } from "../../core/summary-endpoint";
+import { buildClaudeExecEndpoint, buildCodexExecEndpoint } from "../../core/summary-endpoint";
 import type {
   ClaudeModelProbeRequest,
   CodexModelProbeRequest,
   ConfigSnapshotRequest,
+  ProviderConnectionRequest,
+  ProviderConnectionResult,
   ProviderKeyTarget,
 } from "../../shared/ipc/providers";
 import type {
@@ -319,6 +322,187 @@ export class ProviderService {
           ? `AgentRecall ${keyTarget} key store`
           : undefined,
     });
+  }
+
+  async testProviderConnection(input: ProviderConnectionRequest): Promise<ProviderConnectionResult> {
+    const startedAt = Date.now();
+    const settings = this.dependencies.getSettings();
+    const prompt = [{ role: "user" as const, content: "Reply with exactly OK." }];
+
+    if (input.target === "claude") {
+      const normalized = normalizeClaudeApiConfig(input.apiConfig);
+      const preset = CLAUDE_API_PROVIDER_PRESETS.find((item) => item.id === normalized.customProviderId);
+      const apiConfig = normalizeClaudeApiConfig({
+        ...normalized,
+        customProviderName: input.apiConfig.customProviderName?.trim() || preset?.providerName || normalized.customProviderId,
+        customBaseUrl: input.apiConfig.customBaseUrl?.trim() || preset?.baseUrl || "",
+        customModel: input.apiConfig.customModel?.trim() || preset?.model || "",
+        customApiFormat: input.apiConfig.customApiFormat ?? preset?.apiFormat ?? "anthropic",
+        customApiKeyField: input.apiConfig.customApiKeyField ?? preset?.apiKeyField ?? "ANTHROPIC_AUTH_TOKEN",
+      });
+      const endpoint = buildClaudeExecEndpoint({
+        ...settings,
+        summaryClaudeModel: apiConfig.activeProvider === "custom" ? apiConfig.customModel : "",
+        summaryClaudeConfigDir: apiConfig.customConfigDir,
+      });
+      let credentialSource = "Claude Code CLI authentication";
+      if (apiConfig.activeProvider === "official") {
+        const officialEnv = {
+          ANTHROPIC_BASE_URL: "",
+          ANTHROPIC_AUTH_TOKEN: "",
+          ANTHROPIC_API_KEY: "",
+          ANTHROPIC_MODEL: "",
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: "",
+          ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME: "",
+          ANTHROPIC_DEFAULT_SONNET_MODEL: "",
+          ANTHROPIC_DEFAULT_SONNET_MODEL_NAME: "",
+          ANTHROPIC_DEFAULT_OPUS_MODEL: "",
+          ANTHROPIC_DEFAULT_OPUS_MODEL_NAME: "",
+        };
+        endpoint.env = { ...endpoint.env, ...officialEnv };
+        endpoint.cliArgs = ["--settings", JSON.stringify({ env: officialEnv })];
+      } else {
+        if (!apiConfig.customBaseUrl.trim()) {
+          throw new Error(`Base URL is required to test ${apiConfig.customProviderName}.`);
+        }
+        const typedKey = apiConfig.customApiKey.trim();
+        const storedKey = typedKey
+          ? ""
+          : await this.dependencies.keys.get("claude", apiConfig.customProviderId);
+        const credential = await this.operations.resolveClaudeProviderCredential({
+          claudeHome: apiConfig.customConfigDir || undefined,
+          apiKeyField: apiConfig.customApiKeyField,
+          apiKey: typedKey || storedKey,
+          apiKeySource: typedKey
+            ? "API key field"
+            : storedKey
+              ? "AgentRecall claude key store"
+              : undefined,
+        });
+        if (credential.apiKey) {
+          endpoint.env = {
+            ...endpoint.env,
+            ANTHROPIC_BASE_URL: apiConfig.customBaseUrl.trim().replace(/\/+$/, ""),
+            [apiConfig.customApiKeyField]: credential.apiKey,
+          };
+          credentialSource = credential.source || credentialSource;
+        } else {
+          const snapshot = await this.operations.loadClaudeConfigSnapshot(apiConfig.customConfigDir || undefined);
+          const configuredBaseUrl = snapshot.route.customBaseUrl?.trim().replace(/\/+$/, "") ?? "";
+          if (
+            snapshot.route.activeProvider !== "custom"
+            || configuredBaseUrl !== apiConfig.customBaseUrl.trim().replace(/\/+$/, "")
+          ) {
+            throw new Error(
+              `No readable API key was found for ${apiConfig.customProviderName}. Write this route to Claude Code settings before testing CLI-managed credentials.`,
+            );
+          }
+          credentialSource = snapshot.credentialSource || credentialSource;
+        }
+      }
+      await this.operations.requestSummaryCompletion(
+        endpoint,
+        prompt,
+        AbortSignal.timeout(30_000),
+      );
+      return {
+        elapsedMs: Math.max(0, Date.now() - startedAt),
+        credentialSource,
+      };
+    }
+
+    const apiConfig = this.withPresetDefaults(input.apiConfig);
+    const endpoint = buildCodexExecEndpoint({
+      ...settings,
+      summaryCodexModel: apiConfig.activeProvider === "custom" ? apiConfig.customModel : "",
+      summaryCodexConfigDir: apiConfig.customConfigDir,
+    });
+    let credentialSource = "Codex CLI authentication";
+    let testProxy: CodexChatProxyPort | null = null;
+    try {
+      if (apiConfig.activeProvider === "official") {
+        // Authentication still comes from CODEX_HOME, while routing/model/plugin config is ignored.
+        endpoint.cliArgs = ["--ignore-user-config"];
+      } else {
+        if (!apiConfig.customBaseUrl.trim()) {
+          throw new Error(`Base URL is required to test ${apiConfig.customProviderName}.`);
+        }
+        const typedKey = apiConfig.customApiKey.trim();
+        const storedKey = typedKey
+          ? ""
+          : await this.dependencies.keys.get("codex", apiConfig.customProviderId);
+        const credential = await this.operations.resolveCodexProviderCredential({
+          codexHome: apiConfig.customConfigDir || undefined,
+          providerId: apiConfig.customProviderId,
+          apiKey: typedKey || storedKey,
+          apiKeySource: typedKey
+            ? "API key field"
+            : storedKey
+              ? "AgentRecall codex key store"
+              : undefined,
+        });
+        credentialSource = credential.source || credentialSource;
+        const requestedBaseUrl = apiConfig.customBaseUrl.trim().replace(/\/+$/, "");
+        const providerId = apiConfig.customProviderId === "custom"
+          ? "agent-recall-connection-test"
+          : apiConfig.customProviderId;
+        const providerKey = /^[A-Za-z0-9_-]+$/.test(providerId)
+          ? providerId
+          : JSON.stringify(providerId);
+        if (!credential.apiKey) {
+          if (apiConfig.customApiFormat === "openai_chat") {
+            throw new Error(
+              `${apiConfig.customProviderName} uses the local Codex Chat proxy, but no API key was readable by AgentRecall.`,
+            );
+          }
+          const snapshot = await this.operations.loadCodexConfigSnapshot(apiConfig.customConfigDir || undefined);
+          const configuredProvider = snapshot.providers.find((provider) => provider.id === providerId);
+          if (
+            !configuredProvider
+            || configuredProvider.baseUrl.trim().replace(/\/+$/, "") !== requestedBaseUrl
+          ) {
+            throw new Error(
+              `No readable API key was found for ${apiConfig.customProviderName}. Write this route to Codex config before testing CLI-managed credentials.`,
+            );
+          }
+          credentialSource = configuredProvider.credentialSource || credentialSource;
+          endpoint.cliArgs = ["-c", `model_provider=${JSON.stringify(providerId)}`];
+        } else {
+          let baseUrl = requestedBaseUrl;
+          if (apiConfig.customApiFormat === "openai_chat") {
+            testProxy = this.operations.createCodexChatProxy({
+              upstreamBaseUrl: baseUrl,
+              apiKey: credential.apiKey,
+              model: apiConfig.customModel,
+              listenHost: "127.0.0.1",
+              listenPort: 0,
+            });
+            baseUrl = (await testProxy.start()).baseUrl;
+          }
+          const prefix = `model_providers.${providerKey}`;
+          endpoint.cliArgs = [
+            "-c", `model_provider=${JSON.stringify(providerId)}`,
+            "-c", `${prefix}.name=${JSON.stringify(apiConfig.customProviderName || providerId)}`,
+            "-c", `${prefix}.base_url=${JSON.stringify(baseUrl)}`,
+            "-c", `${prefix}.wire_api="responses"`,
+            "-c", `${prefix}.requires_openai_auth=true`,
+            "-c", `${prefix}.env_key="OPENAI_API_KEY"`,
+          ];
+          endpoint.env = { ...endpoint.env, OPENAI_API_KEY: credential.apiKey };
+        }
+      }
+      await this.operations.requestSummaryCompletion(
+        endpoint,
+        prompt,
+        AbortSignal.timeout(30_000),
+      );
+      return {
+        elapsedMs: Math.max(0, Date.now() - startedAt),
+        credentialSource,
+      };
+    } finally {
+      await testProxy?.stop();
+    }
   }
 
   async testSummaryProviderConnection(

--- a/apps/main-2.0/src/main/services/provider-service.ts
+++ b/apps/main-2.0/src/main/services/provider-service.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import {
   API_PROVIDER_PRESETS,
   CLAUDE_API_PROVIDER_PRESETS,
@@ -114,6 +117,26 @@ function summaryConnectionApiFormat(
   }
   return apiFormat;
 }
+
+const CLAUDE_CONNECTION_TEST_ARGS = [
+  "--safe-mode",
+  "--tools",
+  "",
+  "--no-session-persistence",
+] as const;
+
+const CODEX_CONNECTION_TEST_ARGS = [
+  "-c", "features.shell_tool=false",
+  "-c", "features.unified_exec=false",
+  "-c", "features.apps=false",
+  "-c", "features.remote_plugin=false",
+  "-c", "features.multi_agent=false",
+  "-c", "features.hooks=false",
+  "-c", 'web_search="disabled"',
+  "-c", "tools.view_image=false",
+  "-c", "mcp_servers={}",
+  "-c", "project_doc_max_bytes=0",
+] as const;
 
 const defaultOperations: ProviderServiceOperations = {
   providerConfigDirectoryExists,
@@ -345,7 +368,9 @@ export class ProviderService {
         summaryClaudeModel: apiConfig.activeProvider === "custom" ? apiConfig.customModel : "",
         summaryClaudeConfigDir: apiConfig.customConfigDir,
       });
+      endpoint.cliArgs = [...CLAUDE_CONNECTION_TEST_ARGS];
       let credentialSource = "Claude Code CLI authentication";
+      let isolateConfigHome = false;
       if (apiConfig.activeProvider === "official") {
         const officialEnv = {
           ANTHROPIC_BASE_URL: "",
@@ -360,38 +385,38 @@ export class ProviderService {
           ANTHROPIC_DEFAULT_OPUS_MODEL_NAME: "",
         };
         endpoint.env = { ...endpoint.env, ...officialEnv };
-        endpoint.cliArgs = ["--settings", JSON.stringify({ env: officialEnv })];
+        endpoint.cliArgs.push("--settings", JSON.stringify({ env: officialEnv }));
       } else {
         if (!apiConfig.customBaseUrl.trim()) {
           throw new Error(`Base URL is required to test ${apiConfig.customProviderName}.`);
         }
+        const requestedBaseUrl = apiConfig.customBaseUrl.trim().replace(/\/+$/, "");
         const typedKey = apiConfig.customApiKey.trim();
-        const storedKey = typedKey
+        const storedKey = (typedKey
           ? ""
-          : await this.dependencies.keys.get("claude", apiConfig.customProviderId);
-        const credential = await this.operations.resolveClaudeProviderCredential({
-          claudeHome: apiConfig.customConfigDir || undefined,
-          apiKeyField: apiConfig.customApiKeyField,
-          apiKey: typedKey || storedKey,
-          apiKeySource: typedKey
-            ? "API key field"
-            : storedKey
-              ? "AgentRecall claude key store"
-              : undefined,
-        });
-        if (credential.apiKey) {
+          : await this.dependencies.keys.get("claude", apiConfig.customProviderId)).trim();
+        const providerKey = typedKey || storedKey;
+        if (providerKey) {
+          const authEnv = {
+            ANTHROPIC_BASE_URL: requestedBaseUrl,
+            ANTHROPIC_AUTH_TOKEN: "",
+            ANTHROPIC_API_KEY: "",
+            CLAUDE_CODE_OAUTH_TOKEN: "",
+            [apiConfig.customApiKeyField]: providerKey,
+          };
           endpoint.env = {
             ...endpoint.env,
-            ANTHROPIC_BASE_URL: apiConfig.customBaseUrl.trim().replace(/\/+$/, ""),
-            [apiConfig.customApiKeyField]: credential.apiKey,
+            ...authEnv,
           };
-          credentialSource = credential.source || credentialSource;
+          isolateConfigHome = true;
+          credentialSource = typedKey ? "API key field" : "AgentRecall claude key store";
         } else {
           const snapshot = await this.operations.loadClaudeConfigSnapshot(apiConfig.customConfigDir || undefined);
           const configuredBaseUrl = snapshot.route.customBaseUrl?.trim().replace(/\/+$/, "") ?? "";
           if (
             snapshot.route.activeProvider !== "custom"
-            || configuredBaseUrl !== apiConfig.customBaseUrl.trim().replace(/\/+$/, "")
+            || configuredBaseUrl !== requestedBaseUrl
+            || !snapshot.hasApiKey
           ) {
             throw new Error(
               `No readable API key was found for ${apiConfig.customProviderName}. Write this route to Claude Code settings before testing CLI-managed credentials.`,
@@ -400,15 +425,22 @@ export class ProviderService {
           credentialSource = snapshot.credentialSource || credentialSource;
         }
       }
-      await this.operations.requestSummaryCompletion(
-        endpoint,
-        prompt,
-        AbortSignal.timeout(30_000),
-      );
-      return {
-        elapsedMs: Math.max(0, Date.now() - startedAt),
-        credentialSource,
-      };
+      const testCwd = await mkdtemp(path.join(tmpdir(), "agent-recall-provider-test-"));
+      endpoint.cwd = testCwd;
+      if (isolateConfigHome) endpoint.env = { ...endpoint.env, CLAUDE_CONFIG_DIR: testCwd };
+      try {
+        await this.operations.requestSummaryCompletion(
+          endpoint,
+          prompt,
+          AbortSignal.timeout(30_000),
+        );
+        return {
+          elapsedMs: Math.max(0, Date.now() - startedAt),
+          credentialSource,
+        };
+      } finally {
+        await rm(testCwd, { recursive: true, force: true });
+      }
     }
 
     const apiConfig = this.withPresetDefaults(input.apiConfig);
@@ -419,31 +451,27 @@ export class ProviderService {
     });
     let credentialSource = "Codex CLI authentication";
     let testProxy: CodexChatProxyPort | null = null;
+    let isolateConfigHome = false;
     try {
       if (apiConfig.activeProvider === "official") {
         // Authentication still comes from CODEX_HOME, while routing/model/plugin config is ignored.
-        endpoint.cliArgs = ["--ignore-user-config"];
+        endpoint.cliArgs = ["--ignore-user-config", ...CODEX_CONNECTION_TEST_ARGS];
       } else {
         if (!apiConfig.customBaseUrl.trim()) {
           throw new Error(`Base URL is required to test ${apiConfig.customProviderName}.`);
         }
         const typedKey = apiConfig.customApiKey.trim();
-        const storedKey = typedKey
+        const storedKey = (typedKey
           ? ""
-          : await this.dependencies.keys.get("codex", apiConfig.customProviderId);
-        const credential = await this.operations.resolveCodexProviderCredential({
-          codexHome: apiConfig.customConfigDir || undefined,
-          providerId: apiConfig.customProviderId,
-          apiKey: typedKey || storedKey,
-          apiKeySource: typedKey
-            ? "API key field"
-            : storedKey
-              ? "AgentRecall codex key store"
-              : undefined,
-        });
-        credentialSource = credential.source || credentialSource;
+          : await this.dependencies.keys.get("codex", apiConfig.customProviderId)).trim();
+        const providerKey = typedKey || storedKey;
+        credentialSource = typedKey
+          ? "API key field"
+          : storedKey
+            ? "AgentRecall codex key store"
+            : credentialSource;
         const requestedBaseUrl = apiConfig.customBaseUrl.trim().replace(/\/+$/, "");
-        if (!credential.apiKey) {
+        if (!providerKey) {
           if (apiConfig.customApiFormat === "openai_chat") {
             throw new Error(
               `${apiConfig.customProviderName} uses the local Codex Chat proxy, but no API key was readable by AgentRecall.`,
@@ -462,7 +490,10 @@ export class ProviderService {
             );
           }
           credentialSource = configuredProvider.credentialSource || credentialSource;
-          endpoint.cliArgs = ["-c", `model_provider=${JSON.stringify(apiConfig.customProviderId)}`];
+          endpoint.cliArgs = [
+            ...CODEX_CONNECTION_TEST_ARGS,
+            "-c", `model_provider=${JSON.stringify(apiConfig.customProviderId)}`,
+          ];
         } else {
           // A reserved one-shot provider prevents an existing provider's mutually exclusive
           // `auth` block from being combined with the env-key authentication below.
@@ -471,7 +502,7 @@ export class ProviderService {
           if (apiConfig.customApiFormat === "openai_chat") {
             testProxy = this.operations.createCodexChatProxy({
               upstreamBaseUrl: baseUrl,
-              apiKey: credential.apiKey,
+              apiKey: providerKey,
               model: apiConfig.customModel,
               listenHost: "127.0.0.1",
               listenPort: 0,
@@ -480,25 +511,35 @@ export class ProviderService {
           }
           const prefix = `model_providers.${providerId}`;
           endpoint.cliArgs = [
+            "--ignore-user-config",
+            ...CODEX_CONNECTION_TEST_ARGS,
             "-c", `model_provider=${JSON.stringify(providerId)}`,
             "-c", `${prefix}.name=${JSON.stringify(apiConfig.customProviderName || providerId)}`,
             "-c", `${prefix}.base_url=${JSON.stringify(baseUrl)}`,
             "-c", `${prefix}.wire_api="responses"`,
-            "-c", `${prefix}.requires_openai_auth=true`,
+            "-c", `${prefix}.requires_openai_auth=false`,
             "-c", `${prefix}.env_key="OPENAI_API_KEY"`,
           ];
-          endpoint.env = { ...endpoint.env, OPENAI_API_KEY: credential.apiKey };
+          endpoint.env = { ...endpoint.env, OPENAI_API_KEY: providerKey };
+          isolateConfigHome = true;
         }
       }
-      await this.operations.requestSummaryCompletion(
-        endpoint,
-        prompt,
-        AbortSignal.timeout(30_000),
-      );
-      return {
-        elapsedMs: Math.max(0, Date.now() - startedAt),
-        credentialSource,
-      };
+      const testCwd = await mkdtemp(path.join(tmpdir(), "agent-recall-provider-test-"));
+      endpoint.cwd = testCwd;
+      if (isolateConfigHome) endpoint.env = { ...endpoint.env, CODEX_HOME: testCwd };
+      try {
+        await this.operations.requestSummaryCompletion(
+          endpoint,
+          prompt,
+          AbortSignal.timeout(30_000),
+        );
+        return {
+          elapsedMs: Math.max(0, Date.now() - startedAt),
+          credentialSource,
+        };
+      } finally {
+        await rm(testCwd, { recursive: true, force: true });
+      }
     } finally {
       await testProxy?.stop();
     }

--- a/apps/main-2.0/src/main/services/provider-service.ts
+++ b/apps/main-2.0/src/main/services/provider-service.ts
@@ -118,6 +118,18 @@ function storedKeyCanHydrateTarget(
     && normalizedProviderBaseUrl(savedTarget.customBaseUrl) === targetBaseUrl;
 }
 
+function providerRouteMatches(
+  target: ProviderKeyTargetConfig,
+  providerId: string,
+  baseUrl: string,
+): boolean {
+  const normalizedBaseUrl = normalizedProviderBaseUrl(baseUrl);
+  return Boolean(normalizedBaseUrl)
+    && target.activeProvider === "custom"
+    && target.customProviderId === providerId
+    && normalizedProviderBaseUrl(target.customBaseUrl) === normalizedBaseUrl;
+}
+
 /** Human-readable provenance for the credential the connection test ended up using. */
 function summaryKeySource(typedKey: string, resolvedKey: string, store: ProviderKeyTarget): string | undefined {
   if (typedKey) return "API key field";
@@ -337,16 +349,15 @@ export class ProviderService {
     const settings = this.dependencies.getSettings();
     const keyTarget = input.keyTarget ?? "codex";
     const targetConfig = keyTarget === "summary" ? settings.summaryApiConfig : settings.apiConfig;
-    const fallbackProviderId = targetConfig.customProviderId;
-    const savedKey = (
-      input.providerId
-        ? await this.dependencies.keys.get(keyTarget, input.providerId)
-        : ""
-    ) || await this.dependencies.keys.get(keyTarget, fallbackProviderId);
+    const providerId = input.providerId || targetConfig.customProviderId;
+    const explicitKey = input.apiKey.trim();
+    const savedKey = !explicitKey && providerRouteMatches(targetConfig, providerId, input.baseUrl)
+      ? await this.dependencies.keys.get(keyTarget, providerId)
+      : "";
     return this.operations.probeCodexModels({
       baseUrl: input.baseUrl,
-      apiKey: input.apiKey || savedKey,
-      providerId: input.providerId,
+      apiKey: explicitKey || savedKey,
+      providerId,
       // The renderer always sends the directory it means, so these fallbacks only cover a probe
       // that omitted one. A summary probe must not fall through to the Codex tab's directory:
       // they are independent routes, and an empty summary directory means the machine's `~/.codex`.
@@ -355,7 +366,7 @@ export class ProviderService {
           ? settings.summaryApiConfig.customConfigDir || settings.summaryCodexConfigDir
           : settings.apiConfig.customConfigDir)
         || undefined,
-      apiKeySource: input.apiKey
+      apiKeySource: explicitKey
         ? "API key field"
         : savedKey
           ? `AgentRecall ${keyTarget} key store`
@@ -368,16 +379,20 @@ export class ProviderService {
     const keyTarget = input.keyTarget ?? "claude";
     const targetConfig = keyTarget === "summary" ? settings.summaryApiConfig : settings.claudeApiConfig;
     const providerId = input.providerId || targetConfig.customProviderId;
-    const savedKey = await this.dependencies.keys.get(keyTarget, providerId);
+    const explicitKey = input.apiKey.trim();
+    const savedKey = !explicitKey && providerRouteMatches(targetConfig, providerId, input.baseUrl)
+      ? await this.dependencies.keys.get(keyTarget, providerId)
+      : "";
     return this.operations.probeClaudeModels({
       baseUrl: input.baseUrl,
-      apiKey: input.apiKey || savedKey,
+      apiKey: explicitKey || savedKey,
+      providerId,
       apiFormat: input.apiFormat,
       apiKeyField: input.apiKeyField,
       claudeHome: input.claudeHome
         || (keyTarget === "summary" ? settings.summaryClaudeConfigDir : settings.claudeApiConfig.customConfigDir)
         || undefined,
-      apiKeySource: input.apiKey
+      apiKeySource: explicitKey
         ? "API key field"
         : savedKey
           ? `AgentRecall ${keyTarget} key store`
@@ -622,9 +637,16 @@ export class ProviderService {
     const typedKey = input.apiKey.trim();
 
     if (input.source === "claude") {
-      const apiKey = typedKey || await this.summaryStoredKey(input.providerId);
+      const id = input.providerId?.trim() || "";
+      const apiKey = typedKey || (
+        id && providerRouteMatches(settings.summaryApiConfig, id, input.baseUrl)
+          ? await this.dependencies.keys.get("summary", id)
+          : ""
+      );
       return this.operations.resolveClaudeProviderCredential({
         claudeHome: input.configDir || settings.summaryClaudeConfigDir || undefined,
+        providerId: input.providerId,
+        baseUrl: input.baseUrl,
         apiKeyField: input.apiKeyField,
         apiKey,
         apiKeySource: summaryKeySource(typedKey, apiKey, "summary"),
@@ -632,32 +654,38 @@ export class ProviderService {
     }
 
     if (input.source === "codex") {
-      const apiKey = typedKey || await this.summaryStoredKey(input.providerId);
+      const id = input.providerId?.trim() || "";
+      const apiKey = typedKey || (
+        id && providerRouteMatches(settings.summaryApiConfig, id, input.baseUrl)
+          ? await this.dependencies.keys.get("summary", id)
+          : ""
+      );
       return this.operations.resolveCodexProviderCredential({
         codexHome: input.configDir || settings.summaryCodexConfigDir || undefined,
         providerId: input.providerId,
+        baseUrl: input.baseUrl,
         apiKey,
         apiKeySource: summaryKeySource(typedKey, apiKey, "summary"),
       });
     }
 
     const keyTarget = input.inherit ? "codex" : "summary";
-    const apiKey = typedKey || await this.dependencies.keys.get(keyTarget, input.providerId);
+    const targetConfig = input.inherit ? settings.apiConfig : settings.summaryApiConfig;
+    const apiKey = typedKey || (
+      providerRouteMatches(targetConfig, input.providerId, input.baseUrl)
+        ? await this.dependencies.keys.get(keyTarget, input.providerId)
+        : ""
+    );
     if (!input.inherit) {
       return { apiKey, source: summaryKeySource(typedKey, apiKey, "summary") ?? null };
     }
     return this.operations.resolveCodexProviderCredential({
       codexHome: input.codexHome || settings.apiConfig.customConfigDir || undefined,
       providerId: input.providerId,
+      baseUrl: input.baseUrl,
       apiKey,
       apiKeySource: summaryKeySource(typedKey, apiKey, "codex"),
     });
-  }
-
-  /** The Codex and Claude summary sources may have no provider id at all when the route is official. */
-  private async summaryStoredKey(providerId: string | undefined): Promise<string> {
-    const id = providerId?.trim();
-    return id ? this.dependencies.keys.get("summary", id) : "";
   }
 
   async applyCodexProfile(apiConfigInput: Partial<ApiConfig>): Promise<ApplyCodexProfileResult> {
@@ -673,8 +701,12 @@ export class ProviderService {
   async applyClaudeProfile(apiConfigInput: Partial<ClaudeApiConfig>): Promise<ApplyClaudeProfileResult> {
     const normalized = { ...apiConfigInput };
     if (normalized.activeProvider === "custom" && !normalized.customApiKey?.trim()) {
-      const providerId = normalizeClaudeApiConfig({ customProviderId: normalized.customProviderId }).customProviderId;
-      normalized.customApiKey = await this.dependencies.keys.get("claude", providerId);
+      const target = normalizeClaudeApiConfig(normalized);
+      const preset = CLAUDE_API_PROVIDER_PRESETS.find((item) => item.id === target.customProviderId);
+      const baseUrl = normalized.customBaseUrl?.trim() || preset?.baseUrl || "";
+      if (providerRouteMatches(this.dependencies.getSettings().claudeApiConfig, target.customProviderId, baseUrl)) {
+        normalized.customApiKey = await this.dependencies.keys.get("claude", target.customProviderId);
+      }
     }
     return this.operations.applyClaudeApiConfig({ apiConfig: normalized });
   }
@@ -735,11 +767,18 @@ export class ProviderService {
 
   private async withCodexCredential(apiConfig: ApiConfig): Promise<ApiConfig> {
     if (apiConfig.activeProvider !== "custom" || apiConfig.customApiKey) return apiConfig;
-    const storedKey = await this.dependencies.keys.get("codex", apiConfig.customProviderId);
+    const storedKey = providerRouteMatches(
+      this.dependencies.getSettings().apiConfig,
+      apiConfig.customProviderId,
+      apiConfig.customBaseUrl,
+    )
+      ? await this.dependencies.keys.get("codex", apiConfig.customProviderId)
+      : "";
     if (storedKey) return { ...apiConfig, customApiKey: storedKey };
     const credential = await this.operations.resolveCodexProviderCredential({
       codexHome: apiConfig.customConfigDir || undefined,
       providerId: apiConfig.customProviderId,
+      baseUrl: apiConfig.customBaseUrl,
       preferConfiguredHelper: true,
     });
     return credential.apiKey ? { ...apiConfig, customApiKey: credential.apiKey } : apiConfig;

--- a/apps/main-2.0/src/preload/providers.ts
+++ b/apps/main-2.0/src/preload/providers.ts
@@ -12,6 +12,8 @@ import {
   type ClaudeModelProbeRequest,
   type CodexModelProbeRequest,
   type ConfigSnapshotRequest,
+  type ProviderConnectionRequest,
+  type ProviderConnectionResult,
   type ProviderKeyTarget,
   type SummaryProviderConnectionRequest,
   type SummaryProviderConnectionResult,
@@ -29,6 +31,10 @@ export function createProvidersApi(ipc: ProvidersIpcRenderer) {
       ipc.invoke(PROVIDERS_IPC.probeCodexModels.channel, input),
     probeClaudeModels: (input: ClaudeModelProbeRequest): Promise<ClaudeModelProbeResult> =>
       ipc.invoke(PROVIDERS_IPC.probeClaudeModels.channel, input),
+    testProviderConnection: (
+      input: ProviderConnectionRequest,
+    ): Promise<ProviderConnectionResult> =>
+      ipc.invoke(PROVIDERS_IPC.testProviderConnection.channel, input),
     pickConfigDirectory: (target: ProviderKeyTarget, defaultPath?: string): Promise<string | null> =>
       ipc.invoke(PROVIDERS_IPC.pickConfigDirectory.channel, target, defaultPath),
     testSummaryProviderConnection: (

--- a/apps/main-2.0/src/renderer/src/features/providers/provider-page.test.tsx
+++ b/apps/main-2.0/src/renderer/src/features/providers/provider-page.test.tsx
@@ -46,15 +46,17 @@ function claudeSnapshot() {
   };
 }
 
-describe("AI summary source pane", () => {
+describe("ProviderPage", () => {
   let container: HTMLDivElement;
   let root: Root;
+  let testProviderConnection: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
     container = document.createElement("div");
     document.body.append(container);
     root = createRoot(container);
+    testProviderConnection = vi.fn(async () => ({ elapsedMs: 1, credentialSource: "test credential" }));
     Object.defineProperty(window, "sessionSearch", {
       configurable: true,
       value: {
@@ -65,6 +67,7 @@ describe("AI summary source pane", () => {
         probeCodexModels: vi.fn(async () => ({ models: [], endpoint: "", endpoints: [], credentialSource: "" })),
         probeClaudeModels: vi.fn(async () => ({ models: [], endpoint: "", endpoints: [], credentialSource: "" })),
         testSummaryProviderConnection: vi.fn(async () => ({ elapsedMs: 1, credentialSource: "" })),
+        testProviderConnection,
       },
     });
   });
@@ -75,15 +78,19 @@ describe("AI summary source pane", () => {
     vi.restoreAllMocks();
   });
 
-  async function mountSummaryPane(): Promise<void> {
+  async function mountProviderPage(settings = structuredClone(defaultSettings)): Promise<void> {
     await act(async () => root.render(createElement(ProviderPage, {
-      settings: structuredClone(defaultSettings),
+      settings,
       language: "en" as const,
       feedback: null,
       onSettingsChange: vi.fn(),
       onApplyToCodex: vi.fn(),
       onApplyToClaude: vi.fn(),
     })));
+  }
+
+  async function mountSummaryPane(): Promise<void> {
+    await mountProviderPage();
     const summaryTab = [...container.querySelectorAll<HTMLButtonElement>(".api-target-tabs button")]
       .find((button) => button.textContent?.includes("AI Summary"));
     if (!summaryTab) throw new Error("AI summary tab not rendered");
@@ -114,6 +121,69 @@ describe("AI summary source pane", () => {
     return [...container.querySelectorAll("[data-summary-row]")]
       .map((element) => element.getAttribute("data-summary-row") ?? "");
   }
+
+  it("tests the current Codex draft and reports progress and success", async () => {
+    let resolveConnection: ((result: { elapsedMs: number; credentialSource: string }) => void) | undefined;
+    testProviderConnection.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveConnection = resolve;
+    }));
+    const settings = structuredClone(defaultSettings);
+    await mountProviderPage(settings);
+    const button = container.querySelector<HTMLButtonElement>('[data-provider-connection-test="codex"]');
+
+    expect(button?.textContent).toContain("Test connection");
+    await act(async () => button?.click());
+
+    expect(testProviderConnection).toHaveBeenCalledWith({
+      target: "codex",
+      apiConfig: settings.apiConfig,
+    });
+    expect(button?.disabled).toBe(true);
+    expect(container.textContent).toContain("Testing Codex connection...");
+
+    await act(async () => resolveConnection?.({ elapsedMs: 42, credentialSource: "Codex auth.json" }));
+
+    expect(button?.disabled).toBe(false);
+    expect(container.textContent).toContain("Codex connection succeeded in 42 ms using Codex auth.json.");
+  });
+
+  it("tests the full Claude draft, reports errors, and clears stale results after edits", async () => {
+    const settings = structuredClone(defaultSettings);
+    settings.claudeApiConfig = {
+      ...settings.claudeApiConfig,
+      activeProvider: "custom",
+      customProviderId: "deepseek",
+      customProviderName: "DeepSeek",
+      customBaseUrl: "https://claude.example/anthropic",
+      customApiKey: "typed-key",
+      customModel: "claude-test-model",
+      customApiFormat: "anthropic",
+      customApiKeyField: "ANTHROPIC_AUTH_TOKEN",
+    };
+    testProviderConnection.mockRejectedValueOnce(new Error("Claude runtime rejected the credential"));
+    await mountProviderPage(settings);
+    const claudeTab = [...container.querySelectorAll<HTMLButtonElement>(".api-target-tabs button")]
+      .find((button) => button.textContent?.includes("Claude Code"));
+    await act(async () => claudeTab?.click());
+    const button = container.querySelector<HTMLButtonElement>('[data-provider-connection-test="claude"]');
+
+    expect(button?.textContent).toContain("Test connection");
+    await act(async () => button?.click());
+
+    expect(testProviderConnection).toHaveBeenCalledWith({
+      target: "claude",
+      apiConfig: settings.claudeApiConfig,
+    });
+    expect(container.textContent).toContain("Claude runtime rejected the credential");
+
+    const baseUrlRow = [...container.querySelectorAll<HTMLElement>(".settings-field")]
+      .find((row) => row.querySelector(".settings-field-title")?.textContent === "Base URL");
+    const baseUrlInput = baseUrlRow?.querySelector<HTMLInputElement>("input");
+    await typeInto(baseUrlInput!, "https://changed.example/anthropic");
+
+    expect(container.textContent).not.toContain("Claude runtime rejected the credential");
+    expect(button?.disabled).toBe(false);
+  });
 
   it("renders the same eight rows in the same order for every source", async () => {
     await mountSummaryPane();

--- a/apps/main-2.0/src/renderer/src/features/providers/provider-page.test.tsx
+++ b/apps/main-2.0/src/renderer/src/features/providers/provider-page.test.tsx
@@ -185,6 +185,76 @@ describe("ProviderPage", () => {
     expect(button?.disabled).toBe(false);
   });
 
+  it("clears hydrated Codex and Claude keys when their manual Base URLs change", async () => {
+    const settings = structuredClone(defaultSettings);
+    settings.apiConfig = {
+      ...settings.apiConfig,
+      activeProvider: "custom",
+      customProviderId: "custom",
+      customProviderName: "Custom Codex",
+      customBaseUrl: "https://old-codex.example/v1",
+      customApiKey: "hydrated-codex-key",
+      customModel: "gpt-test",
+    };
+    settings.claudeApiConfig = {
+      ...settings.claudeApiConfig,
+      activeProvider: "custom",
+      customProviderId: "custom",
+      customProviderName: "Custom Claude",
+      customBaseUrl: "https://old-claude.example/anthropic",
+      customApiKey: "hydrated-claude-key",
+      customModel: "claude-test",
+    };
+    await mountProviderPage(settings);
+
+    const codexFields = [...container.querySelectorAll<HTMLElement>(".settings-field")];
+    const codexBaseUrl = codexFields
+      .find((row) => row.querySelector(".settings-field-title")?.textContent === "Base URL")
+      ?.querySelector<HTMLInputElement>("input");
+    const codexKey = codexFields
+      .find((row) => row.querySelector(".settings-field-title")?.textContent === "API Key")
+      ?.querySelector<HTMLInputElement>("input");
+    expect(codexKey?.value).toBe("hydrated-codex-key");
+
+    await typeInto(codexBaseUrl!, "https://new-codex.example/v1");
+
+    expect(codexKey?.value).toBe("");
+    const codexTest = container.querySelector<HTMLButtonElement>('[data-provider-connection-test="codex"]');
+    await act(async () => codexTest?.click());
+    expect(testProviderConnection).toHaveBeenLastCalledWith({
+      target: "codex",
+      apiConfig: expect.objectContaining({
+        customBaseUrl: "https://new-codex.example/v1",
+        customApiKey: "",
+      }),
+    });
+
+    const claudeTab = [...container.querySelectorAll<HTMLButtonElement>(".api-target-tabs button")]
+      .find((button) => button.textContent?.includes("Claude Code"));
+    await act(async () => claudeTab?.click());
+    const claudeFields = [...container.querySelectorAll<HTMLElement>(".settings-field")];
+    const claudeBaseUrl = claudeFields
+      .find((row) => row.querySelector(".settings-field-title")?.textContent === "Base URL")
+      ?.querySelector<HTMLInputElement>("input");
+    const claudeKey = claudeFields
+      .find((row) => row.querySelector(".settings-field-title")?.textContent === "API Key")
+      ?.querySelector<HTMLInputElement>("input");
+    expect(claudeKey?.value).toBe("hydrated-claude-key");
+
+    await typeInto(claudeBaseUrl!, "https://new-claude.example/anthropic");
+
+    expect(claudeKey?.value).toBe("");
+    const claudeTest = container.querySelector<HTMLButtonElement>('[data-provider-connection-test="claude"]');
+    await act(async () => claudeTest?.click());
+    expect(testProviderConnection).toHaveBeenLastCalledWith({
+      target: "claude",
+      apiConfig: expect.objectContaining({
+        customBaseUrl: "https://new-claude.example/anthropic",
+        customApiKey: "",
+      }),
+    });
+  });
+
   it("renders the same eight rows in the same order for every source", async () => {
     await mountSummaryPane();
 

--- a/apps/main-2.0/src/renderer/src/features/providers/provider-page.test.tsx
+++ b/apps/main-2.0/src/renderer/src/features/providers/provider-page.test.tsx
@@ -219,6 +219,13 @@ describe("ProviderPage", () => {
     await typeInto(codexBaseUrl!, "https://new-codex.example/v1");
 
     expect(codexKey?.value).toBe("");
+    const codexDetect = container.querySelector<HTMLButtonElement>(".codex-model-detect-button");
+    await act(async () => codexDetect?.click());
+    expect(window.sessionSearch.probeCodexModels).toHaveBeenLastCalledWith(expect.objectContaining({
+      baseUrl: "https://new-codex.example/v1",
+      apiKey: "",
+      providerId: "custom",
+    }));
     const codexTest = container.querySelector<HTMLButtonElement>('[data-provider-connection-test="codex"]');
     await act(async () => codexTest?.click());
     expect(testProviderConnection).toHaveBeenLastCalledWith({
@@ -244,6 +251,13 @@ describe("ProviderPage", () => {
     await typeInto(claudeBaseUrl!, "https://new-claude.example/anthropic");
 
     expect(claudeKey?.value).toBe("");
+    const claudeDetect = container.querySelector<HTMLButtonElement>(".codex-model-detect-button");
+    await act(async () => claudeDetect?.click());
+    expect(window.sessionSearch.probeClaudeModels).toHaveBeenLastCalledWith(expect.objectContaining({
+      baseUrl: "https://new-claude.example/anthropic",
+      apiKey: "",
+      providerId: "custom",
+    }));
     const claudeTest = container.querySelector<HTMLButtonElement>('[data-provider-connection-test="claude"]');
     await act(async () => claudeTest?.click());
     expect(testProviderConnection).toHaveBeenLastCalledWith({

--- a/apps/main-2.0/src/renderer/src/features/providers/provider-page.tsx
+++ b/apps/main-2.0/src/renderer/src/features/providers/provider-page.tsx
@@ -348,10 +348,16 @@ export function ProviderPage({
   const detectCodexModels = async () => {
     setCodexModelProbeStatus({ kind: "running", message: l("Detecting models...", "正在探测模型...") });
     try {
+      const configuredProviderId = selectedCodexConfigProviderId || codexConfig?.activeProviderId;
+      const configuredProvider = codexConfig?.providers.find((provider) => provider.id === configuredProviderId);
+      const providerId = configuredProvider
+        && normalizeProviderBaseUrl(configuredProvider.baseUrl) === normalizeProviderBaseUrl(draftApiConfig.customBaseUrl)
+        ? configuredProvider.id
+        : draftApiConfig.customProviderId;
       const result = await window.sessionSearch.probeCodexModels({
         baseUrl: draftApiConfig.customBaseUrl,
         apiKey: draftApiConfig.customApiKey,
-        providerId: selectedCodexConfigProviderId || codexConfig?.activeProviderId,
+        providerId,
         codexHome: draftApiConfig.customConfigDir || undefined,
         keyTarget: "codex",
       });
@@ -1649,7 +1655,11 @@ export function ProviderPage({
                   value={summaryView.baseUrl}
                   disabled={!settings || saving || !summaryView.baseUrlEditable}
                   placeholder={summaryView.baseUrlPlaceholder}
-                  onChange={(event) => updateDraftSummaryApiConfig({ customBaseUrl: event.currentTarget.value })}
+                  onChange={(event) => updateDraftSummaryApiConfig({
+                    customProviderId: "custom",
+                    customBaseUrl: event.currentTarget.value,
+                    customApiKey: "",
+                  })}
                 />
               </label>
               <div className="settings-field" data-summary-row="model">

--- a/apps/main-2.0/src/renderer/src/features/providers/provider-page.tsx
+++ b/apps/main-2.0/src/renderer/src/features/providers/provider-page.tsx
@@ -19,15 +19,6 @@ import type { SummaryProviderConnectionRequest } from "../../../../shared/ipc/pr
 import type { SettingsFeedback } from "../../app-types";
 import { localize, type LanguageMode } from "../../language";
 
-type ProviderConnectionRequest =
-  | { target: "codex"; apiConfig: ApiConfig }
-  | { target: "claude"; apiConfig: ClaudeApiConfig };
-
-interface ProviderConnectionResult {
-  elapsedMs: number;
-  credentialSource: string;
-}
-
 // The summary route is a plain OpenAI-compatible route just like the Codex one, so it
 // offers the same presets; only the stored credential differs.
 const SUMMARY_API_PROVIDER_PRESETS = API_PROVIDER_PRESETS;
@@ -125,9 +116,6 @@ export function ProviderPage({
   const claudeConnectionSignatureRef = useRef(claudeConnectionSignature);
   codexConnectionSignatureRef.current = codexConnectionSignature;
   claudeConnectionSignatureRef.current = claudeConnectionSignature;
-  const providerConnectionApi = window.sessionSearch as typeof window.sessionSearch & {
-    testProviderConnection(input: ProviderConnectionRequest): Promise<ProviderConnectionResult>;
-  };
   const updateDraftSummaryApiConfig = (next: Partial<ApiConfig>) => setDraftSummaryApiConfig((current) => ({ ...current, ...next }));
   const selectedPreset = API_PROVIDER_PRESETS.find((preset) => preset.id === draftApiConfig.customProviderId);
   const customName = selectedPreset?.label ?? (draftApiConfig.customProviderName || "Custom");
@@ -366,7 +354,7 @@ export function ProviderPage({
     const testedSignature = codexConnectionSignature;
     setCodexConnectionStatus({ kind: "running", message: l("Testing Codex connection...", "正在测试 Codex 连接...") });
     try {
-      const result = await providerConnectionApi.testProviderConnection({
+      const result = await window.sessionSearch.testProviderConnection({
         target: "codex",
         apiConfig: { ...draftApiConfig },
       });
@@ -395,7 +383,7 @@ export function ProviderPage({
     const testedSignature = claudeConnectionSignature;
     setClaudeConnectionStatus({ kind: "running", message: l("Testing Claude Code connection...", "正在测试 Claude Code 连接...") });
     try {
-      const result = await providerConnectionApi.testProviderConnection({
+      const result = await window.sessionSearch.testProviderConnection({
         target: "claude",
         apiConfig: { ...draftClaudeApiConfig },
       });

--- a/apps/main-2.0/src/renderer/src/features/providers/provider-page.tsx
+++ b/apps/main-2.0/src/renderer/src/features/providers/provider-page.tsx
@@ -19,6 +19,15 @@ import type { SummaryProviderConnectionRequest } from "../../../../shared/ipc/pr
 import type { SettingsFeedback } from "../../app-types";
 import { localize, type LanguageMode } from "../../language";
 
+type ProviderConnectionRequest =
+  | { target: "codex"; apiConfig: ApiConfig }
+  | { target: "claude"; apiConfig: ClaudeApiConfig };
+
+interface ProviderConnectionResult {
+  elapsedMs: number;
+  credentialSource: string;
+}
+
 // The summary route is a plain OpenAI-compatible route just like the Codex one, so it
 // offers the same presets; only the stored credential differs.
 const SUMMARY_API_PROVIDER_PRESETS = API_PROVIDER_PRESETS;
@@ -84,12 +93,14 @@ export function ProviderPage({
   const [codexModelOptions, setCodexModelOptions] = useState<string[]>([]);
   const [codexModelMenuOpen, setCodexModelMenuOpen] = useState(false);
   const [codexModelProbeStatus, setCodexModelProbeStatus] = useState<SettingsFeedback>(null);
+  const [codexConnectionStatus, setCodexConnectionStatus] = useState<SettingsFeedback>(null);
   const [claudeConfig, setClaudeConfig] = useState<ClaudeConfigSnapshot | null>(null);
   const [claudeConfigError, setClaudeConfigError] = useState("");
   const [selectedClaudeConfigRoute, setSelectedClaudeConfigRoute] = useState("");
   const [claudeModelOptions, setClaudeModelOptions] = useState<string[]>([]);
   const [claudeModelMenuOpen, setClaudeModelMenuOpen] = useState(false);
   const [claudeModelProbeStatus, setClaudeModelProbeStatus] = useState<SettingsFeedback>(null);
+  const [claudeConnectionStatus, setClaudeConnectionStatus] = useState<SettingsFeedback>(null);
   const [summaryModelOptions, setSummaryModelOptions] = useState<string[]>([]);
   const [summaryModelMenuOpen, setSummaryModelMenuOpen] = useState(false);
   const [summaryModelProbeStatus, setSummaryModelProbeStatus] = useState<SettingsFeedback>(null);
@@ -104,8 +115,19 @@ export function ProviderPage({
   const summaryApiPresetSelectionRef = useRef(0);
   const codexConfigHydrationRef = useRef("");
   const claudeConfigHydrationRef = useRef("");
+  const codexConnectionTestIdRef = useRef(0);
+  const claudeConnectionTestIdRef = useRef(0);
   const updateDraftApiConfig = (next: Partial<ApiConfig>) => setDraftApiConfig((current) => ({ ...current, ...next }));
   const updateDraftClaudeApiConfig = (next: Partial<ClaudeApiConfig>) => setDraftClaudeApiConfig((current) => ({ ...current, ...next }));
+  const codexConnectionSignature = JSON.stringify(draftApiConfig);
+  const claudeConnectionSignature = JSON.stringify(draftClaudeApiConfig);
+  const codexConnectionSignatureRef = useRef(codexConnectionSignature);
+  const claudeConnectionSignatureRef = useRef(claudeConnectionSignature);
+  codexConnectionSignatureRef.current = codexConnectionSignature;
+  claudeConnectionSignatureRef.current = claudeConnectionSignature;
+  const providerConnectionApi = window.sessionSearch as typeof window.sessionSearch & {
+    testProviderConnection(input: ProviderConnectionRequest): Promise<ProviderConnectionResult>;
+  };
   const updateDraftSummaryApiConfig = (next: Partial<ApiConfig>) => setDraftSummaryApiConfig((current) => ({ ...current, ...next }));
   const selectedPreset = API_PROVIDER_PRESETS.find((preset) => preset.id === draftApiConfig.customProviderId);
   const customName = selectedPreset?.label ?? (draftApiConfig.customProviderName || "Custom");
@@ -336,6 +358,64 @@ export function ProviderPage({
       });
     } catch (error) {
       setClaudeModelProbeStatus({ kind: "error", message: error instanceof Error ? error.message : String(error) });
+    }
+  };
+
+  const testCodexConnection = async () => {
+    const testId = ++codexConnectionTestIdRef.current;
+    const testedSignature = codexConnectionSignature;
+    setCodexConnectionStatus({ kind: "running", message: l("Testing Codex connection...", "正在测试 Codex 连接...") });
+    try {
+      const result = await providerConnectionApi.testProviderConnection({
+        target: "codex",
+        apiConfig: { ...draftApiConfig },
+      });
+      if (
+        testId !== codexConnectionTestIdRef.current
+        || testedSignature !== codexConnectionSignatureRef.current
+      ) return;
+      setCodexConnectionStatus({
+        kind: "success",
+        message: l(
+          `Codex connection succeeded in ${result.elapsedMs} ms using ${result.credentialSource}.`,
+          `Codex 连接成功，使用 ${result.credentialSource}，耗时 ${result.elapsedMs} 毫秒。`,
+        ),
+      });
+    } catch (error) {
+      if (
+        testId !== codexConnectionTestIdRef.current
+        || testedSignature !== codexConnectionSignatureRef.current
+      ) return;
+      setCodexConnectionStatus({ kind: "error", message: error instanceof Error ? error.message : String(error) });
+    }
+  };
+
+  const testClaudeConnection = async () => {
+    const testId = ++claudeConnectionTestIdRef.current;
+    const testedSignature = claudeConnectionSignature;
+    setClaudeConnectionStatus({ kind: "running", message: l("Testing Claude Code connection...", "正在测试 Claude Code 连接...") });
+    try {
+      const result = await providerConnectionApi.testProviderConnection({
+        target: "claude",
+        apiConfig: { ...draftClaudeApiConfig },
+      });
+      if (
+        testId !== claudeConnectionTestIdRef.current
+        || testedSignature !== claudeConnectionSignatureRef.current
+      ) return;
+      setClaudeConnectionStatus({
+        kind: "success",
+        message: l(
+          `Claude Code connection succeeded in ${result.elapsedMs} ms using ${result.credentialSource}.`,
+          `Claude Code 连接成功，使用 ${result.credentialSource}，耗时 ${result.elapsedMs} 毫秒。`,
+        ),
+      });
+    } catch (error) {
+      if (
+        testId !== claudeConnectionTestIdRef.current
+        || testedSignature !== claudeConnectionSignatureRef.current
+      ) return;
+      setClaudeConnectionStatus({ kind: "error", message: error instanceof Error ? error.message : String(error) });
     }
   };
 
@@ -794,6 +874,16 @@ export function ProviderPage({
     setDraftSummaryReasoningEffort(settings?.summaryReasoningEffort ?? "medium");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [settingsSignature]);
+
+  useEffect(() => {
+    codexConnectionTestIdRef.current += 1;
+    setCodexConnectionStatus(null);
+  }, [codexConnectionSignature]);
+
+  useEffect(() => {
+    claudeConnectionTestIdRef.current += 1;
+    setClaudeConnectionStatus(null);
+  }, [claudeConnectionSignature]);
 
   useEffect(() => {
     // Re-read whenever the directory changes, otherwise the pane keeps showing the config
@@ -1681,9 +1771,38 @@ export function ProviderPage({
           )}
         </div>
         <div className="dialog-actions api-config-actions">
-          <span className={`api-config-status ${feedback?.kind ?? ""}`} aria-live="polite">
-            {feedback?.message ?? ""}
-          </span>
+          <div className="api-config-feedback" aria-live="polite">
+            {feedback ? <span className={`api-config-status ${feedback.kind}`}>{feedback.message}</span> : null}
+            {apiTarget === "codex" && codexConnectionStatus ? (
+              <span className={`api-config-status ${codexConnectionStatus.kind}`}>{codexConnectionStatus.message}</span>
+            ) : null}
+            {apiTarget === "claude" && claudeConnectionStatus ? (
+              <span className={`api-config-status ${claudeConnectionStatus.kind}`}>{claudeConnectionStatus.message}</span>
+            ) : null}
+          </div>
+          {apiTarget === "codex" ? (
+            <button
+              type="button"
+              data-provider-connection-test="codex"
+              disabled={!settings || saving || codexConnectionStatus?.kind === "running"}
+              onClick={() => void testCodexConnection()}
+            >
+              {codexConnectionStatus?.kind === "running"
+                ? l("Testing connection...", "正在测试连接...")
+                : l("Test connection", "测试连接")}
+            </button>
+          ) : apiTarget === "claude" ? (
+            <button
+              type="button"
+              data-provider-connection-test="claude"
+              disabled={!settings || saving || claudeConnectionStatus?.kind === "running"}
+              onClick={() => void testClaudeConnection()}
+            >
+              {claudeConnectionStatus?.kind === "running"
+                ? l("Testing connection...", "正在测试连接...")
+                : l("Test connection", "测试连接")}
+            </button>
+          ) : null}
           <button type="button" className={apiTarget === "summary" ? "primary-action" : ""} disabled={!settings || saving} onClick={saveDraft}>
             {apiTarget === "summary"
               ? l("Save summary settings", "保存摘要设置")

--- a/apps/main-2.0/src/renderer/src/features/providers/provider-page.tsx
+++ b/apps/main-2.0/src/renderer/src/features/providers/provider-page.tsx
@@ -31,6 +31,16 @@ function hasSavedCustomRoute(
     && Boolean(config.customBaseUrl.trim() || config.customModel.trim() || config.customApiKey.trim());
 }
 
+function providerTargetMatches(
+  config: Pick<ApiConfig | ClaudeApiConfig, "activeProvider" | "customProviderId" | "customBaseUrl"> | null | undefined,
+  providerId: string,
+  baseUrl: string,
+): boolean {
+  return config?.activeProvider === "custom"
+    && config.customProviderId === providerId
+    && normalizeProviderBaseUrl(config.customBaseUrl) === normalizeProviderBaseUrl(baseUrl);
+}
+
 function buildSummaryDraftFromSettings(settings: AppSettings | null): ApiConfig {
   return settings?.summaryApiConfig ?? { ...defaultApiConfig };
 }
@@ -142,21 +152,26 @@ export function ProviderPage({
     const activeProvider = snapshot.providers.find((provider) => provider.id === snapshot.activeProviderId);
     if (!activeProvider || snapshot.activeProviderId === "openai") {
       setSelectedCodexConfigProviderId("");
-      setDraftApiConfig((current) => ({ ...current, activeProvider: "official" }));
+      setDraftApiConfig((current) => ({ ...current, activeProvider: "official", customApiKey: "" }));
       return;
     }
     const preset = API_PROVIDER_PRESETS.find(
       (item) => item.id !== "custom" && (item.id === activeProvider.id || normalizeProviderBaseUrl(item.baseUrl) === normalizeProviderBaseUrl(activeProvider.baseUrl)),
     );
+    const nextProviderId = preset?.id ?? activeProvider.id;
+    const nextBaseUrl = activeProvider.baseUrl || preset?.baseUrl || "";
     setSelectedCodexConfigProviderId(preset ? "" : activeProvider.id);
     setDraftApiConfig((current) => ({
       ...current,
       activeProvider: "custom",
       // A preset match must keep the preset's own id, otherwise the preset button stops
       // looking selected and the stored key is looked up under the wrong name.
-      customProviderId: preset?.id ?? activeProvider.id,
+      customProviderId: nextProviderId,
       customProviderName: preset?.providerName ?? activeProvider.name ?? activeProvider.id,
-      customBaseUrl: activeProvider.baseUrl || preset?.baseUrl || current.customBaseUrl,
+      customBaseUrl: nextBaseUrl || current.customBaseUrl,
+      customApiKey: Boolean(nextBaseUrl) && providerTargetMatches(current, nextProviderId, nextBaseUrl)
+        ? current.customApiKey
+        : "",
       customModel: snapshot.activeModel || preset?.model || current.customModel,
       customApiFormat: activeProvider.wireApi === "chat" ? "openai_chat" : preset?.apiFormat ?? "openai_responses",
     }));
@@ -166,17 +181,21 @@ export function ProviderPage({
     `${snapshot.configPath}:${snapshot.activeProviderId}:${snapshot.activeModel}:${snapshot.providers.map((provider) => `${provider.id}:${provider.baseUrl}`).join("|")}`;
 
   const claudeConfigHydrationKey = (snapshot: ClaudeConfigSnapshot) =>
-    `${snapshot.settingsPath}:${snapshot.route.activeProvider}:${snapshot.route.customBaseUrl}:${snapshot.route.customModel}`;
+    `${snapshot.settingsPath}:${snapshot.route.activeProvider}:${snapshot.route.customProviderId}:${snapshot.route.customBaseUrl}:${snapshot.route.customModel}`;
 
   const hydrateDraftFromClaudeConfig = (snapshot: ClaudeConfigSnapshot, configDir?: string) => {
     if (snapshot.route.activeProvider !== "custom") return;
     setSelectedClaudeConfigRoute("config");
-    setDraftClaudeApiConfig((current) => ({
-      ...current,
-      ...snapshot.route,
-      customConfigDir: configDir ?? current.customConfigDir,
-      customApiKey: current.customApiKey,
-    }));
+    setDraftClaudeApiConfig((current) => {
+      const nextProviderId = snapshot.route.customProviderId ?? current.customProviderId;
+      const nextBaseUrl = snapshot.route.customBaseUrl ?? current.customBaseUrl;
+      return {
+        ...current,
+        ...snapshot.route,
+        customConfigDir: configDir ?? current.customConfigDir,
+        customApiKey: providerTargetMatches(current, nextProviderId, nextBaseUrl) ? current.customApiKey : "",
+      };
+    });
   };
 
   const selectClaudeConfigRoute = (useConfigRoute: boolean) => {
@@ -194,21 +213,34 @@ export function ProviderPage({
   const selectApiPreset = async (presetId: ApiProviderPresetId) => {
     const selectionId = ++apiPresetSelectionRef.current;
     const preset = API_PROVIDER_PRESETS.find((item) => item.id === presetId) ?? API_PROVIDER_PRESETS[0];
-    const apiKey = await window.sessionSearch.getApiProviderKey("codex", preset.id).catch(() => "");
+    const activeProvider = preset.id === "custom"
+      ? codexConfig?.providers.find((provider) => provider.id === codexConfig.activeProviderId)
+      : undefined;
+    const nextProviderId = activeProvider?.id ?? preset.id;
+    const apiKey = preset.id === "custom"
+      ? ""
+      : await window.sessionSearch.getApiProviderKey("codex", preset.id).catch(() => "");
     if (selectionId !== apiPresetSelectionRef.current) return;
     if (preset.id === "custom") {
-      const activeProvider = codexConfig?.providers.find((provider) => provider.id === codexConfig.activeProviderId);
       setSelectedCodexConfigProviderId(activeProvider?.id ?? "");
-      setDraftApiConfig((current) => ({
-        ...current,
-        activeProvider: "custom",
-        customProviderId: "custom",
-        customProviderName: activeProvider?.name || current.customProviderName || preset.providerName,
-        customBaseUrl: activeProvider?.baseUrl || current.customBaseUrl,
-        customApiKey: apiKey || current.customApiKey,
-        customModel: codexConfig?.activeModel || current.customModel,
-        customApiFormat: activeProvider?.wireApi === "chat" ? "openai_chat" : current.customApiFormat || preset.apiFormat,
-      }));
+      setDraftApiConfig((current) => {
+        const nextBaseUrl = activeProvider?.baseUrl || current.customBaseUrl;
+        const reusableKey = providerTargetMatches(current, nextProviderId, nextBaseUrl)
+          ? current.customApiKey
+          : providerTargetMatches(settings?.apiConfig, nextProviderId, nextBaseUrl)
+            ? settings?.apiConfig.customApiKey ?? ""
+            : "";
+        return {
+          ...current,
+          activeProvider: "custom",
+          customProviderId: nextProviderId,
+          customProviderName: activeProvider?.name || current.customProviderName || preset.providerName,
+          customBaseUrl: nextBaseUrl,
+          customApiKey: reusableKey,
+          customModel: codexConfig?.activeModel || current.customModel,
+          customApiFormat: activeProvider?.wireApi === "chat" ? "openai_chat" : current.customApiFormat || preset.apiFormat,
+        };
+      });
     } else {
       setSelectedCodexConfigProviderId("");
       setDraftApiConfig((current) => ({
@@ -289,21 +321,28 @@ export function ProviderPage({
     // has typed, instead of snapping the select back to the previous provider.
     if (!providerId) {
       setSelectedCodexConfigProviderId("");
-      updateDraftApiConfig({ activeProvider: "custom", customProviderId: "custom" });
+      setDraftApiConfig((current) => ({
+        ...current,
+        activeProvider: "custom",
+        customProviderId: "custom",
+        customApiKey: providerTargetMatches(current, "custom", current.customBaseUrl) ? current.customApiKey : "",
+      }));
       return;
     }
     const provider = codexConfig?.providers.find((item) => item.id === providerId);
     if (!provider) return;
     setSelectedCodexConfigProviderId(provider.id);
-    updateDraftApiConfig({
+    setDraftApiConfig((current) => ({
+      ...current,
       activeProvider: "custom",
       // Keep the config's own id so the credential lookup and the applied config.toml
       // section both point at the provider the user just picked.
       customProviderId: provider.id,
       customProviderName: provider.name || provider.id,
       customBaseUrl: provider.baseUrl,
+      customApiKey: providerTargetMatches(current, provider.id, provider.baseUrl) ? current.customApiKey : "",
       customApiFormat: provider.wireApi === "chat" ? "openai_chat" : "openai_responses",
-    });
+    }));
   };
 
   const detectCodexModels = async () => {
@@ -764,18 +803,25 @@ export function ProviderPage({
   const selectClaudeApiPreset = async (presetId: ClaudeApiProviderPresetId) => {
     const selectionId = ++claudeApiPresetSelectionRef.current;
     const preset = CLAUDE_API_PROVIDER_PRESETS.find((item) => item.id === presetId) ?? CLAUDE_API_PROVIDER_PRESETS[0];
-    const apiKey = await window.sessionSearch.getApiProviderKey("claude", preset.id).catch(() => "");
+    const apiKey = preset.id === "custom"
+      ? ""
+      : await window.sessionSearch.getApiProviderKey("claude", preset.id).catch(() => "");
     if (selectionId !== claudeApiPresetSelectionRef.current) return;
     setDraftClaudeApiConfig((current) => {
       if (preset.id === "custom") {
+        const nextProviderId = "custom";
+        const nextBaseUrl = current.customBaseUrl;
+        const reusableKey = providerTargetMatches(current, nextProviderId, nextBaseUrl)
+          ? current.customApiKey
+          : providerTargetMatches(settings?.claudeApiConfig, nextProviderId, nextBaseUrl)
+            ? settings?.claudeApiConfig.customApiKey ?? ""
+            : "";
         return {
           ...current,
           activeProvider: "custom",
-          customProviderId: "custom",
+          customProviderId: nextProviderId,
           customProviderName: current.customProviderName || preset.providerName,
-          // Custom has no route of its own to restore, so a missing stored key must not
-          // erase whatever the user has already typed into the field.
-          customApiKey: apiKey || current.customApiKey,
+          customApiKey: reusableKey,
         };
       }
       return {
@@ -1086,7 +1132,14 @@ export function ProviderPage({
                       value={draftApiConfig.customBaseUrl}
                       disabled={!settings || saving}
                       placeholder="https://api.example.com/v1"
-                      onChange={(event) => updateDraftApiConfig({ customBaseUrl: event.currentTarget.value })}
+                      onChange={(event) => {
+                        setSelectedCodexConfigProviderId("");
+                        updateDraftApiConfig({
+                          customProviderId: "custom",
+                          customBaseUrl: event.currentTarget.value,
+                          customApiKey: "",
+                        });
+                      }}
                     />
                   </label>
                   <label className="settings-field">
@@ -1339,7 +1392,14 @@ export function ProviderPage({
                       value={draftClaudeApiConfig.customBaseUrl}
                       disabled={!settings || saving}
                       placeholder="https://api.example.com/anthropic"
-                      onChange={(event) => updateDraftClaudeApiConfig({ customBaseUrl: event.currentTarget.value })}
+                      onChange={(event) => {
+                        setSelectedClaudeConfigRoute("");
+                        updateDraftClaudeApiConfig({
+                          customProviderId: "custom",
+                          customBaseUrl: event.currentTarget.value,
+                          customApiKey: "",
+                        });
+                      }}
                     />
                   </label>
                   <label className="settings-field">

--- a/apps/main-2.0/src/renderer/src/styles/providers.css
+++ b/apps/main-2.0/src/renderer/src/styles/providers.css
@@ -359,6 +359,17 @@
   box-shadow: 0 1px 2px var(--accent-ring, rgba(0, 0, 0, 0.12));
 }
 
+.api-config-feedback {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+  margin-right: auto;
+}
+
+.api-config-feedback .api-config-status {
+  margin-right: 0;
+}
+
 .api-config-status {
   min-width: 0;
   margin-right: auto;

--- a/apps/main-2.0/src/shared/ipc/providers.ts
+++ b/apps/main-2.0/src/shared/ipc/providers.ts
@@ -57,6 +57,17 @@ export const claudeModelProbeInput = z.object({
 
 export const providerKeyTarget = z.enum(["codex", "claude", "summary"]);
 
+export const providerConnectionInput = z.discriminatedUnion("target", [
+  z.object({
+    target: z.literal("codex"),
+    apiConfig: apiConfigInput,
+  }).strict(),
+  z.object({
+    target: z.literal("claude"),
+    apiConfig: claudeApiConfigInput,
+  }).strict(),
+]);
+
 const summaryConnectionFields = {
   baseUrl: boundedString(8_192).trim().min(1),
   apiKey: boundedString(65_536),
@@ -105,18 +116,25 @@ export type ProviderKeyTarget = z.infer<typeof providerKeyTarget>;
 export type ConfigSnapshotRequest = z.infer<typeof configSnapshotInput>;
 export type CodexModelProbeRequest = z.infer<typeof codexModelProbeInput>;
 export type ClaudeModelProbeRequest = z.infer<typeof claudeModelProbeInput>;
+export type ProviderConnectionRequest = z.infer<typeof providerConnectionInput>;
 export type SummaryProviderConnectionRequest = z.infer<typeof summaryProviderConnectionInput>;
 
-export interface SummaryProviderConnectionResult {
+export interface ProviderConnectionResult {
   elapsedMs: number;
   credentialSource: string;
 }
+
+export type SummaryProviderConnectionResult = ProviderConnectionResult;
 
 export const PROVIDERS_IPC = {
   getCodexConfig: defineIpcRequest("codex-config:get", z.tuple([configSnapshotInput])),
   getClaudeConfig: defineIpcRequest("claude-config:get", z.tuple([configSnapshotInput])),
   probeCodexModels: defineIpcRequest("codex-config:probe-models", z.tuple([codexModelProbeInput])),
   probeClaudeModels: defineIpcRequest("claude-config:probe-models", z.tuple([claudeModelProbeInput])),
+  testProviderConnection: defineIpcRequest(
+    "provider:test-connection",
+    z.tuple([providerConnectionInput]),
+  ),
   pickConfigDirectory: defineIpcRequest(
     "provider-config:pick-directory",
     z.tuple([providerKeyTarget, z.union([boundedString(8_192), z.undefined()])]),


### PR DESCRIPTION
## Summary

- add Test connection actions for Codex and Claude Provider drafts in V1 and V2
- test through the real CLIs so environment, keychain, auth-command, and apiKeyHelper credentials work without assuming the key lives in one config file
- isolate probes from tools and user workspaces, bind stored keys to their Provider destination, and abort temporary Chat proxy requests during cleanup

## Validation

- V1 changed suites: 124 tests passed
- V1 script suite: 79 tests passed
- V2 full suite: 1930 tests passed across 212 files
- V2 script suite: 165 tests passed
- V1 and V2 builds passed
- V1 and V2 package smoke tests passed with temporary HOME and npm prefixes
- release-note and diff checks passed