### PR TITLE
fix(sessions): correct DeepSeek token accounting

### DIFF
--- a/.release-notes/fix-deepseek-token-accounting.md
+++ b/.release-notes/fix-deepseek-token-accounting.md
@@ -1,0 +1,7 @@
+# DeepSeek Harness Token 统计修复
+
+<!-- release-target: both -->
+
+## Bug 修复
+
+- DeepSeek Harness 会话现在会正确区分缓存写入、缓存读取和推理 Token，并完整统计不同会话与各轮用量，避免遗漏或重复。

--- a/apps/main-1.0/src/core/deepseek-harness.test.ts
+++ b/apps/main-1.0/src/core/deepseek-harness.test.ts
@@ -60,12 +60,13 @@ describe("deepseek harness session parser", () => {
         { type: "turn/start", seq: 1, time: 1700000000002, data: { turn: 1 } },
         { type: "step/start", seq: 2, time: 1700000000003, data: { turn: 1, step: 1 } },
         { type: "user/message", seq: 3, time: 1700000000004, data: { id: "m1", role: "user", content: [{ type: "text", text: "请修复登录 bug" }], source: { kind: "user", rpcId: "rpc1" } }, surfaceOp: "append" },
-        { type: "assistant/message", seq: 4, time: 1700000000005, data: { turn: 1, step: 1, message: { id: "m2", role: "assistant", content: [{ type: "text", text: "好的，先查看代码。" }], source: { kind: "model", provider: "tt-switch", model: "deepseek-v4-pro-ioa" } }, usage: { inputTokens: 10, outputTokens: 5, cacheReadTokens: 2 } }, surfaceOp: "append" },
-        { type: "tool/call", seq: 5, time: 1700000000006, data: { turn: 1, step: 1, callId: "call_1", name: "bash", arguments: "ls" } },
-        { type: "tool/result", seq: 6, time: 1700000000007, data: { turn: 1, step: 1, message: { id: "m3", role: "user", content: [{ type: "tool-result", toolCallId: "call_1", content: [{ type: "text", text: "demo" }] }], source: { kind: "tool", callId: "call_1" } } } },
-        { type: "step/end", seq: 7, time: 1700000000008, data: { turn: 1, step: 1 } },
-        { type: "turn/end", seq: 8, time: 1700000000009, data: { turn: 1, reason: { kind: "completed" } } },
-        { type: "session/title", seq: 9, time: 1700000000010, data: { title: "修复登录 bug", messageSeqs: [3], source: { kind: "fallback" } } },
+        { type: "assistant/chunk", seq: 4, time: 1700000000005, data: { turn: 1, step: 1, chunk: { type: "usage", usage: { inputTokens: 9, outputTokens: 4, cacheReadTokens: 1, cacheWriteTokens: 1, reasoningTokens: 1 } } } },
+        { type: "assistant/message", seq: 5, time: 1700000000006, data: { turn: 1, step: 1, message: { id: "m2", role: "assistant", content: [{ type: "text", text: "好的，先查看代码。" }], source: { kind: "model", provider: "tt-switch", model: "deepseek-v4-pro-ioa" } }, usage: { inputTokens: 10, outputTokens: 5, cacheReadTokens: 2, cacheWriteTokens: 3, reasoningTokens: 2 } }, surfaceOp: "append" },
+        { type: "tool/call", seq: 6, time: 1700000000007, data: { turn: 1, step: 1, callId: "call_1", name: "bash", arguments: "ls" } },
+        { type: "tool/result", seq: 7, time: 1700000000008, data: { turn: 1, step: 1, message: { id: "m3", role: "user", content: [{ type: "tool-result", toolCallId: "call_1", content: [{ type: "text", text: "demo" }] }], source: { kind: "tool", callId: "call_1" } } } },
+        { type: "step/end", seq: 8, time: 1700000000009, data: { turn: 1, step: 1 } },
+        { type: "turn/end", seq: 9, time: 1700000000010, data: { turn: 1, reason: { kind: "completed" } } },
+        { type: "session/title", seq: 10, time: 1700000000011, data: { title: "修复登录 bug", messageSeqs: [3], source: { kind: "fallback" } } },
       ];
       const text = lines.map((line) => JSON.stringify(line)).join("\n") + "\n";
       const compressed = zstdCompressSync(Buffer.from(text));
@@ -76,14 +77,29 @@ describe("deepseek harness session parser", () => {
 
       const loaded = loadDeepSeekCliSessions(root);
       expect(loaded).toHaveLength(1);
-      const { session, messages, traceEvents = [] } = loaded[0];
+      const { session, messages, tokenEvents = [], traceEvents = [] } = loaded[0];
       expect(session.rawId).toBe("session-abc");
       expect(session.projectPath).toBe("/work/demo");
       expect(session.originalTitle).toBe("修复登录 bug");
       expect(session.source).toBe("deepseek-cli");
-      expect(session.tokenUsage?.inputTokens).toBe(10);
-      expect(session.tokenUsage?.outputTokens).toBe(5);
-      expect(session.tokenUsage?.cachedInputTokens).toBe(2);
+      expect(session.tokenUsage).toEqual({
+        inputTokens: 10,
+        outputTokens: 3,
+        cachedInputTokens: 2,
+        cacheCreationInputTokens: 3,
+        reasoningOutputTokens: 2,
+        totalTokens: 20,
+      });
+      expect(tokenEvents).toEqual([{
+        inputTokens: 10,
+        outputTokens: 3,
+        cachedInputTokens: 2,
+        cacheCreationInputTokens: 3,
+        reasoningOutputTokens: 2,
+        totalTokens: 20,
+        timestamp: 1700000000006,
+        dedupeKey: "deepseek:session-abc:1:1",
+      }]);
       expect(messages.map((message) => message.role)).toEqual(["user", "assistant"]);
       expect(messages[0].content).toBe("请修复登录 bug");
       expect(messages[1].content).toBe("好的，先查看代码。");

--- a/apps/main-1.0/src/core/deepseek-harness.ts
+++ b/apps/main-1.0/src/core/deepseek-harness.ts
@@ -359,16 +359,18 @@ interface DeepSeekUsage {
   cacheWriteTokens: number;
 }
 
-function deepSeekUsageOf(event: DeepSeekSessionEvent): DeepSeekUsage | null {
-  const data = deepSeekRecord(event.data);
-  const usage = deepSeekRecord(data?.usage);
+function normalizeDeepSeekUsage(value: unknown): DeepSeekUsage | null {
+  const usage = deepSeekRecord(value);
   if (!usage) return null;
   const number = (value: unknown): number => typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+  const outputTokens = number(usage.outputTokens);
+  const reasoningTokens = number(usage.reasoningTokens);
+  // Harness output already includes reasoning; AgentRecall stores disjoint buckets.
   return {
     inputTokens: number(usage.inputTokens),
-    outputTokens: number(usage.outputTokens),
+    outputTokens: Math.max(0, outputTokens - reasoningTokens),
     cacheReadTokens: number(usage.cacheReadTokens),
-    reasoningTokens: number(usage.reasoningTokens),
+    reasoningTokens,
     cacheWriteTokens: number(usage.cacheWriteTokens),
   };
 }
@@ -377,26 +379,19 @@ function deepSeekUsageOfEvent(event: DeepSeekSessionEvent): { turn: number; step
   const data = deepSeekRecord(event.data);
   if (data === null) return null;
   if (event.type === "assistant/message") {
-    const usage = deepSeekUsageOf(event);
+    const usage = normalizeDeepSeekUsage(data.usage);
     if (usage === null) return null;
     return { turn: deepSeekNumber(data.turn), step: deepSeekNumber(data.step), usage };
   }
   if (event.type === "assistant/chunk") {
     const chunk = deepSeekRecord(data.chunk);
     if (chunk === null || chunk.type !== "usage") return null;
-    const usageRecord = deepSeekRecord(chunk.usage);
-    if (usageRecord === null) return null;
-    const number = (value: unknown): number => typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+    const usage = normalizeDeepSeekUsage(chunk.usage);
+    if (usage === null) return null;
     return {
       turn: deepSeekNumber(data.turn),
       step: deepSeekNumber(data.step),
-      usage: {
-        inputTokens: number(usageRecord.inputTokens),
-        outputTokens: number(usageRecord.outputTokens),
-        cacheReadTokens: number(usageRecord.cacheReadTokens),
-        reasoningTokens: number(usageRecord.reasoningTokens),
-        cacheWriteTokens: number(usageRecord.cacheWriteTokens),
-      },
+      usage,
     };
   }
   return null;
@@ -409,21 +404,21 @@ function deepSeekNumber(value: unknown): number {
 /**
  * Token usage fold that mirrors deepseek-harness tokenUsageProjection:
  * usage samples for the same turn/step replace each other (last wins) instead
- * of double counting, and samples for a later step replace the previous step.
+ * of double counting, while later turn/step samples accumulate independently.
  */
 interface DeepSeekUsageFold {
   usage: DeepSeekUsage;
   tokenEvents: TokenUsageEvent[];
 }
 
-function deepSeekTotalUsage(events: DeepSeekSessionEvent[]): DeepSeekUsageFold {
+function deepSeekTotalUsage(events: DeepSeekSessionEvent[], sessionId: string): DeepSeekUsageFold {
   const totals: DeepSeekUsage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, reasoningTokens: 0, cacheWriteTokens: 0 };
   const tokenEvents: TokenUsageEvent[] = [];
   let last: { turn: number; step: number; usage: DeepSeekUsage } | null = null;
   for (const event of events) {
     const sample = deepSeekUsageOfEvent(event);
     if (sample === null || sample.turn < 0 || sample.step < 0) continue;
-    const dedupeKey = "deepseek:" + sample.turn + ":" + sample.step;
+    const dedupeKey = `deepseek:${sessionId}:${sample.turn}:${sample.step}`;
     if (last !== null && last.turn === sample.turn && last.step === sample.step) {
       if (
         last.usage.inputTokens === sample.usage.inputTokens
@@ -448,11 +443,17 @@ function deepSeekTotalUsage(events: DeepSeekSessionEvent[]): DeepSeekUsageFold {
       inputTokens: sample.usage.inputTokens,
       outputTokens: sample.usage.outputTokens,
       cachedInputTokens: sample.usage.cacheReadTokens,
+      ...(sample.usage.cacheWriteTokens > 0
+        ? { cacheCreationInputTokens: sample.usage.cacheWriteTokens }
+        : {}),
       reasoningOutputTokens: sample.usage.reasoningTokens,
-      totalTokens: sample.usage.inputTokens + sample.usage.outputTokens + sample.usage.cacheReadTokens + sample.usage.reasoningTokens,
+      totalTokens: sample.usage.inputTokens
+        + sample.usage.outputTokens
+        + sample.usage.cacheReadTokens
+        + sample.usage.cacheWriteTokens
+        + sample.usage.reasoningTokens,
       timestamp: deepSeekEventTimeMs(event),
       dedupeKey,
-      sourceTurnId: sample.turn + ":" + sample.step,
     });
     last = sample;
   }
@@ -601,7 +602,7 @@ export interface DeepSeekSessionView {
  * user/assistant messages, tool trace events, the latest title, and usage.
  */
 export function projectDeepSeekSession(log: DeepSeekSessionLog, source: SessionFormat = "deepseek"): DeepSeekSessionView {
-  const fold = deepSeekTotalUsage(log.events);
+  const fold = deepSeekTotalUsage(log.events, log.header.id);
   return {
     title: deepSeekTitle(log.events),
     messages: deepSeekSessionMessages(log),

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -3146,12 +3146,19 @@ function extractProjectPathFromJson(value: unknown): string {
   return firstStringField(parsed, ["cwd", "directory", "projectPath", "project_path", "workdir", "workspacePath", "workspace_path"]);
 }
 
-function createSourceTokenUsage(inputTokens: number, outputTokens: number, cachedInputTokens: number, reasoningOutputTokens: number): TokenUsage {
+function createSourceTokenUsage(
+  inputTokens: number,
+  outputTokens: number,
+  cachedInputTokens: number,
+  reasoningOutputTokens: number,
+  cacheCreationInputTokens = 0,
+): TokenUsage {
   return createTokenUsage(
     Math.max(0, inputTokens),
     Math.max(0, outputTokens),
     Math.max(0, cachedInputTokens),
     Math.max(0, reasoningOutputTokens),
+    Math.max(0, cacheCreationInputTokens),
   );
 }
 
@@ -3172,6 +3179,7 @@ export function loadDeepSeekCliSessionFile(filePath: string, stat: VirtualSessio
     view.usage.outputTokens,
     view.usage.cacheReadTokens,
     view.usage.reasoningTokens,
+    view.usage.cacheWriteTokens,
   );
   return {
     session: createIndexedSession({

--- a/apps/main-1.0/src/core/store/schema.test.ts
+++ b/apps/main-1.0/src/core/store/schema.test.ts
@@ -316,6 +316,64 @@ describe("session store schema", () => {
     }
   });
 
+  it("invalidates DeepSeek token accounting exactly once", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      migrateSessionStore(db);
+      db.prepare("DELETE FROM data_migrations WHERE id = 'deepseek-token-accounting-v1'").run();
+      const insert = db.prepare(`
+        INSERT INTO sessions (
+          session_key, raw_id, source, project_path, file_path,
+          original_title, first_question, timestamp, file_mtime_ms, file_size,
+          content_indexed_mtime_ms, content_indexed_size
+        ) VALUES (?, ?, ?, '/repo', ?, 'Title', 'Question', 1, 123, 456, 123, 456)
+      `);
+      insert.run("deepseek:legacy", "legacy", "deepseek-cli", "/tmp/deepseek.jsonl.zstd");
+      insert.run("claude:unchanged", "unchanged", "claude-cli", "/tmp/claude.jsonl");
+
+      migrateSessionStore(db);
+
+      expect(db.prepare(`
+        SELECT session_key, file_mtime_ms, content_indexed_mtime_ms, content_indexed_size
+        FROM sessions
+        ORDER BY session_key
+      `).all()).toEqual([
+        {
+          session_key: "claude:unchanged",
+          file_mtime_ms: 123,
+          content_indexed_mtime_ms: 123,
+          content_indexed_size: 456,
+        },
+        {
+          session_key: "deepseek:legacy",
+          file_mtime_ms: 0,
+          content_indexed_mtime_ms: 0,
+          content_indexed_size: 0,
+        },
+      ]);
+
+      db.prepare(`
+        UPDATE sessions
+        SET file_mtime_ms = 789,
+            content_indexed_mtime_ms = 789,
+            content_indexed_size = 456
+        WHERE session_key = 'deepseek:legacy'
+      `).run();
+      migrateSessionStore(db);
+      expect(db.prepare(`
+        SELECT file_mtime_ms, content_indexed_mtime_ms, content_indexed_size
+        FROM sessions
+        WHERE session_key = 'deepseek:legacy'
+      `).get()).toEqual({
+        file_mtime_ms: 789,
+        content_indexed_mtime_ms: 789,
+        content_indexed_size: 456,
+      });
+    } finally {
+      db.close();
+    }
+  });
+
   it("invalidates session relation and branch metadata exactly once", () => {
     const db = new DatabaseSync(":memory:");
     try {

--- a/apps/main-1.0/src/core/store/schema.ts
+++ b/apps/main-1.0/src/core/store/schema.ts
@@ -317,6 +317,7 @@ export function migrateSessionStore(db: SessionStoreDatabase): void {
   runCursorEmptyComposerShellsMigration(db);
   runRemoveClaudeCodexInternalSourcesMigration(db);
   runCacheTokenSemanticsMigration(db);
+  runDeepSeekTokenAccountingMigration(db);
   runCodexSessionSemanticsMigration(db);
   runCodexTraceDetailMigration(db);
   runInjectedUserNoiseMigration(db);
@@ -614,6 +615,30 @@ function runCacheTokenSemanticsMigration(db: SessionStoreDatabase): void {
               content_indexed_mtime_ms = 0,
               content_indexed_size = 0
           WHERE source IN ('claude-cli', 'claude-app', 'tclaude-cli', 'zcode-cli')
+        `,
+      ).run();
+      db.prepare("INSERT INTO data_migrations (id, applied_at) VALUES (?, ?)").run(migrationId, Date.now());
+    }
+    db.exec("COMMIT");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    throw error;
+  }
+}
+
+function runDeepSeekTokenAccountingMigration(db: SessionStoreDatabase): void {
+  const migrationId = "deepseek-token-accounting-v1";
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    const applied = db.prepare("SELECT 1 FROM data_migrations WHERE id = ?").get(migrationId);
+    if (!applied) {
+      db.prepare(
+        `
+          UPDATE sessions
+          SET file_mtime_ms = 0,
+              content_indexed_mtime_ms = 0,
+              content_indexed_size = 0
+          WHERE source = 'deepseek-cli'
         `,
       ).run();
       db.prepare("INSERT INTO data_migrations (id, applied_at) VALUES (?, ?)").run(migrationId, Date.now());

--- a/apps/main-2.0/src/core/deepseek-harness.test.ts
+++ b/apps/main-2.0/src/core/deepseek-harness.test.ts
@@ -9,6 +9,7 @@ import {
   scanDeepSeekZstdFrames,
 } from "./deepseek-harness";
 import { loadDeepSeekCliSessions } from "./session-loader";
+import { deriveSessionTimeline } from "./turns/derive-turns";
 
 describe("deepseek harness session parser", () => {
   it("rejects non-zstd garbage", () => {
@@ -60,12 +61,13 @@ describe("deepseek harness session parser", () => {
         { type: "turn/start", seq: 1, time: 1700000000002, data: { turn: 1 } },
         { type: "step/start", seq: 2, time: 1700000000003, data: { turn: 1, step: 1 } },
         { type: "user/message", seq: 3, time: 1700000000004, data: { id: "m1", role: "user", content: [{ type: "text", text: "请修复登录 bug" }], source: { kind: "user", rpcId: "rpc1" } }, surfaceOp: "append" },
-        { type: "assistant/message", seq: 4, time: 1700000000005, data: { turn: 1, step: 1, message: { id: "m2", role: "assistant", content: [{ type: "text", text: "好的，先查看代码。" }], source: { kind: "model", provider: "tt-switch", model: "deepseek-v4-pro-ioa" } }, usage: { inputTokens: 10, outputTokens: 5, cacheReadTokens: 2 } }, surfaceOp: "append" },
-        { type: "tool/call", seq: 5, time: 1700000000006, data: { turn: 1, step: 1, callId: "call_1", name: "bash", arguments: "ls" } },
-        { type: "tool/result", seq: 6, time: 1700000000007, data: { turn: 1, step: 1, message: { id: "m3", role: "user", content: [{ type: "tool-result", toolCallId: "call_1", content: [{ type: "text", text: "demo" }] }], source: { kind: "tool", callId: "call_1" } } } },
-        { type: "step/end", seq: 7, time: 1700000000008, data: { turn: 1, step: 1 } },
-        { type: "turn/end", seq: 8, time: 1700000000009, data: { turn: 1, reason: { kind: "completed" } } },
-        { type: "session/title", seq: 9, time: 1700000000010, data: { title: "修复登录 bug", messageSeqs: [3], source: { kind: "fallback" } } },
+        { type: "assistant/chunk", seq: 4, time: 1700000000005, data: { turn: 1, step: 1, chunk: { type: "usage", usage: { inputTokens: 9, outputTokens: 4, cacheReadTokens: 1, cacheWriteTokens: 1, reasoningTokens: 1 } } } },
+        { type: "assistant/message", seq: 5, time: 1700000000006, data: { turn: 1, step: 1, message: { id: "m2", role: "assistant", content: [{ type: "text", text: "好的，先查看代码。" }], source: { kind: "model", provider: "tt-switch", model: "deepseek-v4-pro-ioa" } }, usage: { inputTokens: 10, outputTokens: 5, cacheReadTokens: 2, cacheWriteTokens: 3, reasoningTokens: 2 } }, surfaceOp: "append" },
+        { type: "tool/call", seq: 6, time: 1700000000007, data: { turn: 1, step: 1, callId: "call_1", name: "bash", arguments: "ls" } },
+        { type: "tool/result", seq: 7, time: 1700000000008, data: { turn: 1, step: 1, message: { id: "m3", role: "user", content: [{ type: "tool-result", toolCallId: "call_1", content: [{ type: "text", text: "demo" }] }], source: { kind: "tool", callId: "call_1" } } } },
+        { type: "step/end", seq: 8, time: 1700000000009, data: { turn: 1, step: 1 } },
+        { type: "turn/end", seq: 9, time: 1700000000010, data: { turn: 1, reason: { kind: "completed" } } },
+        { type: "session/title", seq: 10, time: 1700000000011, data: { title: "修复登录 bug", messageSeqs: [3], source: { kind: "fallback" } } },
       ];
       const text = lines.map((line) => JSON.stringify(line)).join("\n") + "\n";
       const compressed = zstdCompressSync(Buffer.from(text));
@@ -76,20 +78,48 @@ describe("deepseek harness session parser", () => {
 
       const loaded = loadDeepSeekCliSessions(root);
       expect(loaded).toHaveLength(1);
-      const { session, messages, traceEvents = [] } = loaded[0];
+      const { session, messages, tokenEvents = [], traceEvents = [] } = loaded[0];
       expect(session.rawId).toBe("session-abc");
       expect(session.projectPath).toBe("/work/demo");
       expect(session.originalTitle).toBe("修复登录 bug");
       expect(session.source).toBe("deepseek-cli");
-      expect(session.tokenUsage?.inputTokens).toBe(10);
-      expect(session.tokenUsage?.outputTokens).toBe(5);
-      expect(session.tokenUsage?.cachedInputTokens).toBe(2);
+      expect(session.tokenUsage).toEqual({
+        inputTokens: 10,
+        outputTokens: 3,
+        cachedInputTokens: 2,
+        cacheCreationInputTokens: 3,
+        reasoningOutputTokens: 2,
+        totalTokens: 20,
+      });
+      expect(tokenEvents).toEqual([{
+        inputTokens: 10,
+        outputTokens: 3,
+        cachedInputTokens: 2,
+        cacheCreationInputTokens: 3,
+        reasoningOutputTokens: 2,
+        totalTokens: 20,
+        timestamp: 1700000000006,
+        dedupeKey: "deepseek:session-abc:1:1",
+      }]);
       expect(messages.map((message) => message.role)).toEqual(["user", "assistant"]);
       expect(messages[0].content).toBe("请修复登录 bug");
       expect(messages[1].content).toBe("好的，先查看代码。");
       expect(traceEvents.map((event) => event.kind)).toEqual(["tool_call"]);
       expect(traceEvents[0].title).toBe("bash");
       expect(traceEvents[0].status).toBe("completed");
+      expect(deriveSessionTimeline({
+        sessionKey: session.sessionKey,
+        messages,
+        tokenEvents,
+        traceEvents,
+      }).turns[0]).toMatchObject({
+        inputTokens: 10,
+        outputTokens: 3,
+        cachedInputTokens: 2,
+        cacheCreationInputTokens: 3,
+        reasoningOutputTokens: 2,
+        totalTokens: 20,
+      });
 
       // Best-effort source deletion removes only the session directory.
       deleteDeepSeekCliSessionDirectory(logPath);

--- a/apps/main-2.0/src/core/deepseek-harness.ts
+++ b/apps/main-2.0/src/core/deepseek-harness.ts
@@ -351,16 +351,18 @@ interface DeepSeekUsage {
   cacheWriteTokens: number;
 }
 
-function deepSeekUsageOf(event: DeepSeekSessionEvent): DeepSeekUsage | null {
-  const data = deepSeekRecord(event.data);
-  const usage = deepSeekRecord(data?.usage);
+function normalizeDeepSeekUsage(value: unknown): DeepSeekUsage | null {
+  const usage = deepSeekRecord(value);
   if (!usage) return null;
   const number = (value: unknown): number => typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+  const outputTokens = number(usage.outputTokens);
+  const reasoningTokens = number(usage.reasoningTokens);
+  // Harness output already includes reasoning; AgentRecall stores disjoint buckets.
   return {
     inputTokens: number(usage.inputTokens),
-    outputTokens: number(usage.outputTokens),
+    outputTokens: Math.max(0, outputTokens - reasoningTokens),
     cacheReadTokens: number(usage.cacheReadTokens),
-    reasoningTokens: number(usage.reasoningTokens),
+    reasoningTokens,
     cacheWriteTokens: number(usage.cacheWriteTokens),
   };
 }
@@ -369,26 +371,19 @@ function deepSeekUsageOfEvent(event: DeepSeekSessionEvent): { turn: number; step
   const data = deepSeekRecord(event.data);
   if (data === null) return null;
   if (event.type === "assistant/message") {
-    const usage = deepSeekUsageOf(event);
+    const usage = normalizeDeepSeekUsage(data.usage);
     if (usage === null) return null;
     return { turn: deepSeekNumber(data.turn), step: deepSeekNumber(data.step), usage };
   }
   if (event.type === "assistant/chunk") {
     const chunk = deepSeekRecord(data.chunk);
     if (chunk === null || chunk.type !== "usage") return null;
-    const usageRecord = deepSeekRecord(chunk.usage);
-    if (usageRecord === null) return null;
-    const number = (value: unknown): number => typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+    const usage = normalizeDeepSeekUsage(chunk.usage);
+    if (usage === null) return null;
     return {
       turn: deepSeekNumber(data.turn),
       step: deepSeekNumber(data.step),
-      usage: {
-        inputTokens: number(usageRecord.inputTokens),
-        outputTokens: number(usageRecord.outputTokens),
-        cacheReadTokens: number(usageRecord.cacheReadTokens),
-        reasoningTokens: number(usageRecord.reasoningTokens),
-        cacheWriteTokens: number(usageRecord.cacheWriteTokens),
-      },
+      usage,
     };
   }
   return null;
@@ -401,21 +396,21 @@ function deepSeekNumber(value: unknown): number {
 /**
  * Token usage fold that mirrors deepseek-harness tokenUsageProjection:
  * usage samples for the same turn/step replace each other (last wins) instead
- * of double counting, and samples for a later step replace the previous step.
+ * of double counting, while later turn/step samples accumulate independently.
  */
 interface DeepSeekUsageFold {
   usage: DeepSeekUsage;
   tokenEvents: TokenUsageEvent[];
 }
 
-function deepSeekTotalUsage(events: DeepSeekSessionEvent[]): DeepSeekUsageFold {
+function deepSeekTotalUsage(events: DeepSeekSessionEvent[], sessionId: string): DeepSeekUsageFold {
   const totals: DeepSeekUsage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, reasoningTokens: 0, cacheWriteTokens: 0 };
   const tokenEvents: TokenUsageEvent[] = [];
   let last: { turn: number; step: number; usage: DeepSeekUsage } | null = null;
   for (const event of events) {
     const sample = deepSeekUsageOfEvent(event);
     if (sample === null || sample.turn < 0 || sample.step < 0) continue;
-    const dedupeKey = "deepseek:" + sample.turn + ":" + sample.step;
+    const dedupeKey = `deepseek:${sessionId}:${sample.turn}:${sample.step}`;
     if (last !== null && last.turn === sample.turn && last.step === sample.step) {
       if (
         last.usage.inputTokens === sample.usage.inputTokens
@@ -440,11 +435,17 @@ function deepSeekTotalUsage(events: DeepSeekSessionEvent[]): DeepSeekUsageFold {
       inputTokens: sample.usage.inputTokens,
       outputTokens: sample.usage.outputTokens,
       cachedInputTokens: sample.usage.cacheReadTokens,
+      ...(sample.usage.cacheWriteTokens > 0
+        ? { cacheCreationInputTokens: sample.usage.cacheWriteTokens }
+        : {}),
       reasoningOutputTokens: sample.usage.reasoningTokens,
-      totalTokens: sample.usage.inputTokens + sample.usage.outputTokens + sample.usage.cacheReadTokens + sample.usage.reasoningTokens,
+      totalTokens: sample.usage.inputTokens
+        + sample.usage.outputTokens
+        + sample.usage.cacheReadTokens
+        + sample.usage.cacheWriteTokens
+        + sample.usage.reasoningTokens,
       timestamp: deepSeekEventTimeMs(event),
       dedupeKey,
-      sourceTurnId: sample.turn + ":" + sample.step,
     });
     last = sample;
   }
@@ -593,7 +594,7 @@ export interface DeepSeekSessionView {
  * user/assistant messages, tool trace events, the latest title, and usage.
  */
 export function projectDeepSeekSession(log: DeepSeekSessionLog, source: SessionFormat = "deepseek"): DeepSeekSessionView {
-  const fold = deepSeekTotalUsage(log.events);
+  const fold = deepSeekTotalUsage(log.events, log.header.id);
   return {
     title: deepSeekTitle(log.events),
     messages: deepSeekSessionMessages(log),

--- a/apps/main-2.0/src/core/postgres/schema.test.ts
+++ b/apps/main-2.0/src/core/postgres/schema.test.ts
@@ -785,4 +785,97 @@ describe("AgentRecall PostgreSQL schema", () => {
     }]);
     await repeatedDatabase.close();
   });
+
+  it("invalidates existing DeepSeek token accounting exactly once", async () => {
+    const pool = new PGliteTestPool();
+    const legacyDatabase = new PostgresDatabase(pool, {
+      migrationLock: false,
+      migrations: POSTGRES_MIGRATIONS.filter((migration) => migration.version <= 39),
+    });
+    await legacyDatabase.initialize();
+    await legacyDatabase.query(`
+      insert into agent_recall.sessions (
+        session_key, raw_id, source, environment_id, project_path, file_path,
+        original_title, first_question, started_at, file_mtime_ms, file_size,
+        indexed_at, content_indexed_mtime_ms, content_indexed_size, is_subagent
+      ) values
+        (
+          'deepseek:legacy', 'legacy', 'deepseek-cli', 'local', '/repo', '/deepseek.jsonl.zstd',
+          'DeepSeek', 'Question', now(), 123, 456, now(), 123, 456, false
+        ),
+        (
+          'claude:unchanged', 'unchanged', 'claude-cli', 'local', '/repo', '/claude.jsonl',
+          'Claude', 'Question', now(), 123, 456, now(), 123, 456, false
+        );
+    `);
+
+    const upgradedDatabase = new PostgresDatabase(pool, {
+      migrationLock: false,
+      migrations: POSTGRES_MIGRATIONS,
+    });
+    await upgradedDatabase.initialize();
+
+    const result = await upgradedDatabase.query<{
+      session_key: string;
+      file_mtime_ms: number | string;
+      content_indexed_mtime_ms: number | string;
+      content_indexed_size: number | string;
+    }>(`
+      select session_key, file_mtime_ms, content_indexed_mtime_ms, content_indexed_size
+      from agent_recall.sessions
+      where session_key in ('deepseek:legacy', 'claude:unchanged')
+      order by session_key
+    `);
+    expect(result.rows.map((row) => ({
+      ...row,
+      file_mtime_ms: Number(row.file_mtime_ms),
+      content_indexed_mtime_ms: Number(row.content_indexed_mtime_ms),
+      content_indexed_size: Number(row.content_indexed_size),
+    }))).toEqual([
+      {
+        session_key: "claude:unchanged",
+        file_mtime_ms: 123,
+        content_indexed_mtime_ms: 123,
+        content_indexed_size: 456,
+      },
+      {
+        session_key: "deepseek:legacy",
+        file_mtime_ms: 0,
+        content_indexed_mtime_ms: 0,
+        content_indexed_size: 0,
+      },
+    ]);
+
+    await upgradedDatabase.query(`
+      update agent_recall.sessions
+      set file_mtime_ms = 789,
+          content_indexed_mtime_ms = 789,
+          content_indexed_size = 456
+      where session_key = 'deepseek:legacy'
+    `);
+    const repeatedDatabase = new PostgresDatabase(pool, {
+      migrationLock: false,
+      migrations: POSTGRES_MIGRATIONS,
+    });
+    await repeatedDatabase.initialize();
+    const repeated = await repeatedDatabase.query<{
+      file_mtime_ms: number | string;
+      content_indexed_mtime_ms: number | string;
+      content_indexed_size: number | string;
+    }>(`
+      select file_mtime_ms, content_indexed_mtime_ms, content_indexed_size
+      from agent_recall.sessions
+      where session_key = 'deepseek:legacy'
+    `);
+    expect(repeated.rows.map((row) => ({
+      file_mtime_ms: Number(row.file_mtime_ms),
+      content_indexed_mtime_ms: Number(row.content_indexed_mtime_ms),
+      content_indexed_size: Number(row.content_indexed_size),
+    }))).toEqual([{
+      file_mtime_ms: 789,
+      content_indexed_mtime_ms: 789,
+      content_indexed_size: 456,
+    }]);
+    await repeatedDatabase.close();
+  });
 });

--- a/apps/main-2.0/src/core/postgres/schema.ts
+++ b/apps/main-2.0/src/core/postgres/schema.ts
@@ -1644,4 +1644,16 @@ export const POSTGRES_MIGRATIONS: readonly PostgresMigration[] = [{
         AND source IN ('codex-cli', 'codex-app', 'tcodex-cli');
     `,
   ],
+}, {
+  version: 40,
+  name: "reindex DeepSeek token accounting",
+  statements: [
+    `
+      UPDATE agent_recall.sessions
+      SET file_mtime_ms = 0,
+          content_indexed_mtime_ms = 0,
+          content_indexed_size = 0
+      WHERE source = 'deepseek-cli';
+    `,
+  ],
 }];

--- a/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
+++ b/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
@@ -887,12 +887,19 @@ function extractProjectPathFromJson(value: unknown): string {
   return firstStringField(parsed, ["cwd", "directory", "projectPath", "project_path", "workdir", "workspacePath", "workspace_path"]);
 }
 
-function createSourceTokenUsage(inputTokens: number, outputTokens: number, cachedInputTokens: number, reasoningOutputTokens: number): TokenUsage {
+function createSourceTokenUsage(
+  inputTokens: number,
+  outputTokens: number,
+  cachedInputTokens: number,
+  reasoningOutputTokens: number,
+  cacheCreationInputTokens = 0,
+): TokenUsage {
   return createTokenUsage(
     Math.max(0, inputTokens),
     Math.max(0, outputTokens),
     Math.max(0, cachedInputTokens),
     Math.max(0, reasoningOutputTokens),
+    Math.max(0, cacheCreationInputTokens),
   );
 }
 
@@ -913,6 +920,7 @@ export function loadDeepSeekCliSessionFile(filePath: string, stat: VirtualSessio
     view.usage.outputTokens,
     view.usage.cacheReadTokens,
     view.usage.reasoningTokens,
+    view.usage.cacheWriteTokens,
   );
   return {
     session: createIndexedSession({


### PR DESCRIPTION
Closes #458

## 变更概述

- 按 DeepSeek Harness 的互斥 Token 桶语义统一修正 V1/V2：从 output 中拆出 reasoning，并将 cache write 映射为 cache creation。
- 让同一 turn/step 的最终 message usage 替换流式 chunk 样本；为 dedupe key 加入 session ID，避免不同会话在 Usage Stats 中互相去重。
- 移除无法匹配 DeepSeek message Turn 的 source turn 标识，使 V2 按时间把 Token event 归入正确 Turn。
- 为 V1 SQLite 和 V2 PostgreSQL 增加一次性 DeepSeek 定向重索引，使升级前已索引的会话自动获得正确统计。
- 补充双版本 usage、last-wins、去重键、Turn 归属和迁移幂等回归测试。

## 更新说明检查

- [x] 本分支已新增且仅新增一个 `.release-notes/<branch-slug>.md`
- [x] 更新说明已在标题后显式声明 `release-target: both`，覆盖 V1/V2
- [x] 更新说明包含面向用户的“Bug 修复”列表
- [x] 更新说明已移除 MR、分支、CI、发布流程、内部服务、路径及其他不应暴露的实现或敏感信息
- [x] 已运行 `node scripts/release-notes.mjs check-range upstream/main HEAD`

## 验证

- [x] V1 Vitest：116 files passed；1561 passed，1 skipped
- [x] V1 script tests：79 passed
- [x] V2 Vitest：220 files / 2019 tests passed（`--maxWorkers=2`）
- [x] V2 script tests：165 passed
- [x] V1/V2 `npm run build`
- [x] V1/V2 `npm run typecheck`
- [x] DeepSeek parser、SQLite/PostgreSQL migration、Usage Stats 和 V2 Turn 派生定向回归
- [x] `git diff --check upstream/main..HEAD`
