### PR TITLE
feat(sessions): support Qwen Code local sessions

### DIFF
--- a/.release-notes/qwen-code-session-support.md
+++ b/.release-notes/qwen-code-session-support.md
@@ -1,0 +1,6 @@
+# 支持索引千问 Code 会话
+<!-- release-target: both -->
+
+## 新增功能
+
+- 支持以只读方式索引本地千问 Code 会话，方便在 AgentRecall 中统一搜索和回顾中文 Agent 工作记录。

--- a/apps/main-1.0/src/core/format-adapters.test.ts
+++ b/apps/main-1.0/src/core/format-adapters.test.ts
@@ -219,6 +219,9 @@ describe("format adapters", () => {
       type: "assistant",
       message: { parts: [{ thought: true, text: "推理" }, { text: "回答" }] },
     })).toMatchObject({ role: "assistant", content: "回答" });
+    expect(getAdapter("qwen").parseLine({ type: "assistant", message: { text: "文本回退" } })).toMatchObject({ role: "assistant", content: "文本回退" });
+    expect(getAdapter("qwen").parseLine({ type: "assistant", message: { text: "不得回退的推理", parts: [{ thought: true, text: "推理" }] } })).toBeNull();
+    expect(getAdapter("qwen").parseLine({ type: "tool_result", message: { text: "工具输出" } })).toBeNull();
   });
 
   it("skips the CodeBuddy CLI bootstrap 'code' root message", () => {

--- a/apps/main-1.0/src/core/format-adapters.test.ts
+++ b/apps/main-1.0/src/core/format-adapters.test.ts
@@ -209,6 +209,18 @@ describe("format adapters", () => {
     })).toMatchObject({ timestamp: "2026-07-31T02:39:01.181Z" });
   });
 
+  it("uses Qwen display text and keeps reasoning out of visible messages", () => {
+    expect(getAdapter("qwen-code").parseLine({
+      type: "user",
+      systemPayload: { displayText: "用户看到的问题" },
+      message: { parts: [{ text: "内部提示" }] },
+    })).toMatchObject({ role: "user", content: "用户看到的问题" });
+    expect(getAdapter("qwen").parseLine({
+      type: "assistant",
+      message: { parts: [{ thought: true, text: "推理" }, { text: "回答" }] },
+    })).toMatchObject({ role: "assistant", content: "回答" });
+  });
+
   it("skips the CodeBuddy CLI bootstrap 'code' root message", () => {
     // The CLI injects a root user message whose text is the literal launch
     // keyword "code"; it must not become the session title.

--- a/apps/main-1.0/src/core/format-adapters.ts
+++ b/apps/main-1.0/src/core/format-adapters.ts
@@ -378,7 +378,8 @@ export const qwenAdapter: FormatAdapter = {
     const message = row.message && typeof row.message === "object" ? row.message as Record<string, unknown> : null;
     const displayText = role === "user" && typeof payload?.displayText === "string" ? payload.displayText : "";
     const parts = Array.isArray(message?.parts) ? message.parts : [];
-    const text = displayText || parts.map((part) => part && typeof part === "object" && (part as Record<string, unknown>).thought !== true && typeof (part as Record<string, unknown>).text === "string" ? (part as Record<string, unknown>).text as string : "").filter(Boolean).join("\n");
+    const partsText = parts.map((part) => part && typeof part === "object" && (part as Record<string, unknown>).thought !== true ? (typeof (part as Record<string, unknown>).text === "string" ? (part as Record<string, unknown>).text as string : typeof (part as Record<string, unknown>).content === "string" ? (part as Record<string, unknown>).content as string : "") : "").filter(Boolean).join("\n");
+    const text = displayText || (parts.length ? partsText : typeof message?.text === "string" ? message.text : typeof message?.content === "string" ? message.content : "");
     return text ? { role, content: text, timestamp: timestampFromRaw(raw) } : null;
   },
 };

--- a/apps/main-1.0/src/core/format-adapters.ts
+++ b/apps/main-1.0/src/core/format-adapters.ts
@@ -367,6 +367,21 @@ export const kimiAdapter: FormatAdapter = {
     return null;
   },
 };
+export const qwenAdapter: FormatAdapter = {
+  format: "qwen",
+  parseLine(raw) {
+    if (!raw || typeof raw !== "object") return null;
+    const row = raw as Record<string, unknown>;
+    const role = row.type === "user" || row.type === "assistant" ? row.type : null;
+    if (!role) return null;
+    const payload = row.systemPayload && typeof row.systemPayload === "object" ? row.systemPayload as Record<string, unknown> : null;
+    const message = row.message && typeof row.message === "object" ? row.message as Record<string, unknown> : null;
+    const displayText = role === "user" && typeof payload?.displayText === "string" ? payload.displayText : "";
+    const parts = Array.isArray(message?.parts) ? message.parts : [];
+    const text = displayText || parts.map((part) => part && typeof part === "object" && (part as Record<string, unknown>).thought !== true && typeof (part as Record<string, unknown>).text === "string" ? (part as Record<string, unknown>).text as string : "").filter(Boolean).join("\n");
+    return text ? { role, content: text, timestamp: timestampFromRaw(raw) } : null;
+  },
+};
 
 export function getFormatForSource(source: SessionSource): SessionFormat {
   return sessionSourceDescriptor(source).format;
@@ -389,6 +404,7 @@ export function getAdapter(sourceOrFormat: SessionSource | SessionFormat): Forma
   if (sourceOrFormat === "pi") return piAdapter;
   if (sourceOrFormat === "deepseek") return deepseekAdapter;
   if (sourceOrFormat === "kimi") return kimiAdapter;
+  if (sourceOrFormat === "qwen") return qwenAdapter;
   const format = getFormatForSource(sourceOrFormat);
   if (format === "claude") return claudeAdapter;
   if (format === "codebuddy") return codebuddyAdapter;
@@ -404,6 +420,7 @@ export function getAdapter(sourceOrFormat: SessionSource | SessionFormat): Forma
   if (format === "pi") return piAdapter;
   if (format === "deepseek") return deepseekAdapter;
   if (format === "kimi") return kimiAdapter;
+  if (format === "qwen") return qwenAdapter;
   return codexAdapter;
 }
 

--- a/apps/main-1.0/src/core/platform.test.ts
+++ b/apps/main-1.0/src/core/platform.test.ts
@@ -117,6 +117,7 @@ describe("platform application resolution", () => {
     expect(defaultSettings.includeQoder).toBe(false);
     expect(defaultSettings.includePi).toBe(false);
     expect(defaultSettings.includeKimiCli).toBe(false);
+    expect(defaultSettings.includeQwenCode).toBe(false);
   });
 
   it("preserves persisted personalization flags across app restarts and updates", () => {

--- a/apps/main-1.0/src/core/platform.ts
+++ b/apps/main-1.0/src/core/platform.ts
@@ -92,6 +92,7 @@ export interface AppSettings {
   includeQoder: boolean;
   includePi: boolean;
   includeKimiCli: boolean;
+  includeQwenCode: boolean;
   includeDeepSeekCli: boolean;
   rulesSyncEnabled: boolean;
   memoriesSyncEnabled: boolean;
@@ -166,6 +167,7 @@ export const defaultSettings: AppSettings = {
   includeQoder: false,
   includePi: false,
   includeKimiCli: false,
+  includeQwenCode: false,
   includeDeepSeekCli: false,
   rulesSyncEnabled: false,
   memoriesSyncEnabled: false,

--- a/apps/main-1.0/src/core/session-environment.test.ts
+++ b/apps/main-1.0/src/core/session-environment.test.ts
@@ -23,6 +23,11 @@ describe("session environment", () => {
       environmentId: "local",
       source: "kimi-cli",
     })).toBe(false);
+    expect(canDeleteSessionLocally({
+      environmentKind: "local",
+      environmentId: "local",
+      source: "qwen-code",
+    })).toBe(false);
   });
 
   it("identifies shared multi-session source databases", () => {

--- a/apps/main-1.0/src/core/session-environment.ts
+++ b/apps/main-1.0/src/core/session-environment.ts
@@ -23,6 +23,7 @@ export function isLocalSessionStorage(session: SessionStorageIdentity): boolean 
 export function canDeleteSessionLocally(session: SessionEnvironmentIdentity): boolean {
   return session.source !== "workbuddy-cli"
     && session.source !== "kimi-cli"
+    && session.source !== "qwen-code"
     && (session.environmentKind !== "ssh" || session.sourceAvailable === false);
 }
 

--- a/apps/main-1.0/src/core/session-loader-qwen.test.ts
+++ b/apps/main-1.0/src/core/session-loader-qwen.test.ts
@@ -25,7 +25,7 @@ function record(uuid: string, parentUuid: string | null, type: "user" | "assista
 describe("Qwen Code sessions", () => {
   it("reads the active parent chain, prefers displayText, and ignores archive duplicates", () => {
     const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(path.join(chats, "archive"), { recursive: true });
-    const rows = [record("u", null, "user", "internal prompt", { systemPayload: { displayText: "visible prompt" } }), record("dead", null, "user", "rewound"), record("a", "u", "assistant", "answer", { usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 3, thoughtsTokenCount: 1 }, message: { role: "model", parts: [{ thought: true, text: "thinking" }, { text: "answer" }, { functionCall: { name: "read_file", id: "c1" } }] } }), { uuid: "t", parentUuid: "a", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:01.000Z", type: "tool_result", cwd: "C:/repo", message: { role: "user", parts: [] }, toolCallResult: { output: "done" } }, { uuid: "title", parentUuid: "t", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:02.000Z", type: "system", subtype: "custom_title", systemPayload: { customTitle: "Named session" } }];
+    const rows = [record("u", null, "user", "internal prompt", { systemPayload: { displayText: "visible prompt" } }), record("dead", null, "user", "rewound"), record("a", "u", "assistant", "answer", { usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 3, thoughtsTokenCount: 1 }, message: { role: "model", parts: [{ thought: true, text: "thinking" }, { text: "answer" }, { functionCall: { name: "read_file", id: "c1" } }] } }), { uuid: "t", parentUuid: "a", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:01.000Z", type: "tool_result", cwd: "C:/repo", message: { role: "user", parts: [] }, toolCallResult: { output: "done" } }, { type: "system", subtype: "metadata" }, { uuid: "title", parentUuid: "t", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:02.000Z", type: "system", subtype: "custom_title", systemPayload: { customTitle: "Named session" } }];
     fs.writeFileSync(path.join(chats, "qwen-1.jsonl"), `${rows.map((row) => JSON.stringify(row)).join("")}\nnot-json\n{"uuid":"tail"`);
     fs.writeFileSync(path.join(chats, "archive", "qwen-1.jsonl"), JSON.stringify(record("old", null, "user", "archive")));
     const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
@@ -72,5 +72,35 @@ describe("Qwen Code sessions", () => {
     const loaded = loadDefaultSessions({ homeDir: root, includeQwenCode: true, shouldSkipFile: (filePath) => filePath === activePath, onSkippedFile });
     expect(loaded.filter((item) => item.session.source === "qwen-code")).toEqual([]);
     expect(onSkippedFile).toHaveBeenCalledWith(activePath, expect.any(Object));
+  });
+
+  it("falls back to valid file-order rows when a parent chain is broken", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    const rows = [
+      record("early", null, "user", "early", { timestamp: "2026-08-23T00:00:00.000Z" }),
+      record("orphan", "missing", "assistant", "later", { usageMetadata: { promptTokenCount: 4, candidatesTokenCount: 2 }, message: { parts: [{ text: "later" }, { functionCall: { name: "read_file", id: "call-1" } }] } }),
+      { uuid: "tool", parentUuid: "orphan", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:02.000Z", type: "tool_result", cwd: "C:/repo", message: { role: "user", parts: [] }, toolCallResult: { output: "done" } },
+      record("leaf", "tool", "assistant", "leaf", { usageMetadata: { promptTokenCount: 6, candidatesTokenCount: 3 } }),
+    ];
+    fs.writeFileSync(path.join(chats, "broken.jsonl"), `${JSON.stringify(rows[0])}\nnot-json\n${rows.slice(1).map((row) => JSON.stringify(row)).join("\n")}\n`);
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
+    expect(loaded.messages.map((message) => message.content)).toEqual(["early", "later", "leaf"]);
+    expect(loaded.tokenEvents?.map((event) => event.dedupeKey)).toEqual(["orphan", "leaf"]);
+    expect(loaded.traceEvents?.some((event) => event.eventType === "qwen.tool_result")).toBe(true);
+    expect(loaded.session.timestamp).toBe(Date.parse("2026-08-23T00:00:00.000Z"));
+  });
+
+  it("falls back to file-order rows when UUIDs are duplicated", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    const rows = [
+      record("early", null, "user", "early"),
+      record("dup", "early", "assistant", "first", { usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1 } }),
+      record("dup", "missing", "assistant", "second", { usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 2 }, message: { parts: [{ text: "second" }, { functionCall: { name: "read_file", id: "dup-call" } }] } }),
+    ];
+    fs.writeFileSync(path.join(chats, "duplicate.jsonl"), `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
+    expect(loaded.messages.map((message) => message.content)).toEqual(["early", "first", "second"]);
+    expect(loaded.tokenEvents?.map((event) => event.dedupeKey)).toEqual(["dup", "dup"]);
+    expect(loaded.traceEvents?.some((event) => event.eventType === "qwen.functionCall")).toBe(true);
   });
 });

--- a/apps/main-1.0/src/core/session-loader-qwen.test.ts
+++ b/apps/main-1.0/src/core/session-loader-qwen.test.ts
@@ -31,11 +31,11 @@ function record(uuid: string, parentUuid: string | null, type: "user" | "assista
 describe("Qwen Code sessions", () => {
   it("reads the active parent chain, prefers displayText, and ignores archive duplicates", () => {
     const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(path.join(chats, "archive"), { recursive: true });
-    const rows = [record("u", null, "user", "internal prompt", { systemPayload: { displayText: "visible prompt" } }), record("dead", null, "user", "rewound"), record("a", "u", "assistant", "answer", { usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 3, thoughtsTokenCount: 1 }, message: { role: "model", parts: [{ thought: true, text: "thinking" }, { text: "answer" }, { functionCall: { name: "read_file", id: "c1" } }] } }), { uuid: "t", parentUuid: "a", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:01.000Z", type: "tool_result", cwd: "C:/repo", message: { role: "user", parts: [] }, toolCallResult: { output: "done" } }, { type: "system", subtype: "metadata" }, { uuid: "title", parentUuid: "t", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:02.000Z", type: "system", subtype: "custom_title", systemPayload: { customTitle: "Named session" } }];
+    const rows = [record("u", null, "user", "internal prompt", { systemPayload: { displayText: "visible prompt" } }), record("dead", null, "user", "rewound"), record("a", "u", "assistant", "answer", { usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 3, thoughtsTokenCount: 1 }, message: { role: "model", parts: [{ thought: true, text: "thinking" }, { text: "answer" }, { functionCall: { name: "read_file", id: "c1" } }] } }), { uuid: "t", parentUuid: "a", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:01.000Z", type: "tool_result", cwd: "C:/repo", message: { role: "user", parts: [{ functionResponse: { id: "c1", name: "read_file", response: { output: "done" } } }] }, toolCallResult: { callId: "c1", output: "done" } }, { type: "system", subtype: "metadata" }, { uuid: "title", parentUuid: "t", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:02.000Z", type: "system", subtype: "custom_title", systemPayload: { customTitle: "Named session" } }];
     fs.writeFileSync(path.join(chats, "qwen-1.jsonl"), `${rows.map((row) => JSON.stringify(row)).join("")}\nnot-json\n{"uuid":"tail"`);
     fs.writeFileSync(path.join(chats, "archive", "qwen-1.jsonl"), JSON.stringify(record("old", null, "user", "archive")));
     const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
-    expect(loaded.session.source).toBe("qwen-code"); expect(loaded.session.originalTitle).toBe("Named session"); expect(loaded.messages.map((m) => m.content)).toEqual(["visible prompt", "answer"]); expect(loaded.session.tokenUsage?.totalTokens).toBe(6); expect(loaded.traceEvents?.some((e) => e.kind === "tool_call")).toBe(true); expect(loaded.traceEvents?.some((e) => e.eventType === "qwen.tool_result")).toBe(true); expect(loaded.messages.some((m) => m.content === "rewound")).toBe(false);
+    expect(loaded.session.source).toBe("qwen-code"); expect(loaded.session.originalTitle).toBe("Named session"); expect(loaded.messages.map((m) => m.content)).toEqual(["visible prompt", "answer"]); expect(loaded.session.tokenUsage?.totalTokens).toBe(6); expect(loaded.traceEvents?.some((e) => e.kind === "tool_call")).toBe(true); expect(loaded.traceEvents?.filter((e) => e.eventType === "qwen.tool_result")).toEqual([expect.objectContaining({ callId: "c1" })]); expect(loaded.messages.some((m) => m.content === "rewound")).toBe(false);
   });
 
   it("uses QWEN_RUNTIME_DIR before QWEN_HOME", () => {
@@ -111,14 +111,14 @@ describe("Qwen Code sessions", () => {
     const rows = [
       record("early", null, "user", "early", { timestamp: "2026-08-23T00:00:00.000Z" }),
       record("orphan", "missing", "assistant", "later", { usageMetadata: { promptTokenCount: 4, candidatesTokenCount: 2 }, message: { parts: [{ text: "later" }, { functionCall: { name: "read_file", id: "call-1" } }] } }),
-      { uuid: "tool", parentUuid: "orphan", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:02.000Z", type: "tool_result", cwd: "C:/repo", message: { role: "user", parts: [] }, toolCallResult: { output: "done" } },
+      { uuid: "tool", parentUuid: "orphan", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:02.000Z", type: "tool_result", cwd: "C:/repo", message: { role: "user", parts: [] }, toolCallResult: { callId: "call-1", output: "done" } },
       record("leaf", "tool", "assistant", "leaf", { usageMetadata: { promptTokenCount: 6, candidatesTokenCount: 3 } }),
     ];
     fs.writeFileSync(path.join(chats, "broken.jsonl"), `${JSON.stringify(rows[0])}\nnot-json\n${rows.slice(1).map((row) => JSON.stringify(row)).join("\n")}\n`);
     const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
     expect(loaded.messages.map((message) => message.content)).toEqual(["early", "later", "leaf"]);
     expect(loaded.tokenEvents?.map((event) => event.dedupeKey)).toEqual(["orphan", "leaf"]);
-    expect(loaded.traceEvents?.some((event) => event.eventType === "qwen.tool_result")).toBe(true);
+    expect(loaded.traceEvents?.filter((event) => event.eventType === "qwen.tool_result")).toEqual([expect.objectContaining({ callId: "call-1" })]);
     expect(loaded.session.timestamp).toBe(Date.parse("2026-08-23T00:00:00.000Z"));
   });
 
@@ -128,11 +128,13 @@ describe("Qwen Code sessions", () => {
       record("early", null, "user", "early"),
       record("dup", "early", "assistant", "first", { usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1 } }),
       record("dup", "missing", "assistant", "second", { usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 2 }, message: { parts: [{ text: "second" }, { functionCall: { name: "read_file", id: "dup-call" } }] } }),
+      { type: "system", subtype: "metadata", usageMetadata: { promptTokenCount: 100, candidatesTokenCount: 100 } },
     ];
     fs.writeFileSync(path.join(chats, "duplicate.jsonl"), `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
     const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
     expect(loaded.messages.map((message) => message.content)).toEqual(["early", "first", "second"]);
-    expect(loaded.tokenEvents?.map((event) => event.dedupeKey)).toEqual(["dup", "dup"]);
+    expect(loaded.tokenEvents?.map((event) => event.dedupeKey)).toEqual(["dup"]);
+    expect(loaded.tokenEvents?.[0].totalTokens).toBe(4);
     expect(loaded.traceEvents?.some((event) => event.eventType === "qwen.functionCall")).toBe(true);
   });
 });

--- a/apps/main-1.0/src/core/session-loader-qwen.test.ts
+++ b/apps/main-1.0/src/core/session-loader-qwen.test.ts
@@ -35,4 +35,29 @@ describe("Qwen Code sessions", () => {
     process.env.QWEN_HOME = home; process.env.QWEN_RUNTIME_DIR = runtime;
     const loaded = loadDefaultSessions({ includeQwenCode: true }).filter((item) => item.session.source === "qwen-code"); expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("runtime");
   });
+
+  it("keeps braces inside valid JSON text and normalizes cached tokens and creation time", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    const createdAt = "2026-08-23T00:00:00.000Z"; const updatedAt = "2026-08-23T01:00:00.000Z";
+    const user = record("u", null, "user", "keep }{ together", { timestamp: createdAt });
+    const assistant = record("a", "u", "assistant", "answer", { timestamp: updatedAt, usageMetadata: { promptTokenCount: 10, cachedContentTokenCount: 4, candidatesTokenCount: 3, thoughtsTokenCount: 2 } });
+    fs.writeFileSync(path.join(chats, "tokens.jsonl"), `${JSON.stringify(user)}\n${JSON.stringify(assistant)}\n`);
+
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
+    expect(loaded.messages.map((message) => message.content)).toEqual(["keep }{ together", "answer"]);
+    expect(loaded.session.timestamp).toBe(Date.parse(createdAt));
+    expect(loaded.session.tokenUsage).toMatchObject({ inputTokens: 6, cachedInputTokens: 4, outputTokens: 3, reasoningOutputTokens: 2, totalTokens: 15 });
+  });
+
+  it("does not let an archive copy replace a skipped active session", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(path.join(chats, "archive"), { recursive: true });
+    const activePath = path.join(chats, "same.jsonl");
+    fs.writeFileSync(activePath, JSON.stringify(record("active", null, "user", "active")));
+    fs.writeFileSync(path.join(chats, "archive", "same.jsonl"), JSON.stringify(record("archive", null, "user", "archive")));
+    const onSkippedFile = vi.fn();
+
+    const loaded = loadDefaultSessions({ homeDir: root, includeQwenCode: true, shouldSkipFile: (filePath) => filePath === activePath, onSkippedFile });
+    expect(loaded.filter((item) => item.session.source === "qwen-code")).toEqual([]);
+    expect(onSkippedFile).toHaveBeenCalledWith(activePath, expect.any(Object));
+  });
 });

--- a/apps/main-1.0/src/core/session-loader-qwen.test.ts
+++ b/apps/main-1.0/src/core/session-loader-qwen.test.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadDefaultSessions } from "./session-loader";
+
+const roots: string[] = [];
+const originalRuntimeDir = process.env.QWEN_RUNTIME_DIR;
+const originalQwenHome = process.env.QWEN_HOME;
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  if (originalRuntimeDir === undefined) delete process.env.QWEN_RUNTIME_DIR;
+  else process.env.QWEN_RUNTIME_DIR = originalRuntimeDir;
+  if (originalQwenHome === undefined) delete process.env.QWEN_HOME;
+  else process.env.QWEN_HOME = originalQwenHome;
+  vi.restoreAllMocks();
+});
+function fixture(): string { const root = fs.mkdtempSync(path.join(os.tmpdir(), "agentrecall-qwen-v1-")); roots.push(root); return root; }
+function record(uuid: string, parentUuid: string | null, type: "user" | "assistant", text: string, extra: Record<string, unknown> = {}) { return { uuid, parentUuid, sessionId: "qwen-1", timestamp: "2026-08-23T00:00:00.000Z", type, cwd: "C:/repo", version: "0.22.0", message: { role: type, parts: [{ text, ...(type === "assistant" ? { thought: false } : {}) }] }, ...extra }; }
+
+describe("Qwen Code sessions", () => {
+  it("reads the active parent chain, prefers displayText, and ignores archive duplicates", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(path.join(chats, "archive"), { recursive: true });
+    const rows = [record("u", null, "user", "internal prompt", { systemPayload: { displayText: "visible prompt" } }), record("dead", null, "user", "rewound"), record("a", "u", "assistant", "answer", { usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 3, thoughtsTokenCount: 1 }, message: { role: "model", parts: [{ thought: true, text: "thinking" }, { text: "answer" }, { functionCall: { name: "read_file", id: "c1" } }] } }), { uuid: "t", parentUuid: "a", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:01.000Z", type: "tool_result", cwd: "C:/repo", message: { role: "user", parts: [] }, toolCallResult: { output: "done" } }, { uuid: "title", parentUuid: "t", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:02.000Z", type: "system", subtype: "custom_title", systemPayload: { customTitle: "Named session" } }];
+    fs.writeFileSync(path.join(chats, "qwen-1.jsonl"), `${rows.map((row) => JSON.stringify(row)).join("")}\nnot-json\n{"uuid":"tail"`);
+    fs.writeFileSync(path.join(chats, "archive", "qwen-1.jsonl"), JSON.stringify(record("old", null, "user", "archive")));
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
+    expect(loaded.session.source).toBe("qwen-code"); expect(loaded.session.originalTitle).toBe("Named session"); expect(loaded.messages.map((m) => m.content)).toEqual(["visible prompt", "answer"]); expect(loaded.session.tokenUsage?.totalTokens).toBe(6); expect(loaded.traceEvents?.some((e) => e.kind === "tool_call")).toBe(true); expect(loaded.traceEvents?.some((e) => e.eventType === "qwen.tool_result")).toBe(true); expect(loaded.messages.some((m) => m.content === "rewound")).toBe(false);
+  });
+
+  it("uses QWEN_RUNTIME_DIR before QWEN_HOME", () => {
+    const runtime = fixture(); const home = fixture(); const syntheticHome = fixture();
+    vi.spyOn(os, "homedir").mockReturnValue(syntheticHome);
+    for (const [base, text] of [[runtime, "runtime"], [home, "home"]] as const) { const chats = path.join(base, "projects", "p", "chats"); fs.mkdirSync(chats, { recursive: true }); fs.writeFileSync(path.join(chats, `${text}.jsonl`), JSON.stringify(record(text, null, "user", text))); }
+    process.env.QWEN_HOME = home; process.env.QWEN_RUNTIME_DIR = runtime;
+    const loaded = loadDefaultSessions({ includeQwenCode: true }).filter((item) => item.session.source === "qwen-code"); expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("runtime");
+  });
+});

--- a/apps/main-1.0/src/core/session-loader-qwen.test.ts
+++ b/apps/main-1.0/src/core/session-loader-qwen.test.ts
@@ -45,18 +45,51 @@ describe("Qwen Code sessions", () => {
     const loaded = loadDefaultSessions({ homeDir: syntheticHome, includeQwenCode: true }).filter((item) => item.session.source === "qwen-code"); expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("runtime");
   });
 
-  it("keeps braces inside valid JSON text and normalizes cached tokens and creation time", () => {
+  it("keeps braces inside valid JSON text and honors authoritative Qwen token totals", () => {
     const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
     const createdAt = "2026-08-23T00:00:00.000Z"; const updatedAt = "2026-08-23T01:00:00.000Z";
     const user = record("u", null, "user", "keep }{ together", { timestamp: createdAt });
-    const assistant = record("a", "u", "assistant", "answer", { timestamp: updatedAt, usageMetadata: { promptTokenCount: 10, cachedContentTokenCount: 4, candidatesTokenCount: 3, thoughtsTokenCount: 2 } });
+    const assistant = record("a", "u", "assistant", "answer", { timestamp: updatedAt, usageMetadata: { promptTokenCount: 10, cachedContentTokenCount: 4, candidatesTokenCount: 3, thoughtsTokenCount: 2, totalTokenCount: 13 } });
     fs.writeFileSync(path.join(chats, "tokens.jsonl"), `${JSON.stringify(user)}\n${JSON.stringify(assistant)}\n`);
 
     const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
     expect(loaded.messages.map((message) => message.content)).toEqual(["keep }{ together", "answer"]);
     expect(loaded.session.timestamp).toBe(Date.parse(createdAt));
+    expect(loaded.session.tokenUsage).toMatchObject({ inputTokens: 6, cachedInputTokens: 4, outputTokens: 1, reasoningOutputTokens: 2, totalTokens: 13 });
+    expect(loaded.tokenEvents).toEqual([{ timestamp: Date.parse(updatedAt), dedupeKey: "a", inputTokens: 6, outputTokens: 1, cachedInputTokens: 4, reasoningOutputTokens: 2, totalTokens: 13 }]);
+  });
+
+  it("keeps separated Qwen reasoning above the candidate count", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    const rows = [record("u", null, "user", "question"), record("a", "u", "assistant", "answer", { usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 2, thoughtsTokenCount: 5, totalTokenCount: 17 } })];
+    fs.writeFileSync(path.join(chats, "separated-tokens.jsonl"), `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
+    expect(loaded.tokenEvents).toEqual([expect.objectContaining({ inputTokens: 10, cachedInputTokens: 0, outputTokens: 2, reasoningOutputTokens: 5, totalTokens: 17 })]);
+    expect(loaded.session.tokenUsage).toMatchObject({ inputTokens: 10, cachedInputTokens: 0, outputTokens: 2, reasoningOutputTokens: 5, totalTokens: 17 });
+  });
+
+  it("falls back to additive Qwen token totals when totalTokenCount is missing", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    const rows = [record("u", null, "user", "question"), record("a", "u", "assistant", "answer", { usageMetadata: { promptTokenCount: 10, cachedContentTokenCount: 4, candidatesTokenCount: 3, thoughtsTokenCount: 2 } })];
+    fs.writeFileSync(path.join(chats, "token-fallback.jsonl"), `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
+    expect(loaded.tokenEvents).toEqual([expect.objectContaining({ inputTokens: 6, cachedInputTokens: 4, outputTokens: 3, reasoningOutputTokens: 2, totalTokens: 15 })]);
     expect(loaded.session.tokenUsage).toMatchObject({ inputTokens: 6, cachedInputTokens: 4, outputTokens: 3, reasoningOutputTokens: 2, totalTokens: 15 });
-    expect(loaded.tokenEvents).toEqual([{ timestamp: Date.parse(updatedAt), dedupeKey: "a", inputTokens: 6, outputTokens: 3, cachedInputTokens: 4, reasoningOutputTokens: 2, totalTokens: 15 }]);
+  });
+
+  it("uses trailing rewind metadata as the leaf and ignores artifact-only records", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    const rows = [
+      record("u", null, "user", "question", { gitBranch: "main" }),
+      record("old", "u", "assistant", "discarded answer", { gitBranch: "discarded" }),
+      { uuid: "rewind", parentUuid: "u", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:01.000Z", type: "system", subtype: "rewind", cwd: "C:/repo", gitBranch: "feature/qwen" },
+      { uuid: "model", parentUuid: "rewind", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:02.000Z", type: "system", subtype: "session_model", cwd: "C:/repo", gitBranch: "feature/qwen", model: "qwen3-coder" },
+      { uuid: "artifact", parentUuid: "old", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:03.000Z", type: "system", subtype: "session_artifact_snapshot", cwd: "C:/repo", gitBranch: "discarded" },
+    ];
+    fs.writeFileSync(path.join(chats, "rewind.jsonl"), `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
+    expect(loaded.messages.map((message) => message.content)).toEqual(["question"]);
+    expect(loaded.session.gitBranch).toBe("feature/qwen");
   });
 
   it("recovers glued objects when the first message contains object-like braces", () => {

--- a/apps/main-1.0/src/core/session-loader-qwen.test.ts
+++ b/apps/main-1.0/src/core/session-loader-qwen.test.ts
@@ -4,7 +4,13 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadDefaultSessions } from "./session-loader";
 
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: vi.fn(() => actual.homedir()) };
+});
+
 const roots: string[] = [];
+const defaultHomeDir = os.homedir();
 const originalRuntimeDir = process.env.QWEN_RUNTIME_DIR;
 const originalQwenHome = process.env.QWEN_HOME;
 const originalHome = process.env.HOME;
@@ -24,6 +30,7 @@ afterEach(() => {
   if (originalUserProfile === undefined) delete process.env.USERPROFILE;
   else process.env.USERPROFILE = originalUserProfile;
   vi.restoreAllMocks();
+  vi.mocked(os.homedir).mockReset().mockReturnValue(defaultHomeDir);
 });
 function fixture(): string { const root = fs.mkdtempSync(path.join(os.tmpdir(), "agentrecall-qwen-v1-")); roots.push(root); return root; }
 function record(uuid: string, parentUuid: string | null, type: "user" | "assistant", text: string, extra: Record<string, unknown> = {}) { return { uuid, parentUuid, sessionId: "qwen-1", timestamp: "2026-08-23T00:00:00.000Z", type, cwd: "C:/repo", version: "0.22.0", message: { role: type, parts: [{ text, ...(type === "assistant" ? { thought: false } : {}) }] }, ...extra }; }
@@ -41,8 +48,9 @@ describe("Qwen Code sessions", () => {
   it("uses QWEN_RUNTIME_DIR before QWEN_HOME", () => {
     const runtime = fixture(); const home = fixture(); const syntheticHome = fixture();
     for (const [base, text] of [[runtime, "runtime"], [home, "home"]] as const) { const chats = path.join(base, "projects", "p", "chats"); fs.mkdirSync(chats, { recursive: true }); fs.writeFileSync(path.join(chats, `${text}.jsonl`), JSON.stringify(record(text, null, "user", text))); }
+    vi.mocked(os.homedir).mockReturnValue(syntheticHome);
     process.env.QWEN_HOME = home; process.env.QWEN_RUNTIME_DIR = runtime;
-    const loaded = loadDefaultSessions({ homeDir: syntheticHome, includeQwenCode: true }).filter((item) => item.session.source === "qwen-code"); expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("runtime");
+    const loaded = loadDefaultSessions({ includeQwenCode: true }).filter((item) => item.session.source === "qwen-code"); expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("runtime");
   });
 
   it("keeps braces inside valid JSON text and honors authoritative Qwen token totals", () => {
@@ -110,21 +118,20 @@ describe("Qwen Code sessions", () => {
   });
 
   it("expands a QWEN_RUNTIME_DIR tilde path", () => {
-    const fakeHome = fixture(); const root = fixture(); process.env.HOME = fakeHome; process.env.USERPROFILE = fakeHome;
+    const fakeHome = fixture(); process.env.HOME = fakeHome; process.env.USERPROFILE = fakeHome; vi.mocked(os.homedir).mockReturnValue(fakeHome);
     const chats = path.join(fakeHome, "qwen-runtime", "nested", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
     fs.writeFileSync(path.join(chats, "tilde.jsonl"), JSON.stringify(record("tilde", null, "user", "tilde")));
     process.env.QWEN_RUNTIME_DIR = "~\\qwen-runtime\\nested";
-    const loaded = loadDefaultSessions({ homeDir: root, includeQwenCode: true }).filter((item) => item.session.source === "qwen-code");
+    const loaded = loadDefaultSessions({ includeQwenCode: true }).filter((item) => item.session.source === "qwen-code");
     expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("tilde");
   });
 
-  it("uses QWEN_HOME when runtime is unset even with an explicit homeDir", () => {
-    const root = fixture(); const qwenHome = fixture();
-    const chats = path.join(qwenHome, "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
-    fs.writeFileSync(path.join(chats, "home.jsonl"), JSON.stringify(record("home", null, "user", "home")));
-    delete process.env.QWEN_RUNTIME_DIR; process.env.QWEN_HOME = qwenHome;
+  it("keeps an explicit homeDir isolated from Qwen environment overrides", () => {
+    const root = fixture(); const runtime = fixture(); const qwenHome = fixture();
+    for (const [base, text] of [[path.join(root, ".qwen"), "explicit"], [runtime, "runtime"], [qwenHome, "home"]] as const) { const chats = path.join(base, "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true }); fs.writeFileSync(path.join(chats, `${text}.jsonl`), JSON.stringify(record(text, null, "user", text))); }
+    process.env.QWEN_RUNTIME_DIR = runtime; process.env.QWEN_HOME = qwenHome;
     const loaded = loadDefaultSessions({ homeDir: root, includeQwenCode: true }).filter((item) => item.session.source === "qwen-code");
-    expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("home");
+    expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("explicit");
   });
 
   it("does not let an archive copy replace a skipped active session", () => {

--- a/apps/main-1.0/src/core/session-loader-qwen.test.ts
+++ b/apps/main-1.0/src/core/session-loader-qwen.test.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import os from "node:os";
+import * as os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadDefaultSessions } from "./session-loader";
@@ -7,6 +7,8 @@ import { loadDefaultSessions } from "./session-loader";
 const roots: string[] = [];
 const originalRuntimeDir = process.env.QWEN_RUNTIME_DIR;
 const originalQwenHome = process.env.QWEN_HOME;
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
 beforeEach(() => {
   delete process.env.QWEN_RUNTIME_DIR;
   delete process.env.QWEN_HOME;
@@ -17,6 +19,10 @@ afterEach(() => {
   else process.env.QWEN_RUNTIME_DIR = originalRuntimeDir;
   if (originalQwenHome === undefined) delete process.env.QWEN_HOME;
   else process.env.QWEN_HOME = originalQwenHome;
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
   vi.restoreAllMocks();
 });
 function fixture(): string { const root = fs.mkdtempSync(path.join(os.tmpdir(), "agentrecall-qwen-v1-")); roots.push(root); return root; }
@@ -51,6 +57,32 @@ describe("Qwen Code sessions", () => {
     expect(loaded.session.timestamp).toBe(Date.parse(createdAt));
     expect(loaded.session.tokenUsage).toMatchObject({ inputTokens: 6, cachedInputTokens: 4, outputTokens: 3, reasoningOutputTokens: 2, totalTokens: 15 });
     expect(loaded.tokenEvents).toEqual([{ timestamp: Date.parse(updatedAt), dedupeKey: "a", inputTokens: 6, outputTokens: 3, cachedInputTokens: 4, reasoningOutputTokens: 2, totalTokens: 15 }]);
+  });
+
+  it("recovers glued objects when the first message contains object-like braces", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    const first = record("first", null, "user", "keep }{ together");
+    const second = record("second", "first", "assistant", "second");
+    fs.writeFileSync(path.join(chats, "glued.jsonl"), `${JSON.stringify(first)}${JSON.stringify(second)}\n`);
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
+    expect(loaded.messages.map((message) => message.content)).toEqual(["keep }{ together", "second"]);
+  });
+
+  it("uses the latest custom title", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    const rows = [record("user", null, "user", "question"), { type: "system", subtype: "custom_title", systemPayload: { customTitle: "Old title" } }, { type: "system", subtype: "custom_title", systemPayload: { customTitle: "Latest title" } }];
+    fs.writeFileSync(path.join(chats, "titles.jsonl"), `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
+    expect(loaded.session.originalTitle).toBe("Latest title");
+  });
+
+  it("expands a QWEN_RUNTIME_DIR tilde path", () => {
+    const fakeHome = fixture(); const root = fixture(); process.env.HOME = fakeHome; process.env.USERPROFILE = fakeHome;
+    const chats = path.join(fakeHome, "qwen-runtime", "nested", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    fs.writeFileSync(path.join(chats, "tilde.jsonl"), JSON.stringify(record("tilde", null, "user", "tilde")));
+    process.env.QWEN_RUNTIME_DIR = "~\\qwen-runtime\\nested";
+    const loaded = loadDefaultSessions({ homeDir: root, includeQwenCode: true }).filter((item) => item.session.source === "qwen-code");
+    expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("tilde");
   });
 
   it("uses QWEN_HOME when runtime is unset even with an explicit homeDir", () => {

--- a/apps/main-1.0/src/core/session-loader-qwen.test.ts
+++ b/apps/main-1.0/src/core/session-loader-qwen.test.ts
@@ -1,12 +1,16 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadDefaultSessions } from "./session-loader";
 
 const roots: string[] = [];
 const originalRuntimeDir = process.env.QWEN_RUNTIME_DIR;
 const originalQwenHome = process.env.QWEN_HOME;
+beforeEach(() => {
+  delete process.env.QWEN_RUNTIME_DIR;
+  delete process.env.QWEN_HOME;
+});
 afterEach(() => {
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
   if (originalRuntimeDir === undefined) delete process.env.QWEN_RUNTIME_DIR;
@@ -30,10 +34,9 @@ describe("Qwen Code sessions", () => {
 
   it("uses QWEN_RUNTIME_DIR before QWEN_HOME", () => {
     const runtime = fixture(); const home = fixture(); const syntheticHome = fixture();
-    vi.spyOn(os, "homedir").mockReturnValue(syntheticHome);
     for (const [base, text] of [[runtime, "runtime"], [home, "home"]] as const) { const chats = path.join(base, "projects", "p", "chats"); fs.mkdirSync(chats, { recursive: true }); fs.writeFileSync(path.join(chats, `${text}.jsonl`), JSON.stringify(record(text, null, "user", text))); }
     process.env.QWEN_HOME = home; process.env.QWEN_RUNTIME_DIR = runtime;
-    const loaded = loadDefaultSessions({ includeQwenCode: true }).filter((item) => item.session.source === "qwen-code"); expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("runtime");
+    const loaded = loadDefaultSessions({ homeDir: syntheticHome, includeQwenCode: true }).filter((item) => item.session.source === "qwen-code"); expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("runtime");
   });
 
   it("keeps braces inside valid JSON text and normalizes cached tokens and creation time", () => {
@@ -47,6 +50,16 @@ describe("Qwen Code sessions", () => {
     expect(loaded.messages.map((message) => message.content)).toEqual(["keep }{ together", "answer"]);
     expect(loaded.session.timestamp).toBe(Date.parse(createdAt));
     expect(loaded.session.tokenUsage).toMatchObject({ inputTokens: 6, cachedInputTokens: 4, outputTokens: 3, reasoningOutputTokens: 2, totalTokens: 15 });
+    expect(loaded.tokenEvents).toEqual([{ timestamp: Date.parse(updatedAt), dedupeKey: "a", inputTokens: 6, outputTokens: 3, cachedInputTokens: 4, reasoningOutputTokens: 2, totalTokens: 15 }]);
+  });
+
+  it("uses QWEN_HOME when runtime is unset even with an explicit homeDir", () => {
+    const root = fixture(); const qwenHome = fixture();
+    const chats = path.join(qwenHome, "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    fs.writeFileSync(path.join(chats, "home.jsonl"), JSON.stringify(record("home", null, "user", "home")));
+    delete process.env.QWEN_RUNTIME_DIR; process.env.QWEN_HOME = qwenHome;
+    const loaded = loadDefaultSessions({ homeDir: root, includeQwenCode: true }).filter((item) => item.session.source === "qwen-code");
+    expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("home");
   });
 
   it("does not let an archive copy replace a skipped active session", () => {

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -62,7 +62,8 @@ const KIMI_CODE_DIR = ".kimi-code";
 const KIMI_LEGACY_DIR = ".kimi";
 const QWEN_DIR = ".qwen";
 
-function resolveQwenCodeRoot(homeDir: string): string {
+function resolveQwenCodeRoot(homeDir: string, options: SessionLoadOptions): string {
+  if (options.homeDir !== undefined) return path.join(homeDir, QWEN_DIR);
   const configured = process.env.QWEN_RUNTIME_DIR?.trim() || process.env.QWEN_HOME?.trim();
   if (!configured) return path.join(homeDir, QWEN_DIR);
   const expanded = configured === "~"
@@ -4381,7 +4382,7 @@ export function* loadDefaultSessionsIterator(options: SessionLoadOptions = {}): 
   }
   if (options.includeKimiCli) yield* loadKimiSessionsIterator(path.join(homeDir, KIMI_LEGACY_DIR), resolveKimiCodeRoot(homeDir, options), options);
   if (options.includeQwenCode) {
-    yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir), options);
+    yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir, options), options);
   }
   if (options.includeOpenClaw) {
     yield* loadOpenClawSessionsIterator(path.join(homeDir, ".openclaw"), options);
@@ -4422,7 +4423,7 @@ export async function* loadDefaultSessionsAsyncIterator(options: SessionLoadOpti
   }
   if (options.includeKimiCli) yield* loadKimiSessionsIterator(path.join(homeDir, KIMI_LEGACY_DIR), resolveKimiCodeRoot(homeDir, options), options);
   if (options.includeQwenCode) {
-    yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir), options);
+    yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir, options), options);
   }
   if (options.includeOpenClaw) {
     yield* loadOpenClawSessionsIterator(path.join(homeDir, ".openclaw"), options);

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -2001,6 +2001,12 @@ function qwenJsonlRows(filePath: string): unknown[] {
   return rows;
 }
 
+function qwenToolResultCallId(row: Record<string, unknown>, parts: Record<string, unknown>[]): string | null {
+  const functionResponse = parts.map((part) => objectField(part, "functionResponse")).find(Boolean);
+  const toolCallResult = objectField(row, "toolCallResult");
+  return stringField(functionResponse, "id") || stringField(toolCallResult, "callId") || stringField(toolCallResult, "id") || stringField(row, "uuid") || null;
+}
+
 function qwenTraceEvents(rows: Record<string, unknown>[]): SessionTraceEvent[] {
   const events: TraceEventDraft[] = [];
   for (const row of rows) {
@@ -2011,13 +2017,14 @@ function qwenTraceEvents(rows: Record<string, unknown>[]): SessionTraceEvent[] {
       const call = objectField(part, "functionCall");
       const result = objectField(part, "functionResponse");
       const thought = part.thought === true;
+      if (row.type === "tool_result" && result) continue;
       if (!call && !result && !thought) continue;
       const value = call || result || part;
       const title = call ? `function: ${stringField(call, "name") || "call"}` : result ? `function result: ${stringField(result, "name") || "result"}` : "reasoning";
       events.push({ kind: call ? "tool_call" : result ? "tool_result" : "event", source: "qwen", title, detail: stringifyDetail(value), timestamp: timestampString(row.timestamp), callId: stringField(call || result, "id") || null, eventType: call ? "qwen.functionCall" : result ? "qwen.functionResponse" : "qwen.thought", status: call ? "running" : result ? "completed" : "unknown" });
     }
     if (row.type === "tool_result") {
-      events.push({ kind: "tool_result", source: "qwen", title: "tool result", detail: stringifyDetail(row.toolCallResult || row.message || row), timestamp: timestampString(row.timestamp), callId: stringField(row, "uuid") || null, eventType: "qwen.tool_result", status: "completed" });
+      events.push({ kind: "tool_result", source: "qwen", title: "tool result", detail: stringifyDetail(row.toolCallResult || row.message || row), timestamp: timestampString(row.timestamp), callId: qwenToolResultCallId(row, parts.filter(isRecord)), eventType: "qwen.tool_result", status: "completed" });
     }
   }
   return dedupeTraceEvents(events);
@@ -2052,7 +2059,7 @@ function loadQwenCodeSessionFile(filePath: string, projectPath: string, stat: Vi
   const activeRows = chainInvalid ? parsedRows : chain.reverse();
   const messages = sourceMessages(activeRows, "qwen");
   if (!messages.length) return null;
-  const usageEvents: TokenUsageEvent[] = [];
+  const usageEvents = new Map<string, TokenUsageEvent>();
   for (const row of activeRows) {
     const usage = objectField(row, "usageMetadata");
     if (!usage) continue;
@@ -2060,14 +2067,17 @@ function loadQwenCodeSessionFile(filePath: string, projectPath: string, stat: Vi
     const inputTokens = Math.max(0, numberField(usage, "promptTokenCount") - cachedInputTokens);
     const outputTokens = numberField(usage, "candidatesTokenCount");
     const reasoningOutputTokens = numberField(usage, "thoughtsTokenCount");
-    usageEvents.push(tokenEvent(timestampMs(row.timestamp), stringField(row, "uuid"), inputTokens, outputTokens, cachedInputTokens, reasoningOutputTokens));
+    const dedupeKey = stringField(row, "uuid");
+    if (!dedupeKey) continue;
+    putTokenEvent(usageEvents, tokenEvent(timestampMs(row.timestamp), dedupeKey, inputTokens, outputTokens, cachedInputTokens, reasoningOutputTokens));
   }
+  const tokenEvents = [...usageEvents.values()];
   const rawId = path.basename(filePath, ".jsonl");
   const firstQuestionText = cleanTitle(firstQuestion(messages));
   const titleRecord = [...parsedRows].reverse().find((row) => row.subtype === "custom_title" && typeof objectField(row, "systemPayload")?.customTitle === "string");
   const title = stringField(objectField(titleRecord, "systemPayload"), "customTitle") || firstQuestionText || rawId;
   const chainTimestamp = activeRows.map((row) => timestampMs(row.timestamp)).find((timestamp) => timestamp > 0) || stat.mtimeMs;
-  return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: firstQuestionText, timestamp: chainTimestamp, tokenUsage: tokenUsageFromEvents(usageEvents), stat }), messages, tokenEvents: usageEvents, traceEvents: qwenTraceEvents(activeRows) };
+  return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: firstQuestionText, timestamp: chainTimestamp, tokenUsage: tokenUsageFromEvents(tokenEvents), stat }), messages, tokenEvents, traceEvents: qwenTraceEvents(activeRows) };
 }
 
 function* loadQwenCodeSessionsIterator(root: string, options: SessionLoadOptions): Generator<LoadedSession> {

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -2007,6 +2007,39 @@ function qwenToolResultCallId(row: Record<string, unknown>, parts: Record<string
   return stringField(functionResponse, "id") || stringField(toolCallResult, "callId") || stringField(toolCallResult, "id") || stringField(row, "uuid") || null;
 }
 
+const QWEN_ARTIFACT_SUBTYPES = new Set(["session_artifact_event", "session_artifact_snapshot"]);
+const QWEN_CONVERSATION_TYPES = new Set(["user", "assistant", "tool_result", "system"]);
+
+function qwenConversationLeaf(rows: Record<string, unknown>[]): Record<string, unknown> | undefined {
+  return [...rows].reverse().find((row) => {
+    const type = stringField(row, "type");
+    return QWEN_CONVERSATION_TYPES.has(type)
+      && Boolean(stringField(row, "uuid"))
+      && !(type === "system" && QWEN_ARTIFACT_SUBTYPES.has(stringField(row, "subtype")));
+  });
+}
+
+function qwenTokenBuckets(
+  usage: Record<string, unknown>,
+): Pick<TokenUsage, "inputTokens" | "outputTokens" | "cachedInputTokens" | "reasoningOutputTokens"> {
+  const promptTokens = Math.max(0, numberField(usage, "promptTokenCount"));
+  const candidateTokens = Math.max(0, numberField(usage, "candidatesTokenCount"));
+  const thoughtTokens = Math.max(0, numberField(usage, "thoughtsTokenCount"));
+  const rawTotalTokens = usage.totalTokenCount;
+  const hasAuthoritativeTotal = typeof rawTotalTokens === "number" && Number.isFinite(rawTotalTokens) && rawTotalTokens >= 0;
+  const cachedInputTokens = Math.min(Math.max(0, numberField(usage, "cachedContentTokenCount")), promptTokens);
+  const inputTokens = promptTokens - cachedInputTokens;
+  if (!hasAuthoritativeTotal) {
+    return { inputTokens, outputTokens: candidateTokens, cachedInputTokens, reasoningOutputTokens: thoughtTokens };
+  }
+  const targetTotalTokens = rawTotalTokens;
+  const boundedCachedInputTokens = Math.min(cachedInputTokens, targetTotalTokens);
+  const boundedInputTokens = Math.min(inputTokens, targetTotalTokens - boundedCachedInputTokens);
+  const outputBudget = targetTotalTokens - boundedInputTokens - boundedCachedInputTokens;
+  const reasoningOutputTokens = Math.min(thoughtTokens, outputBudget);
+  return { inputTokens: boundedInputTokens, outputTokens: outputBudget - reasoningOutputTokens, cachedInputTokens: boundedCachedInputTokens, reasoningOutputTokens };
+}
+
 function qwenTraceEvents(rows: Record<string, unknown>[]): SessionTraceEvent[] {
   const events: TraceEventDraft[] = [];
   for (const row of rows) {
@@ -2040,7 +2073,7 @@ function loadQwenCodeSessionFile(filePath: string, projectPath: string, stat: Vi
     if (records.has(uuid)) chainInvalid = true;
     records.set(uuid, row);
   }
-  const leaf = [...parsedRows].reverse().find((row) => row.type === "user" || row.type === "assistant" || row.type === "tool_result");
+  const leaf = qwenConversationLeaf(parsedRows);
   if (!leaf) return null;
   const chain: Record<string, unknown>[] = [];
   const visited = new Set<string>();
@@ -2063,10 +2096,7 @@ function loadQwenCodeSessionFile(filePath: string, projectPath: string, stat: Vi
   for (const row of activeRows) {
     const usage = objectField(row, "usageMetadata");
     if (!usage) continue;
-    const cachedInputTokens = numberField(usage, "cachedContentTokenCount");
-    const inputTokens = Math.max(0, numberField(usage, "promptTokenCount") - cachedInputTokens);
-    const outputTokens = numberField(usage, "candidatesTokenCount");
-    const reasoningOutputTokens = numberField(usage, "thoughtsTokenCount");
+    const { inputTokens, outputTokens, cachedInputTokens, reasoningOutputTokens } = qwenTokenBuckets(usage);
     const dedupeKey = stringField(row, "uuid");
     if (!dedupeKey) continue;
     putTokenEvent(usageEvents, tokenEvent(timestampMs(row.timestamp), dedupeKey, inputTokens, outputTokens, cachedInputTokens, reasoningOutputTokens));
@@ -2077,7 +2107,8 @@ function loadQwenCodeSessionFile(filePath: string, projectPath: string, stat: Vi
   const titleRecord = [...parsedRows].reverse().find((row) => row.subtype === "custom_title" && typeof objectField(row, "systemPayload")?.customTitle === "string");
   const title = stringField(objectField(titleRecord, "systemPayload"), "customTitle") || firstQuestionText || rawId;
   const chainTimestamp = activeRows.map((row) => timestampMs(row.timestamp)).find((timestamp) => timestamp > 0) || stat.mtimeMs;
-  return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: firstQuestionText, timestamp: chainTimestamp, tokenUsage: tokenUsageFromEvents(tokenEvents), stat }), messages, tokenEvents, traceEvents: qwenTraceEvents(activeRows) };
+  const gitBranch = [...activeRows].reverse().map((row) => stringField(row, "gitBranch")).find(Boolean) || null;
+  return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: firstQuestionText, timestamp: chainTimestamp, gitBranch, tokenUsage: tokenUsageFromEvents(tokenEvents), stat }), messages, tokenEvents, traceEvents: qwenTraceEvents(activeRows) };
 }
 
 function* loadQwenCodeSessionsIterator(root: string, options: SessionLoadOptions): Generator<LoadedSession> {

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -63,7 +63,14 @@ const KIMI_LEGACY_DIR = ".kimi";
 const QWEN_DIR = ".qwen";
 
 function resolveQwenCodeRoot(homeDir: string): string {
-  return process.env.QWEN_RUNTIME_DIR?.trim() || process.env.QWEN_HOME?.trim() || path.join(homeDir, QWEN_DIR);
+  const configured = process.env.QWEN_RUNTIME_DIR?.trim() || process.env.QWEN_HOME?.trim();
+  if (!configured) return path.join(homeDir, QWEN_DIR);
+  const expanded = configured === "~"
+    ? os.homedir()
+    : configured.startsWith("~/") || configured.startsWith("~\\")
+      ? path.join(os.homedir(), ...configured.slice(2).split(/[\\/]+/u).filter(Boolean))
+      : configured;
+  return path.resolve(expanded);
 }
 const TRAE_DIR_NAMES = [".trae", ".trae-cn"] as const;
 const CODEX_WORKSPACE_PLACEHOLDER = /^<[^>]+>$/u;
@@ -1970,9 +1977,25 @@ function qwenJsonlRows(filePath: string): unknown[] {
       rows.push(JSON.parse(trimmed));
       continue;
     } catch { /* a malformed or glued line may still contain valid objects */ }
-    const candidates = trimmed.split(/\}\s*(?=\{)/u).map((part, index, parts) => index < parts.length - 1 ? `${part}}` : part);
-    for (const candidate of candidates) {
-      try { rows.push(JSON.parse(candidate)); } catch { /* malformed or incomplete tail */ }
+    let start = -1;
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let index = 0; index < trimmed.length; index += 1) {
+      const character = trimmed[index];
+      if (start < 0) {
+        if (character === "{") { start = index; depth = 1; }
+        continue;
+      }
+      if (escaped) { escaped = false; continue; }
+      if (inString && character === "\\") { escaped = true; continue; }
+      if (character === '"') { inString = !inString; continue; }
+      if (inString) continue;
+      if (character === "{") depth += 1;
+      else if (character === "}" && --depth === 0) {
+        try { rows.push(JSON.parse(trimmed.slice(start, index + 1))); } catch { /* malformed object */ }
+        start = -1;
+      }
     }
   }
   return rows;
@@ -2041,7 +2064,7 @@ function loadQwenCodeSessionFile(filePath: string, projectPath: string, stat: Vi
   }
   const rawId = path.basename(filePath, ".jsonl");
   const firstQuestionText = cleanTitle(firstQuestion(messages));
-  const titleRecord = parsedRows.find((row) => row.subtype === "custom_title");
+  const titleRecord = [...parsedRows].reverse().find((row) => row.subtype === "custom_title" && typeof objectField(row, "systemPayload")?.customTitle === "string");
   const title = stringField(objectField(titleRecord, "systemPayload"), "customTitle") || firstQuestionText || rawId;
   const chainTimestamp = activeRows.map((row) => timestampMs(row.timestamp)).find((timestamp) => timestamp > 0) || stat.mtimeMs;
   return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: firstQuestionText, timestamp: chainTimestamp, tokenUsage: tokenUsageFromEvents(usageEvents), stat }), messages, tokenEvents: usageEvents, traceEvents: qwenTraceEvents(activeRows) };

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -2003,27 +2003,34 @@ function qwenTraceEvents(rows: Record<string, unknown>[]): SessionTraceEvent[] {
 function loadQwenCodeSessionFile(filePath: string, projectPath: string, stat: VirtualSessionFileStat): LoadedSession | null {
   const parsedRows = qwenJsonlRows(filePath).filter(isRecord);
   const records = new Map<string, Record<string, unknown>>();
+  let chainInvalid = false;
   for (const row of parsedRows) {
     const uuid = stringField(row, "uuid");
-    if (uuid) records.set(uuid, row);
+    if (!uuid) continue;
+    if (records.has(uuid)) chainInvalid = true;
+    records.set(uuid, row);
   }
-  const leaf = [...records.values()].reverse().find((row) => row.type === "user" || row.type === "assistant" || row.type === "tool_result");
+  const leaf = [...parsedRows].reverse().find((row) => row.type === "user" || row.type === "assistant" || row.type === "tool_result");
   if (!leaf) return null;
   const chain: Record<string, unknown>[] = [];
   const visited = new Set<string>();
   let current: Record<string, unknown> | undefined = leaf;
   while (current) {
     const uuid = stringField(current, "uuid");
-    if (!uuid || visited.has(uuid)) break;
+    if (!uuid || visited.has(uuid)) { chainInvalid = true; break; }
     visited.add(uuid); chain.push(current);
-    const parent = stringField(current, "parentUuid");
-    current = parent ? records.get(parent) : undefined;
+    const parentValue = unknownField(current, "parentUuid");
+    if (parentValue === null || parentValue === undefined || parentValue === "") { current = undefined; continue; }
+    if (typeof parentValue !== "string") { chainInvalid = true; break; }
+    const parent = parentValue;
+    current = records.get(parent);
+    if (!current) chainInvalid = true;
   }
-  chain.reverse();
-  const messages = sourceMessages(chain, "qwen");
+  const activeRows = chainInvalid ? parsedRows : chain.reverse();
+  const messages = sourceMessages(activeRows, "qwen");
   if (!messages.length) return null;
   const usageEvents: TokenUsageEvent[] = [];
-  for (const row of chain) {
+  for (const row of activeRows) {
     const usage = objectField(row, "usageMetadata");
     if (!usage) continue;
     const cachedInputTokens = numberField(usage, "cachedContentTokenCount");
@@ -2036,8 +2043,8 @@ function loadQwenCodeSessionFile(filePath: string, projectPath: string, stat: Vi
   const firstQuestionText = cleanTitle(firstQuestion(messages));
   const titleRecord = parsedRows.find((row) => row.subtype === "custom_title");
   const title = stringField(objectField(titleRecord, "systemPayload"), "customTitle") || firstQuestionText || rawId;
-  const chainTimestamp = chain.map((row) => timestampMs(row.timestamp)).find((timestamp) => timestamp > 0) || stat.mtimeMs;
-  return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: firstQuestionText, timestamp: chainTimestamp, tokenUsage: tokenUsageFromEvents(usageEvents), stat }), messages, tokenEvents: usageEvents, traceEvents: qwenTraceEvents(chain) };
+  const chainTimestamp = activeRows.map((row) => timestampMs(row.timestamp)).find((timestamp) => timestamp > 0) || stat.mtimeMs;
+  return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: firstQuestionText, timestamp: chainTimestamp, tokenUsage: tokenUsageFromEvents(usageEvents), stat }), messages, tokenEvents: usageEvents, traceEvents: qwenTraceEvents(activeRows) };
 }
 
 function* loadQwenCodeSessionsIterator(root: string, options: SessionLoadOptions): Generator<LoadedSession> {

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -62,10 +62,8 @@ const KIMI_CODE_DIR = ".kimi-code";
 const KIMI_LEGACY_DIR = ".kimi";
 const QWEN_DIR = ".qwen";
 
-function resolveQwenCodeRoot(homeDir: string, options: SessionLoadOptions): string {
-  return options.homeDir === undefined
-    ? process.env.QWEN_RUNTIME_DIR?.trim() || process.env.QWEN_HOME?.trim() || path.join(homeDir, QWEN_DIR)
-    : path.join(homeDir, QWEN_DIR);
+function resolveQwenCodeRoot(homeDir: string): string {
+  return process.env.QWEN_RUNTIME_DIR?.trim() || process.env.QWEN_HOME?.trim() || path.join(homeDir, QWEN_DIR);
 }
 const TRAE_DIR_NAMES = [".trae", ".trae-cn"] as const;
 const CODEX_WORKSPACE_PLACEHOLDER = /^<[^>]+>$/u;
@@ -1980,22 +1978,6 @@ function qwenJsonlRows(filePath: string): unknown[] {
   return rows;
 }
 
-function qwenPartText(part: unknown): string {
-  if (!isRecord(part)) return "";
-  if (part.thought === true) return "";
-  return stringField(part, "text") || stringField(part, "content");
-}
-
-function qwenRecordText(row: Record<string, unknown>): string {
-  const payload = objectField(row, "systemPayload");
-  const displayText = stringField(payload, "displayText");
-  if (row.type === "user" && displayText) return displayText;
-  const message = objectField(row, "message");
-  const parts = message?.parts;
-  if (Array.isArray(parts)) return parts.map(qwenPartText).filter(Boolean).join("\n");
-  return qwenPartText(message);
-}
-
 function qwenTraceEvents(rows: Record<string, unknown>[]): SessionTraceEvent[] {
   const events: TraceEventDraft[] = [];
   for (const row of rows) {
@@ -2038,13 +2020,7 @@ function loadQwenCodeSessionFile(filePath: string, projectPath: string, stat: Vi
     current = parent ? records.get(parent) : undefined;
   }
   chain.reverse();
-  const messages: SessionMessage[] = [];
-  for (const row of chain) {
-    if (row.type !== "user" && row.type !== "assistant") continue;
-    const content = qwenRecordText(row);
-    if (!content || (row.type === "user" && !isMeaningfulUserMessage(content))) continue;
-    messages.push(messageFromParts(row.type, content, timestampString(row.timestamp), messages.length));
-  }
+  const messages = sourceMessages(chain, "qwen");
   if (!messages.length) return null;
   const usageEvents: TokenUsageEvent[] = [];
   for (const row of chain) {
@@ -2061,7 +2037,7 @@ function loadQwenCodeSessionFile(filePath: string, projectPath: string, stat: Vi
   const titleRecord = parsedRows.find((row) => row.subtype === "custom_title");
   const title = stringField(objectField(titleRecord, "systemPayload"), "customTitle") || firstQuestionText || rawId;
   const chainTimestamp = chain.map((row) => timestampMs(row.timestamp)).find((timestamp) => timestamp > 0) || stat.mtimeMs;
-  return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: firstQuestionText, timestamp: chainTimestamp, tokenUsage: tokenUsageFromEvents(usageEvents), stat }), messages, traceEvents: qwenTraceEvents(chain) };
+  return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: firstQuestionText, timestamp: chainTimestamp, tokenUsage: tokenUsageFromEvents(usageEvents), stat }), messages, tokenEvents: usageEvents, traceEvents: qwenTraceEvents(chain) };
 }
 
 function* loadQwenCodeSessionsIterator(root: string, options: SessionLoadOptions): Generator<LoadedSession> {
@@ -4334,7 +4310,7 @@ export function* loadDefaultSessionsIterator(options: SessionLoadOptions = {}): 
   }
   if (options.includeKimiCli) yield* loadKimiSessionsIterator(path.join(homeDir, KIMI_LEGACY_DIR), resolveKimiCodeRoot(homeDir, options), options);
   if (options.includeQwenCode) {
-    yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir, options), options);
+    yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir), options);
   }
   if (options.includeOpenClaw) {
     yield* loadOpenClawSessionsIterator(path.join(homeDir, ".openclaw"), options);
@@ -4375,7 +4351,7 @@ export async function* loadDefaultSessionsAsyncIterator(options: SessionLoadOpti
   }
   if (options.includeKimiCli) yield* loadKimiSessionsIterator(path.join(homeDir, KIMI_LEGACY_DIR), resolveKimiCodeRoot(homeDir, options), options);
   if (options.includeQwenCode) {
-    yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir, options), options);
+    yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir), options);
   }
   if (options.includeOpenClaw) {
     yield* loadOpenClawSessionsIterator(path.join(homeDir, ".openclaw"), options);

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -60,6 +60,13 @@ const QODER_DIR = ".qoder";
 const PI_SESSIONS_DIR = path.join(".pi", "agent", "sessions");
 const KIMI_CODE_DIR = ".kimi-code";
 const KIMI_LEGACY_DIR = ".kimi";
+const QWEN_DIR = ".qwen";
+
+function resolveQwenCodeRoot(homeDir: string, options: SessionLoadOptions): string {
+  return options.homeDir === undefined
+    ? process.env.QWEN_RUNTIME_DIR?.trim() || process.env.QWEN_HOME?.trim() || path.join(homeDir, QWEN_DIR)
+    : path.join(homeDir, QWEN_DIR);
+}
 const TRAE_DIR_NAMES = [".trae", ".trae-cn"] as const;
 const CODEX_WORKSPACE_PLACEHOLDER = /^<[^>]+>$/u;
 
@@ -73,6 +80,7 @@ export interface SessionLoadOptions {
   homeDir?: string;
   includePi?: boolean;
   includeKimiCli?: boolean;
+  includeQwenCode?: boolean;
   includeTclaude?: boolean;
   includeTcodex?: boolean;
   includeCodeBuddyCli?: boolean;
@@ -1374,7 +1382,7 @@ function readGitBranchAt(gitPath: string): string | null {
 }
 
 function createIndexedSession(input: {
-  keyPrefix: "claude" | "codex" | "tclaude" | "tcodex" | "codebuddy" | "workbuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder" | "pi" | "deepseek" | "kimi";
+  keyPrefix: "claude" | "codex" | "tclaude" | "tcodex" | "codebuddy" | "workbuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder" | "pi" | "deepseek" | "kimi" | "qwen";
   rawId: string;
   source: SessionSource;
   projectPath: string;
@@ -1950,6 +1958,129 @@ function* loadKimiSessionsIterator(legacyRoot: string, codeRoot: string, options
     const indexEntry = indexed && path.resolve(indexed.sessionDir) === path.resolve(candidate.sessionDir) ? indexed : undefined;
     const loaded = loadKimiCodeSessionFile(candidate.filePath, codeRoot, indexEntry, state, stat);
     if (loaded) yield loaded;
+  }
+}
+
+function qwenJsonlRows(filePath: string): unknown[] {
+  let text = "";
+  try { text = fs.readFileSync(filePath, "utf8"); } catch { return []; }
+  const rows: unknown[] = [];
+  for (const line of text.split(/\r?\n/u)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const candidates = trimmed.split(/\}\s*(?=\{)/u).map((part, index, parts) => index < parts.length - 1 ? `${part}}` : part);
+    for (const candidate of candidates) {
+      try { rows.push(JSON.parse(candidate)); } catch { /* malformed or incomplete tail */ }
+    }
+  }
+  return rows;
+}
+
+function qwenPartText(part: unknown): string {
+  if (!isRecord(part)) return "";
+  if (part.thought === true) return "";
+  return stringField(part, "text") || stringField(part, "content");
+}
+
+function qwenRecordText(row: Record<string, unknown>): string {
+  const payload = objectField(row, "systemPayload");
+  const displayText = stringField(payload, "displayText");
+  if (row.type === "user" && displayText) return displayText;
+  const message = objectField(row, "message");
+  const parts = message?.parts;
+  if (Array.isArray(parts)) return parts.map(qwenPartText).filter(Boolean).join("\n");
+  return qwenPartText(message);
+}
+
+function qwenTraceEvents(rows: Record<string, unknown>[]): SessionTraceEvent[] {
+  const events: TraceEventDraft[] = [];
+  for (const row of rows) {
+    const message = objectField(row, "message");
+    const parts = Array.isArray(message?.parts) ? message.parts : [];
+    for (const part of parts) {
+      if (!isRecord(part)) continue;
+      const call = objectField(part, "functionCall");
+      const result = objectField(part, "functionResponse");
+      const thought = part.thought === true;
+      if (!call && !result && !thought) continue;
+      const value = call || result || part;
+      const title = call ? `function: ${stringField(call, "name") || "call"}` : result ? `function result: ${stringField(result, "name") || "result"}` : "reasoning";
+      events.push({ kind: call ? "tool_call" : result ? "tool_result" : "event", source: "qwen", title, detail: stringifyDetail(value), timestamp: timestampString(row.timestamp), callId: stringField(call || result, "id") || null, eventType: call ? "qwen.functionCall" : result ? "qwen.functionResponse" : "qwen.thought", status: call ? "running" : result ? "completed" : "unknown" });
+    }
+    if (row.type === "tool_result") {
+      events.push({ kind: "tool_result", source: "qwen", title: "tool result", detail: stringifyDetail(row.toolCallResult || row.message || row), timestamp: timestampString(row.timestamp), callId: stringField(row, "uuid") || null, eventType: "qwen.tool_result", status: "completed" });
+    }
+  }
+  return dedupeTraceEvents(events);
+}
+
+function loadQwenCodeSessionFile(filePath: string, projectPath: string, stat: VirtualSessionFileStat): LoadedSession | null {
+  const parsedRows = qwenJsonlRows(filePath).filter(isRecord);
+  const records = new Map<string, Record<string, unknown>>();
+  for (const row of parsedRows) {
+    const uuid = stringField(row, "uuid");
+    if (uuid) records.set(uuid, row);
+  }
+  const leaf = [...records.values()].reverse().find((row) => row.type === "user" || row.type === "assistant" || row.type === "tool_result");
+  if (!leaf) return null;
+  const chain: Record<string, unknown>[] = [];
+  const visited = new Set<string>();
+  let current: Record<string, unknown> | undefined = leaf;
+  while (current) {
+    const uuid = stringField(current, "uuid");
+    if (!uuid || visited.has(uuid)) break;
+    visited.add(uuid); chain.push(current);
+    const parent = stringField(current, "parentUuid");
+    current = parent ? records.get(parent) : undefined;
+  }
+  chain.reverse();
+  const messages: SessionMessage[] = [];
+  for (const row of chain) {
+    if (row.type !== "user" && row.type !== "assistant") continue;
+    const content = qwenRecordText(row);
+    if (!content || (row.type === "user" && !isMeaningfulUserMessage(content))) continue;
+    messages.push(messageFromParts(row.type, content, timestampString(row.timestamp), messages.length));
+  }
+  if (!messages.length) return null;
+  const usageEvents: TokenUsageEvent[] = [];
+  for (const row of chain) {
+    const usage = objectField(row, "usageMetadata");
+    if (!usage) continue;
+    const inputTokens = numberField(usage, "promptTokenCount");
+    const outputTokens = numberField(usage, "candidatesTokenCount");
+    const cachedInputTokens = numberField(usage, "cachedContentTokenCount");
+    const reasoningOutputTokens = numberField(usage, "thoughtsTokenCount");
+    usageEvents.push(tokenEvent(timestampMs(row.timestamp), stringField(row, "uuid"), inputTokens, outputTokens, cachedInputTokens, reasoningOutputTokens));
+  }
+  const rawId = path.basename(filePath, ".jsonl");
+  const firstQuestionText = cleanTitle(firstQuestion(messages));
+  const titleRecord = parsedRows.find((row) => row.subtype === "custom_title");
+  const title = stringField(objectField(titleRecord, "systemPayload"), "customTitle") || firstQuestionText || rawId;
+  return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: firstQuestionText, timestamp: timestampMs(leaf.timestamp) || stat.mtimeMs, tokenUsage: tokenUsageFromEvents(usageEvents), stat }), messages, traceEvents: qwenTraceEvents(chain) };
+}
+
+function* loadQwenCodeSessionsIterator(root: string, options: SessionLoadOptions): Generator<LoadedSession> {
+  const chatsRoot = path.join(root, "projects");
+  let projectDirs: string[] = [];
+  try { projectDirs = fs.readdirSync(chatsRoot, { withFileTypes: true }).filter((entry) => entry.isDirectory()).map((entry) => path.join(chatsRoot, entry.name)); } catch { return; }
+  for (const projectDir of projectDirs) {
+    const projectPath = projectDir;
+    const activeIds = new Set<string>();
+    const chats = path.join(projectDir, "chats");
+    for (const filePath of walkJsonlFiles(chats)) {
+      const relative = path.relative(chats, filePath);
+      if (relative.split(/[\\/]+/u).includes("archive")) continue;
+      const stat = safeStat(filePath);
+      if (shouldSkipFile(options, filePath, stat)) continue;
+      const loaded = loadQwenCodeSessionFile(filePath, projectPath, stat);
+      if (loaded) { activeIds.add(loaded.session.rawId); yield loaded; }
+    }
+    for (const filePath of walkJsonlFiles(path.join(chats, "archive"))) {
+      const stat = safeStat(filePath);
+      if (shouldSkipFile(options, filePath, stat)) continue;
+      const loaded = loadQwenCodeSessionFile(filePath, projectPath, stat);
+      if (loaded && !activeIds.has(loaded.session.rawId)) yield loaded;
+    }
   }
 }
 
@@ -4196,6 +4327,9 @@ export function* loadDefaultSessionsIterator(options: SessionLoadOptions = {}): 
     yield* loadPiSessionsIterator(path.join(homeDir, PI_SESSIONS_DIR), options);
   }
   if (options.includeKimiCli) yield* loadKimiSessionsIterator(path.join(homeDir, KIMI_LEGACY_DIR), resolveKimiCodeRoot(homeDir, options), options);
+  if (options.includeQwenCode) {
+    yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir, options), options);
+  }
   if (options.includeOpenClaw) {
     yield* loadOpenClawSessionsIterator(path.join(homeDir, ".openclaw"), options);
     yield* loadOpenClawSessionsIterator(path.join(homeDir, ".clawdbot"), options);
@@ -4234,6 +4368,9 @@ export async function* loadDefaultSessionsAsyncIterator(options: SessionLoadOpti
     yield* loadPiSessionsIterator(path.join(homeDir, PI_SESSIONS_DIR), options);
   }
   if (options.includeKimiCli) yield* loadKimiSessionsIterator(path.join(homeDir, KIMI_LEGACY_DIR), resolveKimiCodeRoot(homeDir, options), options);
+  if (options.includeQwenCode) {
+    yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir, options), options);
+  }
   if (options.includeOpenClaw) {
     yield* loadOpenClawSessionsIterator(path.join(homeDir, ".openclaw"), options);
     yield* loadOpenClawSessionsIterator(path.join(homeDir, ".clawdbot"), options);

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -1968,6 +1968,10 @@ function qwenJsonlRows(filePath: string): unknown[] {
   for (const line of text.split(/\r?\n/u)) {
     const trimmed = line.trim();
     if (!trimmed) continue;
+    try {
+      rows.push(JSON.parse(trimmed));
+      continue;
+    } catch { /* a malformed or glued line may still contain valid objects */ }
     const candidates = trimmed.split(/\}\s*(?=\{)/u).map((part, index, parts) => index < parts.length - 1 ? `${part}}` : part);
     for (const candidate of candidates) {
       try { rows.push(JSON.parse(candidate)); } catch { /* malformed or incomplete tail */ }
@@ -2046,9 +2050,9 @@ function loadQwenCodeSessionFile(filePath: string, projectPath: string, stat: Vi
   for (const row of chain) {
     const usage = objectField(row, "usageMetadata");
     if (!usage) continue;
-    const inputTokens = numberField(usage, "promptTokenCount");
-    const outputTokens = numberField(usage, "candidatesTokenCount");
     const cachedInputTokens = numberField(usage, "cachedContentTokenCount");
+    const inputTokens = Math.max(0, numberField(usage, "promptTokenCount") - cachedInputTokens);
+    const outputTokens = numberField(usage, "candidatesTokenCount");
     const reasoningOutputTokens = numberField(usage, "thoughtsTokenCount");
     usageEvents.push(tokenEvent(timestampMs(row.timestamp), stringField(row, "uuid"), inputTokens, outputTokens, cachedInputTokens, reasoningOutputTokens));
   }
@@ -2056,7 +2060,8 @@ function loadQwenCodeSessionFile(filePath: string, projectPath: string, stat: Vi
   const firstQuestionText = cleanTitle(firstQuestion(messages));
   const titleRecord = parsedRows.find((row) => row.subtype === "custom_title");
   const title = stringField(objectField(titleRecord, "systemPayload"), "customTitle") || firstQuestionText || rawId;
-  return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: firstQuestionText, timestamp: timestampMs(leaf.timestamp) || stat.mtimeMs, tokenUsage: tokenUsageFromEvents(usageEvents), stat }), messages, traceEvents: qwenTraceEvents(chain) };
+  const chainTimestamp = chain.map((row) => timestampMs(row.timestamp)).find((timestamp) => timestamp > 0) || stat.mtimeMs;
+  return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: firstQuestionText, timestamp: chainTimestamp, tokenUsage: tokenUsageFromEvents(usageEvents), stat }), messages, traceEvents: qwenTraceEvents(chain) };
 }
 
 function* loadQwenCodeSessionsIterator(root: string, options: SessionLoadOptions): Generator<LoadedSession> {
@@ -2070,10 +2075,11 @@ function* loadQwenCodeSessionsIterator(root: string, options: SessionLoadOptions
     for (const filePath of walkJsonlFiles(chats)) {
       const relative = path.relative(chats, filePath);
       if (relative.split(/[\\/]+/u).includes("archive")) continue;
+      activeIds.add(path.basename(filePath, ".jsonl"));
       const stat = safeStat(filePath);
       if (shouldSkipFile(options, filePath, stat)) continue;
       const loaded = loadQwenCodeSessionFile(filePath, projectPath, stat);
-      if (loaded) { activeIds.add(loaded.session.rawId); yield loaded; }
+      if (loaded) yield loaded;
     }
     for (const filePath of walkJsonlFiles(path.join(chats, "archive"))) {
       const stat = safeStat(filePath);

--- a/apps/main-1.0/src/core/session-sources.test.ts
+++ b/apps/main-1.0/src/core/session-sources.test.ts
@@ -28,6 +28,7 @@ const ALL_SOURCES = [
   "qoder",
   "pi-cli",
   "kimi-cli",
+  "qwen-code",
   "deepseek-cli",
 ] as const satisfies readonly SessionSource[];
 
@@ -68,6 +69,7 @@ describe("session source capability registry", () => {
       "includeQoder",
       "includePi",
       "includeKimiCli",
+      "includeQwenCode",
       "includeDeepSeekCli",
     ]);
     expect(sessionSourceDescriptor("tclaude-cli")).toMatchObject({ liveFamily: "tclaude", migrationAgent: "claude" });
@@ -120,6 +122,12 @@ describe("session source capability registry", () => {
     expect(remoteSessionAgentForSource("hermes")).toBe("hermes");
     expect(remoteSessionAgentForSource("zcode-cli")).toBeNull();
     expect(remoteSessionAgentForSource("workbuddy-cli")).toBeNull();
+    expect(sessionSourceDescriptor("qwen-code")).toMatchObject({
+      label: "Qwen Code",
+      format: "qwen",
+      optionalSetting: "includeQwenCode",
+      capabilities: { live: false, resume: false, migrate: false, sessionSync: false, openApp: false },
+    });
     expect(OPTIONAL_SESSION_SOURCE_DESCRIPTORS.filter(({ remoteCollectorOptional }) => remoteCollectorOptional).map(({ id }) => id)).toEqual([
       "tclaude-cli",
       "tcodex-cli",

--- a/apps/main-1.0/src/core/session-sources.ts
+++ b/apps/main-1.0/src/core/session-sources.ts
@@ -15,6 +15,7 @@ export type OptionalSessionSourceSetting =
   | "includeQoder"
   | "includePi"
   | "includeKimiCli"
+  | "includeQwenCode"
   | "includeDeepSeekCli";
 
 export type SessionSourceFamily =
@@ -34,6 +35,7 @@ export type SessionSourceFamily =
   | "qoder"
   | "pi"
   | "kimi"
+  | "qwen"
   | "deepseek";
 
 export type SessionSourceUiFamily = "claude" | "codex" | "codebuddy" | "codewiz" | "zcode" | "other";
@@ -173,6 +175,12 @@ export const SESSION_SOURCE_REGISTRY = {
   "kimi-cli": {
     id: "kimi-cli", label: "Kimi Code", format: "kimi", family: "kimi", uiFamily: "other", statsGroup: null,
     optionalSetting: "includeKimiCli", pendingKey: "kimi", remoteCollectorOptional: false, liveFamily: null, migrationAgent: null,
+    resumeTarget: null, remoteFamily: null, nativeAppFamily: null,
+    capabilities: { live: false, resume: false, migrate: false, sessionSync: false, openApp: false },
+  },
+  "qwen-code": {
+    id: "qwen-code", label: "Qwen Code", format: "qwen", family: "qwen", uiFamily: "other", statsGroup: null,
+    optionalSetting: "includeQwenCode", pendingKey: "qwen", remoteCollectorOptional: false, liveFamily: null, migrationAgent: null,
     resumeTarget: null, remoteFamily: null, nativeAppFamily: null,
     capabilities: { live: false, resume: false, migrate: false, sessionSync: false, openApp: false },
   },

--- a/apps/main-1.0/src/core/store/sessions.ts
+++ b/apps/main-1.0/src/core/store/sessions.ts
@@ -711,7 +711,7 @@ export class SessionsStore {
     const targets = this.getSessionDeletionTargets([sessionKey]);
     const row = targets.find((target) => target.sessionKey === sessionKey);
     if (!row) return false;
-    if (row.source === "workbuddy-cli" || row.source === "kimi-cli") {
+    if (row.source === "workbuddy-cli" || row.source === "kimi-cli" || row.source === "qwen-code") {
       throw new Error(`${sessionSourceDescriptor(row.source).label} session source files are read-only.`);
     }
     if (row.source === "zcode-cli") {

--- a/apps/main-1.0/src/core/trace-presentation.test.ts
+++ b/apps/main-1.0/src/core/trace-presentation.test.ts
@@ -69,6 +69,7 @@ describe("tracePresentation", () => {
       expect(tracePresentation({ kind: "event", eventType }).category).toBe("collaboration");
     }
     expect(tracePresentation({ kind: "event", eventType: "codex.reasoning_summary" }).category).toBe("reasoning");
+    expect(tracePresentation({ kind: "event", eventType: "qwen.thought" }).category).toBe("reasoning");
     expect(tracePresentation({ kind: "event", eventType: "codex.context.compaction" }).category).toBe("context");
     expect(tracePresentation({ kind: "event", eventType: "codex.thread.settings" }).category).toBe("context");
     expect(tracePresentation({ kind: "tool_call", eventType: "codex.custom_tool" }).category).toBe("tool");

--- a/apps/main-1.0/src/core/trace-presentation.ts
+++ b/apps/main-1.0/src/core/trace-presentation.ts
@@ -38,7 +38,7 @@ export function tracePresentation(
   ) {
     return { category: "lifecycle", visibility: "turn_summary" };
   }
-  if (eventType === "codex.reasoning_summary" || eventType === "agent_reasoning") {
+  if (eventType === "codex.reasoning_summary" || eventType === "agent_reasoning" || eventType === "qwen.thought") {
     return { category: "reasoning", visibility: "timeline" };
   }
   if (

--- a/apps/main-1.0/src/core/types.ts
+++ b/apps/main-1.0/src/core/types.ts
@@ -17,8 +17,9 @@ export type SessionSource =
   | "qoder"
   | "pi-cli"
   | "deepseek-cli"
-  | "kimi-cli";
-export type SessionFormat = "claude" | "codex" | "codebuddy" | "workbuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder" | "pi" | "deepseek" | "kimi";
+  | "kimi-cli"
+  | "qwen-code";
+export type SessionFormat = "claude" | "codex" | "codebuddy" | "workbuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder" | "pi" | "deepseek" | "kimi" | "qwen";
 export type SessionSortBy = "smart" | "activity" | "created";
 export type EnvironmentKind = "local" | "wsl" | "ssh";
 export type EnvironmentSyncState = "idle" | "syncing" | "watching" | "disconnected" | "error";

--- a/apps/main-1.0/src/main/index.ts
+++ b/apps/main-1.0/src/main/index.ts
@@ -1294,7 +1294,6 @@ function runIndexSync(): Promise<IndexStatus> {
       timeBudgetMs: 8,
       disabledSources: disabledOptionalSources(settings),
       loadOptions: {
-        homeDir: app.getPath("home"),
         includeTclaude: settings.includeTclaude,
         includeTcodex: settings.includeTcodex,
         includeCodeBuddyCli: settings.includeCodeBuddyCli,

--- a/apps/main-1.0/src/main/index.ts
+++ b/apps/main-1.0/src/main/index.ts
@@ -1306,6 +1306,7 @@ function runIndexSync(): Promise<IndexStatus> {
         includeZcode: settings.includeZcode,
         includePi: settings.includePi,
         includeKimiCli: settings.includeKimiCli,
+        includeQwenCode: settings.includeQwenCode,
         includeCursorAgent: settings.includeCursorAgent,
         includeTrae: settings.includeTrae,
         includeQoder: settings.includeQoder,
@@ -2270,7 +2271,7 @@ function registerIpc(): void {
     if (confirmed && !confirmationFingerprint) {
       throw new Error(SESSION_DELETE_CONFIRMATION_REQUIRED_MESSAGE);
     }
-    if (session?.source === "workbuddy-cli" || session?.source === "kimi-cli") {
+    if (session?.source === "workbuddy-cli" || session?.source === "kimi-cli" || session?.source === "qwen-code") {
       throw new Error(`${sessionSourceDescriptor(session.source).label} session source files are read-only.`);
     }
     if (session && !canDeleteSessionLocally(session)) {

--- a/apps/main-1.0/src/main/services/session-bulk-delete-service.test.ts
+++ b/apps/main-1.0/src/main/services/session-bulk-delete-service.test.ts
@@ -53,6 +53,7 @@ describe("SessionBulkDeleteService", () => {
       target("recent", { lastActivityAt: 500 }),
       target("pi", { source: "pi-cli" }),
       target("kimi", { source: "kimi-cli" }),
+      target("qwen", { source: "qwen-code" }),
       target("hermes", { source: "hermes" as SessionSource }),
       target("opencode", { source: "opencode-cli" }),
       target("codewiz", { source: "codewiz-cli" }),
@@ -65,7 +66,7 @@ describe("SessionBulkDeleteService", () => {
     });
     expect(preview.deletableCount).toBe(2);
     expect(preview.skipped.map((item) => item.reason)).toEqual([
-      "live", "favorite", "recent", "read-only",
+      "live", "favorite", "recent", "read-only", "read-only",
       "shared-database", "shared-database", "shared-database", "shared-database", "not-found",
     ]);
     expect(store.getSessionDeletionTargets).toHaveBeenCalledTimes(1);

--- a/apps/main-1.0/src/main/services/session-bulk-delete-service.ts
+++ b/apps/main-1.0/src/main/services/session-bulk-delete-service.ts
@@ -251,7 +251,7 @@ function classifyTarget(
   if (request.inactiveBefore !== undefined && target.lastActivityAt >= request.inactiveBefore) {
     return issueFor(target.sessionKey, "recent", "Session is not older than the selected cutoff.");
   }
-  if (target.source === "workbuddy-cli" || target.source === "kimi-cli") {
+  if (target.source === "workbuddy-cli" || target.source === "kimi-cli" || target.source === "qwen-code") {
     return issueFor(target.sessionKey, "read-only", `${sessionSourceDescriptor(target.source).label} session source files are read-only.`);
   }
   if (SHARED_DATABASE_SOURCES.has(target.source)) return issueFor(target.sessionKey, "shared-database", "This source stores multiple sessions in a shared database.");

--- a/apps/main-1.0/src/main/session-index-worker-protocol.ts
+++ b/apps/main-1.0/src/main/session-index-worker-protocol.ts
@@ -16,6 +16,7 @@ export type SessionIndexWorkerLoadOptions = Pick<
   | "includeZcode"
   | "includePi"
   | "includeKimiCli"
+  | "includeQwenCode"
   | "includeCursorAgent"
   | "includeTrae"
   | "includeQoder"

--- a/apps/main-1.0/src/main/session-index-worker-runner.test.ts
+++ b/apps/main-1.0/src/main/session-index-worker-runner.test.ts
@@ -1,10 +1,15 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { SessionStore } from "../core/session-store";
 import { runSessionIndexWorker } from "./session-index-worker-runner";
 import type { SessionIndexWorkerMessage } from "./session-index-worker-protocol";
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: vi.fn(() => actual.homedir()) };
+});
 
 describe("runSessionIndexWorker", () => {
   it("indexes an isolated home and reports progress through the worker protocol", async () => {
@@ -33,6 +38,8 @@ describe("runSessionIndexWorker", () => {
     ].join("\n"));
     new SessionStore(dbPath).close();
     const messages: SessionIndexWorkerMessage[] = [];
+    const defaultHomeDir = os.homedir();
+    vi.mocked(os.homedir).mockReturnValue(homeDir);
 
     try {
       const result = await runSessionIndexWorker({
@@ -41,7 +48,7 @@ describe("runSessionIndexWorker", () => {
         userDataPath,
         batchSize: 1,
         timeBudgetMs: 1,
-        loadOptions: { homeDir },
+        loadOptions: {},
         disabledSources: [],
       }, (message) => messages.push(message));
 
@@ -70,6 +77,7 @@ describe("runSessionIndexWorker", () => {
         prunedStore.close();
       }
     } finally {
+      vi.mocked(os.homedir).mockReset().mockReturnValue(defaultHomeDir);
       fs.rmSync(root, { recursive: true, force: true });
     }
   });

--- a/apps/main-1.0/src/renderer/src/features/settings/settings-dialog.tsx
+++ b/apps/main-1.0/src/renderer/src/features/settings/settings-dialog.tsx
@@ -551,6 +551,10 @@ export function SettingsDialog({
                   <input type="checkbox" className="switch" checked={Boolean(settings?.includeKimiCli)} disabled={!settings} onChange={(event) => onSettingsChange({ includeKimiCli: event.currentTarget.checked })} />
                 </label>
                 <label className="settings-field settings-toggle">
+                  <div className="settings-field-text"><span className="settings-field-title">Include Qwen Code</span><span className="settings-field-sub">{l("Indexes local Qwen Code sessions read-only.", "以只读方式索引本地千问 Code 会话。")}</span></div>
+                  <input type="checkbox" className="switch" checked={Boolean(settings?.includeQwenCode)} disabled={!settings} onChange={(event) => onSettingsChange({ includeQwenCode: event.currentTarget.checked })} />
+                </label>
+                <label className="settings-field settings-toggle">
                   <div className="settings-field-text">
                     <span className="settings-field-title">Include ~/.tclaude</span>
                     <span className="settings-field-sub">{l("Indexes TClaude CLI sessions and allows migration to that CLI.", "索引 TClaude CLI 会话，并允许迁移到该 CLI。")}</span>

--- a/apps/main-2.0/src/core/format-adapters.test.ts
+++ b/apps/main-2.0/src/core/format-adapters.test.ts
@@ -83,6 +83,20 @@ describe("WorkBuddy format adapter", () => {
   });
 });
 
+describe("Qwen format adapter", () => {
+  it("uses display text and keeps reasoning out of visible messages", () => {
+    expect(getAdapter("qwen-code").parseLine({
+      type: "user",
+      systemPayload: { displayText: "用户看到的问题" },
+      message: { parts: [{ text: "内部提示" }] },
+    })).toMatchObject({ role: "user", content: "用户看到的问题" });
+    expect(getAdapter("qwen").parseLine({
+      type: "assistant",
+      message: { parts: [{ thought: true, text: "推理" }, { text: "回答" }] },
+    })).toMatchObject({ role: "assistant", content: "回答" });
+  });
+});
+
 describe("cleanTitle", () => {
   it("keeps the first useful line and truncates by code point", () => {
     expect(cleanTitle("\n  Fix login flow\nsecond line")).toBe("Fix login flow");

--- a/apps/main-2.0/src/core/format-adapters.test.ts
+++ b/apps/main-2.0/src/core/format-adapters.test.ts
@@ -94,6 +94,9 @@ describe("Qwen format adapter", () => {
       type: "assistant",
       message: { parts: [{ thought: true, text: "推理" }, { text: "回答" }] },
     })).toMatchObject({ role: "assistant", content: "回答" });
+    expect(getAdapter("qwen").parseLine({ type: "assistant", message: { text: "文本回退" } })).toMatchObject({ role: "assistant", content: "文本回退" });
+    expect(getAdapter("qwen").parseLine({ type: "assistant", message: { text: "不得回退的推理", parts: [{ thought: true, text: "推理" }] } })).toBeNull();
+    expect(getAdapter("qwen").parseLine({ type: "tool_result", message: { text: "工具输出" } })).toBeNull();
   });
 });
 

--- a/apps/main-2.0/src/core/format-adapters.ts
+++ b/apps/main-2.0/src/core/format-adapters.ts
@@ -365,6 +365,21 @@ export const kimiAdapter: FormatAdapter = {
     return null;
   },
 };
+export const qwenAdapter: FormatAdapter = {
+  format: "qwen",
+  parseLine(raw) {
+    if (!raw || typeof raw !== "object") return null;
+    const row = raw as Record<string, unknown>;
+    const role = row.type === "user" || row.type === "assistant" ? row.type : null;
+    if (!role) return null;
+    const payload = row.systemPayload && typeof row.systemPayload === "object" ? row.systemPayload as Record<string, unknown> : null;
+    const message = row.message && typeof row.message === "object" ? row.message as Record<string, unknown> : null;
+    const displayText = role === "user" && typeof payload?.displayText === "string" ? payload.displayText : "";
+    const parts = Array.isArray(message?.parts) ? message.parts : [];
+    const text = displayText || parts.map((part) => part && typeof part === "object" && (part as Record<string, unknown>).thought !== true && typeof (part as Record<string, unknown>).text === "string" ? (part as Record<string, unknown>).text as string : "").filter(Boolean).join("\n");
+    return text ? { role, content: text, timestamp: timestampFromRaw(raw) } : null;
+  },
+};
 
 export function getFormatForSource(source: SessionSource): SessionFormat {
   return sessionSourceDescriptor(source).format;
@@ -387,6 +402,7 @@ export function getAdapter(sourceOrFormat: SessionSource | SessionFormat): Forma
   if (sourceOrFormat === "pi") return piAdapter;
   if (sourceOrFormat === "deepseek") return deepseekAdapter;
   if (sourceOrFormat === "kimi") return kimiAdapter;
+  if (sourceOrFormat === "qwen") return qwenAdapter;
   const format = getFormatForSource(sourceOrFormat);
   if (format === "claude") return claudeAdapter;
   if (format === "codebuddy") return codebuddyAdapter;
@@ -402,6 +418,7 @@ export function getAdapter(sourceOrFormat: SessionSource | SessionFormat): Forma
   if (format === "pi") return piAdapter;
   if (format === "deepseek") return deepseekAdapter;
   if (format === "kimi") return kimiAdapter;
+  if (format === "qwen") return qwenAdapter;
   return codexAdapter;
 }
 

--- a/apps/main-2.0/src/core/format-adapters.ts
+++ b/apps/main-2.0/src/core/format-adapters.ts
@@ -376,7 +376,8 @@ export const qwenAdapter: FormatAdapter = {
     const message = row.message && typeof row.message === "object" ? row.message as Record<string, unknown> : null;
     const displayText = role === "user" && typeof payload?.displayText === "string" ? payload.displayText : "";
     const parts = Array.isArray(message?.parts) ? message.parts : [];
-    const text = displayText || parts.map((part) => part && typeof part === "object" && (part as Record<string, unknown>).thought !== true && typeof (part as Record<string, unknown>).text === "string" ? (part as Record<string, unknown>).text as string : "").filter(Boolean).join("\n");
+    const partsText = parts.map((part) => part && typeof part === "object" && (part as Record<string, unknown>).thought !== true ? (typeof (part as Record<string, unknown>).text === "string" ? (part as Record<string, unknown>).text as string : typeof (part as Record<string, unknown>).content === "string" ? (part as Record<string, unknown>).content as string : "") : "").filter(Boolean).join("\n");
+    const text = displayText || (parts.length ? partsText : typeof message?.text === "string" ? message.text : typeof message?.content === "string" ? message.content : "");
     return text ? { role, content: text, timestamp: timestampFromRaw(raw) } : null;
   },
 };

--- a/apps/main-2.0/src/core/indexer.test.ts
+++ b/apps/main-2.0/src/core/indexer.test.ts
@@ -322,6 +322,31 @@ describe("indexer", () => {
     }
   });
 
+  it("skips unchanged active and archived Qwen sessions through source-scoped snapshots", async () => {
+    const store = createInMemoryStore();
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-v2-qwen-skip-"));
+    try {
+      const activePath = writeQwenSession(homeDir, "active", "active question");
+      const archivePath = writeQwenSession(homeDir, "archived", "archived question", true);
+      const cold = await syncDefaultSessionsInBatches(store, { batchSize: 1, loadOptions: { homeDir, includeQwenCode: true } });
+      expect(cold).toMatchObject({ indexed: 2, skipped: 0, total: 2 });
+
+      const snapshots = await store.listIndexedSessionFiles();
+      for (const filePath of [activePath, archivePath]) {
+        const snapshot = snapshots.find((item) => item.filePath === filePath)!;
+        fs.writeFileSync(filePath, "{not jsonl".padEnd(snapshot.fileSize, "x"));
+        fs.utimesSync(filePath, snapshot.fileMtimeMs / 1000, snapshot.fileMtimeMs / 1000);
+      }
+
+      const warm = await syncDefaultSessionsInBatches(store, { batchSize: 1, loadOptions: { homeDir, includeQwenCode: true } });
+      expect(warm).toMatchObject({ indexed: 0, skipped: 2, total: 2 });
+      await expect(store.searchSessions({ query: "question", limit: 10 })).resolves.toHaveLength(2);
+    } finally {
+      await store.close();
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
   it("indexes a StepCode Claude variant when enabled after the native session was already indexed", async () => {
     const store = createInMemoryStore();
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-stepcode-claude-"));
@@ -1146,6 +1171,17 @@ function writeClaudeSession(homeDir: string, id: string, question: string): stri
       message: { role: "user", content: question },
     }),
   );
+  return filePath;
+}
+
+function writeQwenSession(homeDir: string, id: string, question: string, archived = false): string {
+  const chatsDir = path.join(homeDir, ".qwen", "projects", "project", "chats", ...(archived ? ["archive"] : []));
+  fs.mkdirSync(chatsDir, { recursive: true });
+  const filePath = path.join(chatsDir, `${id}.jsonl`);
+  fs.writeFileSync(filePath, [
+    { uuid: `${id}-user`, parentUuid: null, sessionId: id, timestamp: "2026-06-01T10:00:00Z", type: "user", cwd: "/repo", message: { role: "user", parts: [{ text: question }] } },
+    { uuid: `${id}-assistant`, parentUuid: `${id}-user`, sessionId: id, timestamp: "2026-06-01T10:01:00Z", type: "assistant", cwd: "/repo", message: { role: "model", parts: [{ text: "answer" }] } },
+  ].map((row) => JSON.stringify(row)).join("\n"));
   return filePath;
 }
 

--- a/apps/main-2.0/src/core/indexer.test.ts
+++ b/apps/main-2.0/src/core/indexer.test.ts
@@ -325,11 +325,20 @@ describe("indexer", () => {
   it("skips unchanged active and archived Qwen sessions through source-scoped snapshots", async () => {
     const store = createInMemoryStore();
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-v2-qwen-skip-"));
+    const runtimeTrapHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-v2-qwen-runtime-trap-"));
+    const qwenHomeTrap = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-v2-qwen-home-trap-"));
+    const previousRuntimeDir = process.env.QWEN_RUNTIME_DIR;
+    const previousQwenHome = process.env.QWEN_HOME;
     try {
       const activePath = writeQwenSession(homeDir, "active", "active question");
       const archivePath = writeQwenSession(homeDir, "archived", "archived question", true);
+      writeQwenSession(runtimeTrapHome, "runtime-trap", "runtime trap question");
+      writeQwenSession(qwenHomeTrap, "home-trap", "home trap question");
+      process.env.QWEN_RUNTIME_DIR = path.join(runtimeTrapHome, ".qwen");
+      process.env.QWEN_HOME = path.join(qwenHomeTrap, ".qwen");
       const cold = await syncDefaultSessionsInBatches(store, { batchSize: 1, loadOptions: { homeDir, includeQwenCode: true } });
       expect(cold).toMatchObject({ indexed: 2, skipped: 0, total: 2 });
+      await expect(store.searchSessions({ query: "trap question", limit: 10 })).resolves.toHaveLength(0);
 
       const snapshots = await store.listIndexedSessionFiles();
       for (const filePath of [activePath, archivePath]) {
@@ -342,8 +351,14 @@ describe("indexer", () => {
       expect(warm).toMatchObject({ indexed: 0, skipped: 2, total: 2 });
       await expect(store.searchSessions({ query: "question", limit: 10 })).resolves.toHaveLength(2);
     } finally {
+      if (previousRuntimeDir === undefined) delete process.env.QWEN_RUNTIME_DIR;
+      else process.env.QWEN_RUNTIME_DIR = previousRuntimeDir;
+      if (previousQwenHome === undefined) delete process.env.QWEN_HOME;
+      else process.env.QWEN_HOME = previousQwenHome;
       await store.close();
       fs.rmSync(homeDir, { recursive: true, force: true });
+      fs.rmSync(runtimeTrapHome, { recursive: true, force: true });
+      fs.rmSync(qwenHomeTrap, { recursive: true, force: true });
     }
   });
 

--- a/apps/main-2.0/src/core/platform.test.ts
+++ b/apps/main-2.0/src/core/platform.test.ts
@@ -19,6 +19,11 @@ describe("app settings", () => {
     expect(mergeAppSettings(defaultSettings, { includeWorkBuddy: true }).includeWorkBuddy).toBe(true);
   });
 
+  it("keeps Qwen Code indexing opt-in while accepting an explicit enable", () => {
+    expect(defaultSettings.includeQwenCode).toBe(false);
+    expect(mergeAppSettings(defaultSettings, { includeQwenCode: true }).includeQwenCode).toBe(true);
+  });
+
   it("keeps StepCode opt-in and resumes Codex and Claude sessions through the StepCode wrapper", () => {
     expect(defaultSettings.includeStepcode).toBe(false);
     const session = {

--- a/apps/main-2.0/src/core/platform.ts
+++ b/apps/main-2.0/src/core/platform.ts
@@ -103,6 +103,7 @@ export interface AppSettings {
   includeQoder: boolean;
   includePi: boolean;
   includeKimiCli: boolean;
+  includeQwenCode: boolean;
   includeDeepSeekCli: boolean;
   evalEnabled: boolean;
   openVikingMemoryEnabled: boolean;
@@ -197,6 +198,7 @@ export const defaultSettings: AppSettings = {
   includeQoder: false,
   includePi: false,
   includeKimiCli: false,
+  includeQwenCode: false,
   includeDeepSeekCli: false,
   evalEnabled: false,
   openVikingMemoryEnabled: false,

--- a/apps/main-2.0/src/core/session-environment.test.ts
+++ b/apps/main-2.0/src/core/session-environment.test.ts
@@ -2,11 +2,16 @@ import { describe, expect, it } from "vitest";
 import { canDeleteSessionLocally } from "./session-environment";
 
 describe("session environment", () => {
-  it("treats externally managed Kimi sessions as read-only", () => {
+  it("treats externally managed Kimi and Qwen sessions as read-only", () => {
     expect(canDeleteSessionLocally({
       environmentKind: "local",
       environmentId: "local",
       source: "kimi-cli",
+    })).toBe(false);
+    expect(canDeleteSessionLocally({
+      environmentKind: "local",
+      environmentId: "local",
+      source: "qwen-code",
     })).toBe(false);
   });
 

--- a/apps/main-2.0/src/core/session-environment.ts
+++ b/apps/main-2.0/src/core/session-environment.ts
@@ -23,6 +23,7 @@ export function isLocalSessionStorage(session: SessionStorageIdentity): boolean 
 export function canDeleteSessionLocally(session: SessionEnvironmentIdentity): boolean {
   return session.source !== "workbuddy-cli"
     && session.source !== "kimi-cli"
+    && session.source !== "qwen-code"
     && (session.environmentKind !== "ssh" || session.sourceAvailable === false);
 }
 

--- a/apps/main-2.0/src/core/session-loader-qwen.test.ts
+++ b/apps/main-2.0/src/core/session-loader-qwen.test.ts
@@ -3,6 +3,7 @@ import * as os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadDefaultSessions } from "./session-loader";
+import { deriveSessionTimeline } from "./turns/derive-turns";
 
 const roots: string[] = [];
 const originalRuntimeDir = process.env.QWEN_RUNTIME_DIR;
@@ -31,9 +32,11 @@ function record(uuid: string, parentUuid: string | null, type: "user" | "assista
 describe("Qwen Code sessions", () => {
   it("reconstructs the active branch and keeps active sessions over archive", () => {
     const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(path.join(chats, "archive"), { recursive: true });
-    const user = record("u", null, "user", "internal", { systemPayload: { displayText: "visible" } }); const dead = record("dead", null, "user", "rewound"); const assistant = record("a", "u", "assistant", "answer", { usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 3, thoughtsTokenCount: 1 }, message: { parts: [{ thought: true, text: "thinking" }, { text: "answer" }, { functionCall: { name: "read_file", id: "c1" } }] } }); const tool = { uuid: "t", parentUuid: "a", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:01.000Z", type: "tool_result", cwd: "C:/repo", message: { role: "user", parts: [] }, toolCallResult: { output: "done" } }; const metadata = { type: "system", subtype: "metadata" }; const title = { uuid: "title", parentUuid: "t", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:02.000Z", type: "system", subtype: "custom_title", systemPayload: { customTitle: "Named session" } };
+    const user = record("u", null, "user", "internal", { systemPayload: { displayText: "visible" } }); const dead = record("dead", null, "user", "rewound"); const assistant = record("a", "u", "assistant", "answer", { usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 3, thoughtsTokenCount: 1 }, message: { parts: [{ thought: true, text: "thinking" }, { text: "answer" }, { functionCall: { name: "read_file", id: "c1" } }] } }); const tool = { uuid: "t", parentUuid: "a", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:01.000Z", type: "tool_result", cwd: "C:/repo", message: { role: "user", parts: [{ functionResponse: { id: "c1", name: "read_file", response: { output: "done" } } }] }, toolCallResult: { callId: "c1", output: "done" } }; const metadata = { type: "system", subtype: "metadata" }; const title = { uuid: "title", parentUuid: "t", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:02.000Z", type: "system", subtype: "custom_title", systemPayload: { customTitle: "Named session" } };
     fs.writeFileSync(path.join(chats, "qwen-1.jsonl"), `${[user, dead, assistant, tool, metadata, title].map((row) => JSON.stringify(row)).join("")}\ninvalid\n{"uuid":"tail"`); fs.writeFileSync(path.join(chats, "archive", "qwen-1.jsonl"), JSON.stringify(record("old", null, "user", "archive")));
-    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true }); expect(loaded.session.source).toBe("qwen-code"); expect(loaded.session.originalTitle).toBe("Named session"); expect(loaded.messages.map((m) => m.content)).toEqual(["visible", "answer"]); expect(loaded.session.tokenUsage?.totalTokens).toBe(6); expect(loaded.traceEvents?.some((e) => e.kind === "tool_call")).toBe(true); expect(loaded.traceEvents?.some((e) => e.eventType === "qwen.tool_result")).toBe(true); expect(loaded.messages.some((m) => m.content === "rewound")).toBe(false);
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true }); expect(loaded.session.source).toBe("qwen-code"); expect(loaded.session.originalTitle).toBe("Named session"); expect(loaded.messages.map((m) => m.content)).toEqual(["visible", "answer"]); expect(loaded.session.tokenUsage?.totalTokens).toBe(6); expect(loaded.traceEvents?.some((e) => e.kind === "tool_call")).toBe(true); expect(loaded.traceEvents?.filter((e) => e.eventType === "qwen.tool_result")).toEqual([expect.objectContaining({ callId: "c1" })]); expect(loaded.messages.some((m) => m.content === "rewound")).toBe(false);
+    const toolSpans = deriveSessionTimeline({ sessionKey: loaded.session.sessionKey, messages: loaded.messages, tokenEvents: loaded.tokenEvents ?? [], traceEvents: loaded.traceEvents ?? [] }).turns.flatMap((turn) => turn.spans).filter((span) => span.callId === "c1");
+    expect(toolSpans).toEqual([expect.objectContaining({ status: "completed", endedAt: expect.any(String) })]);
   });
 
   it("uses QWEN_RUNTIME_DIR before QWEN_HOME", () => {
@@ -111,7 +114,7 @@ describe("Qwen Code sessions", () => {
       usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 3 },
       message: { parts: [{ text: "answer" }, { functionCall: { name: "read_file", id: "call-1" } }] },
     });
-    const tool = { uuid: "t", parentUuid: "a", sessionId: "qwen-1", timestamp: toolMilliseconds, type: "tool_result", cwd: "C:/repo", message: { role: "user", parts: [] }, toolCallResult: { output: "done" } };
+    const tool = { uuid: "t", parentUuid: "a", sessionId: "qwen-1", timestamp: toolMilliseconds, type: "tool_result", cwd: "C:/repo", message: { role: "user", parts: [] }, toolCallResult: { callId: "call-1", output: "done" } };
     fs.writeFileSync(path.join(chats, "numeric.jsonl"), `${JSON.stringify(user)}\n${JSON.stringify(assistant)}\n${JSON.stringify(tool)}\n`);
 
     const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
@@ -122,7 +125,7 @@ describe("Qwen Code sessions", () => {
     ]);
     expect(loaded.tokenEvents?.[0]).toMatchObject({ timestamp: assistantMilliseconds, dedupeKey: "a" });
     expect(loaded.traceEvents?.find((event) => event.eventType === "qwen.functionCall")).toMatchObject({ timestamp: new Date(assistantMilliseconds).toISOString() });
-    expect(loaded.traceEvents?.find((event) => event.eventType === "qwen.tool_result")).toMatchObject({ timestamp: new Date(toolMilliseconds).toISOString() });
+    expect(loaded.traceEvents?.filter((event) => event.eventType === "qwen.tool_result")).toEqual([expect.objectContaining({ callId: "call-1", timestamp: new Date(toolMilliseconds).toISOString() })]);
   });
 
   it("falls back to valid file-order rows when a parent chain is broken", () => {
@@ -147,11 +150,13 @@ describe("Qwen Code sessions", () => {
       record("early", null, "user", "early"),
       record("dup", "early", "assistant", "first", { usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1 } }),
       record("dup", "missing", "assistant", "second", { usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 2 }, message: { parts: [{ text: "second" }, { functionCall: { name: "read_file", id: "dup-call" } }] } }),
+      { type: "system", subtype: "metadata", usageMetadata: { promptTokenCount: 100, candidatesTokenCount: 100 } },
     ];
     fs.writeFileSync(path.join(chats, "duplicate.jsonl"), `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
     const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
     expect(loaded.messages.map((message) => message.content)).toEqual(["early", "first", "second"]);
-    expect(loaded.tokenEvents?.map((event) => event.dedupeKey)).toEqual(["dup", "dup"]);
+    expect(loaded.tokenEvents?.map((event) => event.dedupeKey)).toEqual(["dup"]);
+    expect(loaded.tokenEvents?.[0].totalTokens).toBe(4);
     expect(loaded.traceEvents?.some((event) => event.eventType === "qwen.functionCall")).toBe(true);
   });
 });

--- a/apps/main-2.0/src/core/session-loader-qwen.test.ts
+++ b/apps/main-2.0/src/core/session-loader-qwen.test.ts
@@ -5,7 +5,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadDefaultSessions } from "./session-loader";
 import { deriveSessionTimeline } from "./turns/derive-turns";
 
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: vi.fn(() => actual.homedir()) };
+});
+
 const roots: string[] = [];
+const defaultHomeDir = os.homedir();
 const originalRuntimeDir = process.env.QWEN_RUNTIME_DIR;
 const originalQwenHome = process.env.QWEN_HOME;
 const originalHome = process.env.HOME;
@@ -25,6 +31,7 @@ afterEach(() => {
   if (originalUserProfile === undefined) delete process.env.USERPROFILE;
   else process.env.USERPROFILE = originalUserProfile;
   vi.restoreAllMocks();
+  vi.mocked(os.homedir).mockReset().mockReturnValue(defaultHomeDir);
 });
 function fixture(): string { const root = fs.mkdtempSync(path.join(os.tmpdir(), "agentrecall-qwen-v2-")); roots.push(root); return root; }
 function record(uuid: string, parentUuid: string | null, type: "user" | "assistant", text: string, extra: Record<string, unknown> = {}) { return { uuid, parentUuid, sessionId: "qwen-1", timestamp: "2026-08-23T00:00:00.000Z", type, cwd: "C:/repo", version: "0.22.0", message: { role: type, parts: [{ text }] }, ...extra }; }
@@ -35,13 +42,18 @@ describe("Qwen Code sessions", () => {
     const user = record("u", null, "user", "internal", { systemPayload: { displayText: "visible" } }); const dead = record("dead", null, "user", "rewound"); const assistant = record("a", "u", "assistant", "answer", { usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 3, thoughtsTokenCount: 1 }, message: { parts: [{ thought: true, text: "thinking" }, { text: "answer" }, { functionCall: { name: "read_file", id: "c1" } }] } }); const tool = { uuid: "t", parentUuid: "a", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:01.000Z", type: "tool_result", cwd: "C:/repo", message: { role: "user", parts: [{ functionResponse: { id: "c1", name: "read_file", response: { output: "done" } } }] }, toolCallResult: { callId: "c1", output: "done" } }; const metadata = { type: "system", subtype: "metadata" }; const title = { uuid: "title", parentUuid: "t", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:02.000Z", type: "system", subtype: "custom_title", systemPayload: { customTitle: "Named session" } };
     fs.writeFileSync(path.join(chats, "qwen-1.jsonl"), `${[user, dead, assistant, tool, metadata, title].map((row) => JSON.stringify(row)).join("")}\ninvalid\n{"uuid":"tail"`); fs.writeFileSync(path.join(chats, "archive", "qwen-1.jsonl"), JSON.stringify(record("old", null, "user", "archive")));
     const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true }); expect(loaded.session.source).toBe("qwen-code"); expect(loaded.session.originalTitle).toBe("Named session"); expect(loaded.messages.map((m) => m.content)).toEqual(["visible", "answer"]); expect(loaded.session.tokenUsage?.totalTokens).toBe(6); expect(loaded.traceEvents?.some((e) => e.kind === "tool_call")).toBe(true); expect(loaded.traceEvents?.filter((e) => e.eventType === "qwen.tool_result")).toEqual([expect.objectContaining({ callId: "c1" })]); expect(loaded.messages.some((m) => m.content === "rewound")).toBe(false);
-    const toolSpans = deriveSessionTimeline({ sessionKey: loaded.session.sessionKey, messages: loaded.messages, tokenEvents: loaded.tokenEvents ?? [], traceEvents: loaded.traceEvents ?? [] }).turns.flatMap((turn) => turn.spans).filter((span) => span.callId === "c1");
+    const timeline = deriveSessionTimeline({ sessionKey: loaded.session.sessionKey, messages: loaded.messages, tokenEvents: loaded.tokenEvents ?? [], traceEvents: loaded.traceEvents ?? [] });
+    const spans = timeline.turns.flatMap((turn) => turn.spans);
+    const toolSpans = spans.filter((span) => span.callId === "c1");
     expect(toolSpans).toEqual([expect.objectContaining({ status: "completed", endedAt: expect.any(String) })]);
+    expect(spans.filter((span) => span.attributes.eventType === "qwen.thought")).toEqual([expect.objectContaining({ kind: "event" })]);
+    expect(timeline.turns.flatMap((turn) => turn.toolNames)).toEqual(["function: read_file"]);
   });
 
   it("uses QWEN_RUNTIME_DIR before QWEN_HOME", () => {
     const runtime = fixture(); const home = fixture(); const syntheticHome = fixture(); for (const [base, text] of [[runtime, "runtime"], [home, "home"]] as const) { const chats = path.join(base, "projects", "p", "chats"); fs.mkdirSync(chats, { recursive: true }); fs.writeFileSync(path.join(chats, `${text}.jsonl`), JSON.stringify(record(text, null, "user", text))); }
-    process.env.QWEN_HOME = home; process.env.QWEN_RUNTIME_DIR = runtime; const loaded = loadDefaultSessions({ homeDir: syntheticHome, includeQwenCode: true }).filter((item) => item.session.source === "qwen-code"); expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("runtime");
+    vi.mocked(os.homedir).mockReturnValue(syntheticHome);
+    process.env.QWEN_HOME = home; process.env.QWEN_RUNTIME_DIR = runtime; const loaded = loadDefaultSessions({ includeQwenCode: true }).filter((item) => item.session.source === "qwen-code"); expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("runtime");
   });
 
   it("keeps braces inside valid JSON text and honors authoritative Qwen token totals", () => {
@@ -109,21 +121,20 @@ describe("Qwen Code sessions", () => {
   });
 
   it("expands a QWEN_RUNTIME_DIR tilde path", () => {
-    const fakeHome = fixture(); const root = fixture(); process.env.HOME = fakeHome; process.env.USERPROFILE = fakeHome;
+    const fakeHome = fixture(); process.env.HOME = fakeHome; process.env.USERPROFILE = fakeHome; vi.mocked(os.homedir).mockReturnValue(fakeHome);
     const chats = path.join(fakeHome, "qwen-runtime", "nested", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
     fs.writeFileSync(path.join(chats, "tilde.jsonl"), JSON.stringify(record("tilde", null, "user", "tilde")));
     process.env.QWEN_RUNTIME_DIR = "~\\qwen-runtime\\nested";
-    const loaded = loadDefaultSessions({ homeDir: root, includeQwenCode: true }).filter((item) => item.session.source === "qwen-code");
+    const loaded = loadDefaultSessions({ includeQwenCode: true }).filter((item) => item.session.source === "qwen-code");
     expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("tilde");
   });
 
-  it("uses QWEN_HOME when runtime is unset even with an explicit homeDir", () => {
-    const root = fixture(); const qwenHome = fixture();
-    const chats = path.join(qwenHome, "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
-    fs.writeFileSync(path.join(chats, "home.jsonl"), JSON.stringify(record("home", null, "user", "home")));
-    delete process.env.QWEN_RUNTIME_DIR; process.env.QWEN_HOME = qwenHome;
+  it("keeps an explicit homeDir isolated from Qwen environment overrides", () => {
+    const root = fixture(); const runtime = fixture(); const qwenHome = fixture();
+    for (const [base, text] of [[path.join(root, ".qwen"), "explicit"], [runtime, "runtime"], [qwenHome, "home"]] as const) { const chats = path.join(base, "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true }); fs.writeFileSync(path.join(chats, `${text}.jsonl`), JSON.stringify(record(text, null, "user", text))); }
+    process.env.QWEN_RUNTIME_DIR = runtime; process.env.QWEN_HOME = qwenHome;
     const loaded = loadDefaultSessions({ homeDir: root, includeQwenCode: true }).filter((item) => item.session.source === "qwen-code");
-    expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("home");
+    expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("explicit");
   });
 
   it("does not let an archive copy replace a skipped active session", () => {

--- a/apps/main-2.0/src/core/session-loader-qwen.test.ts
+++ b/apps/main-2.0/src/core/session-loader-qwen.test.ts
@@ -1,12 +1,16 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadDefaultSessions } from "./session-loader";
 
 const roots: string[] = [];
 const originalRuntimeDir = process.env.QWEN_RUNTIME_DIR;
 const originalQwenHome = process.env.QWEN_HOME;
+beforeEach(() => {
+  delete process.env.QWEN_RUNTIME_DIR;
+  delete process.env.QWEN_HOME;
+});
 afterEach(() => {
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
   if (originalRuntimeDir === undefined) delete process.env.QWEN_RUNTIME_DIR;
@@ -27,8 +31,8 @@ describe("Qwen Code sessions", () => {
   });
 
   it("uses QWEN_RUNTIME_DIR before QWEN_HOME", () => {
-    const runtime = fixture(); const home = fixture(); const syntheticHome = fixture(); vi.spyOn(os, "homedir").mockReturnValue(syntheticHome); for (const [base, text] of [[runtime, "runtime"], [home, "home"]] as const) { const chats = path.join(base, "projects", "p", "chats"); fs.mkdirSync(chats, { recursive: true }); fs.writeFileSync(path.join(chats, `${text}.jsonl`), JSON.stringify(record(text, null, "user", text))); }
-    process.env.QWEN_HOME = home; process.env.QWEN_RUNTIME_DIR = runtime; const loaded = loadDefaultSessions({ includeQwenCode: true }).filter((item) => item.session.source === "qwen-code"); expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("runtime");
+    const runtime = fixture(); const home = fixture(); const syntheticHome = fixture(); for (const [base, text] of [[runtime, "runtime"], [home, "home"]] as const) { const chats = path.join(base, "projects", "p", "chats"); fs.mkdirSync(chats, { recursive: true }); fs.writeFileSync(path.join(chats, `${text}.jsonl`), JSON.stringify(record(text, null, "user", text))); }
+    process.env.QWEN_HOME = home; process.env.QWEN_RUNTIME_DIR = runtime; const loaded = loadDefaultSessions({ homeDir: syntheticHome, includeQwenCode: true }).filter((item) => item.session.source === "qwen-code"); expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("runtime");
   });
 
   it("keeps braces inside valid JSON text and normalizes cached tokens and creation time", () => {
@@ -42,6 +46,16 @@ describe("Qwen Code sessions", () => {
     expect(loaded.messages.map((message) => message.content)).toEqual(["keep }{ together", "answer"]);
     expect(loaded.session.timestamp).toBe(Date.parse(createdAt));
     expect(loaded.session.tokenUsage).toMatchObject({ inputTokens: 6, cachedInputTokens: 4, outputTokens: 3, reasoningOutputTokens: 2, totalTokens: 15 });
+    expect(loaded.tokenEvents).toEqual([{ timestamp: Date.parse(updatedAt), dedupeKey: "a", inputTokens: 6, outputTokens: 3, cachedInputTokens: 4, reasoningOutputTokens: 2, totalTokens: 15 }]);
+  });
+
+  it("uses QWEN_HOME when runtime is unset even with an explicit homeDir", () => {
+    const root = fixture(); const qwenHome = fixture();
+    const chats = path.join(qwenHome, "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    fs.writeFileSync(path.join(chats, "home.jsonl"), JSON.stringify(record("home", null, "user", "home")));
+    delete process.env.QWEN_RUNTIME_DIR; process.env.QWEN_HOME = qwenHome;
+    const loaded = loadDefaultSessions({ homeDir: root, includeQwenCode: true }).filter((item) => item.session.source === "qwen-code");
+    expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("home");
   });
 
   it("does not let an archive copy replace a skipped active session", () => {

--- a/apps/main-2.0/src/core/session-loader-qwen.test.ts
+++ b/apps/main-2.0/src/core/session-loader-qwen.test.ts
@@ -25,8 +25,8 @@ function record(uuid: string, parentUuid: string | null, type: "user" | "assista
 describe("Qwen Code sessions", () => {
   it("reconstructs the active branch and keeps active sessions over archive", () => {
     const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(path.join(chats, "archive"), { recursive: true });
-    const user = record("u", null, "user", "internal", { systemPayload: { displayText: "visible" } }); const dead = record("dead", null, "user", "rewound"); const assistant = record("a", "u", "assistant", "answer", { usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 3, thoughtsTokenCount: 1 }, message: { parts: [{ thought: true, text: "thinking" }, { text: "answer" }, { functionCall: { name: "read_file", id: "c1" } }] } }); const tool = { uuid: "t", parentUuid: "a", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:01.000Z", type: "tool_result", cwd: "C:/repo", message: { role: "user", parts: [] }, toolCallResult: { output: "done" } }; const title = { uuid: "title", parentUuid: "t", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:02.000Z", type: "system", subtype: "custom_title", systemPayload: { customTitle: "Named session" } };
-    fs.writeFileSync(path.join(chats, "qwen-1.jsonl"), `${[user, dead, assistant, tool, title].map((row) => JSON.stringify(row)).join("")}\ninvalid\n{"uuid":"tail"`); fs.writeFileSync(path.join(chats, "archive", "qwen-1.jsonl"), JSON.stringify(record("old", null, "user", "archive")));
+    const user = record("u", null, "user", "internal", { systemPayload: { displayText: "visible" } }); const dead = record("dead", null, "user", "rewound"); const assistant = record("a", "u", "assistant", "answer", { usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 3, thoughtsTokenCount: 1 }, message: { parts: [{ thought: true, text: "thinking" }, { text: "answer" }, { functionCall: { name: "read_file", id: "c1" } }] } }); const tool = { uuid: "t", parentUuid: "a", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:01.000Z", type: "tool_result", cwd: "C:/repo", message: { role: "user", parts: [] }, toolCallResult: { output: "done" } }; const metadata = { type: "system", subtype: "metadata" }; const title = { uuid: "title", parentUuid: "t", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:02.000Z", type: "system", subtype: "custom_title", systemPayload: { customTitle: "Named session" } };
+    fs.writeFileSync(path.join(chats, "qwen-1.jsonl"), `${[user, dead, assistant, tool, metadata, title].map((row) => JSON.stringify(row)).join("")}\ninvalid\n{"uuid":"tail"`); fs.writeFileSync(path.join(chats, "archive", "qwen-1.jsonl"), JSON.stringify(record("old", null, "user", "archive")));
     const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true }); expect(loaded.session.source).toBe("qwen-code"); expect(loaded.session.originalTitle).toBe("Named session"); expect(loaded.messages.map((m) => m.content)).toEqual(["visible", "answer"]); expect(loaded.session.tokenUsage?.totalTokens).toBe(6); expect(loaded.traceEvents?.some((e) => e.kind === "tool_call")).toBe(true); expect(loaded.traceEvents?.some((e) => e.eventType === "qwen.tool_result")).toBe(true); expect(loaded.messages.some((m) => m.content === "rewound")).toBe(false);
   });
 
@@ -91,5 +91,35 @@ describe("Qwen Code sessions", () => {
     expect(loaded.tokenEvents?.[0]).toMatchObject({ timestamp: assistantMilliseconds, dedupeKey: "a" });
     expect(loaded.traceEvents?.find((event) => event.eventType === "qwen.functionCall")).toMatchObject({ timestamp: new Date(assistantMilliseconds).toISOString() });
     expect(loaded.traceEvents?.find((event) => event.eventType === "qwen.tool_result")).toMatchObject({ timestamp: new Date(toolMilliseconds).toISOString() });
+  });
+
+  it("falls back to valid file-order rows when a parent chain is broken", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    const rows = [
+      record("early", null, "user", "early", { timestamp: "2026-08-23T00:00:00.000Z" }),
+      record("orphan", "missing", "assistant", "later", { usageMetadata: { promptTokenCount: 4, candidatesTokenCount: 2 }, message: { parts: [{ text: "later" }, { functionCall: { name: "read_file", id: "call-1" } }] } }),
+      { uuid: "tool", parentUuid: "orphan", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:02.000Z", type: "tool_result", cwd: "C:/repo", message: { role: "user", parts: [] }, toolCallResult: { output: "done" } },
+      record("leaf", "tool", "assistant", "leaf", { usageMetadata: { promptTokenCount: 6, candidatesTokenCount: 3 } }),
+    ];
+    fs.writeFileSync(path.join(chats, "broken.jsonl"), `${JSON.stringify(rows[0])}\nnot-json\n${rows.slice(1).map((row) => JSON.stringify(row)).join("\n")}\n`);
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
+    expect(loaded.messages.map((message) => message.content)).toEqual(["early", "later", "leaf"]);
+    expect(loaded.tokenEvents?.map((event) => event.dedupeKey)).toEqual(["orphan", "leaf"]);
+    expect(loaded.traceEvents?.some((event) => event.eventType === "qwen.tool_result")).toBe(true);
+    expect(loaded.session.timestamp).toBe(Date.parse("2026-08-23T00:00:00.000Z"));
+  });
+
+  it("falls back to file-order rows when UUIDs are duplicated", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    const rows = [
+      record("early", null, "user", "early"),
+      record("dup", "early", "assistant", "first", { usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1 } }),
+      record("dup", "missing", "assistant", "second", { usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 2 }, message: { parts: [{ text: "second" }, { functionCall: { name: "read_file", id: "dup-call" } }] } }),
+    ];
+    fs.writeFileSync(path.join(chats, "duplicate.jsonl"), `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
+    expect(loaded.messages.map((message) => message.content)).toEqual(["early", "first", "second"]);
+    expect(loaded.tokenEvents?.map((event) => event.dedupeKey)).toEqual(["dup", "dup"]);
+    expect(loaded.traceEvents?.some((event) => event.eventType === "qwen.functionCall")).toBe(true);
   });
 });

--- a/apps/main-2.0/src/core/session-loader-qwen.test.ts
+++ b/apps/main-2.0/src/core/session-loader-qwen.test.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import os from "node:os";
+import * as os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadDefaultSessions } from "./session-loader";
@@ -7,6 +7,8 @@ import { loadDefaultSessions } from "./session-loader";
 const roots: string[] = [];
 const originalRuntimeDir = process.env.QWEN_RUNTIME_DIR;
 const originalQwenHome = process.env.QWEN_HOME;
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
 beforeEach(() => {
   delete process.env.QWEN_RUNTIME_DIR;
   delete process.env.QWEN_HOME;
@@ -17,6 +19,10 @@ afterEach(() => {
   else process.env.QWEN_RUNTIME_DIR = originalRuntimeDir;
   if (originalQwenHome === undefined) delete process.env.QWEN_HOME;
   else process.env.QWEN_HOME = originalQwenHome;
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
   vi.restoreAllMocks();
 });
 function fixture(): string { const root = fs.mkdtempSync(path.join(os.tmpdir(), "agentrecall-qwen-v2-")); roots.push(root); return root; }
@@ -47,6 +53,32 @@ describe("Qwen Code sessions", () => {
     expect(loaded.session.timestamp).toBe(Date.parse(createdAt));
     expect(loaded.session.tokenUsage).toMatchObject({ inputTokens: 6, cachedInputTokens: 4, outputTokens: 3, reasoningOutputTokens: 2, totalTokens: 15 });
     expect(loaded.tokenEvents).toEqual([{ timestamp: Date.parse(updatedAt), dedupeKey: "a", inputTokens: 6, outputTokens: 3, cachedInputTokens: 4, reasoningOutputTokens: 2, totalTokens: 15 }]);
+  });
+
+  it("recovers glued objects when the first message contains object-like braces", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    const first = record("first", null, "user", "keep }{ together");
+    const second = record("second", "first", "assistant", "second");
+    fs.writeFileSync(path.join(chats, "glued.jsonl"), `${JSON.stringify(first)}${JSON.stringify(second)}\n`);
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
+    expect(loaded.messages.map((message) => message.content)).toEqual(["keep }{ together", "second"]);
+  });
+
+  it("uses the latest custom title", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    const rows = [record("user", null, "user", "question"), { type: "system", subtype: "custom_title", systemPayload: { customTitle: "Old title" } }, { type: "system", subtype: "custom_title", systemPayload: { customTitle: "Latest title" } }];
+    fs.writeFileSync(path.join(chats, "titles.jsonl"), `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
+    expect(loaded.session.originalTitle).toBe("Latest title");
+  });
+
+  it("expands a QWEN_RUNTIME_DIR tilde path", () => {
+    const fakeHome = fixture(); const root = fixture(); process.env.HOME = fakeHome; process.env.USERPROFILE = fakeHome;
+    const chats = path.join(fakeHome, "qwen-runtime", "nested", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    fs.writeFileSync(path.join(chats, "tilde.jsonl"), JSON.stringify(record("tilde", null, "user", "tilde")));
+    process.env.QWEN_RUNTIME_DIR = "~\\qwen-runtime\\nested";
+    const loaded = loadDefaultSessions({ homeDir: root, includeQwenCode: true }).filter((item) => item.session.source === "qwen-code");
+    expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("tilde");
   });
 
   it("uses QWEN_HOME when runtime is unset even with an explicit homeDir", () => {

--- a/apps/main-2.0/src/core/session-loader-qwen.test.ts
+++ b/apps/main-2.0/src/core/session-loader-qwen.test.ts
@@ -69,4 +69,27 @@ describe("Qwen Code sessions", () => {
     expect(loaded.filter((item) => item.session.source === "qwen-code")).toEqual([]);
     expect(onSkippedFile).toHaveBeenCalledWith(activePath, expect.any(Object));
   });
+
+  it("normalizes numeric second and millisecond timestamps across Qwen records", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    const userSeconds = 1787443200; const assistantMilliseconds = userSeconds * 1000 + 1000; const toolMilliseconds = assistantMilliseconds + 1000;
+    const user = record("u", null, "user", "question", { timestamp: userSeconds });
+    const assistant = record("a", "u", "assistant", "answer", {
+      timestamp: assistantMilliseconds,
+      usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 3 },
+      message: { parts: [{ text: "answer" }, { functionCall: { name: "read_file", id: "call-1" } }] },
+    });
+    const tool = { uuid: "t", parentUuid: "a", sessionId: "qwen-1", timestamp: toolMilliseconds, type: "tool_result", cwd: "C:/repo", message: { role: "user", parts: [] }, toolCallResult: { output: "done" } };
+    fs.writeFileSync(path.join(chats, "numeric.jsonl"), `${JSON.stringify(user)}\n${JSON.stringify(assistant)}\n${JSON.stringify(tool)}\n`);
+
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
+    expect(loaded.session.timestamp).toBe(userSeconds * 1000);
+    expect(loaded.messages.map((message) => message.timestamp)).toEqual([
+      new Date(userSeconds * 1000).toISOString(),
+      new Date(assistantMilliseconds).toISOString(),
+    ]);
+    expect(loaded.tokenEvents?.[0]).toMatchObject({ timestamp: assistantMilliseconds, dedupeKey: "a" });
+    expect(loaded.traceEvents?.find((event) => event.eventType === "qwen.functionCall")).toMatchObject({ timestamp: new Date(assistantMilliseconds).toISOString() });
+    expect(loaded.traceEvents?.find((event) => event.eventType === "qwen.tool_result")).toMatchObject({ timestamp: new Date(toolMilliseconds).toISOString() });
+  });
 });

--- a/apps/main-2.0/src/core/session-loader-qwen.test.ts
+++ b/apps/main-2.0/src/core/session-loader-qwen.test.ts
@@ -1,0 +1,33 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadDefaultSessions } from "./session-loader";
+
+const roots: string[] = [];
+const originalRuntimeDir = process.env.QWEN_RUNTIME_DIR;
+const originalQwenHome = process.env.QWEN_HOME;
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  if (originalRuntimeDir === undefined) delete process.env.QWEN_RUNTIME_DIR;
+  else process.env.QWEN_RUNTIME_DIR = originalRuntimeDir;
+  if (originalQwenHome === undefined) delete process.env.QWEN_HOME;
+  else process.env.QWEN_HOME = originalQwenHome;
+  vi.restoreAllMocks();
+});
+function fixture(): string { const root = fs.mkdtempSync(path.join(os.tmpdir(), "agentrecall-qwen-v2-")); roots.push(root); return root; }
+function record(uuid: string, parentUuid: string | null, type: "user" | "assistant", text: string, extra: Record<string, unknown> = {}) { return { uuid, parentUuid, sessionId: "qwen-1", timestamp: "2026-08-23T00:00:00.000Z", type, cwd: "C:/repo", version: "0.22.0", message: { role: type, parts: [{ text }] }, ...extra }; }
+
+describe("Qwen Code sessions", () => {
+  it("reconstructs the active branch and keeps active sessions over archive", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(path.join(chats, "archive"), { recursive: true });
+    const user = record("u", null, "user", "internal", { systemPayload: { displayText: "visible" } }); const dead = record("dead", null, "user", "rewound"); const assistant = record("a", "u", "assistant", "answer", { usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 3, thoughtsTokenCount: 1 }, message: { parts: [{ thought: true, text: "thinking" }, { text: "answer" }, { functionCall: { name: "read_file", id: "c1" } }] } }); const tool = { uuid: "t", parentUuid: "a", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:01.000Z", type: "tool_result", cwd: "C:/repo", message: { role: "user", parts: [] }, toolCallResult: { output: "done" } }; const title = { uuid: "title", parentUuid: "t", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:02.000Z", type: "system", subtype: "custom_title", systemPayload: { customTitle: "Named session" } };
+    fs.writeFileSync(path.join(chats, "qwen-1.jsonl"), `${[user, dead, assistant, tool, title].map((row) => JSON.stringify(row)).join("")}\ninvalid\n{"uuid":"tail"`); fs.writeFileSync(path.join(chats, "archive", "qwen-1.jsonl"), JSON.stringify(record("old", null, "user", "archive")));
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true }); expect(loaded.session.source).toBe("qwen-code"); expect(loaded.session.originalTitle).toBe("Named session"); expect(loaded.messages.map((m) => m.content)).toEqual(["visible", "answer"]); expect(loaded.session.tokenUsage?.totalTokens).toBe(6); expect(loaded.traceEvents?.some((e) => e.kind === "tool_call")).toBe(true); expect(loaded.traceEvents?.some((e) => e.eventType === "qwen.tool_result")).toBe(true); expect(loaded.messages.some((m) => m.content === "rewound")).toBe(false);
+  });
+
+  it("uses QWEN_RUNTIME_DIR before QWEN_HOME", () => {
+    const runtime = fixture(); const home = fixture(); const syntheticHome = fixture(); vi.spyOn(os, "homedir").mockReturnValue(syntheticHome); for (const [base, text] of [[runtime, "runtime"], [home, "home"]] as const) { const chats = path.join(base, "projects", "p", "chats"); fs.mkdirSync(chats, { recursive: true }); fs.writeFileSync(path.join(chats, `${text}.jsonl`), JSON.stringify(record(text, null, "user", text))); }
+    process.env.QWEN_HOME = home; process.env.QWEN_RUNTIME_DIR = runtime; const loaded = loadDefaultSessions({ includeQwenCode: true }).filter((item) => item.session.source === "qwen-code"); expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("runtime");
+  });
+});

--- a/apps/main-2.0/src/core/session-loader-qwen.test.ts
+++ b/apps/main-2.0/src/core/session-loader-qwen.test.ts
@@ -44,18 +44,51 @@ describe("Qwen Code sessions", () => {
     process.env.QWEN_HOME = home; process.env.QWEN_RUNTIME_DIR = runtime; const loaded = loadDefaultSessions({ homeDir: syntheticHome, includeQwenCode: true }).filter((item) => item.session.source === "qwen-code"); expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("runtime");
   });
 
-  it("keeps braces inside valid JSON text and normalizes cached tokens and creation time", () => {
+  it("keeps braces inside valid JSON text and honors authoritative Qwen token totals", () => {
     const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
     const createdAt = "2026-08-23T00:00:00.000Z"; const updatedAt = "2026-08-23T01:00:00.000Z";
     const user = record("u", null, "user", "keep }{ together", { timestamp: createdAt });
-    const assistant = record("a", "u", "assistant", "answer", { timestamp: updatedAt, usageMetadata: { promptTokenCount: 10, cachedContentTokenCount: 4, candidatesTokenCount: 3, thoughtsTokenCount: 2 } });
+    const assistant = record("a", "u", "assistant", "answer", { timestamp: updatedAt, usageMetadata: { promptTokenCount: 10, cachedContentTokenCount: 4, candidatesTokenCount: 3, thoughtsTokenCount: 2, totalTokenCount: 13 } });
     fs.writeFileSync(path.join(chats, "tokens.jsonl"), `${JSON.stringify(user)}\n${JSON.stringify(assistant)}\n`);
 
     const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
     expect(loaded.messages.map((message) => message.content)).toEqual(["keep }{ together", "answer"]);
     expect(loaded.session.timestamp).toBe(Date.parse(createdAt));
+    expect(loaded.session.tokenUsage).toMatchObject({ inputTokens: 6, cachedInputTokens: 4, outputTokens: 1, reasoningOutputTokens: 2, totalTokens: 13 });
+    expect(loaded.tokenEvents).toEqual([{ timestamp: Date.parse(updatedAt), dedupeKey: "a", inputTokens: 6, outputTokens: 1, cachedInputTokens: 4, reasoningOutputTokens: 2, totalTokens: 13 }]);
+  });
+
+  it("keeps separated Qwen reasoning above the candidate count", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    const rows = [record("u", null, "user", "question"), record("a", "u", "assistant", "answer", { usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 2, thoughtsTokenCount: 5, totalTokenCount: 17 } })];
+    fs.writeFileSync(path.join(chats, "separated-tokens.jsonl"), `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
+    expect(loaded.tokenEvents).toEqual([expect.objectContaining({ inputTokens: 10, cachedInputTokens: 0, outputTokens: 2, reasoningOutputTokens: 5, totalTokens: 17 })]);
+    expect(loaded.session.tokenUsage).toMatchObject({ inputTokens: 10, cachedInputTokens: 0, outputTokens: 2, reasoningOutputTokens: 5, totalTokens: 17 });
+  });
+
+  it("falls back to additive Qwen token totals when totalTokenCount is missing", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    const rows = [record("u", null, "user", "question"), record("a", "u", "assistant", "answer", { usageMetadata: { promptTokenCount: 10, cachedContentTokenCount: 4, candidatesTokenCount: 3, thoughtsTokenCount: 2 } })];
+    fs.writeFileSync(path.join(chats, "token-fallback.jsonl"), `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
+    expect(loaded.tokenEvents).toEqual([expect.objectContaining({ inputTokens: 6, cachedInputTokens: 4, outputTokens: 3, reasoningOutputTokens: 2, totalTokens: 15 })]);
     expect(loaded.session.tokenUsage).toMatchObject({ inputTokens: 6, cachedInputTokens: 4, outputTokens: 3, reasoningOutputTokens: 2, totalTokens: 15 });
-    expect(loaded.tokenEvents).toEqual([{ timestamp: Date.parse(updatedAt), dedupeKey: "a", inputTokens: 6, outputTokens: 3, cachedInputTokens: 4, reasoningOutputTokens: 2, totalTokens: 15 }]);
+  });
+
+  it("uses trailing rewind metadata as the leaf and ignores artifact-only records", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    const rows = [
+      record("u", null, "user", "question", { gitBranch: "main" }),
+      record("old", "u", "assistant", "discarded answer", { gitBranch: "discarded" }),
+      { uuid: "rewind", parentUuid: "u", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:01.000Z", type: "system", subtype: "rewind", cwd: "C:/repo", gitBranch: "feature/qwen" },
+      { uuid: "model", parentUuid: "rewind", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:02.000Z", type: "system", subtype: "session_model", cwd: "C:/repo", gitBranch: "feature/qwen", model: "qwen3-coder" },
+      { uuid: "artifact", parentUuid: "old", sessionId: "qwen-1", timestamp: "2026-08-23T00:00:03.000Z", type: "system", subtype: "session_artifact_snapshot", cwd: "C:/repo", gitBranch: "discarded" },
+    ];
+    fs.writeFileSync(path.join(chats, "rewind.jsonl"), `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
+    expect(loaded.messages.map((message) => message.content)).toEqual(["question"]);
+    expect(loaded.session.gitBranch).toBe("feature/qwen");
   });
 
   it("recovers glued objects when the first message contains object-like braces", () => {

--- a/apps/main-2.0/src/core/session-loader-qwen.test.ts
+++ b/apps/main-2.0/src/core/session-loader-qwen.test.ts
@@ -30,4 +30,29 @@ describe("Qwen Code sessions", () => {
     const runtime = fixture(); const home = fixture(); const syntheticHome = fixture(); vi.spyOn(os, "homedir").mockReturnValue(syntheticHome); for (const [base, text] of [[runtime, "runtime"], [home, "home"]] as const) { const chats = path.join(base, "projects", "p", "chats"); fs.mkdirSync(chats, { recursive: true }); fs.writeFileSync(path.join(chats, `${text}.jsonl`), JSON.stringify(record(text, null, "user", text))); }
     process.env.QWEN_HOME = home; process.env.QWEN_RUNTIME_DIR = runtime; const loaded = loadDefaultSessions({ includeQwenCode: true }).filter((item) => item.session.source === "qwen-code"); expect(loaded).toHaveLength(1); expect(loaded[0].messages[0].content).toBe("runtime");
   });
+
+  it("keeps braces inside valid JSON text and normalizes cached tokens and creation time", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(chats, { recursive: true });
+    const createdAt = "2026-08-23T00:00:00.000Z"; const updatedAt = "2026-08-23T01:00:00.000Z";
+    const user = record("u", null, "user", "keep }{ together", { timestamp: createdAt });
+    const assistant = record("a", "u", "assistant", "answer", { timestamp: updatedAt, usageMetadata: { promptTokenCount: 10, cachedContentTokenCount: 4, candidatesTokenCount: 3, thoughtsTokenCount: 2 } });
+    fs.writeFileSync(path.join(chats, "tokens.jsonl"), `${JSON.stringify(user)}\n${JSON.stringify(assistant)}\n`);
+
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeQwenCode: true });
+    expect(loaded.messages.map((message) => message.content)).toEqual(["keep }{ together", "answer"]);
+    expect(loaded.session.timestamp).toBe(Date.parse(createdAt));
+    expect(loaded.session.tokenUsage).toMatchObject({ inputTokens: 6, cachedInputTokens: 4, outputTokens: 3, reasoningOutputTokens: 2, totalTokens: 15 });
+  });
+
+  it("does not let an archive copy replace a skipped active session", () => {
+    const root = fixture(); const chats = path.join(root, ".qwen", "projects", "project", "chats"); fs.mkdirSync(path.join(chats, "archive"), { recursive: true });
+    const activePath = path.join(chats, "same.jsonl");
+    fs.writeFileSync(activePath, JSON.stringify(record("active", null, "user", "active")));
+    fs.writeFileSync(path.join(chats, "archive", "same.jsonl"), JSON.stringify(record("archive", null, "user", "archive")));
+    const onSkippedFile = vi.fn();
+
+    const loaded = loadDefaultSessions({ homeDir: root, includeQwenCode: true, shouldSkipFile: (filePath) => filePath === activePath, onSkippedFile });
+    expect(loaded.filter((item) => item.session.source === "qwen-code")).toEqual([]);
+    expect(onSkippedFile).toHaveBeenCalledWith(activePath, expect.any(Object));
+  });
 });

--- a/apps/main-2.0/src/core/session-loader.ts
+++ b/apps/main-2.0/src/core/session-loader.ts
@@ -104,7 +104,8 @@ function resolveKimiCodeRoot(homeDir: string, options: SessionLoadOptions): stri
     : path.join(homeDir, KIMI_CODE_DIR);
 }
 
-function resolveQwenCodeRoot(homeDir: string): string {
+function resolveQwenCodeRoot(homeDir: string, options: SessionLoadOptions): string {
+  if (options.homeDir !== undefined) return path.join(homeDir, QWEN_DIR);
   const configured = process.env.QWEN_RUNTIME_DIR?.trim() || process.env.QWEN_HOME?.trim();
   if (!configured) return path.join(homeDir, QWEN_DIR);
   const expanded = configured === "~"
@@ -1948,7 +1949,7 @@ export function* loadDefaultSessionsIterator(options: SessionLoadOptions = {}): 
     options,
   );
   if (options.includeQwenCode) {
-    yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir), options);
+    yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir, options), options);
   }
   if (options.includeTclaude) yield* loadClaudeCliSessionsIterator(path.join(homeDir, TCLAUDE_DIR), "tclaude-cli", options);
   if (options.includeTcodex) yield* loadCodexSessionsIterator(path.join(homeDir, TCODEX_DIR), "tcodex-cli", options);
@@ -2001,7 +2002,7 @@ export async function* loadDefaultSessionsAsyncIterator(options: SessionLoadOpti
     options,
   );
   if (options.includeQwenCode) {
-    yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir), options);
+    yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir, options), options);
   }
   if (options.includeTclaude) yield* loadClaudeCliSessionsIterator(path.join(homeDir, TCLAUDE_DIR), "tclaude-cli", options);
   if (options.includeTcodex) yield* loadCodexSessionsAsyncIterator(path.join(homeDir, TCODEX_DIR), "tcodex-cli", options);

--- a/apps/main-2.0/src/core/session-loader.ts
+++ b/apps/main-2.0/src/core/session-loader.ts
@@ -105,7 +105,14 @@ function resolveKimiCodeRoot(homeDir: string, options: SessionLoadOptions): stri
 }
 
 function resolveQwenCodeRoot(homeDir: string): string {
-  return process.env.QWEN_RUNTIME_DIR?.trim() || process.env.QWEN_HOME?.trim() || path.join(homeDir, QWEN_DIR);
+  const configured = process.env.QWEN_RUNTIME_DIR?.trim() || process.env.QWEN_HOME?.trim();
+  if (!configured) return path.join(homeDir, QWEN_DIR);
+  const expanded = configured === "~"
+    ? os.homedir()
+    : configured.startsWith("~/") || configured.startsWith("~\\")
+      ? path.join(os.homedir(), ...configured.slice(2).split(/[\\/]+/u).filter(Boolean))
+      : configured;
+  return path.resolve(expanded);
 }
 
 interface CodexSessionMeta {

--- a/apps/main-2.0/src/core/session-loader.ts
+++ b/apps/main-2.0/src/core/session-loader.ts
@@ -19,6 +19,7 @@ import {
   KIMI_LEGACY_DIR,
   PI_SESSIONS_DIR,
   QODER_DIR,
+  QWEN_DIR,
   TRAE_DIR_NAMES,
   loadCodeWizSessions,
   loadCursorAgentSessionsIterator,
@@ -28,6 +29,7 @@ import {
   loadOpenCodeSessions,
   loadPiSessionsIterator,
   loadKimiSessionsIterator,
+  loadQwenCodeSessionsIterator,
   loadQoderSessionsIterator,
   loadTraeSessionsIterator,
   loadZcodeSessions,
@@ -100,6 +102,12 @@ function resolveKimiCodeRoot(homeDir: string, options: SessionLoadOptions): stri
   return options.homeDir === undefined
     ? process.env.KIMI_CODE_HOME?.trim() || path.join(homeDir, KIMI_CODE_DIR)
     : path.join(homeDir, KIMI_CODE_DIR);
+}
+
+function resolveQwenCodeRoot(homeDir: string, options: SessionLoadOptions): string {
+  return options.homeDir === undefined
+    ? process.env.QWEN_RUNTIME_DIR?.trim() || process.env.QWEN_HOME?.trim() || path.join(homeDir, QWEN_DIR)
+    : path.join(homeDir, QWEN_DIR);
 }
 
 interface CodexSessionMeta {
@@ -1934,6 +1942,9 @@ export function* loadDefaultSessionsIterator(options: SessionLoadOptions = {}): 
     resolveKimiCodeRoot(homeDir, options),
     options,
   );
+  if (options.includeQwenCode) {
+    yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir, options), options);
+  }
   if (options.includeTclaude) yield* loadClaudeCliSessionsIterator(path.join(homeDir, TCLAUDE_DIR), "tclaude-cli", options);
   if (options.includeTcodex) yield* loadCodexSessionsIterator(path.join(homeDir, TCODEX_DIR), "tcodex-cli", options);
   if (options.includeCodeBuddyCli) yield* loadCodeBuddyCliSessionsIterator(path.join(homeDir, CODEBUDDY_DIR), options);
@@ -1984,6 +1995,9 @@ export async function* loadDefaultSessionsAsyncIterator(options: SessionLoadOpti
     resolveKimiCodeRoot(homeDir, options),
     options,
   );
+  if (options.includeQwenCode) {
+    yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir, options), options);
+  }
   if (options.includeTclaude) yield* loadClaudeCliSessionsIterator(path.join(homeDir, TCLAUDE_DIR), "tclaude-cli", options);
   if (options.includeTcodex) yield* loadCodexSessionsAsyncIterator(path.join(homeDir, TCODEX_DIR), "tcodex-cli", options);
   if (options.includeCodeBuddyCli) yield* loadCodeBuddyCliSessionsIterator(path.join(homeDir, CODEBUDDY_DIR), options);

--- a/apps/main-2.0/src/core/session-loader.ts
+++ b/apps/main-2.0/src/core/session-loader.ts
@@ -104,10 +104,8 @@ function resolveKimiCodeRoot(homeDir: string, options: SessionLoadOptions): stri
     : path.join(homeDir, KIMI_CODE_DIR);
 }
 
-function resolveQwenCodeRoot(homeDir: string, options: SessionLoadOptions): string {
-  return options.homeDir === undefined
-    ? process.env.QWEN_RUNTIME_DIR?.trim() || process.env.QWEN_HOME?.trim() || path.join(homeDir, QWEN_DIR)
-    : path.join(homeDir, QWEN_DIR);
+function resolveQwenCodeRoot(homeDir: string): string {
+  return process.env.QWEN_RUNTIME_DIR?.trim() || process.env.QWEN_HOME?.trim() || path.join(homeDir, QWEN_DIR);
 }
 
 interface CodexSessionMeta {
@@ -1943,7 +1941,7 @@ export function* loadDefaultSessionsIterator(options: SessionLoadOptions = {}): 
     options,
   );
   if (options.includeQwenCode) {
-    yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir, options), options);
+    yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir), options);
   }
   if (options.includeTclaude) yield* loadClaudeCliSessionsIterator(path.join(homeDir, TCLAUDE_DIR), "tclaude-cli", options);
   if (options.includeTcodex) yield* loadCodexSessionsIterator(path.join(homeDir, TCODEX_DIR), "tcodex-cli", options);
@@ -1996,7 +1994,7 @@ export async function* loadDefaultSessionsAsyncIterator(options: SessionLoadOpti
     options,
   );
   if (options.includeQwenCode) {
-    yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir, options), options);
+    yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir), options);
   }
   if (options.includeTclaude) yield* loadClaudeCliSessionsIterator(path.join(homeDir, TCLAUDE_DIR), "tclaude-cli", options);
   if (options.includeTcodex) yield* loadCodexSessionsAsyncIterator(path.join(homeDir, TCODEX_DIR), "tcodex-cli", options);

--- a/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
+++ b/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
@@ -684,6 +684,39 @@ function qwenToolResultCallId(row: Record<string, unknown>, parts: Record<string
   return stringField(functionResponse, "id") || stringField(toolCallResult, "callId") || stringField(toolCallResult, "id") || stringField(row, "uuid") || null;
 }
 
+const QWEN_ARTIFACT_SUBTYPES = new Set(["session_artifact_event", "session_artifact_snapshot"]);
+const QWEN_CONVERSATION_TYPES = new Set(["user", "assistant", "tool_result", "system"]);
+
+function qwenConversationLeaf(rows: Record<string, unknown>[]): Record<string, unknown> | undefined {
+  return [...rows].reverse().find((row) => {
+    const type = stringField(row, "type");
+    return QWEN_CONVERSATION_TYPES.has(type)
+      && Boolean(stringField(row, "uuid"))
+      && !(type === "system" && QWEN_ARTIFACT_SUBTYPES.has(stringField(row, "subtype")));
+  });
+}
+
+function qwenTokenBuckets(
+  usage: Record<string, unknown>,
+): Pick<TokenUsage, "inputTokens" | "outputTokens" | "cachedInputTokens" | "reasoningOutputTokens"> {
+  const promptTokens = Math.max(0, numberField(usage, "promptTokenCount"));
+  const candidateTokens = Math.max(0, numberField(usage, "candidatesTokenCount"));
+  const thoughtTokens = Math.max(0, numberField(usage, "thoughtsTokenCount"));
+  const rawTotalTokens = usage.totalTokenCount;
+  const hasAuthoritativeTotal = typeof rawTotalTokens === "number" && Number.isFinite(rawTotalTokens) && rawTotalTokens >= 0;
+  const cachedInputTokens = Math.min(Math.max(0, numberField(usage, "cachedContentTokenCount")), promptTokens);
+  const inputTokens = promptTokens - cachedInputTokens;
+  if (!hasAuthoritativeTotal) {
+    return { inputTokens, outputTokens: candidateTokens, cachedInputTokens, reasoningOutputTokens: thoughtTokens };
+  }
+  const targetTotalTokens = rawTotalTokens;
+  const boundedCachedInputTokens = Math.min(cachedInputTokens, targetTotalTokens);
+  const boundedInputTokens = Math.min(inputTokens, targetTotalTokens - boundedCachedInputTokens);
+  const outputBudget = targetTotalTokens - boundedInputTokens - boundedCachedInputTokens;
+  const reasoningOutputTokens = Math.min(thoughtTokens, outputBudget);
+  return { inputTokens: boundedInputTokens, outputTokens: outputBudget - reasoningOutputTokens, cachedInputTokens: boundedCachedInputTokens, reasoningOutputTokens };
+}
+
 function qwenTraces(rows: Record<string, unknown>[]): SessionTraceEvent[] {
   const events: TraceEventDraft[] = [];
   for (const row of rows) {
@@ -706,19 +739,20 @@ function qwenTraces(rows: Record<string, unknown>[]): SessionTraceEvent[] {
 function loadQwenFile(filePath: string, projectPath: string, stat = safeStat(filePath)): LoadedSession | null {
   const rows = qwenRows(filePath).filter(isRecord); const byId = new Map<string, Record<string, unknown>>(); let chainInvalid = false;
   for (const row of rows) { const uuid = stringField(row, "uuid"); if (!uuid) continue; if (byId.has(uuid)) chainInvalid = true; byId.set(uuid, row); }
-  const leaf = [...rows].reverse().find((row) => row.type === "user" || row.type === "assistant" || row.type === "tool_result"); if (!leaf) return null;
+  const leaf = qwenConversationLeaf(rows); if (!leaf) return null;
   const chain: Record<string, unknown>[] = []; const visited = new Set<string>(); let current: Record<string, unknown> | undefined = leaf;
   while (current) { const uuid = stringField(current, "uuid"); if (!uuid || visited.has(uuid)) { chainInvalid = true; break; } visited.add(uuid); chain.push(current); const parentValue = unknownField(current, "parentUuid"); if (parentValue === null || parentValue === undefined || parentValue === "") { current = undefined; continue; } if (typeof parentValue !== "string") { chainInvalid = true; break; } current = byId.get(parentValue); if (!current) chainInvalid = true; }
   const activeRows = chainInvalid ? rows : chain.reverse(); const messages = sourceMessages(activeRows, "qwen");
   if (!messages.length) return null;
   const tokenEntries = new Map<string, TokenUsageEvent>();
-  for (const row of activeRows) { const usage = objectField(row, "usageMetadata"); if (!usage) continue; const cachedInputTokens = numberField(usage, "cachedContentTokenCount"); const inputTokens = Math.max(0, numberField(usage, "promptTokenCount") - cachedInputTokens); const outputTokens = numberField(usage, "candidatesTokenCount"); const reasoningOutputTokens = numberField(usage, "thoughtsTokenCount"); const dedupeKey = stringField(row, "uuid"); if (!dedupeKey) continue; putTokenEvent(tokenEntries, { timestamp: timestampMs(unknownField(row, "timestamp")), dedupeKey, inputTokens, outputTokens, cachedInputTokens, reasoningOutputTokens, totalTokens: inputTokens + outputTokens + cachedInputTokens + reasoningOutputTokens }); }
+  for (const row of activeRows) { const usage = objectField(row, "usageMetadata"); if (!usage) continue; const { inputTokens, outputTokens, cachedInputTokens, reasoningOutputTokens } = qwenTokenBuckets(usage); const dedupeKey = stringField(row, "uuid"); if (!dedupeKey) continue; putTokenEvent(tokenEntries, tokenEvent(timestampMs(unknownField(row, "timestamp")), dedupeKey, inputTokens, outputTokens, cachedInputTokens, reasoningOutputTokens)); }
   const tokenEvents = [...tokenEntries.values()];
   const rawId = path.basename(filePath, ".jsonl"); const question = cleanTitle(firstQuestion(messages));
   const titleRecord = [...rows].reverse().find((row) => row.subtype === "custom_title" && typeof objectField(row, "systemPayload")?.customTitle === "string");
   const title = stringField(objectField(titleRecord, "systemPayload"), "customTitle") || question || rawId;
   const chainTimestamp = activeRows.map((row) => timestampMs(unknownField(row, "timestamp"))).find((timestamp) => timestamp > 0) || stat.mtimeMs;
-  return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: question, timestamp: chainTimestamp, tokenUsage: tokenUsageFromEvents(tokenEvents), stat }), messages, tokenEvents, traceEvents: qwenTraces(activeRows) };
+  const gitBranch = [...activeRows].reverse().map((row) => stringField(row, "gitBranch")).find(Boolean) || null;
+  return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: question, timestamp: chainTimestamp, gitBranch, tokenUsage: tokenUsageFromEvents(tokenEvents), stat }), messages, tokenEvents, traceEvents: qwenTraces(activeRows) };
 }
 
 export function* loadQwenCodeSessionsIterator(root: string, options: SessionLoadOptions = {}): Generator<LoadedSession> {
@@ -727,8 +761,8 @@ export function* loadQwenCodeSessionsIterator(root: string, options: SessionLoad
   for (const project of projects) {
     const chats = path.join(project, "chats");
     const activeIds = new Set<string>();
-    for (const filePath of walkJsonlFiles(chats)) { if (path.relative(chats, filePath).split(/[\\/]+/u).includes("archive")) continue; activeIds.add(path.basename(filePath, ".jsonl")); const stat = safeStat(filePath); if (shouldSkipFile(options, filePath, stat)) continue; const loaded = loadQwenFile(filePath, project, stat); if (loaded) yield loaded; }
-    for (const filePath of walkJsonlFiles(path.join(chats, "archive"))) { const stat = safeStat(filePath); if (shouldSkipFile(options, filePath, stat)) continue; const loaded = loadQwenFile(filePath, project, stat); if (loaded && !activeIds.has(loaded.session.rawId)) yield loaded; }
+    for (const filePath of walkJsonlFiles(chats)) { if (path.relative(chats, filePath).split(/[\\/]+/u).includes("archive")) continue; activeIds.add(path.basename(filePath, ".jsonl")); const stat = safeStat(filePath); if (shouldSkipFile(options, filePath, stat, 0, "qwen-code")) continue; const loaded = loadQwenFile(filePath, project, stat); if (loaded) yield loaded; }
+    for (const filePath of walkJsonlFiles(path.join(chats, "archive"))) { const stat = safeStat(filePath); if (shouldSkipFile(options, filePath, stat, 0, "qwen-code")) continue; const loaded = loadQwenFile(filePath, project, stat); if (loaded && !activeIds.has(loaded.session.rawId)) yield loaded; }
   }
 }
 

--- a/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
+++ b/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
@@ -645,6 +645,80 @@ export function* loadKimiSessionsIterator(
   }
 }
 
+export const QWEN_DIR = ".qwen";
+
+function qwenRows(filePath: string): unknown[] {
+  let text = "";
+  try { text = fs.readFileSync(filePath, "utf8"); } catch { return []; }
+  const rows: unknown[] = [];
+  for (const line of text.split(/\r?\n/u)) {
+    const trimmed = line.trim(); if (!trimmed) continue;
+    const parts = trimmed.split(/\}\s*(?=\{)/u).map((part, index, all) => index < all.length - 1 ? `${part}}` : part);
+    for (const part of parts) { try { rows.push(JSON.parse(part)); } catch { /* malformed/incomplete lines are ignored */ } }
+  }
+  return rows;
+}
+
+function qwenText(row: Record<string, unknown>): string {
+  const payload = objectField(row, "systemPayload");
+  if (row.type === "user" && stringField(payload, "displayText")) return stringField(payload, "displayText");
+  const message = objectField(row, "message");
+  const parts = message?.parts;
+  if (Array.isArray(parts)) {
+    return parts
+      .map((part) => isRecord(part) && part.thought !== true ? stringField(part, "text") || stringField(part, "content") : "")
+      .filter(Boolean)
+      .join("\n");
+  }
+  return stringField(message, "text") || stringField(message, "content");
+}
+
+function qwenTraces(rows: Record<string, unknown>[]): SessionTraceEvent[] {
+  const events: TraceEventDraft[] = [];
+  for (const row of rows) {
+    const rawParts = objectField(row, "message")?.parts;
+    const parts = Array.isArray(rawParts) ? rawParts : [];
+    for (const part of parts) {
+      if (!isRecord(part)) continue;
+      const call = objectField(part, "functionCall"); const result = objectField(part, "functionResponse");
+      if (!call && !result && part.thought !== true) continue;
+      events.push({ kind: call ? "tool_call" : result ? "tool_result" : "event", source: "qwen", title: call ? `function: ${stringField(call, "name") || "call"}` : result ? `function result: ${stringField(result, "name") || "result"}` : "reasoning", detail: stringifyDetail(call || result || part), timestamp: stringField(row, "timestamp"), callId: stringField(call || result, "id") || null, eventType: call ? "qwen.functionCall" : result ? "qwen.functionResponse" : "qwen.thought", status: call ? "running" : result ? "completed" : "unknown" });
+    }
+    if (row.type === "tool_result") {
+      events.push({ kind: "tool_result", source: "qwen", title: "tool result", detail: stringifyDetail(row.toolCallResult || row.message || row), timestamp: stringField(row, "timestamp"), callId: stringField(row, "uuid") || null, eventType: "qwen.tool_result", status: "completed" });
+    }
+  }
+  return dedupeTraceEvents(events);
+}
+
+function loadQwenFile(filePath: string, projectPath: string, stat = safeStat(filePath)): LoadedSession | null {
+  const rows = qwenRows(filePath).filter(isRecord); const byId = new Map<string, Record<string, unknown>>();
+  for (const row of rows) { const uuid = stringField(row, "uuid"); if (uuid) byId.set(uuid, row); }
+  const leaf = [...byId.values()].reverse().find((row) => row.type === "user" || row.type === "assistant" || row.type === "tool_result"); if (!leaf) return null;
+  const chain: Record<string, unknown>[] = []; const visited = new Set<string>(); let current: Record<string, unknown> | undefined = leaf;
+  while (current) { const uuid = stringField(current, "uuid"); if (!uuid || visited.has(uuid)) break; visited.add(uuid); chain.push(current); const parent = stringField(current, "parentUuid"); current = parent ? byId.get(parent) : undefined; }
+  chain.reverse(); const messages: SessionMessage[] = [];
+  for (const row of chain) { if (row.type !== "user" && row.type !== "assistant") continue; const content = qwenText(row); if (!content || row.type === "user" && !isMeaningfulUserMessage(content)) continue; messages.push({ role: row.type, content, timestamp: stringField(row, "timestamp"), index: messages.length }); }
+  if (!messages.length) return null;
+  const tokenEvents: TokenUsageEvent[] = [];
+  for (const row of chain) { const usage = objectField(row, "usageMetadata"); if (!usage) continue; tokenEvents.push({ timestamp: Date.parse(stringField(row, "timestamp")) || 0, dedupeKey: stringField(row, "uuid"), inputTokens: numberField(usage, "promptTokenCount"), outputTokens: numberField(usage, "candidatesTokenCount"), cachedInputTokens: numberField(usage, "cachedContentTokenCount"), reasoningOutputTokens: numberField(usage, "thoughtsTokenCount"), totalTokens: numberField(usage, "promptTokenCount") + numberField(usage, "candidatesTokenCount") + numberField(usage, "cachedContentTokenCount") + numberField(usage, "thoughtsTokenCount") }); }
+  const rawId = path.basename(filePath, ".jsonl"); const question = cleanTitle(firstQuestion(messages));
+  const titleRecord = rows.find((row) => row.subtype === "custom_title");
+  const title = stringField(objectField(titleRecord, "systemPayload"), "customTitle") || question || rawId;
+  return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: question, timestamp: Date.parse(stringField(leaf, "timestamp")) || stat.mtimeMs, tokenUsage: tokenUsageFromEvents(tokenEvents), stat }), messages, traceEvents: qwenTraces(chain) };
+}
+
+export function* loadQwenCodeSessionsIterator(root: string, options: SessionLoadOptions = {}): Generator<LoadedSession> {
+  const projectsRoot = path.join(root, "projects"); let projects: string[] = [];
+  try { projects = fs.readdirSync(projectsRoot, { withFileTypes: true }).filter((entry) => entry.isDirectory()).map((entry) => path.join(projectsRoot, entry.name)); } catch { return; }
+  for (const project of projects) {
+    const chats = path.join(project, "chats");
+    const activeIds = new Set<string>();
+    for (const filePath of walkJsonlFiles(chats)) { if (path.relative(chats, filePath).split(/[\\/]+/u).includes("archive")) continue; const stat = safeStat(filePath); if (shouldSkipFile(options, filePath, stat)) continue; const loaded = loadQwenFile(filePath, project, stat); if (loaded) { activeIds.add(loaded.session.rawId); yield loaded; } }
+    for (const filePath of walkJsonlFiles(path.join(chats, "archive"))) { const stat = safeStat(filePath); if (shouldSkipFile(options, filePath, stat)) continue; const loaded = loadQwenFile(filePath, project, stat); if (loaded && !activeIds.has(loaded.session.rawId)) yield loaded; }
+  }
+}
+
 function loadOpenClawSessionFile(filePath: string, stat = safeStat(filePath)): LoadedSession | null {
   const rows = readJsonl(filePath);
   if (rows.length === 0) return null;

--- a/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
+++ b/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
@@ -669,10 +669,10 @@ function qwenTraces(rows: Record<string, unknown>[]): SessionTraceEvent[] {
       if (!isRecord(part)) continue;
       const call = objectField(part, "functionCall"); const result = objectField(part, "functionResponse");
       if (!call && !result && part.thought !== true) continue;
-      events.push({ kind: call ? "tool_call" : result ? "tool_result" : "event", source: "qwen", title: call ? `function: ${stringField(call, "name") || "call"}` : result ? `function result: ${stringField(result, "name") || "result"}` : "reasoning", detail: stringifyDetail(call || result || part), timestamp: stringField(row, "timestamp"), callId: stringField(call || result, "id") || null, eventType: call ? "qwen.functionCall" : result ? "qwen.functionResponse" : "qwen.thought", status: call ? "running" : result ? "completed" : "unknown" });
+      events.push({ kind: call ? "tool_call" : result ? "tool_result" : "event", source: "qwen", title: call ? `function: ${stringField(call, "name") || "call"}` : result ? `function result: ${stringField(result, "name") || "result"}` : "reasoning", detail: stringifyDetail(call || result || part), timestamp: timestampString(unknownField(row, "timestamp")), callId: stringField(call || result, "id") || null, eventType: call ? "qwen.functionCall" : result ? "qwen.functionResponse" : "qwen.thought", status: call ? "running" : result ? "completed" : "unknown" });
     }
     if (row.type === "tool_result") {
-      events.push({ kind: "tool_result", source: "qwen", title: "tool result", detail: stringifyDetail(row.toolCallResult || row.message || row), timestamp: stringField(row, "timestamp"), callId: stringField(row, "uuid") || null, eventType: "qwen.tool_result", status: "completed" });
+      events.push({ kind: "tool_result", source: "qwen", title: "tool result", detail: stringifyDetail(row.toolCallResult || row.message || row), timestamp: timestampString(unknownField(row, "timestamp")), callId: stringField(row, "uuid") || null, eventType: "qwen.tool_result", status: "completed" });
     }
   }
   return dedupeTraceEvents(events);
@@ -687,11 +687,11 @@ function loadQwenFile(filePath: string, projectPath: string, stat = safeStat(fil
   chain.reverse(); const messages = sourceMessages(chain, "qwen");
   if (!messages.length) return null;
   const tokenEvents: TokenUsageEvent[] = [];
-  for (const row of chain) { const usage = objectField(row, "usageMetadata"); if (!usage) continue; const cachedInputTokens = numberField(usage, "cachedContentTokenCount"); const inputTokens = Math.max(0, numberField(usage, "promptTokenCount") - cachedInputTokens); const outputTokens = numberField(usage, "candidatesTokenCount"); const reasoningOutputTokens = numberField(usage, "thoughtsTokenCount"); tokenEvents.push({ timestamp: Date.parse(stringField(row, "timestamp")) || 0, dedupeKey: stringField(row, "uuid"), inputTokens, outputTokens, cachedInputTokens, reasoningOutputTokens, totalTokens: inputTokens + outputTokens + cachedInputTokens + reasoningOutputTokens }); }
+  for (const row of chain) { const usage = objectField(row, "usageMetadata"); if (!usage) continue; const cachedInputTokens = numberField(usage, "cachedContentTokenCount"); const inputTokens = Math.max(0, numberField(usage, "promptTokenCount") - cachedInputTokens); const outputTokens = numberField(usage, "candidatesTokenCount"); const reasoningOutputTokens = numberField(usage, "thoughtsTokenCount"); tokenEvents.push({ timestamp: timestampMs(unknownField(row, "timestamp")), dedupeKey: stringField(row, "uuid"), inputTokens, outputTokens, cachedInputTokens, reasoningOutputTokens, totalTokens: inputTokens + outputTokens + cachedInputTokens + reasoningOutputTokens }); }
   const rawId = path.basename(filePath, ".jsonl"); const question = cleanTitle(firstQuestion(messages));
   const titleRecord = rows.find((row) => row.subtype === "custom_title");
   const title = stringField(objectField(titleRecord, "systemPayload"), "customTitle") || question || rawId;
-  const chainTimestamp = chain.map((row) => Date.parse(stringField(row, "timestamp")) || 0).find((timestamp) => timestamp > 0) || stat.mtimeMs;
+  const chainTimestamp = chain.map((row) => timestampMs(unknownField(row, "timestamp"))).find((timestamp) => timestamp > 0) || stat.mtimeMs;
   return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: question, timestamp: chainTimestamp, tokenUsage: tokenUsageFromEvents(tokenEvents), stat }), messages, tokenEvents, traceEvents: qwenTraces(chain) };
 }
 

--- a/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
+++ b/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
@@ -654,8 +654,26 @@ function qwenRows(filePath: string): unknown[] {
   for (const line of text.split(/\r?\n/u)) {
     const trimmed = line.trim(); if (!trimmed) continue;
     try { rows.push(JSON.parse(trimmed)); continue; } catch { /* a malformed or glued line may still contain valid objects */ }
-    const parts = trimmed.split(/\}\s*(?=\{)/u).map((part, index, all) => index < all.length - 1 ? `${part}}` : part);
-    for (const part of parts) { try { rows.push(JSON.parse(part)); } catch { /* malformed/incomplete lines are ignored */ } }
+    let start = -1;
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let index = 0; index < trimmed.length; index += 1) {
+      const character = trimmed[index];
+      if (start < 0) {
+        if (character === "{") { start = index; depth = 1; }
+        continue;
+      }
+      if (escaped) { escaped = false; continue; }
+      if (inString && character === "\\") { escaped = true; continue; }
+      if (character === '"') { inString = !inString; continue; }
+      if (inString) continue;
+      if (character === "{") depth += 1;
+      else if (character === "}" && --depth === 0) {
+        try { rows.push(JSON.parse(trimmed.slice(start, index + 1))); } catch { /* malformed object */ }
+        start = -1;
+      }
+    }
   }
   return rows;
 }
@@ -689,7 +707,7 @@ function loadQwenFile(filePath: string, projectPath: string, stat = safeStat(fil
   const tokenEvents: TokenUsageEvent[] = [];
   for (const row of activeRows) { const usage = objectField(row, "usageMetadata"); if (!usage) continue; const cachedInputTokens = numberField(usage, "cachedContentTokenCount"); const inputTokens = Math.max(0, numberField(usage, "promptTokenCount") - cachedInputTokens); const outputTokens = numberField(usage, "candidatesTokenCount"); const reasoningOutputTokens = numberField(usage, "thoughtsTokenCount"); tokenEvents.push({ timestamp: timestampMs(unknownField(row, "timestamp")), dedupeKey: stringField(row, "uuid"), inputTokens, outputTokens, cachedInputTokens, reasoningOutputTokens, totalTokens: inputTokens + outputTokens + cachedInputTokens + reasoningOutputTokens }); }
   const rawId = path.basename(filePath, ".jsonl"); const question = cleanTitle(firstQuestion(messages));
-  const titleRecord = rows.find((row) => row.subtype === "custom_title");
+  const titleRecord = [...rows].reverse().find((row) => row.subtype === "custom_title" && typeof objectField(row, "systemPayload")?.customTitle === "string");
   const title = stringField(objectField(titleRecord, "systemPayload"), "customTitle") || question || rawId;
   const chainTimestamp = activeRows.map((row) => timestampMs(unknownField(row, "timestamp"))).find((timestamp) => timestamp > 0) || stat.mtimeMs;
   return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: question, timestamp: chainTimestamp, tokenUsage: tokenUsageFromEvents(tokenEvents), stat }), messages, tokenEvents, traceEvents: qwenTraces(activeRows) };

--- a/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
+++ b/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
@@ -653,6 +653,7 @@ function qwenRows(filePath: string): unknown[] {
   const rows: unknown[] = [];
   for (const line of text.split(/\r?\n/u)) {
     const trimmed = line.trim(); if (!trimmed) continue;
+    try { rows.push(JSON.parse(trimmed)); continue; } catch { /* a malformed or glued line may still contain valid objects */ }
     const parts = trimmed.split(/\}\s*(?=\{)/u).map((part, index, all) => index < all.length - 1 ? `${part}}` : part);
     for (const part of parts) { try { rows.push(JSON.parse(part)); } catch { /* malformed/incomplete lines are ignored */ } }
   }
@@ -701,11 +702,12 @@ function loadQwenFile(filePath: string, projectPath: string, stat = safeStat(fil
   for (const row of chain) { if (row.type !== "user" && row.type !== "assistant") continue; const content = qwenText(row); if (!content || row.type === "user" && !isMeaningfulUserMessage(content)) continue; messages.push({ role: row.type, content, timestamp: stringField(row, "timestamp"), index: messages.length }); }
   if (!messages.length) return null;
   const tokenEvents: TokenUsageEvent[] = [];
-  for (const row of chain) { const usage = objectField(row, "usageMetadata"); if (!usage) continue; tokenEvents.push({ timestamp: Date.parse(stringField(row, "timestamp")) || 0, dedupeKey: stringField(row, "uuid"), inputTokens: numberField(usage, "promptTokenCount"), outputTokens: numberField(usage, "candidatesTokenCount"), cachedInputTokens: numberField(usage, "cachedContentTokenCount"), reasoningOutputTokens: numberField(usage, "thoughtsTokenCount"), totalTokens: numberField(usage, "promptTokenCount") + numberField(usage, "candidatesTokenCount") + numberField(usage, "cachedContentTokenCount") + numberField(usage, "thoughtsTokenCount") }); }
+  for (const row of chain) { const usage = objectField(row, "usageMetadata"); if (!usage) continue; const cachedInputTokens = numberField(usage, "cachedContentTokenCount"); const inputTokens = Math.max(0, numberField(usage, "promptTokenCount") - cachedInputTokens); const outputTokens = numberField(usage, "candidatesTokenCount"); const reasoningOutputTokens = numberField(usage, "thoughtsTokenCount"); tokenEvents.push({ timestamp: Date.parse(stringField(row, "timestamp")) || 0, dedupeKey: stringField(row, "uuid"), inputTokens, outputTokens, cachedInputTokens, reasoningOutputTokens, totalTokens: inputTokens + outputTokens + cachedInputTokens + reasoningOutputTokens }); }
   const rawId = path.basename(filePath, ".jsonl"); const question = cleanTitle(firstQuestion(messages));
   const titleRecord = rows.find((row) => row.subtype === "custom_title");
   const title = stringField(objectField(titleRecord, "systemPayload"), "customTitle") || question || rawId;
-  return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: question, timestamp: Date.parse(stringField(leaf, "timestamp")) || stat.mtimeMs, tokenUsage: tokenUsageFromEvents(tokenEvents), stat }), messages, traceEvents: qwenTraces(chain) };
+  const chainTimestamp = chain.map((row) => Date.parse(stringField(row, "timestamp")) || 0).find((timestamp) => timestamp > 0) || stat.mtimeMs;
+  return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: question, timestamp: chainTimestamp, tokenUsage: tokenUsageFromEvents(tokenEvents), stat }), messages, traceEvents: qwenTraces(chain) };
 }
 
 export function* loadQwenCodeSessionsIterator(root: string, options: SessionLoadOptions = {}): Generator<LoadedSession> {
@@ -714,7 +716,7 @@ export function* loadQwenCodeSessionsIterator(root: string, options: SessionLoad
   for (const project of projects) {
     const chats = path.join(project, "chats");
     const activeIds = new Set<string>();
-    for (const filePath of walkJsonlFiles(chats)) { if (path.relative(chats, filePath).split(/[\\/]+/u).includes("archive")) continue; const stat = safeStat(filePath); if (shouldSkipFile(options, filePath, stat)) continue; const loaded = loadQwenFile(filePath, project, stat); if (loaded) { activeIds.add(loaded.session.rawId); yield loaded; } }
+    for (const filePath of walkJsonlFiles(chats)) { if (path.relative(chats, filePath).split(/[\\/]+/u).includes("archive")) continue; activeIds.add(path.basename(filePath, ".jsonl")); const stat = safeStat(filePath); if (shouldSkipFile(options, filePath, stat)) continue; const loaded = loadQwenFile(filePath, project, stat); if (loaded) yield loaded; }
     for (const filePath of walkJsonlFiles(path.join(chats, "archive"))) { const stat = safeStat(filePath); if (shouldSkipFile(options, filePath, stat)) continue; const loaded = loadQwenFile(filePath, project, stat); if (loaded && !activeIds.has(loaded.session.rawId)) yield loaded; }
   }
 }

--- a/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
+++ b/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
@@ -679,20 +679,20 @@ function qwenTraces(rows: Record<string, unknown>[]): SessionTraceEvent[] {
 }
 
 function loadQwenFile(filePath: string, projectPath: string, stat = safeStat(filePath)): LoadedSession | null {
-  const rows = qwenRows(filePath).filter(isRecord); const byId = new Map<string, Record<string, unknown>>();
-  for (const row of rows) { const uuid = stringField(row, "uuid"); if (uuid) byId.set(uuid, row); }
-  const leaf = [...byId.values()].reverse().find((row) => row.type === "user" || row.type === "assistant" || row.type === "tool_result"); if (!leaf) return null;
+  const rows = qwenRows(filePath).filter(isRecord); const byId = new Map<string, Record<string, unknown>>(); let chainInvalid = false;
+  for (const row of rows) { const uuid = stringField(row, "uuid"); if (!uuid) continue; if (byId.has(uuid)) chainInvalid = true; byId.set(uuid, row); }
+  const leaf = [...rows].reverse().find((row) => row.type === "user" || row.type === "assistant" || row.type === "tool_result"); if (!leaf) return null;
   const chain: Record<string, unknown>[] = []; const visited = new Set<string>(); let current: Record<string, unknown> | undefined = leaf;
-  while (current) { const uuid = stringField(current, "uuid"); if (!uuid || visited.has(uuid)) break; visited.add(uuid); chain.push(current); const parent = stringField(current, "parentUuid"); current = parent ? byId.get(parent) : undefined; }
-  chain.reverse(); const messages = sourceMessages(chain, "qwen");
+  while (current) { const uuid = stringField(current, "uuid"); if (!uuid || visited.has(uuid)) { chainInvalid = true; break; } visited.add(uuid); chain.push(current); const parentValue = unknownField(current, "parentUuid"); if (parentValue === null || parentValue === undefined || parentValue === "") { current = undefined; continue; } if (typeof parentValue !== "string") { chainInvalid = true; break; } current = byId.get(parentValue); if (!current) chainInvalid = true; }
+  const activeRows = chainInvalid ? rows : chain.reverse(); const messages = sourceMessages(activeRows, "qwen");
   if (!messages.length) return null;
   const tokenEvents: TokenUsageEvent[] = [];
-  for (const row of chain) { const usage = objectField(row, "usageMetadata"); if (!usage) continue; const cachedInputTokens = numberField(usage, "cachedContentTokenCount"); const inputTokens = Math.max(0, numberField(usage, "promptTokenCount") - cachedInputTokens); const outputTokens = numberField(usage, "candidatesTokenCount"); const reasoningOutputTokens = numberField(usage, "thoughtsTokenCount"); tokenEvents.push({ timestamp: timestampMs(unknownField(row, "timestamp")), dedupeKey: stringField(row, "uuid"), inputTokens, outputTokens, cachedInputTokens, reasoningOutputTokens, totalTokens: inputTokens + outputTokens + cachedInputTokens + reasoningOutputTokens }); }
+  for (const row of activeRows) { const usage = objectField(row, "usageMetadata"); if (!usage) continue; const cachedInputTokens = numberField(usage, "cachedContentTokenCount"); const inputTokens = Math.max(0, numberField(usage, "promptTokenCount") - cachedInputTokens); const outputTokens = numberField(usage, "candidatesTokenCount"); const reasoningOutputTokens = numberField(usage, "thoughtsTokenCount"); tokenEvents.push({ timestamp: timestampMs(unknownField(row, "timestamp")), dedupeKey: stringField(row, "uuid"), inputTokens, outputTokens, cachedInputTokens, reasoningOutputTokens, totalTokens: inputTokens + outputTokens + cachedInputTokens + reasoningOutputTokens }); }
   const rawId = path.basename(filePath, ".jsonl"); const question = cleanTitle(firstQuestion(messages));
   const titleRecord = rows.find((row) => row.subtype === "custom_title");
   const title = stringField(objectField(titleRecord, "systemPayload"), "customTitle") || question || rawId;
-  const chainTimestamp = chain.map((row) => timestampMs(unknownField(row, "timestamp"))).find((timestamp) => timestamp > 0) || stat.mtimeMs;
-  return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: question, timestamp: chainTimestamp, tokenUsage: tokenUsageFromEvents(tokenEvents), stat }), messages, tokenEvents, traceEvents: qwenTraces(chain) };
+  const chainTimestamp = activeRows.map((row) => timestampMs(unknownField(row, "timestamp"))).find((timestamp) => timestamp > 0) || stat.mtimeMs;
+  return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: question, timestamp: chainTimestamp, tokenUsage: tokenUsageFromEvents(tokenEvents), stat }), messages, tokenEvents, traceEvents: qwenTraces(activeRows) };
 }
 
 export function* loadQwenCodeSessionsIterator(root: string, options: SessionLoadOptions = {}): Generator<LoadedSession> {

--- a/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
+++ b/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
@@ -678,6 +678,12 @@ function qwenRows(filePath: string): unknown[] {
   return rows;
 }
 
+function qwenToolResultCallId(row: Record<string, unknown>, parts: Record<string, unknown>[]): string | null {
+  const functionResponse = parts.map((part) => objectField(part, "functionResponse")).find(Boolean);
+  const toolCallResult = objectField(row, "toolCallResult");
+  return stringField(functionResponse, "id") || stringField(toolCallResult, "callId") || stringField(toolCallResult, "id") || stringField(row, "uuid") || null;
+}
+
 function qwenTraces(rows: Record<string, unknown>[]): SessionTraceEvent[] {
   const events: TraceEventDraft[] = [];
   for (const row of rows) {
@@ -686,11 +692,12 @@ function qwenTraces(rows: Record<string, unknown>[]): SessionTraceEvent[] {
     for (const part of parts) {
       if (!isRecord(part)) continue;
       const call = objectField(part, "functionCall"); const result = objectField(part, "functionResponse");
+      if (row.type === "tool_result" && result) continue;
       if (!call && !result && part.thought !== true) continue;
       events.push({ kind: call ? "tool_call" : result ? "tool_result" : "event", source: "qwen", title: call ? `function: ${stringField(call, "name") || "call"}` : result ? `function result: ${stringField(result, "name") || "result"}` : "reasoning", detail: stringifyDetail(call || result || part), timestamp: timestampString(unknownField(row, "timestamp")), callId: stringField(call || result, "id") || null, eventType: call ? "qwen.functionCall" : result ? "qwen.functionResponse" : "qwen.thought", status: call ? "running" : result ? "completed" : "unknown" });
     }
     if (row.type === "tool_result") {
-      events.push({ kind: "tool_result", source: "qwen", title: "tool result", detail: stringifyDetail(row.toolCallResult || row.message || row), timestamp: timestampString(unknownField(row, "timestamp")), callId: stringField(row, "uuid") || null, eventType: "qwen.tool_result", status: "completed" });
+      events.push({ kind: "tool_result", source: "qwen", title: "tool result", detail: stringifyDetail(row.toolCallResult || row.message || row), timestamp: timestampString(unknownField(row, "timestamp")), callId: qwenToolResultCallId(row, parts.filter(isRecord)), eventType: "qwen.tool_result", status: "completed" });
     }
   }
   return dedupeTraceEvents(events);
@@ -704,8 +711,9 @@ function loadQwenFile(filePath: string, projectPath: string, stat = safeStat(fil
   while (current) { const uuid = stringField(current, "uuid"); if (!uuid || visited.has(uuid)) { chainInvalid = true; break; } visited.add(uuid); chain.push(current); const parentValue = unknownField(current, "parentUuid"); if (parentValue === null || parentValue === undefined || parentValue === "") { current = undefined; continue; } if (typeof parentValue !== "string") { chainInvalid = true; break; } current = byId.get(parentValue); if (!current) chainInvalid = true; }
   const activeRows = chainInvalid ? rows : chain.reverse(); const messages = sourceMessages(activeRows, "qwen");
   if (!messages.length) return null;
-  const tokenEvents: TokenUsageEvent[] = [];
-  for (const row of activeRows) { const usage = objectField(row, "usageMetadata"); if (!usage) continue; const cachedInputTokens = numberField(usage, "cachedContentTokenCount"); const inputTokens = Math.max(0, numberField(usage, "promptTokenCount") - cachedInputTokens); const outputTokens = numberField(usage, "candidatesTokenCount"); const reasoningOutputTokens = numberField(usage, "thoughtsTokenCount"); tokenEvents.push({ timestamp: timestampMs(unknownField(row, "timestamp")), dedupeKey: stringField(row, "uuid"), inputTokens, outputTokens, cachedInputTokens, reasoningOutputTokens, totalTokens: inputTokens + outputTokens + cachedInputTokens + reasoningOutputTokens }); }
+  const tokenEntries = new Map<string, TokenUsageEvent>();
+  for (const row of activeRows) { const usage = objectField(row, "usageMetadata"); if (!usage) continue; const cachedInputTokens = numberField(usage, "cachedContentTokenCount"); const inputTokens = Math.max(0, numberField(usage, "promptTokenCount") - cachedInputTokens); const outputTokens = numberField(usage, "candidatesTokenCount"); const reasoningOutputTokens = numberField(usage, "thoughtsTokenCount"); const dedupeKey = stringField(row, "uuid"); if (!dedupeKey) continue; putTokenEvent(tokenEntries, { timestamp: timestampMs(unknownField(row, "timestamp")), dedupeKey, inputTokens, outputTokens, cachedInputTokens, reasoningOutputTokens, totalTokens: inputTokens + outputTokens + cachedInputTokens + reasoningOutputTokens }); }
+  const tokenEvents = [...tokenEntries.values()];
   const rawId = path.basename(filePath, ".jsonl"); const question = cleanTitle(firstQuestion(messages));
   const titleRecord = [...rows].reverse().find((row) => row.subtype === "custom_title" && typeof objectField(row, "systemPayload")?.customTitle === "string");
   const title = stringField(objectField(titleRecord, "systemPayload"), "customTitle") || question || rawId;

--- a/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
+++ b/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
@@ -660,20 +660,6 @@ function qwenRows(filePath: string): unknown[] {
   return rows;
 }
 
-function qwenText(row: Record<string, unknown>): string {
-  const payload = objectField(row, "systemPayload");
-  if (row.type === "user" && stringField(payload, "displayText")) return stringField(payload, "displayText");
-  const message = objectField(row, "message");
-  const parts = message?.parts;
-  if (Array.isArray(parts)) {
-    return parts
-      .map((part) => isRecord(part) && part.thought !== true ? stringField(part, "text") || stringField(part, "content") : "")
-      .filter(Boolean)
-      .join("\n");
-  }
-  return stringField(message, "text") || stringField(message, "content");
-}
-
 function qwenTraces(rows: Record<string, unknown>[]): SessionTraceEvent[] {
   const events: TraceEventDraft[] = [];
   for (const row of rows) {
@@ -698,8 +684,7 @@ function loadQwenFile(filePath: string, projectPath: string, stat = safeStat(fil
   const leaf = [...byId.values()].reverse().find((row) => row.type === "user" || row.type === "assistant" || row.type === "tool_result"); if (!leaf) return null;
   const chain: Record<string, unknown>[] = []; const visited = new Set<string>(); let current: Record<string, unknown> | undefined = leaf;
   while (current) { const uuid = stringField(current, "uuid"); if (!uuid || visited.has(uuid)) break; visited.add(uuid); chain.push(current); const parent = stringField(current, "parentUuid"); current = parent ? byId.get(parent) : undefined; }
-  chain.reverse(); const messages: SessionMessage[] = [];
-  for (const row of chain) { if (row.type !== "user" && row.type !== "assistant") continue; const content = qwenText(row); if (!content || row.type === "user" && !isMeaningfulUserMessage(content)) continue; messages.push({ role: row.type, content, timestamp: stringField(row, "timestamp"), index: messages.length }); }
+  chain.reverse(); const messages = sourceMessages(chain, "qwen");
   if (!messages.length) return null;
   const tokenEvents: TokenUsageEvent[] = [];
   for (const row of chain) { const usage = objectField(row, "usageMetadata"); if (!usage) continue; const cachedInputTokens = numberField(usage, "cachedContentTokenCount"); const inputTokens = Math.max(0, numberField(usage, "promptTokenCount") - cachedInputTokens); const outputTokens = numberField(usage, "candidatesTokenCount"); const reasoningOutputTokens = numberField(usage, "thoughtsTokenCount"); tokenEvents.push({ timestamp: Date.parse(stringField(row, "timestamp")) || 0, dedupeKey: stringField(row, "uuid"), inputTokens, outputTokens, cachedInputTokens, reasoningOutputTokens, totalTokens: inputTokens + outputTokens + cachedInputTokens + reasoningOutputTokens }); }
@@ -707,7 +692,7 @@ function loadQwenFile(filePath: string, projectPath: string, stat = safeStat(fil
   const titleRecord = rows.find((row) => row.subtype === "custom_title");
   const title = stringField(objectField(titleRecord, "systemPayload"), "customTitle") || question || rawId;
   const chainTimestamp = chain.map((row) => Date.parse(stringField(row, "timestamp")) || 0).find((timestamp) => timestamp > 0) || stat.mtimeMs;
-  return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: question, timestamp: chainTimestamp, tokenUsage: tokenUsageFromEvents(tokenEvents), stat }), messages, traceEvents: qwenTraces(chain) };
+  return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: question, timestamp: chainTimestamp, tokenUsage: tokenUsageFromEvents(tokenEvents), stat }), messages, tokenEvents, traceEvents: qwenTraces(chain) };
 }
 
 export function* loadQwenCodeSessionsIterator(root: string, options: SessionLoadOptions = {}): Generator<LoadedSession> {

--- a/apps/main-2.0/src/core/session-loaders/common.ts
+++ b/apps/main-2.0/src/core/session-loaders/common.ts
@@ -34,6 +34,7 @@ export interface SessionLoadOptions {
   includeQoder?: boolean;
   includePi?: boolean;
   includeKimiCli?: boolean;
+  includeQwenCode?: boolean;
   includeDeepSeekCli?: boolean;
   cursorStateDbPath?: string;
   cursorWorkspacePathMap?: ReadonlyMap<string, string>;
@@ -315,6 +316,7 @@ export function createIndexedSession(input: {
     | "qoder"
     | "pi"
     | "kimi"
+    | "qwen"
     | "deepseek";
   rawId: string;
   source: SessionSource;

--- a/apps/main-2.0/src/core/session-sources.test.ts
+++ b/apps/main-2.0/src/core/session-sources.test.ts
@@ -12,4 +12,13 @@ describe("StepCode session source semantics", () => {
       pendingKey: "stepcode",
     });
   });
+
+  it("keeps Qwen Code opt-in and read-only", () => {
+    expect(sessionSourceDescriptor("qwen-code")).toMatchObject({
+      label: "Qwen Code",
+      format: "qwen",
+      optionalSetting: "includeQwenCode",
+      capabilities: { live: false, resume: false, migrate: false, sessionSync: false, openApp: false },
+    });
+  });
 });

--- a/apps/main-2.0/src/core/session-sources.ts
+++ b/apps/main-2.0/src/core/session-sources.ts
@@ -16,6 +16,7 @@ export type OptionalSessionSourceSetting =
   | "includeQoder"
   | "includePi"
   | "includeKimiCli"
+  | "includeQwenCode"
   | "includeDeepSeekCli";
 
 export type SessionSourceFamily =
@@ -36,6 +37,7 @@ export type SessionSourceFamily =
   | "qoder"
   | "pi"
   | "kimi"
+  | "qwen"
   | "deepseek";
 
 export type SessionSourceUiFamily = "claude" | "codex" | "codebuddy" | "codewiz" | "zcode" | "other";
@@ -187,6 +189,12 @@ export const SESSION_SOURCE_REGISTRY = {
   "kimi-cli": {
     id: "kimi-cli", label: "Kimi Code", format: "kimi", family: "kimi", uiFamily: "other", statsGroup: null,
     optionalSetting: "includeKimiCli", pendingKey: "kimi", remoteCollectorOptional: false, liveFamily: null, migrationAgent: null,
+    resumeTarget: null, remoteFamily: null, nativeAppFamily: null,
+    capabilities: { live: false, resume: false, migrate: false, sessionSync: false, openApp: false },
+  },
+  "qwen-code": {
+    id: "qwen-code", label: "Qwen Code", format: "qwen", family: "qwen", uiFamily: "other", statsGroup: null,
+    optionalSetting: "includeQwenCode", pendingKey: "qwen", remoteCollectorOptional: false, liveFamily: null, migrationAgent: null,
     resumeTarget: null, remoteFamily: null, nativeAppFamily: null,
     capabilities: { live: false, resume: false, migrate: false, sessionSync: false, openApp: false },
   },

--- a/apps/main-2.0/src/core/session-store.ts
+++ b/apps/main-2.0/src/core/session-store.ts
@@ -5,6 +5,7 @@ import {
   isLocalSessionStorage,
   isSharedSessionSourceDatabase,
 } from "./session-environment";
+import { sessionSourceDescriptor } from "./session-sources";
 import { deleteLocalSessionSources } from "./session-source-delete";
 import { deleteZcodeSessions } from "./zcode-session-writer";
 import {
@@ -249,9 +250,8 @@ export class SessionStore {
     await this.ready;
     const target = targets.find((item) => item.sessionKey === requestedSessionKey);
     if (!target) return false;
-    if (target.source === "workbuddy-cli" || target.source === "kimi-cli") {
-      const label = target.source === "workbuddy-cli" ? "WorkBuddy" : "Kimi Code";
-      throw new Error(`${label} session source files are read-only.`);
+    if (target.source === "workbuddy-cli" || target.source === "kimi-cli" || target.source === "qwen-code") {
+      throw new Error(`${sessionSourceDescriptor(target.source).label} session source files are read-only.`);
     }
     if (!canDeleteSessionLocally(target)) {
       throw new Error("Cannot delete sessions stored on SSH remote environments.");

--- a/apps/main-2.0/src/core/trace-presentation.test.ts
+++ b/apps/main-2.0/src/core/trace-presentation.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { traceCompactionSummary } from "./trace-presentation";
+import { traceCompactionSummary, tracePresentation } from "./trace-presentation";
+
+describe("tracePresentation", () => {
+  it("classifies Qwen thoughts as reasoning", () => {
+    expect(tracePresentation({ kind: "event", eventType: "qwen.thought" })).toEqual({
+      category: "reasoning",
+      visibility: "timeline",
+    });
+  });
+});
 
 describe("traceCompactionSummary", () => {
   it("returns displayable compact statistics", () => {

--- a/apps/main-2.0/src/core/trace-presentation.ts
+++ b/apps/main-2.0/src/core/trace-presentation.ts
@@ -38,7 +38,7 @@ export function tracePresentation(
   ) {
     return { category: "lifecycle", visibility: "turn_summary" };
   }
-  if (eventType === "codex.reasoning_summary" || eventType === "agent_reasoning") {
+  if (eventType === "codex.reasoning_summary" || eventType === "agent_reasoning" || eventType === "qwen.thought") {
     return { category: "reasoning", visibility: "timeline" };
   }
   if (

--- a/apps/main-2.0/src/core/types.ts
+++ b/apps/main-2.0/src/core/types.ts
@@ -19,8 +19,9 @@ export type SessionSource =
   | "qoder"
   | "pi-cli"
   | "deepseek-cli"
-  | "kimi-cli";
-export type SessionFormat = "claude" | "codex" | "codebuddy" | "workbuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder" | "pi" | "deepseek" | "kimi";
+  | "kimi-cli"
+  | "qwen-code";
+export type SessionFormat = "claude" | "codex" | "codebuddy" | "workbuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder" | "pi" | "deepseek" | "kimi" | "qwen";
 export type SessionSortBy = "smart" | "activity" | "created";
 export type EnvironmentKind = "local" | "wsl" | "ssh";
 export type EnvironmentSyncState = "idle" | "syncing" | "watching" | "disconnected" | "error";

--- a/apps/main-2.0/src/main/index.ts
+++ b/apps/main-2.0/src/main/index.ts
@@ -1781,6 +1781,7 @@ function runIndexSync(): Promise<IndexStatus> {
         includeZcode: settings.includeZcode,
         includePi: settings.includePi,
         includeKimiCli: settings.includeKimiCli,
+        includeQwenCode: settings.includeQwenCode,
         includeCursorAgent: settings.includeCursorAgent,
         includeTrae: settings.includeTrae,
         includeQoder: settings.includeQoder,

--- a/apps/main-2.0/src/main/services/session-bulk-delete-service.test.ts
+++ b/apps/main-2.0/src/main/services/session-bulk-delete-service.test.ts
@@ -54,6 +54,7 @@ describe("SessionBulkDeleteService", () => {
       target("pi", { source: "pi-cli" }),
       target("workbuddy", { source: "workbuddy-cli", filePath: "/fixtures/workbuddy.jsonl", sourceAvailable: true }),
       target("kimi", { source: "kimi-cli", filePath: "/fixtures/kimi/context.jsonl", sourceAvailable: true }),
+      target("qwen", { source: "qwen-code", filePath: "/fixtures/qwen/session.jsonl", sourceAvailable: true }),
       target("hermes", { source: "hermes" as SessionSource }),
       target("opencode", { source: "opencode-cli" }),
       target("codewiz", { source: "codewiz-cli" }),
@@ -66,7 +67,7 @@ describe("SessionBulkDeleteService", () => {
     });
     expect(preview.deletableCount).toBe(2);
     expect(preview.skipped.map((item) => item.reason)).toEqual([
-      "live", "favorite", "recent", "read-only", "read-only",
+      "live", "favorite", "recent", "read-only", "read-only", "read-only",
       "shared-database", "shared-database", "shared-database", "shared-database", "not-found",
     ]);
     expect(store.getSessionDeletionTargets).toHaveBeenCalledTimes(1);

--- a/apps/main-2.0/src/main/services/session-bulk-delete-service.ts
+++ b/apps/main-2.0/src/main/services/session-bulk-delete-service.ts
@@ -286,9 +286,8 @@ function classifyTarget(
   if (request.inactiveBefore !== undefined && target.lastActivityAt >= request.inactiveBefore) {
     return issueFor(target.sessionKey, "recent", "Session is not older than the selected cutoff.");
   }
-  if (target.source === "workbuddy-cli" || target.source === "kimi-cli") {
-    const label = target.source === "workbuddy-cli" ? "WorkBuddy" : "Kimi Code";
-    return issueFor(target.sessionKey, "read-only", `${label} session source files are read-only.`);
+  if (target.source === "workbuddy-cli" || target.source === "kimi-cli" || target.source === "qwen-code") {
+    return issueFor(target.sessionKey, "read-only", `${sessionSourceDescriptor(target.source).label} session source files are read-only.`);
   }
   if (SHARED_DATABASE_SOURCES.has(target.source)) return issueFor(target.sessionKey, "shared-database", "This source stores multiple sessions in a shared database.");
   if (target.source === "cursor-agent" && /(^|[\\/])state\.vscdb$/iu.test(target.filePath) && target.sourceAvailable) {

--- a/apps/main-2.0/src/main/services/session-catalog-service.ts
+++ b/apps/main-2.0/src/main/services/session-catalog-service.ts
@@ -201,8 +201,8 @@ export class SessionCatalogService {
   async delete(sessionKey: string, options?: unknown): Promise<boolean> {
     const normalizedOptions = normalizeSessionDeleteOptions(options);
     const session = await this.dependencies.store.getSession(sessionKey);
-    if (session?.source === "workbuddy-cli" || session?.source === "kimi-cli") {
-      const label = session.source === "workbuddy-cli" ? "WorkBuddy" : "Kimi Code";
+    if (session?.source === "workbuddy-cli" || session?.source === "kimi-cli" || session?.source === "qwen-code") {
+      const label = session.source === "workbuddy-cli" ? "WorkBuddy" : session.source === "kimi-cli" ? "Kimi Code" : "Qwen Code";
       throw new Error(`${label} session source files are read-only.`);
     }
     if (session && !canDeleteSessionLocally(session)) {

--- a/apps/main-2.0/src/main/services/v1-session-import-service.ts
+++ b/apps/main-2.0/src/main/services/v1-session-import-service.ts
@@ -43,6 +43,7 @@ const V1_SETTINGS_KEYS = [
   "includeQoder",
   "includePi",
   "includeKimiCli",
+  "includeQwenCode",
   "summaryAutoBackfill",
   "summaryMaxAgeDays",
   "compressionConcurrency",
@@ -68,7 +69,7 @@ const V1_SETTINGS_KEYS = [
 const SESSION_SOURCES = new Set<SessionSource>([
   "claude-cli", "claude-app", "codex-cli", "codex-app", "tclaude-cli", "tcodex-cli",
   "codebuddy-cli", "workbuddy-cli", "codewiz-cli", "openclaw", "hermes", "opencode-cli", "zcode-cli",
-  "cursor-agent", "trae", "qoder", "pi-cli", "kimi-cli", "deepseek-cli",
+  "cursor-agent", "trae", "qoder", "pi-cli", "kimi-cli", "qwen-code", "deepseek-cli",
 ]);
 
 interface V1SessionRow {

--- a/apps/main-2.0/src/renderer/src/features/settings/settings-dialog.tsx
+++ b/apps/main-2.0/src/renderer/src/features/settings/settings-dialog.tsx
@@ -580,6 +580,10 @@ export function SettingsDialog({
                   <input type="checkbox" className="switch" checked={Boolean(settings?.includeKimiCli)} disabled={!settings} onChange={(event) => onSettingsChange({ includeKimiCli: event.currentTarget.checked })} />
                 </label>
                 <label className="settings-field settings-toggle">
+                  <div className="settings-field-text"><span className="settings-field-title">Include Qwen Code</span><span className="settings-field-sub">{l("Indexes local Qwen Code sessions read-only.", "以只读方式索引本地千问 Code 会话。")}</span></div>
+                  <input type="checkbox" className="switch" checked={Boolean(settings?.includeQwenCode)} disabled={!settings} onChange={(event) => onSettingsChange({ includeQwenCode: event.currentTarget.checked })} />
+                </label>
+                <label className="settings-field settings-toggle">
                   <div className="settings-field-text">
                     <span className="settings-field-title">Include CodeWiz</span>
                     <span className="settings-field-sub">{l("Indexes CodeWiz sessions from ~/.local/share/codewiz.", "索引 ~/.local/share/codewiz 中的 CodeWiz 会话。")}</span>


### PR DESCRIPTION
## 变更概述

- 新增 Qwen Code 本地会话来源，支持 V1 和 V2。
- 按 Qwen Code 当前 JSONL transcript 结构索引 active 与 archive 会话，并使用 parentUuid 重建当前活动链。
- 支持 QWEN_RUNTIME_DIR、QWEN_HOME 与默认 ~/.qwen 的目录解析优先级。
- 提取用户可见文本、助手回答、思考与工具轨迹、Token 用量和自定义标题。
- 对损坏行、粘连 JSON 对象和截断尾部采取容错读取。
- Qwen Code 原始会话保持只读，不提供删除、恢复、迁移或子代理独立索引。

Closes #475

## 更新说明检查

- [x] 本分支已新增且仅新增一个 `.release-notes/<branch-slug>.md`
- [x] 更新说明已在标题后显式声明 `release-target: both`，并覆盖 V1/V2
- [x] 更新说明包含面向用户的“新增功能”列表
- [x] 更新说明已移除 MR、分支、CI、发布流程、内部服务、路径及其他不应暴露的实现或敏感信息
- [x] 已运行 release note 检查（使用 `upstream/main` 作为正确基线）

## 验证

- `npm --prefix apps/main-1.0 run typecheck`
- `npm --prefix apps/main-2.0 run typecheck`
- V1 Qwen loader 与 format adapter 聚焦测试：21 项通过
- V2 Qwen loader 与 format adapter 聚焦测试：9 项通过
- V1 来源注册、环境、存储和批量删除相关回归：通过
- V2 来源注册、环境、存储、catalog 和批量删除相关回归：通过
- `node scripts/release-notes.mjs check-range upstream/main HEAD`
- `git diff --check upstream/main...HEAD`

备注：仓库默认 `npm run release-note:check` 使用陈旧的 fork `origin/main`，会把上游已有的 124 条 release note 误计入当前范围；显式使用 PR 目标 `upstream/main` 后检查通过。