### PR TITLE
fix: load remote CLI environment before migration

### DIFF
--- a/.release-notes/fix-remote-migration-cli-detection.md
+++ b/.release-notes/fix-remote-migration-cli-detection.md
@@ -1,0 +1,6 @@
+# 修复远程会话迁移预检
+<!-- release-target: both -->
+
+## Bug 修复
+
+- 修复通过 SSH 迁移会话时，已安装在 NVM 环境中的 Codex 或 Claude Code 被误报为不可用的问题。

--- a/apps/main-1.0/src/core/platform.test.ts
+++ b/apps/main-1.0/src/core/platform.test.ts
@@ -18,6 +18,7 @@ import {
   getSafeMigrationResumeCommand,
   getResumeCommand,
   getResumeProcessSpec,
+  getRemoteMigrationCliVersionCommand,
   inspectMigrationCli,
   mergeProcessEnvOverrides,
   mergeAppSettings,
@@ -1157,6 +1158,12 @@ describe("migration cli process specs", () => {
     await expect(
       inspectMigrationCli("codebuddy", defaultSettings, async () => "version banana"),
     ).rejects.toThrow("CodeBuddy CLI returned an unparseable version");
+  });
+
+  it("loads NVM before probing a migration CLI over SSH", () => {
+    expect(getRemoteMigrationCliVersionCommand("codex", ["--version"])).toBe(
+      'bash -lc \'if [ -s "$HOME/.nvm/nvm.sh" ]; then . "$HOME/.nvm/nvm.sh"; fi; codex --version\'',
+    );
   });
 
   it("does not echo potentially sensitive unparseable version output", async () => {

--- a/apps/main-1.0/src/core/platform.ts
+++ b/apps/main-1.0/src/core/platform.ts
@@ -1430,6 +1430,12 @@ function migrationCliVersionErrorMessage(target: MigrationTarget, binary: string
   return `${prefix} --version failed for ${binary}.`;
 }
 
+export function getRemoteMigrationCliVersionCommand(command: string, args: string[]): string {
+  const invocation = buildShellCommand(command, args, null, { shell: "posix", withCwd: false });
+  const script = `if [ -s "$HOME/.nvm/nvm.sh" ]; then . "$HOME/.nvm/nvm.sh"; fi; ${invocation}`;
+  return `bash -lc ${shellQuote(script)}`;
+}
+
 export async function inspectMigrationCli(
   target: MigrationTarget,
   settings: AppSettings,

--- a/apps/main-1.0/src/main/index.ts
+++ b/apps/main-1.0/src/main/index.ts
@@ -48,6 +48,7 @@ import {
   getMigrationResumeProcessSpec,
   getSafeMigrationResumeCommand,
   getResumeCommand,
+  getRemoteMigrationCliVersionCommand,
   inspectMigrationCli,
   mergeAppSettings,
   normalizeTerminal,
@@ -1559,7 +1560,7 @@ async function inspectSshMigrationCli(environment: SessionEnvironment, target: M
     { ...settings, claudeBinary: "claude", codexBinary: "codex" },
     (command, args) => runSshSessionCommand(
       environment,
-      [command, ...args].map(quotePosixToken).join(" "),
+      getRemoteMigrationCliVersionCommand(command, args),
     ),
     { platform: "linux" },
   );

--- a/apps/main-1.0/src/main/main-startup-wiring.test.ts
+++ b/apps/main-1.0/src/main/main-startup-wiring.test.ts
@@ -54,6 +54,7 @@ describe("main process startup wiring", () => {
     expect(source).toContain('{ allowSsh: session.environmentKind === "ssh" }');
     expect(source).toContain("createSourceRemoteRestoreDependencies(environment, progress)");
     expect(source).toContain('environment.kind === "ssh" ? inspectSshMigrationCli(environment, target)');
+    expect(source).toContain("getRemoteMigrationCliVersionCommand(command, args)");
     expect(source).toContain('const sshArgs = buildRemoteSyncSshArgs(environment, "").slice(0, -1)');
     expect(source).toContain("await openResumeInTerminal(session, getSettings(), { sshArgs })");
   });

--- a/apps/main-2.0/src/core/platform.test.ts
+++ b/apps/main-2.0/src/core/platform.test.ts
@@ -1,8 +1,19 @@
 import { describe, expect, it } from "vitest";
 import type { SessionSearchResult } from "./types";
-import { defaultSettings, getResumeCommand, mergeAppSettings } from "./platform";
+import {
+  defaultSettings,
+  getRemoteMigrationCliVersionCommand,
+  getResumeCommand,
+  mergeAppSettings,
+} from "./platform";
 
 describe("app settings", () => {
+  it("loads NVM before probing a migration CLI over SSH", () => {
+    expect(getRemoteMigrationCliVersionCommand("codex", ["--version"])).toBe(
+      'bash -lc \'if [ -s "$HOME/.nvm/nvm.sh" ]; then . "$HOME/.nvm/nvm.sh"; fi; codex --version\'',
+    );
+  });
+
   it("keeps WorkBuddy indexing opt-in while accepting an explicit enable", () => {
     expect(defaultSettings.includeWorkBuddy).toBe(false);
     expect(mergeAppSettings(defaultSettings, { includeWorkBuddy: true }).includeWorkBuddy).toBe(true);

--- a/apps/main-2.0/src/core/platform.ts
+++ b/apps/main-2.0/src/core/platform.ts
@@ -1509,6 +1509,12 @@ function migrationCliVersionErrorMessage(target: MigrationTarget, binary: string
   return `${prefix} --version failed for ${binary}.`;
 }
 
+export function getRemoteMigrationCliVersionCommand(command: string, args: string[]): string {
+  const invocation = buildShellCommand(command, args, null, { shell: "posix", withCwd: false });
+  const script = `if [ -s "$HOME/.nvm/nvm.sh" ]; then . "$HOME/.nvm/nvm.sh"; fi; ${invocation}`;
+  return `bash -lc ${shellQuote(script)}`;
+}
+
 export async function inspectMigrationCli(
   target: MigrationTarget,
   settings: AppSettings,

--- a/apps/main-2.0/src/main/index.ts
+++ b/apps/main-2.0/src/main/index.ts
@@ -41,6 +41,7 @@ import {
   defaultSettings,
   getMigrationResumeProcessSpec,
   getSafeMigrationResumeCommand,
+  getRemoteMigrationCliVersionCommand,
   inspectMigrationCli,
   mergeAppSettings,
   normalizeTerminal,
@@ -1962,7 +1963,7 @@ async function inspectSshMigrationCli(environment: SessionEnvironment, target: M
     { ...settings, claudeBinary: "claude", codexBinary: "codex" },
     (command, args) => runSshSessionCommand(
       environment,
-      [command, ...args].map(quotePosixToken).join(" "),
+      getRemoteMigrationCliVersionCommand(command, args),
     ),
     { platform: "linux" },
   );

--- a/apps/main-2.0/src/main/main-startup-wiring.test.ts
+++ b/apps/main-2.0/src/main/main-startup-wiring.test.ts
@@ -10,6 +10,7 @@ describe("main process SSH migration wiring", () => {
     expect(source).toContain('allowSsh: migrationSource.source.environmentKind === "ssh"');
     expect(source).toContain("createSourceRemoteRestoreDependencies(environment, progress)");
     expect(source).toContain('environment.kind === "ssh" ? inspectSshMigrationCli(environment, target)');
+    expect(source).toContain("getRemoteMigrationCliVersionCommand(command, args)");
     expect(source).toContain('const sshArgs = buildRemoteSyncSshArgs(environment, "").slice(0, -1)');
     expect(source).toContain("await openResumeInTerminal(session, getSettings(), { sshArgs })");
   });


### PR DESCRIPTION
## 问题

SSH 会话迁移在非交互 shell 中直接执行 Codex 或 Claude Code 的版本预检。CLI 安装在 NVM 环境时，交互终端可以运行，但迁移预检的 PATH 找不到命令，因而报 CLI --version failed。

## 修复

- V1/V2 的 SSH 迁移预检统一通过 POSIX 登录 shell 执行。
- 执行版本检查前显式加载远端用户的 NVM 环境。
- 继续使用安全的 POSIX 参数转义，不改变本地和 WSL 迁移路径。

## 验证

- V1/V2 新增远端 CLI 命令行为测试与迁移接线测试
- npm run typecheck（apps/main-1.0）
- npm run typecheck（apps/main-2.0）
- npm run release-note:check

注：V1 platform/main-startup 测试文件在 Windows 全量运行时仍有既有的 POSIX 默认终端与 LF 换行假设失败；本次新增用例已通过 testNamePattern 独立验证。