### PR TITLE
feat(v2): add bundled DSH quality skills

### DIFF
--- a/.release-notes/add-dsh-quality-skills.md
+++ b/.release-notes/add-dsh-quality-skills.md
@@ -1,0 +1,8 @@
+# 新增四个代码质量 Skill
+
+<!-- release-target: v2 -->
+
+## 新增功能
+
+- 本 App Skill 新增代码审查、简化机会分析、技术文案规范和推理过程残留清理四个 DeepSeek Harness Skill。
+- Skill 库新增编程、写作、效率、探索和生活分类，可按分类筛选；无法判断类别的导入 Skill 会保留在未分类。

--- a/apps/main-2.0/assets/bundled-skills/dsh-code-review/LICENSE
+++ b/apps/main-2.0/assets/bundled-skills/dsh-code-review/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 DeepSeek
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/main-2.0/assets/bundled-skills/dsh-code-review/SKILL.md
+++ b/apps/main-2.0/assets/bundled-skills/dsh-code-review/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: dsh-code-review
+description: Review a branch or pull request for correctness, lifecycle, security, compatibility, and missing behavior using the target repository's own instructions and live base/head rather than DeepSeek Harness-specific commands.
+---
+
+# Code Review
+
+Produce a findings-first review grounded in the live diff, surrounding implementation, current consumers, and the target repository's rules. Prefer one substantiated blocker over many speculative nits.
+
+## Orient the review
+
+1. Read the applicable `AGENTS.md` files and owning subsystem documentation.
+2. Verify the live base and exact head. Refresh them after a retarget, merge, or new commit.
+3. Inspect the diff, then read enough unchanged code, tests, call sites, and entrypoints to understand behavior and ownership.
+4. Identify which checks ran, but do not treat green automation as semantic proof.
+
+## Review priorities
+
+- **Correctness and contracts:** trace both sides of changed interfaces, including errors, cancellation, ordering, durability, and compatibility.
+- **Lifecycle and concurrency:** verify ownership and deterministic cleanup for timers, listeners, subprocesses, watchers, leases, callbacks, and temporary resources.
+- **Security and enforcement:** follow permissions and validation to the operation that performs the action; check alternate callers and renderer/main or client/server boundaries.
+- **Consumer fit:** challenge new public APIs, options, abstractions, compatibility paths, and duplicated state without current consumers.
+- **Untrusted data:** validate files, durable records, IPC, network, subprocess, model/tool JSON, and user input at their real boundaries without duplicating same-process type checks.
+- **Bounds:** apply limits to the complete retained or emitted value, including wrappers, metadata, multibyte input, and oversized single items.
+- **Tests:** require observable behavior through the shipped entry path and a negative control that would fail for the intended regression.
+- **Documentation and prose:** verify current behavior, defaults, configuration, failures, and limitations. Remove review history and implementation narration from durable surfaces.
+- **Packaging and platforms:** check generated assets, install/update paths, browser safety, and Windows/macOS differences when the diff crosses those surfaces.
+
+## Reporting
+
+Each finding states the defect, tightest location, impact, trigger, and evidence. Use the repository's priority convention when one exists. Separate blockers from suggestions, omit issues already fully enforced by a required green gate, and say explicitly when no actionable findings remain.
+
+Review-only requests do not authorize fixes, pushes, comments, or merges. When receiving a review comment, verify the claim against code and behavior before accepting or rebutting it.

--- a/apps/main-2.0/assets/bundled-skills/dsh-find-simplifications/LICENSE
+++ b/apps/main-2.0/assets/bundled-skills/dsh-find-simplifications/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 DeepSeek
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/main-2.0/assets/bundled-skills/dsh-find-simplifications/SKILL.md
+++ b/apps/main-2.0/assets/bundled-skills/dsh-find-simplifications/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: dsh-find-simplifications
+description: Find evidence-backed opportunities to remove dead, duplicated, speculative, over-built, or hand-rolled code without treating complexity, tests, or unused-looking symbols as proof by themselves.
+---
+
+# Find Simplifications
+
+Turn a broad cleanup request into a small set of well-supported changes or proposals that reduce owned code, APIs, states, and maintenance obligations while preserving current product behavior.
+
+## Establish context
+
+Read the applicable repository instructions, architecture documentation, tests, and durable design records before judging a subsystem. Identify intentional seams, supported variants, compatibility promises, generated surfaces, and user-visible behavior that must remain.
+
+Tests and design records are evidence, not unquestionable truth. A test that only protects unused behavior may be removed with that behavior; a recorded compatibility or data-format obligation requires stronger evidence before changing it.
+
+## Strong candidates
+
+- A public method, event, option, helper, package, or durable field has no production consumer.
+- Tests or documentation are the only consumers and do not protect a current obligation.
+- Multiple representations or state flags mirror the same authoritative fact.
+- An abstraction exists for one caller without isolating a meaningful lifecycle, safety, transaction, or ownership decision.
+- Compatibility, retry, rollback, or defensive machinery protects a scenario the product does not support.
+- A maintained dependency or platform builtin would remove substantial implementation and dedicated tests with little glue remaining.
+- A feature implements speculative generality without a current product owner or execution path.
+
+Complex code, a large file, one unused-looking symbol, or a tool report alone is not sufficient evidence.
+
+## Prove or reject a candidate
+
+1. Search exact symbols, strings, configuration keys, dynamic registrations, loaders, subprocess entries, and package exports.
+2. Classify consumers as production, test/documentation, generated, or ambiguous; inspect ambiguous examples and scripts before deciding.
+3. Trace both sides of changed interfaces and identify the user-visible behavior, durable data, lifecycle owner, and failure semantics.
+4. For asynchronous code, map timers, listeners, processes, leases, abort signals, readiness promises, and cleanup paths to distinct owners and transitions.
+5. For validators and defensive copies, identify where data becomes untrusted or crosses a real process, persistence, network, model, or user-input boundary.
+6. Reject the candidate when a current production caller exists and removal would be a feature decision rather than cleanup.
+7. Compare net deletion against replacement glue, migrations, documentation churn, and new failure modes.
+
+Use static-analysis tools as discovery aids, never as substitutes for call-site and entrypoint tracing.
+
+## Output and implementation
+
+For each accepted candidate, state:
+
+- the exact surface and owner;
+- production-consumer evidence;
+- what will be deleted, folded, or made private;
+- behavior and compatibility that remain;
+- risks and the smallest checks that prove the result.
+
+Review requests report candidates without editing. Change requests implement only well-proven candidates in the lowest owning area, update obsolete tests and documentation, and avoid unrelated formatting or cleanup. Prefer a few meaningful simplifications over a long list of speculative suggestions.

--- a/apps/main-2.0/assets/bundled-skills/dsh-prose-standard/LICENSE
+++ b/apps/main-2.0/assets/bundled-skills/dsh-prose-standard/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 DeepSeek
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/main-2.0/assets/bundled-skills/dsh-prose-standard/SKILL.md
+++ b/apps/main-2.0/assets/bundled-skills/dsh-prose-standard/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: dsh-prose-standard
+description: Write, review, or trim technical prose in Markdown, JSDoc, comments, prompts, diagnostics, and visible strings while preserving complete contracts and removing repetition or authoring-session narration.
+---
+
+# Technical Prose Standard
+
+Write enough to preserve the behavior a reader relies on, then remove repetition, decoration, and reasoning transcripts. A contract is an obligation, invariant, precondition, postcondition, compatibility promise, ownership rule, timing point, or failure behavior.
+
+Prefer the exact subject over vague technical nouns. Use terms such as contract, boundary, shape, surface, seam, or gate only when they name the actual caller obligation, process/security boundary, field set, component split, or enforced check.
+
+## Scope and authority
+
+Require a concrete file, directory, document, diff, or other bounded scope before a prose-wide audit. Read applicable repository instructions and owning code first. Review requests report findings; rewrite or cleanup requests may edit within the authorized scope.
+
+Honor repository exclusions. Treat vendored code, generated catalogs, snapshots, fixtures, and frozen historical records as derivative or immutable: update their owner or generator instead of casually rewriting them.
+
+## Preserve the complete proposition
+
+Before editing a passage, identify every relevant:
+
+- actor and action;
+- condition, timing, and ordering;
+- requirement, permission, or prohibition;
+- negative guarantee and exception;
+- ownership, side effect, failure mode, and consequence.
+
+Remove words only when those facts survive more clearly. Keep non-obvious rationale when omitting it could cause misuse or a tempting but incorrect simplification. Put extended architecture, history, and examples in one owning document and link to it; repeat only the local facts required for safe use.
+
+## Coverage by location
+
+- **Public JSDoc:** returns, errors, side effects, ownership, timing, cancellation, and durability that callers cannot infer from types.
+- **Internal comments:** non-local invariants, race ordering, security decisions, ownership, and surprising failures; never obvious control flow.
+- **Module documentation:** the module's role, dependencies, responsibilities, and non-obvious placement.
+- **Tests:** only why a fixture, platform exception, real entry path, or indirect observation is necessary.
+- **Guides and READMEs:** prerequisites, real entry paths, current configuration and defaults, observable verification, failures, limits, and extension points.
+- **Design records and postmortems:** durable rationale, alternatives, consequences, evidence, causal sequence, and prevention rather than implementation walkthroughs.
+- **Skills and agent instructions:** discriminating trigger conditions, scope limits, decision rules, and necessary workflow without generic capability tutorials.
+- **Prompts and visible strings:** wording is behavior; verify generated output, snapshots, and user next actions.
+- **Diagnostics:** identify the failing subject, violated rule, and corrective action without exposing internal stacks by default.
+
+## Workflow
+
+1. Confirm scope, task type, current revision, and applicable instructions.
+2. Read the owning behavior before judging its prose.
+3. Classify candidates as keep, add, trim, restore, restructure, or defer.
+4. Update authoritative prose before translations, catalogs, snapshots, or generated copies.
+5. Apply clear changes only when authorized; do not manufacture edits to meet a deletion target.
+6. Run the narrow documentation, formatting, generation, snapshot, or behavior checks for touched surfaces.
+7. Report inspected scope, changes, deliberate keeps, unresolved ambiguities, and checks actually run.

--- a/apps/main-2.0/assets/bundled-skills/dsh-trim-cot-leakage/LICENSE
+++ b/apps/main-2.0/assets/bundled-skills/dsh-trim-cot-leakage/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 DeepSeek
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/main-2.0/assets/bundled-skills/dsh-trim-cot-leakage/SKILL.md
+++ b/apps/main-2.0/assets/bundled-skills/dsh-trim-cot-leakage/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: dsh-trim-cot-leakage
+description: Audit or rewrite repository prose that exposes authoring-session reasoning, review history, dead draft references, change narration, or unsupported planning residue while preserving every durable technical fact.
+---
+
+# Trim Chain-of-Thought Leakage
+
+Rewrite prose from the repository's present-tense perspective. Preserve facts that maintainers need; remove the transcript of how those facts were discovered, debated, or reviewed.
+
+## Decision test
+
+For every suspect passage, ask whether a reader at the current revision can resolve every reference and verify every claim without access to a chat transcript, review thread, or uncommitted draft.
+
+- If not, restate the durable facts using committed code, documentation, issues, or stable external references.
+- If the passage contains no durable fact, remove it.
+- If the task is review-only, report the passage and proposed rewrite without editing.
+
+Shorter text is not automatically better. Preserve the actor, behavior, conditions, timing, ownership, failure mode, exceptions, modality, and consequences that remain true.
+
+## Common leakage
+
+- Draft-only citations such as `decision 7`, `audit C2`, phase labels, or sections of an uncommitted plan.
+- PR or stack narration such as “this PR adds,” “a later change will,” or “the previous commit.”
+- Change narration such as “used to,” “no longer,” “the old implementation,” or “this cut.”
+- Review choreography such as “rejected in review” or “the reviewer confirmed.”
+- Comments that argue correctness instead of naming the invariant that makes the code safe.
+- Control-flow walkthroughs, obvious derivations, and test narration that repeat the implementation.
+- Hedges such as “probably fine for now” or unowned deferrals without a tracked issue or TODO.
+- Working-language fragments that do not match the surrounding document.
+
+## Keep these
+
+- Issue references and owned TODO/FIXME markers that resolve from the repository.
+- Required suppression, coverage-ignore, and best-effort error-handling justifications.
+- Present-tense counterfactuals that pin regressions, such as “without this guard, cancellation publishes stale state.”
+- Measured bounds whose provenance explains a chosen limit.
+- Runtime lifecycle wording such as an old connection draining before a replacement accepts work.
+- External standards and committed documents with stable section identifiers.
+- Incident timelines and design history in the repository surface that explicitly owns that history.
+
+## Workflow
+
+1. Confirm the requested scope and read the applicable repository instructions.
+2. Exclude generated output, vendored code, snapshots, fixtures, and frozen historical records unless the user explicitly includes them. Fix their owning source instead.
+3. Search for likely patterns, then read the densest prose semantically; pattern matches are probes, not findings.
+4. Enumerate every factual proposition before rewriting. Keep the proposition and remove only its session-specific framing.
+5. Update paired translations and generated derivatives through their owning workflow when applicable.
+6. Run the narrow documentation, formatting, or behavior checks for the touched surfaces and verify that remaining citations resolve.

--- a/apps/main-2.0/src/core/managed-skill-library.test.ts
+++ b/apps/main-2.0/src/core/managed-skill-library.test.ts
@@ -127,6 +127,7 @@ describe("AgentRecall bundled Skills", () => {
       id: "aihot",
       installId: "aihot",
       sourceUrl: "https://github.com/KKKKhazix/khazix-skills/tree/main/aihot",
+      categoryId: "explore",
     });
     expect(
       fs.existsSync(fileURLToPath(new URL("../../assets/bundled-skills/aihot/SKILL.md", import.meta.url))),
@@ -138,12 +139,34 @@ describe("AgentRecall bundled Skills", () => {
       id: "resume-optimization",
       installId: "resume-optimization",
       sourceUrl: "https://github.com/melodic-software/claude-code-plugins/tree/main/plugins/soft-skills/skills/resume-optimization",
+      categoryId: "writing",
     });
     const bundledSkillUrl = new URL("../../assets/bundled-skills/resume-optimization/", import.meta.url);
     expect(fs.existsSync(fileURLToPath(new URL("SKILL.md", bundledSkillUrl)))).toBe(true);
     expect(fs.existsSync(fileURLToPath(new URL("SKILL.zh.md", bundledSkillUrl)))).toBe(true);
     expect(fs.existsSync(fileURLToPath(new URL("metadata.json", bundledSkillUrl)))).toBe(true);
     expect(fs.existsSync(fileURLToPath(new URL("LICENSE", bundledSkillUrl)))).toBe(true);
+  });
+
+  it("ships the adapted DeepSeek Harness quality Skills with their licenses", () => {
+    const skills = [
+      { id: "dsh-code-review", categoryId: "coding" },
+      { id: "dsh-find-simplifications", categoryId: "coding" },
+      { id: "dsh-prose-standard", categoryId: "writing" },
+      { id: "dsh-trim-cot-leakage", categoryId: "writing" },
+    ];
+
+    for (const { id, categoryId } of skills) {
+      expect(AGENT_RECALL_BUILTIN_SKILLS).toContainEqual({
+        id,
+        installId: id,
+        sourceUrl: `https://github.com/deepseek-ai/deepseek-harness/tree/master/.agents/skills/${id}`,
+        categoryId,
+      });
+      const bundledSkillUrl = new URL(`../../assets/bundled-skills/${id}/`, import.meta.url);
+      expect(fs.existsSync(fileURLToPath(new URL("SKILL.md", bundledSkillUrl)))).toBe(true);
+      expect(fs.existsSync(fileURLToPath(new URL("LICENSE", bundledSkillUrl)))).toBe(true);
+    }
   });
 
   it("imports aihot into a fresh managed library with built-in origin metadata", () => {
@@ -167,6 +190,38 @@ describe("AgentRecall bundled Skills", () => {
       label: "AgentRecall",
       url: "https://github.com/melodic-software/claude-code-plugins/tree/main/plugins/soft-skills/skills/resume-optimization",
     });
+    expect(library.list().skills.find((skill) => skill.managedId === "dsh-trim-cot-leakage")?.origin).toEqual({
+      kind: "builtin",
+      label: "AgentRecall",
+      url: "https://github.com/deepseek-ai/deepseek-harness/tree/master/.agents/skills/dsh-trim-cot-leakage",
+    });
+    expect(library.list().skills.find((skill) => skill.managedId === "aihot")?.categoryId).toBe("explore");
+    expect(library.list().skills.find((skill) => skill.managedId === "resume-optimization")?.categoryId).toBe("writing");
+    expect(library.list().skills.find((skill) => skill.managedId === "dsh-code-review")?.categoryId).toBe("coding");
+    expect(library.list().skills.find((skill) => skill.managedId === "dsh-trim-cot-leakage")?.categoryId).toBe("writing");
+  });
+
+  it("adds the current category to existing built-in metadata without re-importing the Skill", () => {
+    const fixtureRoot = fs.mkdtempSync(path.join(tmpdir(), "agent-recall-builtin-category-"));
+    temporaryDirectories.push(fixtureRoot);
+    const libraryRoot = path.join(fixtureRoot, "skills");
+    const library = new ManagedSkillLibrary({
+      libraryRoot,
+      homeDir: path.join(fixtureRoot, "home"),
+    });
+    const bundledRoot = fileURLToPath(new URL("../../assets/bundled-skills", import.meta.url));
+
+    library.ensureBuiltinSkills(bundledRoot);
+    const metadataPath = path.join(libraryRoot, ".metadata", "aihot.json");
+    const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8")) as Record<string, unknown>;
+    const importedAt = metadata.importedAt;
+    delete metadata.categoryId;
+    fs.writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, "utf8");
+
+    library.ensureBuiltinSkills(bundledRoot);
+
+    expect(library.list().skills.find((skill) => skill.managedId === "aihot")?.categoryId).toBe("explore");
+    expect((JSON.parse(fs.readFileSync(metadataPath, "utf8")) as Record<string, unknown>).importedAt).toBe(importedAt);
   });
 
   it("installs a managed Skill into the shared Codex agents directory", () => {

--- a/apps/main-2.0/src/core/managed-skill-library.ts
+++ b/apps/main-2.0/src/core/managed-skill-library.ts
@@ -10,6 +10,7 @@ import {
 } from "./skill-manager";
 import { AGENT_SKILL_REGISTRY, SKILL_INSTALL_TARGETS, type SkillInstallTarget } from "./agent-skill-registry";
 import { agentInstallTargetDir } from "./agent-skill-paths";
+import { isSkillCategoryId, type SkillCategoryId } from "./skill-categories";
 
 export type { SkillInstallTarget } from "./agent-skill-registry";
 export type ManagedSkillOriginKind = "local" | "skills-sh" | "remote" | "builtin";
@@ -33,6 +34,7 @@ export interface ManagedSkill extends InstalledSkill {
   source: "agent-recall-v2";
   managedId: string;
   origin: ManagedSkillOrigin;
+  categoryId: SkillCategoryId | null;
   installations: ManagedSkillInstallation[];
 }
 
@@ -67,6 +69,7 @@ interface ManagedSkillMetadata {
   managedId: string;
   importedAt: string;
   origin: ManagedSkillOrigin;
+  categoryId: SkillCategoryId | null;
 }
 
 export interface AgentRecallBuiltinSkillDefinition {
@@ -75,6 +78,7 @@ export interface AgentRecallBuiltinSkillDefinition {
   /** Managed library directory name after import. */
   installId: string;
   sourceUrl: string;
+  categoryId: SkillCategoryId;
 }
 
 export const AGENT_RECALL_BUILTIN_SKILLS: AgentRecallBuiltinSkillDefinition[] = [
@@ -82,36 +86,67 @@ export const AGENT_RECALL_BUILTIN_SKILLS: AgentRecallBuiltinSkillDefinition[] = 
     id: "aihot",
     installId: "aihot",
     sourceUrl: "https://github.com/KKKKhazix/khazix-skills/tree/main/aihot",
+    categoryId: "explore",
   },
   {
     id: "resume-optimization",
     installId: "resume-optimization",
     sourceUrl: "https://github.com/melodic-software/claude-code-plugins/tree/main/plugins/soft-skills/skills/resume-optimization",
+    categoryId: "writing",
   },
   {
     id: "brainstorming",
     installId: "brainstorming",
     sourceUrl: "https://github.com/obra/superpowers/tree/main/skills/brainstorming",
+    categoryId: "explore",
+  },
+  {
+    id: "dsh-code-review",
+    installId: "dsh-code-review",
+    sourceUrl: "https://github.com/deepseek-ai/deepseek-harness/tree/master/.agents/skills/dsh-code-review",
+    categoryId: "coding",
+  },
+  {
+    id: "dsh-find-simplifications",
+    installId: "dsh-find-simplifications",
+    sourceUrl: "https://github.com/deepseek-ai/deepseek-harness/tree/master/.agents/skills/dsh-find-simplifications",
+    categoryId: "coding",
+  },
+  {
+    id: "dsh-prose-standard",
+    installId: "dsh-prose-standard",
+    sourceUrl: "https://github.com/deepseek-ai/deepseek-harness/tree/master/.agents/skills/dsh-prose-standard",
+    categoryId: "writing",
+  },
+  {
+    id: "dsh-trim-cot-leakage",
+    installId: "dsh-trim-cot-leakage",
+    sourceUrl: "https://github.com/deepseek-ai/deepseek-harness/tree/master/.agents/skills/dsh-trim-cot-leakage",
+    categoryId: "writing",
   },
   {
     id: "grill-me",
     installId: "grill-me",
     sourceUrl: "https://github.com/mattpocock/skills/tree/main/skills/grill-me",
+    categoryId: "productivity",
   },
   {
     id: "systematic-debugging",
     installId: "systematic-debugging",
     sourceUrl: "https://github.com/obra/superpowers/tree/main/skills/systematic-debugging",
+    categoryId: "coding",
   },
   {
     id: "test-driven-development",
     installId: "test-driven-development",
     sourceUrl: "https://github.com/obra/superpowers/tree/main/skills/test-driven-development",
+    categoryId: "coding",
   },
   {
     id: "verification-before-completion",
     installId: "verification-before-completion",
     sourceUrl: "https://github.com/obra/superpowers/tree/main/skills/verification-before-completion",
+    categoryId: "coding",
   },
 ];
 
@@ -157,6 +192,7 @@ export class ManagedSkillLibrary {
           source: "agent-recall-v2",
           managedId,
           origin: metadata?.origin ?? { kind: "local", label: "AgentRecall" },
+          categoryId: metadata?.categoryId ?? null,
           installations: INSTALL_TARGETS.map((target) => this.inspectInstallation(managedId, target)),
         };
       })
@@ -201,14 +237,24 @@ export class ManagedSkillLibrary {
       if (!fs.existsSync(path.join(sourceDir, "SKILL.md"))) continue;
       const managedId = safeManagedSkillId(definition.installId);
       const targetPath = this.managedSkillDirectory(managedId);
-      // Idempotent: skip when the built-in skill is already present.
-      if (fs.existsSync(targetPath)) continue;
+      const origin: ManagedSkillOrigin = {
+        kind: "builtin",
+        label: "AgentRecall",
+        url: definition.sourceUrl,
+      };
+      if (fs.existsSync(targetPath)) {
+        const metadata = this.readMetadata(managedId);
+        if (metadata?.origin.kind === "builtin" && metadata.categoryId !== definition.categoryId) {
+          try {
+            this.writeMetadata(managedId, metadata.origin, definition.categoryId);
+          } catch {
+            // A metadata refresh must not block startup; retried next launch.
+          }
+        }
+        continue;
+      }
       try {
-        this.importDirectory(managedId, sourceDir, {
-          kind: "builtin",
-          label: "AgentRecall",
-          url: definition.sourceUrl,
-        });
+        this.importDirectory(managedId, sourceDir, origin, definition.categoryId);
       } catch {
         // A failed built-in import must not block startup; retried next launch.
       }
@@ -682,7 +728,12 @@ export class ManagedSkillLibrary {
     };
   }
 
-  private importDirectory(managedId: string, sourceDirectory: string, origin: ManagedSkillOrigin): ManagedSkillImportResult {
+  private importDirectory(
+    managedId: string,
+    sourceDirectory: string,
+    origin: ManagedSkillOrigin,
+    categoryId?: SkillCategoryId,
+  ): ManagedSkillImportResult {
     return this.importIntoStaging(managedId, origin, (stagingPath) => {
       fs.cpSync(sourceDirectory, stagingPath, {
         recursive: true,
@@ -690,7 +741,7 @@ export class ManagedSkillLibrary {
         force: false,
         verbatimSymlinks: true,
       });
-    });
+    }, false, categoryId);
   }
 
   private importIntoStaging(
@@ -698,6 +749,7 @@ export class ManagedSkillLibrary {
     origin: ManagedSkillOrigin,
     populate: (stagingPath: string) => void,
     replaceExisting = false,
+    categoryId?: SkillCategoryId,
   ): ManagedSkillImportResult {
     fs.mkdirSync(this.libraryRoot, { recursive: true });
     const targetPath = this.managedSkillDirectory(managedId);
@@ -711,7 +763,7 @@ export class ManagedSkillLibrary {
       if (fs.existsSync(targetPath)) {
         if (directoryContentHash(targetPath) === directoryContentHash(stagingPath)) {
           fs.rmSync(stagingPath, { recursive: true, force: true });
-          this.writeMetadata(managedId, origin);
+          this.writeMetadata(managedId, origin, categoryId);
           return { status: "existing", managedId, skill: this.requireManagedSkill(managedId) };
         }
         if (!replaceExisting) {
@@ -721,7 +773,7 @@ export class ManagedSkillLibrary {
         fs.renameSync(targetPath, backupPath);
         try {
           fs.renameSync(stagingPath, targetPath);
-          this.writeMetadata(managedId, origin);
+          this.writeMetadata(managedId, origin, categoryId);
           fs.rmSync(backupPath, { recursive: true, force: true });
           return { status: "updated", managedId, skill: this.requireManagedSkill(managedId) };
         } catch (error) {
@@ -731,7 +783,7 @@ export class ManagedSkillLibrary {
         }
       }
       fs.renameSync(stagingPath, targetPath);
-      this.writeMetadata(managedId, origin);
+      this.writeMetadata(managedId, origin, categoryId);
       return { status: "imported", managedId, skill: this.requireManagedSkill(managedId) };
     } catch (error) {
       fs.rmSync(stagingPath, { recursive: true, force: true });
@@ -759,20 +811,28 @@ export class ManagedSkillLibrary {
     try {
       const value = JSON.parse(fs.readFileSync(this.metadataPath(managedId), "utf8")) as Partial<ManagedSkillMetadata>;
       if (value.schemaVersion !== 1 || value.managedId !== managedId || !isManagedSkillOrigin(value.origin)) return null;
-      return value as ManagedSkillMetadata;
+      return {
+        schemaVersion: 1,
+        managedId,
+        importedAt: typeof value.importedAt === "string" ? value.importedAt : "",
+        origin: value.origin,
+        categoryId: isSkillCategoryId(value.categoryId) ? value.categoryId : null,
+      };
     } catch {
       return null;
     }
   }
 
-  private writeMetadata(managedId: string, origin: ManagedSkillOrigin): void {
+  private writeMetadata(managedId: string, origin: ManagedSkillOrigin, categoryId?: SkillCategoryId): void {
     const metadataPath = this.metadataPath(managedId);
     const temporaryPath = `${metadataPath}.${randomUUID()}.tmp`;
+    const existing = this.readMetadata(managedId);
     const metadata: ManagedSkillMetadata = {
       schemaVersion: 1,
       managedId,
-      importedAt: new Date(this.now()).toISOString(),
+      importedAt: existing?.importedAt || new Date(this.now()).toISOString(),
       origin,
+      categoryId: categoryId ?? existing?.categoryId ?? null,
     };
     fs.mkdirSync(path.dirname(metadataPath), { recursive: true });
     fs.writeFileSync(temporaryPath, `${JSON.stringify(metadata, null, 2)}\n`, "utf8");

--- a/apps/main-2.0/src/core/skill-categories.ts
+++ b/apps/main-2.0/src/core/skill-categories.ts
@@ -1,0 +1,7 @@
+export const SKILL_CATEGORY_IDS = ["coding", "writing", "productivity", "explore", "life"] as const;
+
+export type SkillCategoryId = (typeof SKILL_CATEGORY_IDS)[number];
+
+export function isSkillCategoryId(value: unknown): value is SkillCategoryId {
+  return typeof value === "string" && SKILL_CATEGORY_IDS.some((categoryId) => categoryId === value);
+}

--- a/apps/main-2.0/src/renderer/src/features/skills/skill-batch-install.test.ts
+++ b/apps/main-2.0/src/renderer/src/features/skills/skill-batch-install.test.ts
@@ -43,6 +43,7 @@ function managedSkill(states: Partial<Record<SkillInstallTarget, "installed" | "
     markdown: "# example",
     mtimeMs: 1,
     origin: { kind: "builtin", label: "Built-in" },
+    categoryId: "coding",
     installations: targets.map((target) => ({
       target,
       path: `/targets/${target}/example`,

--- a/apps/main-2.0/src/renderer/src/features/skills/skill-library-list.test.ts
+++ b/apps/main-2.0/src/renderer/src/features/skills/skill-library-list.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { ManagedSkill } from "../../../../core/managed-skill-library";
+import {
+  categoryGroupOrder,
+  categoryLabel,
+  filterManagedSkills,
+  type ManagedSkillCategoryGroup,
+} from "./skill-library-list";
+
+describe("managed Skill categories", () => {
+  const skills = [
+    managedSkill("review", "Code review", "coding"),
+    managedSkill("prose", "Prose standard", "writing"),
+    managedSkill("imported", "Imported Skill", null, "local"),
+  ];
+
+  it("filters by category independently from origin", () => {
+    expect(filterManagedSkills(skills, "", "coding", "all", "name").map((skill) => skill.managedId))
+      .toEqual(["review"]);
+    expect(filterManagedSkills(skills, "", "uncategorized", "local", "name").map((skill) => skill.managedId))
+      .toEqual(["imported"]);
+    expect(filterManagedSkills(skills, "", "writing", "local", "name")).toEqual([]);
+  });
+
+  it("orders the five system categories before uncategorized and localizes their labels", () => {
+    const categories: ManagedSkillCategoryGroup[] = ["life", "uncategorized", "writing", "coding", "explore", "productivity"];
+    expect(categories.sort((left, right) => categoryGroupOrder(left) - categoryGroupOrder(right))).toEqual([
+      "coding",
+      "writing",
+      "productivity",
+      "explore",
+      "life",
+      "uncategorized",
+    ]);
+    expect(categoryLabel("coding", "zh")).toBe("编程");
+    expect(categoryLabel("uncategorized", "zh")).toBe("未分类");
+  });
+});
+
+function managedSkill(
+  managedId: string,
+  name: string,
+  categoryId: ManagedSkill["categoryId"],
+  originKind: ManagedSkill["origin"]["kind"] = "builtin",
+): ManagedSkill {
+  return {
+    id: `agent-recall-v2:${managedId}`,
+    managedId,
+    name,
+    description: "fixture",
+    agent: "codex",
+    source: "agent-recall-v2",
+    path: `/managed/${managedId}/SKILL.md`,
+    directoryPath: `/managed/${managedId}`,
+    rootPath: "/managed",
+    markdown: `# ${name}`,
+    mtimeMs: 1,
+    origin: { kind: originKind, label: originKind },
+    categoryId,
+    installations: [],
+  };
+}

--- a/apps/main-2.0/src/renderer/src/features/skills/skill-library-list.tsx
+++ b/apps/main-2.0/src/renderer/src/features/skills/skill-library-list.tsx
@@ -2,23 +2,28 @@ import { useMemo, useState } from "react";
 import type { KeyboardEvent as ReactKeyboardEvent, ReactElement } from "react";
 import { Check, ChevronDown, ChevronRight, Search } from "lucide-react";
 import type { ManagedSkill, ManagedSkillOriginKind, ManagedSkillTargetState } from "../../../../core/managed-skill-library";
+import { SKILL_CATEGORY_IDS, type SkillCategoryId } from "../../../../core/skill-categories";
 import type { RemoteSkillGroup } from "../../../../core/skill-sync";
 import { formatCompactNumber } from "../../format-count";
 import { localize, type LanguageMode } from "../../language";
 import { TARGET_LABELS } from "./skill-target-dialog";
 
 export type ManagedSkillOriginFilter = "all" | ManagedSkillOriginKind;
+export type ManagedSkillCategoryGroup = SkillCategoryId | "uncategorized";
+export type ManagedSkillCategoryFilter = "all" | ManagedSkillCategoryGroup;
 export type ManagedSkillSort = "usage" | "name" | "updated";
 
 export function filterManagedSkills(
   skills: ManagedSkill[],
   query: string,
+  categoryFilter: ManagedSkillCategoryFilter,
   originFilter: ManagedSkillOriginFilter,
   sort: ManagedSkillSort,
 ): ManagedSkill[] {
   const normalizedQuery = query.trim().toLowerCase();
   return skills
     .filter((skill) => {
+      if (categoryFilter !== "all" && (skill.categoryId ?? "uncategorized") !== categoryFilter) return false;
       if (originFilter !== "all" && skill.origin.kind !== originFilter) return false;
       if (!normalizedQuery) return true;
       return [skill.name, skill.description, skill.origin.label, skill.origin.source ?? ""]
@@ -40,11 +45,13 @@ export function SkillLibraryList({
   selectedId,
   selectedIds,
   query,
+  categoryFilter,
   originFilter,
   sort,
   loading,
   language,
   onQueryChange,
+  onCategoryFilterChange,
   onOriginFilterChange,
   onSortChange,
   onSelect,
@@ -59,11 +66,13 @@ export function SkillLibraryList({
   selectedId: string | null;
   selectedIds: Set<string>;
   query: string;
+  categoryFilter: ManagedSkillCategoryFilter;
   originFilter: ManagedSkillOriginFilter;
   sort: ManagedSkillSort;
   loading: boolean;
   language: LanguageMode;
   onQueryChange: (query: string) => void;
+  onCategoryFilterChange: (filter: ManagedSkillCategoryFilter) => void;
   onOriginFilterChange: (filter: ManagedSkillOriginFilter) => void;
   onSortChange: (sort: ManagedSkillSort) => void;
   onSelect: (managedId: string) => void;
@@ -75,25 +84,26 @@ export function SkillLibraryList({
   onNavigateToEval?: (skillName: string) => void;
 }): ReactElement {
   const l = (en: string, zh: string) => localize(language, en, zh);
-  const [collapsedGroups, setCollapsedGroups] = useState<Set<ManagedSkillOriginKind>>(() => new Set());
-  const toggleGroup = (kind: ManagedSkillOriginKind) => {
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<ManagedSkillCategoryGroup>>(() => new Set());
+  const toggleGroup = (category: ManagedSkillCategoryGroup) => {
     setCollapsedGroups((current) => {
       const next = new Set(current);
-      if (next.has(kind)) next.delete(kind);
-      else next.add(kind);
+      if (next.has(category)) next.delete(category);
+      else next.add(category);
       return next;
     });
   };
   const groups = useMemo(() => {
-    const byKind = new Map<ManagedSkillOriginKind, ManagedSkill[]>();
+    const byCategory = new Map<ManagedSkillCategoryGroup, ManagedSkill[]>();
     for (const skill of skills) {
-      const group = byKind.get(skill.origin.kind) ?? [];
+      const category = skill.categoryId ?? "uncategorized";
+      const group = byCategory.get(category) ?? [];
       group.push(skill);
-      byKind.set(skill.origin.kind, group);
+      byCategory.set(category, group);
     }
-    return [...byKind.entries()]
-      .sort((left, right) => originGroupOrder(left[0]) - originGroupOrder(right[0]))
-      .map(([kind, groupSkills]) => ({ kind, skills: groupSkills }));
+    return [...byCategory.entries()]
+      .sort((left, right) => categoryGroupOrder(left[0]) - categoryGroupOrder(right[0]))
+      .map(([category, groupSkills]) => ({ category, skills: groupSkills }));
   }, [skills]);
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
     if (skills.length === 0) return;
@@ -121,7 +131,18 @@ export function SkillLibraryList({
             aria-label={l("Search managed Skills", "搜索 Skill 库")}
           />
         </label>
-        <div className="skill-library-filter-row">
+        <div className="skill-library-filter-row managed-skill-filter-row">
+          <select
+            value={categoryFilter}
+            onChange={(event) => onCategoryFilterChange(event.currentTarget.value as ManagedSkillCategoryFilter)}
+            aria-label={l("Filter by category", "按分类筛选")}
+          >
+            <option value="all">{l("All categories", "全部分类")}</option>
+            {SKILL_CATEGORY_IDS.map((category) => (
+              <option key={category} value={category}>{categoryLabel(category, language)}</option>
+            ))}
+            <option value="uncategorized">{categoryLabel("uncategorized", language)}</option>
+          </select>
           <select
             value={originFilter}
             onChange={(event) => onOriginFilterChange(event.currentTarget.value as ManagedSkillOriginFilter)}
@@ -160,17 +181,17 @@ export function SkillLibraryList({
           </div>
         ) : null}
         {groups.map((group) => {
-          const collapsed = collapsedGroups.has(group.kind);
+          const collapsed = collapsedGroups.has(group.category);
           return (
-            <section key={group.kind} className="skill-library-group">
+            <section key={group.category} className="skill-library-group">
               <button
                 type="button"
                 className="skill-library-group-header"
                 aria-expanded={!collapsed}
-                onClick={() => toggleGroup(group.kind)}
+                onClick={() => toggleGroup(group.category)}
               >
                 {collapsed ? <ChevronRight size={13} /> : <ChevronDown size={13} />}
-                <span>{groupLabel(group.kind, language)}</span>
+                <span>{categoryLabel(group.category, language)}</span>
                 <small>{formatCompactNumber(group.skills.length)}</small>
               </button>
               {!collapsed ? group.skills.map((skill) => {
@@ -281,18 +302,18 @@ export function originLabel(skill: ManagedSkill, language: LanguageMode): string
   return skill.origin.label || localize(language, "Local", "本机");
 }
 
-export function groupLabel(kind: ManagedSkillOriginKind, language: LanguageMode): string {
-  if (kind === "builtin") return localize(language, "Built-in", "内置");
-  if (kind === "skills-sh") return "skills.sh";
-  if (kind === "remote") return localize(language, "Cloud", "云端");
-  return localize(language, "Local", "本机");
+export function categoryLabel(category: ManagedSkillCategoryGroup, language: LanguageMode): string {
+  if (category === "coding") return localize(language, "Coding", "编程");
+  if (category === "writing") return localize(language, "Writing", "写作");
+  if (category === "productivity") return localize(language, "Productivity", "效率");
+  if (category === "explore") return localize(language, "Explore", "探索");
+  if (category === "life") return localize(language, "Life", "生活");
+  return localize(language, "Uncategorized", "未分类");
 }
 
-export function originGroupOrder(kind: ManagedSkillOriginKind): number {
-  if (kind === "builtin") return 0;
-  if (kind === "skills-sh") return 1;
-  if (kind === "remote") return 2;
-  return 3;
+export function categoryGroupOrder(category: ManagedSkillCategoryGroup): number {
+  const index = SKILL_CATEGORY_IDS.indexOf(category as SkillCategoryId);
+  return index === -1 ? SKILL_CATEGORY_IDS.length : index;
 }
 
 function installStateLabel(state: ManagedSkillTargetState, language: LanguageMode): string {

--- a/apps/main-2.0/src/renderer/src/features/skills/skill-target-dialog.test.tsx
+++ b/apps/main-2.0/src/renderer/src/features/skills/skill-target-dialog.test.tsx
@@ -151,6 +151,7 @@ function createSkill(
     markdown: "# Example",
     mtimeMs: 0,
     origin: { kind: "builtin", label: "AgentRecall" },
+    categoryId: "coding",
     installations: SKILL_INSTALL_TARGETS.map((target) => ({
       target,
       path: `C:/target/${target}`,

--- a/apps/main-2.0/src/renderer/src/features/skills/skills-page.tsx
+++ b/apps/main-2.0/src/renderer/src/features/skills/skills-page.tsx
@@ -4,6 +4,7 @@ import { Compass, PackagePlus, RefreshCw, Upload, X } from "lucide-react";
 import type { InstalledSkill, InstalledSkillsSnapshot } from "../../../../core/skill-manager";
 import type { ManagedSkill, SkillInstallTarget } from "../../../../core/managed-skill-library";
 import type { RemoteSkill, SkillSyncSnapshot, SkillSyncUploadOutcome } from "../../../../core/skill-sync";
+import { isSkillCategoryId } from "../../../../core/skill-categories";
 import { formatCompactNumber } from "../../format-count";
 import { localize, type LanguageMode } from "../../language";
 import { buildUnifiedSkillEntries } from "../../skill-sync-view-model";
@@ -17,6 +18,7 @@ import { SkillLibraryDetail } from "./skill-library-detail";
 import {
   filterManagedSkills,
   SkillLibraryList,
+  type ManagedSkillCategoryFilter,
   type ManagedSkillOriginFilter,
   type ManagedSkillSort,
 } from "./skill-library-list";
@@ -83,6 +85,7 @@ export function SkillsPage({
   }, [evalBadgeCounts]);
   const unifiedEntries = useMemo(() => buildUnifiedSkillEntries(snapshot, syncSnapshot), [snapshot, syncSnapshot]);
   const [query, setQuery] = useState("");
+  const [categoryFilter, setCategoryFilter] = useState<ManagedSkillCategoryFilter>("all");
   const [originFilter, setOriginFilter] = useState<ManagedSkillOriginFilter>("all");
   const [sort, setSort] = useState<ManagedSkillSort>("usage");
   const [activeTab, setActiveTab] = useState<"app" | "local">("app");
@@ -97,8 +100,8 @@ export function SkillsPage({
   const [appFeedback, setAppFeedback] = useState<{ kind: "success" | "warning" | "error"; message: string } | null>(null);
   const [pendingSelection, setPendingSelection] = useState<string | null>(null);
   const filteredSkills = useMemo(
-    () => filterManagedSkills(managedSkills, query, originFilter, sort),
-    [managedSkills, originFilter, query, sort],
+    () => filterManagedSkills(managedSkills, query, categoryFilter, originFilter, sort),
+    [categoryFilter, managedSkills, originFilter, query, sort],
   );
   const selectedSkill = selectedRemoteFingerprint
     ? null
@@ -350,11 +353,13 @@ export function SkillsPage({
               selectedId={selectedSkill?.managedId ?? null}
               selectedIds={checkedIds}
               query={query}
+              categoryFilter={categoryFilter}
               originFilter={originFilter}
               sort={sort}
               loading={loading}
               language={language}
               onQueryChange={setQuery}
+              onCategoryFilterChange={setCategoryFilter}
               onOriginFilterChange={setOriginFilter}
               onSortChange={setSort}
               onSelect={(managedId) => {
@@ -461,5 +466,6 @@ export function isManagedSkill(skill: InstalledSkill): skill is ManagedSkill {
   const candidate = skill as Partial<ManagedSkill>;
   return typeof candidate.managedId === "string"
     && Boolean(candidate.origin)
+    && (candidate.categoryId === null || isSkillCategoryId(candidate.categoryId))
     && Array.isArray(candidate.installations);
 }

--- a/apps/main-2.0/src/renderer/src/styles/skills-page.css
+++ b/apps/main-2.0/src/renderer/src/styles/skills-page.css
@@ -316,8 +316,16 @@
 
 .skill-library-filter-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 6px;
+}
+
+.managed-skill-filter-row {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.managed-skill-filter-row > select:first-child {
+  grid-column: 1 / -1;
 }
 
 .skill-library-filter-row select {


### PR DESCRIPTION
## Summary

- bundle four adapted DeepSeek Harness quality Skills with their MIT licenses
- classify managed Skills as coding, writing, productivity, explore, life, or uncategorized
- add category grouping and filtering to the V2 Skill library
- migrate existing built-in metadata without re-importing Skill contents

## Verification

- 44 focused V2 tests passed
- V2 typecheck passed
- source entrypoint check passed for 592 production modules
- release-note validation passed