### PR TITLE
fix(v2): prevent duplicate Codex MCP config

### DIFF
--- a/.release-notes/fix-codex-mcp-config-rewrite.md
+++ b/.release-notes/fix-codex-mcp-config-rewrite.md
@@ -1,0 +1,7 @@
+# 修复 Codex MCP 配置重复
+
+<!-- release-target: v2 -->
+
+## Bug 修复
+
+- 修复重复连接 AgentRecall Gateway 后 Codex 配置无法加载的问题。

--- a/apps/main-2.0/bin/setup-mcp.cjs
+++ b/apps/main-2.0/bin/setup-mcp.cjs
@@ -310,15 +310,16 @@ function removeCodexBlock(toml) {
   const out = [];
   let skipping = false;
   for (const line of lines) {
-    if (line.trim() === `[${CODEX_SECTION}]` || line.trim() === `[${LEGACY_CODEX_SECTION}]`) {
-      skipping = true;
-      continue;
+    const tableHeader = line.trim().match(/^(?:\[([^\[\]]+)\]|\[\[([^\[\]]+)\]\])\s*(?:#.*)?$/);
+    if (tableHeader) {
+      const section = tableHeader[1] || tableHeader[2];
+      skipping = section === CODEX_SECTION
+        || section.startsWith(`${CODEX_SECTION}.`)
+        || section === LEGACY_CODEX_SECTION
+        || section.startsWith(`${LEGACY_CODEX_SECTION}.`);
+      if (skipping) continue;
     }
-    if (skipping) {
-      // Stop skipping at the next table header.
-      if (/^\s*\[/.test(line)) skipping = false;
-      else continue;
-    }
+    if (skipping) continue;
     out.push(line);
   }
   return out.join("\n");

--- a/apps/main-2.0/src/core/setup-mcp.test.ts
+++ b/apps/main-2.0/src/core/setup-mcp.test.ts
@@ -104,6 +104,32 @@ describe("setup-mcp Codex config", () => {
     expect(next).toContain('args = ["/abs/gateway.js"]');
   });
 
+  it("replaces nested AgentRecall tables without touching similarly named servers", () => {
+    const current = [
+      "[mcp_servers.agent_recall.env]",
+      'AGENT_RECALL_MCP_BRIDGE = "/old/bridge.json"',
+      "",
+      "[mcp_servers.agent_recall.tools.search_sessions]",
+      'approval_mode = "approve"',
+      "",
+      "[mcp_servers.agent_recall_v2.env]",
+      'AGENT_RECALL_MCP_BRIDGE = "/legacy/bridge.json"',
+      "",
+      "[mcp_servers.agent_recall_extra]",
+      'command = "keep-me"',
+    ].join("\n");
+
+    const next = applyCodexConfig(current, "/abs/gateway.js", false, "node", "/new/bridge.json");
+
+    expect(next).not.toContain("[mcp_servers.agent_recall.env]");
+    expect(next).not.toContain("[mcp_servers.agent_recall.tools.search_sessions]");
+    expect(next).not.toContain("[mcp_servers.agent_recall_v2.env]");
+    expect(next).toContain("[mcp_servers.agent_recall_extra]");
+    expect(next).toContain('command = "keep-me"');
+    expect(next.match(/\[mcp_servers\.agent_recall\]/g)).toHaveLength(1);
+    expect(next).toContain('env = { AGENT_RECALL_MCP_BRIDGE = "/new/bridge.json" }');
+  });
+
   it("pins the Gateway to the current AgentRecall bridge", () => {
     const next = applyCodexConfig("", "/abs/gateway.js", false, "node", "/data/automation-mcp-bridge.json");
     expect(next).toContain('env = { AGENT_RECALL_MCP_BRIDGE = "/data/automation-mcp-bridge.json" }');


### PR DESCRIPTION
## Summary

- remove the complete AgentRecall Codex MCP table subtree before rewriting it
- clean up legacy nested Gateway tables while preserving similarly named servers
- add regression coverage for nested TOML tables

## Validation

- `npm exec vitest run src/core/setup-mcp.test.ts`
- `npm run typecheck` (V2)
- `npm run release-note:check`
- `git diff --check`
- `codex mcp list`