### PR TITLE
feat(v2): improve managed Skill workflows

### DIFF
--- a/.release-notes/local-skill-roots.md
+++ b/.release-notes/local-skill-roots.md
@@ -1,0 +1,11 @@
+# 完善 V2 Skill 管理与使用统计
+<!-- release-target: v2 -->
+
+## 新增功能
+
+- 选择多个本 App Skill 后，可以一次安装到多个 Agent，无需逐个设置。
+
+## Bug 修复
+
+- 本地 Skill 列表不再把项目 Skill 和未安装的 Claude 插件市场 Skill 计入其中。
+- Skill 使用次数现在会计入 StepCode 会话，并能识别 Codex Desktop 包装后的命令调用。

--- a/apps/main-2.0/src/core/managed-skill-library.ts
+++ b/apps/main-2.0/src/core/managed-skill-library.ts
@@ -172,6 +172,7 @@ export class ManagedSkillLibrary {
       homeDir: this.homeDir,
       codexHome: this.codexHome,
       projectDirs,
+      localAgentRootsOnly: true,
     });
     return {
       ...snapshot,

--- a/apps/main-2.0/src/core/skill-manager.test.ts
+++ b/apps/main-2.0/src/core/skill-manager.test.ts
@@ -15,6 +15,44 @@ afterEach(() => {
 });
 
 describe("listInstalledSkills", () => {
+  it("can limit local candidates to the Codex, Claude, and shared user roots", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-local-skill-scan-"));
+    temporaryDirectories.push(homeDir);
+    const codexHome = path.join(homeDir, ".codex");
+    const projectDir = path.join(homeDir, "project");
+
+    writeSkill(path.join(codexHome, "skills", "codex-user"), "Codex user");
+    writeSkill(path.join(codexHome, "skills", ".system", "codex-system"), "Codex system");
+    writeSkill(path.join(homeDir, ".claude", "skills", "claude-user"), "Claude user");
+    writeSkill(path.join(homeDir, ".agents", "skills", "shared"), "Shared");
+    writeSkill(path.join(homeDir, ".qoder", "skills", "qoder-user"), "Qoder user");
+    writeSkill(path.join(projectDir, ".codex", "skills", "project-skill"), "Project Skill");
+    writeSkill(
+      path.join(homeDir, ".claude", "plugins", "marketplaces", "official", "plugins", "example", "skills", "plugin-skill"),
+      "Plugin Skill",
+    );
+
+    const snapshot = listInstalledSkills({
+      homeDir,
+      codexHome,
+      projectDirs: [projectDir],
+      localAgentRootsOnly: true,
+    });
+
+    expect(snapshot.skills.map((skill) => skill.name)).toEqual([
+      "Claude user",
+      "Codex system",
+      "Codex user",
+      "Shared",
+    ]);
+    expect(snapshot.roots.map((root) => root.source)).toEqual([
+      "codex-user",
+      "codex-system",
+      "codex-shared",
+      "claude-user",
+    ]);
+  });
+
   it("skips only root-level managed Skill backup directories", () => {
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-skill-scan-"));
     temporaryDirectories.push(homeDir);

--- a/apps/main-2.0/src/core/skill-manager.ts
+++ b/apps/main-2.0/src/core/skill-manager.ts
@@ -58,6 +58,7 @@ export interface SkillManagerOptions {
   codexHome?: string;
   managedRoot?: string;
   managedOnly?: boolean;
+  localAgentRootsOnly?: boolean;
   projectDirs?: string[];
   claudePluginsDir?: string;
 }
@@ -105,27 +106,29 @@ export function listInstalledSkills(options: SkillManagerOptions = {}): Installe
   const codexHome = options.codexHome || process.env.CODEX_HOME || path.join(homeDir, ".codex");
   const projectDirs = dedupePaths(options.projectDirs ?? [process.cwd()]);
   const defaultRoots: SkillRootConfig[] = [
-    ...AGENT_SKILL_REGISTRY.flatMap((entry) => {
-      const roots: SkillRootConfig[] = [];
-      if (!entry.hasUserSource || !entry.skillDir) return roots;
-      const dir = agentSkillDir(entry.id, homeDir);
-      if (!dir) return roots;
-      if (entry.id === "codex") {
-        roots.push({ agent: "codex", source: "codex-user", path: path.join(codexHome, "skills") });
-        roots.push({ agent: "codex", source: "codex-system", path: path.join(codexHome, "skills", ".system") });
-        roots.push({ agent: "codex", source: "codex-shared", path: path.join(homeDir, ".agents", "skills") });
-      } else {
-        roots.push({ agent: entry.id, source: `${entry.id}-user` as SkillSource, path: dir });
-      }
-      if (entry.hasProjectSource) {
-        roots.push(...projectDirs.map((projectDir): SkillRootConfig => ({
-          agent: entry.id,
-          source: `${entry.id}-project` as SkillSource,
-          path: path.join(projectDir, entry.skillDir!),
-        })));
-      }
-      return roots;
-    }),
+    ...AGENT_SKILL_REGISTRY
+      .filter((entry) => !options.localAgentRootsOnly || entry.id === "codex" || entry.id === "claude")
+      .flatMap((entry) => {
+        const roots: SkillRootConfig[] = [];
+        if (!entry.hasUserSource || !entry.skillDir) return roots;
+        const dir = agentSkillDir(entry.id, homeDir);
+        if (!dir) return roots;
+        if (entry.id === "codex") {
+          roots.push({ agent: "codex", source: "codex-user", path: path.join(codexHome, "skills") });
+          roots.push({ agent: "codex", source: "codex-system", path: path.join(codexHome, "skills", ".system") });
+          roots.push({ agent: "codex", source: "codex-shared", path: path.join(homeDir, ".agents", "skills") });
+        } else {
+          roots.push({ agent: entry.id, source: `${entry.id}-user` as SkillSource, path: dir });
+        }
+        if (entry.hasProjectSource && !options.localAgentRootsOnly) {
+          roots.push(...projectDirs.map((projectDir): SkillRootConfig => ({
+            agent: entry.id,
+            source: `${entry.id}-project` as SkillSource,
+            path: path.join(projectDir, entry.skillDir!),
+          })));
+        }
+        return roots;
+      }),
   ];
   const roots: SkillRootConfig[] = [
     ...(options.managedRoot
@@ -148,7 +151,7 @@ export function listInstalledSkills(options: SkillManagerOptions = {}): Installe
     skills.push(...rootSkills);
   }
 
-  if (!options.managedOnly) {
+  if (!options.managedOnly && !options.localAgentRootsOnly) {
     const pluginsDir = options.claudePluginsDir || path.join(homeDir, ".claude", "plugins");
     const pluginRoots = collectClaudePluginRoots(pluginsDir);
     const pluginSkills: InstalledSkill[] = [];

--- a/apps/main-2.0/src/core/skill-usage.ts
+++ b/apps/main-2.0/src/core/skill-usage.ts
@@ -23,6 +23,7 @@ export type SkillUsageSourceKind =
   | "claude-hook"
   | "claude-session"
   | "codex-session"
+  | "stepcode-session"
   | "codebuddy-session"
   | "workbuddy-session"
   | "cursor-session"
@@ -38,6 +39,8 @@ export type SkillUsageProvider =
   | "codex"
   | "tclaude"
   | "tcodex"
+  | "stepcode-claude"
+  | "stepcode-codex"
   | "codebuddy"
   | "workbuddy"
   | "cursor"
@@ -101,6 +104,7 @@ export interface SkillUsageOptions {
   codexSessionsDir?: string | null;
   includeTclaude?: boolean;
   includeTcodex?: boolean;
+  includeStepcode?: boolean;
   includeCodeBuddyCli?: boolean;
   includeWorkBuddy?: boolean;
   includeCodeWizCli?: boolean;
@@ -183,6 +187,11 @@ export function listSkillUsageSources(options: SkillUsageOptions = {}): SkillUsa
   if (options.includeTcodex !== false) {
     addJsonlSources(sources, path.join(homeDir, ".tcodex", "sessions"), "codex", "tcodex", "codex-session");
   }
+  if (options.includeStepcode) {
+    addJsonlSources(sources, path.join(homeDir, ".stepcode", "sessions"), "claude", "stepcode-claude", "stepcode-session");
+    addJsonlSources(sources, path.join(homeDir, ".stepcode", "codex", "sessions"), "codex", "stepcode-codex", "stepcode-session");
+    addJsonlSources(sources, path.join(homeDir, ".stepcode", "codex", "archived_sessions"), "codex", "stepcode-codex", "stepcode-session");
+  }
   if (options.includeCodeBuddyCli !== false) {
     addJsonlSources(sources, path.join(homeDir, ".codebuddy", "projects"), "codex", "codebuddy", "codebuddy-session");
   }
@@ -245,6 +254,11 @@ export async function listSkillUsageSourcesAsync(options: SkillUsageOptions = {}
   }
   if (options.includeTcodex !== false) {
     await addJsonlSourcesAsync(sources, path.join(homeDir, ".tcodex", "sessions"), "codex", "tcodex", "codex-session");
+  }
+  if (options.includeStepcode) {
+    await addJsonlSourcesAsync(sources, path.join(homeDir, ".stepcode", "sessions"), "claude", "stepcode-claude", "stepcode-session");
+    await addJsonlSourcesAsync(sources, path.join(homeDir, ".stepcode", "codex", "sessions"), "codex", "stepcode-codex", "stepcode-session");
+    await addJsonlSourcesAsync(sources, path.join(homeDir, ".stepcode", "codex", "archived_sessions"), "codex", "stepcode-codex", "stepcode-session");
   }
   if (options.includeCodeBuddyCli !== false) {
     await addJsonlSourcesAsync(sources, path.join(homeDir, ".codebuddy", "projects"), "codex", "codebuddy", "codebuddy-session");
@@ -496,7 +510,7 @@ function parseSessionUsageRecord(
 ): ScannedUsageEvent[] {
   if (!isRecord(parsed)) return [];
 
-  const timestamp = timestampFrom(parsed.timestamp ?? parsed.createdAt ?? parsed.created_at);
+  const timestamp = timestampFrom(parsed.timestamp ?? parsed.createdAt ?? parsed.created_at ?? parsed.ts);
   if (source.kind === "codex-session") {
     if (readCodexSessionMeta(parsed, context)) return [];
     const envelope = codexSkillEnvelopeEvent(parsed, timestamp, context);
@@ -505,24 +519,34 @@ function parseSessionUsageRecord(
   collectFailedToolUseIds(parsed, context);
   const calls = source.kind === "codex-session"
     ? codexToolCalls(parsed)
-    : source.kind === "codebuddy-session"
-      ? codeBuddyToolCalls(parsed)
-      : source.kind === "workbuddy-session"
-        ? workBuddyToolCalls(parsed)
-        : source.kind === "openclaw-session"
-          ? openClawToolCalls(parsed)
-          : assistantToolCalls(parsed);
-  const defaultOwner = source.provider === "claude" || source.provider === "tclaude"
+    : source.kind === "stepcode-session"
+      ? stepCodeToolCalls(parsed)
+      : source.kind === "codebuddy-session"
+        ? codeBuddyToolCalls(parsed)
+        : source.kind === "workbuddy-session"
+          ? workBuddyToolCalls(parsed)
+          : source.kind === "openclaw-session"
+            ? openClawToolCalls(parsed)
+            : assistantToolCalls(parsed);
+  const defaultOwner = source.provider === "claude" || source.provider === "tclaude" || source.provider === "stepcode-claude"
     ? "claude"
-    : source.provider === "codex" || source.provider === "tcodex"
+    : source.provider === "codex" || source.provider === "tcodex" || source.provider === "stepcode-codex"
       ? "codex"
       : source.provider === "qoder"
         ? "qoder"
         : undefined;
+  // StepCode logs both Claude and Codex turns in one file and tags each record
+  // with its own agent, so trust that over the source-level default.
+  let owner: SkillUsageAgent | undefined = defaultOwner;
+  if (source.kind === "stepcode-session") {
+    const recordAgent = optionalText(parsed.agent);
+    if (recordAgent === "codex") owner = "codex";
+    else if (recordAgent === "claude") owner = "claude";
+  }
   const sessionId = optionalText(parsed.sessionId ?? parsed.session_id) || context.sessionId;
   const cwd = optionalText(parsed.cwd) || context.cwd;
 
-  return calls.flatMap((call) => usageEventsFromToolCall(call, timestamp, defaultOwner).map((event) => ({
+  return calls.flatMap((call) => usageEventsFromToolCall(call, timestamp, owner).map((event) => ({
     ...event,
     ...(sessionId ? { sessionId } : {}),
     ...(cwd ? { cwd } : {}),
@@ -596,7 +620,26 @@ function codexToolCalls(row: Record<string, unknown>): StructuredToolCall[] {
   const payload = recordField(row, "payload");
   if (!payload || (payload.type !== "function_call" && payload.type !== "custom_tool_call")) return [];
   if (typeof payload.name !== "string") return [];
-  return [{ name: payload.name, input: payload.type === "custom_tool_call" ? payload.input : payload.arguments }];
+  const input = payload.type === "custom_tool_call"
+    ? unwrapCodexExecInput(payload.input)
+    : payload.arguments;
+  return [{ name: payload.name, input }];
+}
+
+// Codex Desktop's `exec` custom tool wraps the real shell command in a JS
+// snippet: `const r = await tools.exec_command({"cmd":"cat …/SKILL.md", …}); text(r.output)`.
+// Pull the exec_command argument object out so shell/skill detection sees the
+// actual command instead of the JS wrapper (whose trailing `; text(r.output)`
+// makes the read-only check reject it).
+function unwrapCodexExecInput(input: unknown): unknown {
+  if (typeof input !== "string" || !input.includes("exec_command(")) return input;
+  const match = input.match(/exec_command\(\s*(\{[\s\S]*\})\s*\)/);
+  if (!match) return input;
+  try {
+    return JSON.parse(match[1]);
+  } catch {
+    return input;
+  }
 }
 
 function codeBuddyToolCalls(row: Record<string, unknown>): StructuredToolCall[] {
@@ -630,6 +673,18 @@ function openClawToolCalls(row: Record<string, unknown>): StructuredToolCall[] {
   const name = typeof data.name === "string" ? data.name : typeof data.tool_name === "string" ? data.tool_name : null;
   if (!name) return [];
   return [{ name, input: data.input ?? data.arguments ?? data }];
+}
+
+// StepCode logs each tool invocation as a flat `tool.call` record with the tool
+// name in `toolName` and the arguments plus outcome under `data`. A call that
+// reported an error was never exercised, so it must not count as usage.
+function stepCodeToolCalls(row: Record<string, unknown>): StructuredToolCall[] {
+  if (row.type !== "tool.call") return [];
+  const data = recordField(row, "data");
+  if (data?.isError === true) return [];
+  const name = typeof row.toolName === "string" ? row.toolName : "";
+  if (!name) return [];
+  return [{ name, input: data ? data.input : undefined }];
 }
 
 function usageEventsFromToolCall(

--- a/apps/main-2.0/src/main/services/skill-service.ts
+++ b/apps/main-2.0/src/main/services/skill-service.ts
@@ -361,9 +361,11 @@ export class SkillService {
     return {
       ...snapshot,
       skills: snapshot.skills.map((skill) => {
-        const stat = isSkillUsageAgent(skill.agent)
-          ? this.operations.usageForSkill(usage, skill.name, skill.agent)
-          : this.operations.usageForSkill(usage, skill.name);
+        // Local candidates are deduped by skill name, so a skill installed for
+        // several agents collapses to one row. Count usage by name (total across
+        // agents) rather than per-agent — otherwise a StepCode/Claude invocation
+        // of a skill whose surviving row is its Codex copy would read as zero.
+        const stat = this.operations.usageForSkill(usage, skill.name);
         return { ...skill, usageCount: stat?.count ?? 0, lastUsedAt: stat?.lastUsedAt ?? null };
       }),
     };
@@ -449,6 +451,7 @@ export class SkillService {
       homeDir: this.dependencies.homeDir,
       includeTclaude: settings.includeTclaude,
       includeTcodex: settings.includeTcodex,
+      includeStepcode: settings.includeStepcode,
       includeCodeBuddyCli: settings.includeCodeBuddyCli,
       includeWorkBuddy: settings.includeWorkBuddy,
       includeCodeWizCli: settings.includeCodeWizCli,

--- a/apps/main-2.0/src/renderer/src/features/skills/skill-batch-install.test.ts
+++ b/apps/main-2.0/src/renderer/src/features/skills/skill-batch-install.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { ManagedSkill, SkillInstallTarget } from "../../../../core/managed-skill-library";
+import { planBatchSkillTargetInstall } from "./skill-batch-install";
+
+describe("planBatchSkillTargetInstall", () => {
+  it("preserves existing targets, adds safe targets, and skips conflicts", () => {
+    const skill = managedSkill({
+      codex: "installed",
+      "codex-shared": "not-installed",
+      claude: "conflict",
+    });
+
+    expect(planBatchSkillTargetInstall(skill, ["codex-shared", "claude"])).toEqual({
+      targets: ["codex", "codex-shared"],
+      conflictTargets: ["claude"],
+      changed: true,
+    });
+  });
+
+  it("does not rewrite a Skill when every requested target is already installed", () => {
+    const skill = managedSkill({ codex: "installed" });
+
+    expect(planBatchSkillTargetInstall(skill, ["codex"])).toEqual({
+      targets: ["codex"],
+      conflictTargets: [],
+      changed: false,
+    });
+  });
+});
+
+function managedSkill(states: Partial<Record<SkillInstallTarget, "installed" | "not-installed" | "conflict">>): ManagedSkill {
+  const targets = Object.keys(states) as SkillInstallTarget[];
+  return {
+    id: "agent-recall-v2:example",
+    managedId: "example",
+    name: "example",
+    description: "fixture",
+    agent: "codex",
+    source: "agent-recall-v2",
+    path: "/managed/example/SKILL.md",
+    directoryPath: "/managed/example",
+    rootPath: "/managed",
+    markdown: "# example",
+    mtimeMs: 1,
+    origin: { kind: "builtin", label: "Built-in" },
+    installations: targets.map((target) => ({
+      target,
+      path: `/targets/${target}/example`,
+      state: states[target]!,
+    })),
+  };
+}

--- a/apps/main-2.0/src/renderer/src/features/skills/skill-batch-install.ts
+++ b/apps/main-2.0/src/renderer/src/features/skills/skill-batch-install.ts
@@ -1,0 +1,31 @@
+import type { ManagedSkill, SkillInstallTarget } from "../../../../core/managed-skill-library";
+
+export interface BatchSkillTargetPlan {
+  targets: SkillInstallTarget[];
+  conflictTargets: SkillInstallTarget[];
+  changed: boolean;
+}
+
+export function planBatchSkillTargetInstall(
+  skill: ManagedSkill,
+  requestedTargets: SkillInstallTarget[],
+): BatchSkillTargetPlan {
+  const requested = new Set(requestedTargets);
+  const installed = new Set(skill.installations
+    .filter((installation) => installation.state === "installed")
+    .map((installation) => installation.target));
+  const conflictTargets = skill.installations
+    .filter((installation) => requested.has(installation.target) && installation.state === "conflict")
+    .map((installation) => installation.target);
+  const conflicts = new Set(conflictTargets);
+  const targets = skill.installations
+    .filter((installation) => installed.has(installation.target)
+      || (requested.has(installation.target) && !conflicts.has(installation.target)))
+    .map((installation) => installation.target);
+
+  return {
+    targets,
+    conflictTargets,
+    changed: targets.some((target) => !installed.has(target)),
+  };
+}

--- a/apps/main-2.0/src/renderer/src/features/skills/skill-batch-target-dialog.tsx
+++ b/apps/main-2.0/src/renderer/src/features/skills/skill-batch-target-dialog.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from "react";
+import type { ReactElement } from "react";
+import { Check, Link2, X } from "lucide-react";
+import type { ManagedSkill, SkillInstallTarget } from "../../../../core/managed-skill-library";
+import { localize, type LanguageMode } from "../../language";
+import { TARGET_LABELS } from "./skill-target-dialog";
+
+export function SkillBatchTargetDialog({
+  open,
+  skills,
+  busy,
+  language,
+  onClose,
+  onSave,
+}: {
+  open: boolean;
+  skills: ManagedSkill[];
+  busy: boolean;
+  language: LanguageMode;
+  onClose: () => void;
+  onSave: (targets: SkillInstallTarget[]) => Promise<void>;
+}): ReactElement | null {
+  const l = (en: string, zh: string) => localize(language, en, zh);
+  const [selected, setSelected] = useState<Set<SkillInstallTarget>>(() => new Set());
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setSelected(new Set());
+    setSaving(false);
+    setError(null);
+  }, [open, skills]);
+
+  if (!open || skills.length === 0) return null;
+
+  const installations = skills[0].installations;
+  const save = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave(installations
+        .filter((installation) => selected.has(installation.target))
+        .map((installation) => installation.target));
+      onClose();
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="dialog-backdrop managed-skill-dialog-backdrop" onMouseDown={onClose}>
+      <section
+        className="command-dialog managed-skill-target-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="skill-batch-target-dialog-title"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <header className="managed-skill-dialog-head">
+          <div>
+            <h3 id="skill-batch-target-dialog-title">{l("Install selected Skills", "安装所选 Skill")}</h3>
+            <p>{l(
+              `Add ${skills.length} selected Skills to one or more agents. Existing installations stay in place; conflicting paths are skipped.`,
+              `将选中的 ${skills.length} 个 Skill 安装到一个或多个 Agent。已有安装会保留，路径冲突会跳过。`,
+            )}</p>
+          </div>
+          <button type="button" className="icon-button" onClick={onClose} aria-label={l("Close", "关闭")}><X size={16} /></button>
+        </header>
+
+        <div className="managed-skill-target-options">
+          {installations.map((installation) => {
+            const checked = selected.has(installation.target);
+            const states = skills.map((skill) => skill.installations.find((item) => item.target === installation.target)?.state);
+            const installedCount = states.filter((state) => state === "installed").length;
+            const conflictCount = states.filter((state) => state === "conflict").length;
+            const label = TARGET_LABELS[installation.target];
+            const status = conflictCount > 0
+              ? l(`${installedCount} installed · ${conflictCount} conflicts will be skipped`, `已安装 ${installedCount} 个 · 将跳过 ${conflictCount} 个冲突`)
+              : l(`${installedCount} of ${skills.length} already installed`, `${skills.length} 个中已有 ${installedCount} 个安装`);
+            return (
+              <button
+                key={installation.target}
+                type="button"
+                className={checked ? "selected" : ""}
+                role="checkbox"
+                aria-checked={checked}
+                aria-label={l(`${label}: ${checked ? "Selected" : "Not selected"}`, `${label}：${checked ? "已选择" : "未选择"}`)}
+                disabled={busy || saving}
+                onClick={() => setSelected((current) => {
+                  const next = new Set(current);
+                  if (next.has(installation.target)) next.delete(installation.target);
+                  else next.add(installation.target);
+                  return next;
+                })}
+              >
+                <span className="managed-skill-target-option-icon">{checked ? <Check size={15} /> : <Link2 size={15} />}</span>
+                <span className="managed-skill-target-option-copy"><strong>{label}</strong><small>{status}</small></span>
+              </button>
+            );
+          })}
+        </div>
+
+        {error ? <div className="managed-skill-dialog-error">{error}</div> : null}
+        <footer className="managed-skill-dialog-actions">
+          <span>{l(`${selected.size} agents selected`, `已选择 ${selected.size} 个 Agent`)}</span>
+          <button type="button" onClick={onClose} disabled={saving}>{l("Cancel", "取消")}</button>
+          <button type="button" className="primary" onClick={() => void save()} disabled={busy || saving || selected.size === 0}>
+            {saving ? l("Installing…", "正在安装…") : l("Install", "安装")}
+          </button>
+        </footer>
+      </section>
+    </div>
+  );
+}

--- a/apps/main-2.0/src/renderer/src/features/skills/skill-library-detail.tsx
+++ b/apps/main-2.0/src/renderer/src/features/skills/skill-library-detail.tsx
@@ -100,16 +100,6 @@ export function SkillLibraryDetail({
           </div>
         </header>
 
-        <section className="managed-skill-document">
-          <div className="managed-skill-document-head">
-            <span>SKILL.md</span>
-            <small>{l(`Used ${skill.usageCount ?? 0} times`, `使用 ${skill.usageCount ?? 0} 次`)}</small>
-          </div>
-          <div className="managed-skill-markdown">
-            <Markdown text={markdownPreview(skill.markdown, 18_000, l("…(truncated)", "…（已截断）"))} language={language} />
-          </div>
-        </section>
-
         <SkillSyncPanel
           skill={skill}
           entry={entry}
@@ -124,6 +114,16 @@ export function SkillLibraryDetail({
           onCopySetupSql={onCopySetupSql}
           onOpenSqlEditor={onOpenSqlEditor}
         />
+
+        <section className="managed-skill-document">
+          <div className="managed-skill-document-head">
+            <span>SKILL.md</span>
+            <small>{l(`Used ${skill.usageCount ?? 0} times`, `使用 ${skill.usageCount ?? 0} 次`)}</small>
+          </div>
+          <div className="managed-skill-markdown">
+            <Markdown text={markdownPreview(skill.markdown, 18_000, l("…(truncated)", "…（已截断）"))} language={language} />
+          </div>
+        </section>
       </main>
       <SkillTargetDialog
         open={targetDialogOpen}

--- a/apps/main-2.0/src/renderer/src/features/skills/skill-library-list.tsx
+++ b/apps/main-2.0/src/renderer/src/features/skills/skill-library-list.tsx
@@ -1,10 +1,11 @@
 import { useMemo, useState } from "react";
 import type { KeyboardEvent as ReactKeyboardEvent, ReactElement } from "react";
 import { Check, ChevronDown, ChevronRight, Search } from "lucide-react";
-import type { ManagedSkill, ManagedSkillOriginKind } from "../../../../core/managed-skill-library";
+import type { ManagedSkill, ManagedSkillOriginKind, ManagedSkillTargetState } from "../../../../core/managed-skill-library";
 import type { RemoteSkillGroup } from "../../../../core/skill-sync";
 import { formatCompactNumber } from "../../format-count";
 import { localize, type LanguageMode } from "../../language";
+import { TARGET_LABELS } from "./skill-target-dialog";
 
 export type ManagedSkillOriginFilter = "all" | ManagedSkillOriginKind;
 export type ManagedSkillSort = "usage" | "name" | "updated";
@@ -95,11 +96,15 @@ export function SkillLibraryList({
       .map(([kind, groupSkills]) => ({ kind, skills: groupSkills }));
   }, [skills]);
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
     if (skills.length === 0) return;
-    event.preventDefault();
     const current = Math.max(0, skills.findIndex((skill) => skill.managedId === selectedId));
-    const next = Math.min(skills.length - 1, Math.max(0, current + (event.key === "ArrowDown" ? 1 : -1)));
+    let next: number;
+    if (event.key === "ArrowDown") next = Math.min(skills.length - 1, current + 1);
+    else if (event.key === "ArrowUp") next = Math.max(0, current - 1);
+    else if (event.key === "Home") next = 0;
+    else if (event.key === "End") next = skills.length - 1;
+    else return;
+    event.preventDefault();
     onSelect(skills[next].managedId);
   };
 
@@ -141,7 +146,13 @@ export function SkillLibraryList({
       </div>
 
       <div className="skill-library-scroll" role="listbox" aria-label={l("Managed Skill library", "托管 Skill 库")}>
-        {loading && skills.length === 0 ? <div className="skill-library-empty">{l("Loading Skills…", "正在加载 Skill…")}</div> : null}
+        {loading && skills.length === 0 ? (
+          <div className="skill-library-skeletons" role="presentation" aria-busy="true" aria-label={l("Loading Skills…", "正在加载 Skill…")}>
+            {[0, 1, 2, 3].map((row) => (
+              <div key={row} className="skill-row-skeleton"><span /><span /></div>
+            ))}
+          </div>
+        ) : null}
         {!loading && skills.length === 0 && remoteOnlyGroups.length === 0 ? (
           <div className="skill-library-empty">
             <strong>{l("No managed Skills", "Skill 库还是空的")}</strong>
@@ -214,7 +225,7 @@ export function SkillLibraryList({
                         })() : null}
                         <span className="skill-target-dots" aria-label={l("Installation targets", "安装目标")}>
                           {skill.installations.map((installation) => (
-                            <i key={installation.target} className={installation.state} title={`${installation.target}: ${installation.state}`} />
+                            <i key={installation.target} className={installation.state} title={`${TARGET_LABELS[installation.target] ?? installation.target}: ${installStateLabel(installation.state, language)}`} />
                           ))}
                         </span>
                       </div>
@@ -282,4 +293,10 @@ export function originGroupOrder(kind: ManagedSkillOriginKind): number {
   if (kind === "skills-sh") return 1;
   if (kind === "remote") return 2;
   return 3;
+}
+
+function installStateLabel(state: ManagedSkillTargetState, language: LanguageMode): string {
+  if (state === "installed") return localize(language, "Installed", "已安装");
+  if (state === "conflict") return localize(language, "Conflict", "冲突");
+  return localize(language, "Not installed", "未安装");
 }

--- a/apps/main-2.0/src/renderer/src/features/skills/skill-target-dialog.tsx
+++ b/apps/main-2.0/src/renderer/src/features/skills/skill-target-dialog.tsx
@@ -5,7 +5,7 @@ import type { ManagedSkill, SkillInstallTarget } from "../../../../core/managed-
 import { AGENT_SKILL_REGISTRY } from "../../../../core/agent-skill-registry";
 import { localize, type LanguageMode } from "../../language";
 
-const TARGET_LABELS: Record<SkillInstallTarget, string> = Object.fromEntries([
+export const TARGET_LABELS: Record<SkillInstallTarget, string> = Object.fromEntries([
   ...AGENT_SKILL_REGISTRY
     .filter((entry) => entry.installTarget !== null)
     .map((entry) => [entry.installTarget!, entry.label]),

--- a/apps/main-2.0/src/renderer/src/features/skills/skills-page.tsx
+++ b/apps/main-2.0/src/renderer/src/features/skills/skills-page.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { ReactElement } from "react";
-import { Compass, RefreshCw, Upload, X } from "lucide-react";
-import type { InstalledSkill, InstalledSkillsSnapshot, SkillRootStatus, SkillSource } from "../../../../core/skill-manager";
+import { Compass, PackagePlus, RefreshCw, Upload, X } from "lucide-react";
+import type { InstalledSkill, InstalledSkillsSnapshot } from "../../../../core/skill-manager";
 import type { ManagedSkill, SkillInstallTarget } from "../../../../core/managed-skill-library";
 import type { RemoteSkill, SkillSyncSnapshot, SkillSyncUploadOutcome } from "../../../../core/skill-sync";
 import { formatCompactNumber } from "../../format-count";
@@ -11,6 +11,8 @@ import type { SkillsFeedback } from "../../app-types";
 import { LocalSkillsTab } from "./local-skills-tab";
 import { CloudSkillDetail } from "./cloud-skill-detail";
 import { SkillDiscoveryDialog } from "./skill-discovery-dialog";
+import { planBatchSkillTargetInstall } from "./skill-batch-install";
+import { SkillBatchTargetDialog } from "./skill-batch-target-dialog";
 import { SkillLibraryDetail } from "./skill-library-detail";
 import {
   filterManagedSkills,
@@ -91,6 +93,7 @@ export function SkillsPage({
   const [deleteCandidate, setDeleteCandidate] = useState<ManagedSkill | null>(null);
   const [targetBusy, setTargetBusy] = useState(false);
   const [batchBusy, setBatchBusy] = useState(false);
+  const [batchTargetDialogOpen, setBatchTargetDialogOpen] = useState(false);
   const [appFeedback, setAppFeedback] = useState<{ kind: "success" | "warning" | "error"; message: string } | null>(null);
   const [pendingSelection, setPendingSelection] = useState<string | null>(null);
   const filteredSkills = useMemo(
@@ -202,6 +205,49 @@ export function SkillsPage({
     }
   };
 
+  const installChecked = async (targets: SkillInstallTarget[]) => {
+    const selected = managedSkills.filter((skill) => checkedIds.has(skill.managedId));
+    if (selected.length === 0 || targets.length === 0) return;
+    setBatchBusy(true);
+    setAppFeedback(null);
+    const remaining = new Set<string>();
+    const problems: string[] = [];
+    let updated = 0;
+    try {
+      for (const skill of selected) {
+        const plan = planBatchSkillTargetInstall(skill, targets);
+        if (plan.conflictTargets.length > 0) {
+          remaining.add(skill.managedId);
+          problems.push(`${skill.name}: ${plan.conflictTargets.join(", ")}`);
+        }
+        if (!plan.changed) continue;
+        try {
+          await window.sessionSearch.updateManagedSkillTargets(skill.managedId, plan.targets, []);
+          updated += 1;
+        } catch (error) {
+          remaining.add(skill.managedId);
+          problems.push(`${skill.name}: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      }
+      setCheckedIds(remaining);
+      setAppFeedback(problems.length > 0
+        ? {
+          kind: "warning",
+          message: l(
+            `${updated} Skills updated. ${remaining.size} need attention: ${problems.slice(0, 3).join(" · ")}`,
+            `已更新 ${updated} 个 Skill，${remaining.size} 个需要处理：${problems.slice(0, 3).join(" · ")}`,
+          ),
+        }
+        : {
+          kind: "success",
+          message: l(`${selected.length} Skills are installed on the selected agents.`, `${selected.length} 个 Skill 已安装到所选 Agent。`),
+        });
+      onRefresh();
+    } finally {
+      setBatchBusy(false);
+    }
+  };
+
   const refreshActiveTab = () => {
     if (activeTab === "local") onRefreshLocal();
     else onRefresh();
@@ -275,11 +321,24 @@ export function SkillsPage({
           aria-labelledby="app-skills-tab"
           hidden={activeTab !== "app"}
         >
-          {feedback ? <div className={`managed-skills-feedback ${feedback.kind}`}>{feedback.message}</div> : null}
-          {appFeedback ? <div className={`managed-skills-feedback ${appFeedback.kind}`}>{appFeedback.message}</div> : null}
+          {(() => {
+            // One feedback slot: an in-flight (running) message always wins, otherwise
+            // show the most recent page-action result, falling back to the controller's.
+            const active = feedback?.kind === "running" ? feedback : appFeedback ?? feedback;
+            if (!active) return null;
+            return (
+              <div className={`managed-skills-feedback ${active.kind}`}>
+                {active.kind === "running"
+                  ? <RefreshCw size={13} className="managed-skills-feedback-spin" aria-hidden="true" />
+                  : null}
+                <span>{active.message}</span>
+              </div>
+            );
+          })()}
           {checkedIds.size > 0 ? (
             <div className="managed-skills-batch-bar">
               <span>{l(`${checkedIds.size} selected`, `已选择 ${checkedIds.size} 个`)}</span>
+              <button type="button" onClick={() => setBatchTargetDialogOpen(true)} disabled={loading || batchBusy}><PackagePlus size={13} />{l("Install selected", "安装所选")}</button>
               <button type="button" onClick={() => void uploadChecked()} disabled={loading || batchBusy || syncSnapshot.status.kind !== "ready"}><Upload size={13} />{l("Upload selected", "上传所选")}</button>
               <button type="button" onClick={() => setCheckedIds(new Set())}>{l("Clear", "清空")}</button>
             </div>
@@ -368,13 +427,28 @@ export function SkillsPage({
       </section>
 
       <SkillDiscoveryDialog open={discoveryOpen} language={language} onClose={() => setDiscoveryOpen(false)} onImported={libraryChanged} />
+      <SkillBatchTargetDialog
+        open={batchTargetDialogOpen}
+        skills={managedSkills.filter((skill) => checkedIds.has(skill.managedId))}
+        busy={batchBusy}
+        language={language}
+        onClose={() => setBatchTargetDialogOpen(false)}
+        onSave={installChecked}
+      />
       {deleteCandidate ? (
         <div className="dialog-backdrop managed-skill-dialog-backdrop" onMouseDown={() => setDeleteCandidate(null)}>
-          <section className="command-dialog managed-skill-delete-dialog" onMouseDown={(event) => event.stopPropagation()}>
-            <header><h3>{l("Delete from Skill library?", "从 Skill 库删除？")}</h3><button type="button" className="icon-button" onClick={() => setDeleteCandidate(null)}><X size={16} /></button></header>
+          <section
+            className="command-dialog managed-skill-delete-dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="skill-delete-dialog-title"
+            onMouseDown={(event) => event.stopPropagation()}
+            onKeyDown={(event) => { if (event.key === "Escape") setDeleteCandidate(null); }}
+          >
+            <header><h3 id="skill-delete-dialog-title">{l("Delete from Skill library?", "从 Skill 库删除？")}</h3><button type="button" className="icon-button" onClick={() => setDeleteCandidate(null)} aria-label={l("Close", "关闭")}><X size={16} /></button></header>
             <p>{l(`AgentRecall will delete “${deleteCandidate.name}” and remove only links it owns. Existing conflicting folders remain untouched.`, `AgentRecall 会删除“${deleteCandidate.name}”，并只移除自己创建的链接；有冲突的原目录不会被修改。`)}</p>
             <code title={deleteCandidate.directoryPath}>{deleteCandidate.directoryPath}</code>
-            <footer><button type="button" onClick={() => setDeleteCandidate(null)}>{l("Cancel", "取消")}</button><button type="button" className="danger-action" onClick={() => void confirmDelete()}>{l("Delete", "删除")}</button></footer>
+            <footer><button type="button" autoFocus onClick={() => setDeleteCandidate(null)}>{l("Cancel", "取消")}</button><button type="button" className="danger-action" onClick={() => void confirmDelete()}>{l("Delete", "删除")}</button></footer>
           </section>
         </div>
       ) : null}
@@ -388,31 +462,4 @@ export function isManagedSkill(skill: InstalledSkill): skill is ManagedSkill {
   return typeof candidate.managedId === "string"
     && Boolean(candidate.origin)
     && Array.isArray(candidate.installations);
-}
-
-export function summarizeSkillRoots(roots: SkillRootStatus[]): SkillRootStatus[] {
-  const visible: SkillRootStatus[] = [];
-  const projectRoots = new Map<SkillSource, SkillRootStatus[]>();
-  for (const root of roots) {
-    if (root.source !== "codex-project" && root.source !== "claude-project") {
-      visible.push(root);
-      continue;
-    }
-    const group = projectRoots.get(root.source) ?? [];
-    group.push(root);
-    projectRoots.set(root.source, group);
-  }
-  for (const [source, group] of projectRoots) {
-    const existing = group.filter((root) => root.exists);
-    const skillCount = group.reduce((sum, root) => sum + root.skillCount, 0);
-    if (existing.length === 0 && skillCount === 0) continue;
-    visible.push({
-      agent: group[0].agent,
-      source,
-      path: (existing.length > 0 ? existing : group).map((root) => root.path).join("\n"),
-      exists: existing.length > 0,
-      skillCount,
-    });
-  }
-  return visible;
 }

--- a/apps/main-2.0/src/renderer/src/styles/skills-page.css
+++ b/apps/main-2.0/src/renderer/src/styles/skills-page.css
@@ -210,6 +210,20 @@
   color: var(--warning, #b7791f);
 }
 
+.managed-skills-feedback.running {
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+}
+
+.managed-skills-feedback-spin {
+  flex: 0 0 auto;
+  animation: skills-spin 0.9s linear infinite;
+}
+
+@keyframes skills-spin {
+  to { transform: rotate(360deg); }
+}
+
 .managed-skills-batch-bar {
   min-height: 38px;
   flex: 0 0 auto;
@@ -1681,4 +1695,43 @@
 .skill-eval-badge-link:hover {
   border-color: var(--accent);
   color: var(--accent);
+}
+
+/* Loading skeleton rows for the managed Skill list */
+.skill-library-skeletons {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+}
+
+.skill-row-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  padding: 9px 12px;
+  border-radius: var(--radius, 8px);
+  background: var(--panel-subtle);
+}
+
+.skill-row-skeleton span {
+  height: 9px;
+  border-radius: 4px;
+  background: var(--border-subtle);
+  animation: skills-skeleton-pulse 1.2s ease-in-out infinite;
+}
+
+.skill-row-skeleton span:first-child { width: 62%; }
+.skill-row-skeleton span:last-child { width: 40%; height: 8px; }
+
+@keyframes skills-skeleton-pulse {
+  0%, 100% { opacity: 0.45; }
+  50% { opacity: 0.9; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .managed-skills-feedback-spin,
+  .skill-row-skeleton span {
+    animation: none;
+  }
 }


### PR DESCRIPTION
## Summary

- limit the local Skill list to user-level Codex, Claude, and shared Skill roots
- add batch installation of managed Skills to multiple agents
- count StepCode sessions and wrapped Codex Desktop commands in Skill usage statistics

## Verification

- focused Skill manager, usage, and batch-install tests
- V2 build and typecheck
- release-note check