### PR TITLE
feat(sessions): index Kimi Code subagent conversations

### DIFF
--- a/.release-notes/feat-kimi-subagent-sessions.md
+++ b/.release-notes/feat-kimi-subagent-sessions.md
@@ -1,0 +1,7 @@
+# 展示 Kimi Code 子 Agent 会话
+
+<!-- release-target: both -->
+
+## 新增功能
+
+- Kimi Code 会话现在会展示子 Agent 的独立对话，并保留主会话与嵌套子 Agent 之间的关系。

--- a/apps/main-1.0/src/core/session-loader-kimi.test.ts
+++ b/apps/main-1.0/src/core/session-loader-kimi.test.ts
@@ -21,6 +21,7 @@ function writeKimiCodeSession(root: string, workDirKey: string, sessionId: strin
   title?: string;
   workDir?: string;
   custom?: Record<string, unknown>;
+  agents?: Record<string, unknown>;
   indexed?: boolean;
   truncatedTail?: boolean;
 } = {}): string {
@@ -31,6 +32,7 @@ function writeKimiCodeSession(root: string, workDirKey: string, sessionId: strin
     updatedAt: 1_700_000_010_000,
     ...(options.workDir ? { workDir: options.workDir } : {}),
     ...(options.custom ? { custom: options.custom } : {}),
+    ...(options.agents ? { agents: options.agents } : {}),
   });
   write(wirePath, [
     { type: "metadata", protocol_version: "1.5", created_at: 1_700_000_000_000 },
@@ -45,6 +47,24 @@ function writeKimiCodeSession(root: string, workDirKey: string, sessionId: strin
     fs.mkdirSync(path.dirname(indexPath), { recursive: true });
     fs.appendFileSync(indexPath, `${JSON.stringify({ sessionId, sessionDir, workDir: options.workDir ?? "D:/indexed-project" })}\n`, "utf8");
   }
+  return wirePath;
+}
+
+function writeKimiCodeAgent(
+  root: string,
+  workDirKey: string,
+  sessionId: string,
+  agentId: string,
+  prompt: string,
+  response: string,
+): string {
+  const wirePath = path.join(root, "sessions", workDirKey, sessionId, "agents", agentId, "wire.jsonl");
+  write(wirePath, [
+    { type: "context.append_message", message: { role: "user", content: [{ type: "text", text: prompt }] }, time: 1_700_000_020_000 },
+    { type: "context.append_loop_event", event: { type: "step.begin", uuid: `${agentId}-step`, turnId: `${agentId}-turn`, step: 0 }, time: 1_700_000_021_000 },
+    { type: "context.append_loop_event", event: { type: "content.part", stepUuid: `${agentId}-step`, part: { type: "text", text: response } }, time: 1_700_000_022_000 },
+    { type: "context.append_loop_event", event: { type: "step.end", uuid: `${agentId}-step`, turnId: `${agentId}-turn`, step: 0 }, time: 1_700_000_023_000 },
+  ]);
   return wirePath;
 }
 
@@ -93,6 +113,80 @@ describe("Kimi Code session loading", () => {
     expect(loaded.session.originalTitle).toBe("Renamed Kimi session");
     expect(loaded.session.projectPath).toBe("D:/new-kimi-project");
     expect(loaded.messages.map((message) => message.content)).toEqual(["Hello Kimi Code", "Hello from the new engine"]);
+  });
+
+  it("indexes registered Kimi Code subagents with stable parent relationships", () => {
+    const root = home();
+    const codeRoot = path.join(root, ".kimi-code");
+    const workDirKey = "wd_subagents_123456789abc";
+    const sessionId = "session-with-subagents";
+    writeKimiCodeSession(codeRoot, workDirKey, sessionId, {
+      workDir: "D:/kimi-subagents",
+      agents: {
+        main: { type: "main" },
+        explorer: { type: "sub", parentAgentId: "main" },
+        nested: {
+          type: "sub",
+          parentAgentId: "main",
+          labels: { parentAgentId: "explorer" },
+        },
+        independent: { type: "independent" },
+        orphan: { type: "sub", parentAgentId: "missing-agent" },
+      },
+    });
+    const explorerWire = writeKimiCodeAgent(codeRoot, workDirKey, sessionId, "explorer", "Explore the parser", "Parser findings");
+    const nestedWire = writeKimiCodeAgent(codeRoot, workDirKey, sessionId, "nested", "Inspect the fixture", "Fixture findings");
+    writeKimiCodeAgent(codeRoot, workDirKey, sessionId, "independent", "Independent prompt", "Independent result");
+    writeKimiCodeAgent(codeRoot, workDirKey, sessionId, "orphan", "Orphan prompt", "Orphan result");
+
+    const loaded = loadDefaultSessions({ homeDir: root, includeKimiCli: true });
+
+    expect(loaded.map((item) => item.session.rawId)).toEqual([
+      sessionId,
+      `${sessionId}:subagent:explorer`,
+      `${sessionId}:subagent:nested`,
+    ]);
+    expect(loaded.slice(1).map((item) => ({
+      filePath: item.session.filePath,
+      isSubagent: item.session.isSubagent,
+      parentSessionId: item.session.parentSessionId,
+      messages: item.messages.map((message) => message.content),
+    }))).toEqual([
+      {
+        filePath: explorerWire,
+        isSubagent: true,
+        parentSessionId: sessionId,
+        messages: ["Explore the parser", "Parser findings"],
+      },
+      {
+        filePath: nestedWire,
+        isSubagent: true,
+        parentSessionId: `${sessionId}:subagent:explorer`,
+        messages: ["Inspect the fixture", "Fixture findings"],
+      },
+    ]);
+  });
+
+  it("applies incremental skip decisions to each Kimi Code agent wire", () => {
+    const root = home();
+    const codeRoot = path.join(root, ".kimi-code");
+    const workDirKey = "wd_incremental_123456789abc";
+    const sessionId = "incremental-session";
+    const mainWire = writeKimiCodeSession(codeRoot, workDirKey, sessionId, {
+      agents: {
+        main: { type: "main" },
+        worker: { type: "sub", parentAgentId: "main" },
+      },
+    });
+    writeKimiCodeAgent(codeRoot, workDirKey, sessionId, "worker", "Updated child", "Child result");
+
+    const loaded = loadDefaultSessions({
+      homeDir: root,
+      includeKimiCli: true,
+      shouldSkipFile: (filePath) => filePath === mainWire,
+    });
+
+    expect(loaded.map((item) => item.session.rawId)).toEqual([`${sessionId}:subagent:worker`]);
   });
 
   it("falls back to filesystem discovery and the indexed work directory", () => {

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -1844,10 +1844,59 @@ function kimiCodeMessages(rows: unknown[]): SessionMessage[] {
     .map((draft, index) => messageFromParts(draft.role, draft.content, draft.timestamp, index));
 }
 
-function kimiCodeMainWireIdentity(filePath: string, root: string): { sessionId: string; sessionDir: string } | null {
+interface KimiCodeWireIdentity {
+  sessionId: string;
+  sessionDir: string;
+  agentId: string;
+}
+
+function kimiCodeWireIdentity(filePath: string, root: string): KimiCodeWireIdentity | null {
   const parts = path.relative(root, filePath).split(/[\\/]+/u);
-  if (parts.length !== 6 || parts[0] !== "sessions" || parts[3] !== "agents" || parts[4] !== "main" || parts[5] !== "wire.jsonl") return null;
-  return { sessionId: parts[2], sessionDir: path.dirname(path.dirname(path.dirname(filePath))) };
+  if (
+    parts.length !== 6
+    || parts[0] !== "sessions"
+    || parts[3] !== "agents"
+    || !parts[2]
+    || !parts[4]
+    || parts[5] !== "wire.jsonl"
+  ) return null;
+  return {
+    sessionId: parts[2],
+    sessionDir: path.dirname(path.dirname(path.dirname(filePath))),
+    agentId: parts[4],
+  };
+}
+
+function kimiCodeAgentRawId(sessionId: string, agentId: string): string {
+  return agentId === "main" ? sessionId : `${sessionId}:subagent:${agentId}`;
+}
+
+function kimiCodeParentAgentId(agentMeta: Record<string, unknown>): string {
+  return stringField(objectField(agentMeta, "labels"), "parentAgentId")
+    || stringField(agentMeta, "parentAgentId");
+}
+
+function kimiCodeSubagentParentSessionId(
+  state: Record<string, unknown>,
+  sessionId: string,
+  agentId: string,
+): string | null {
+  const agents = objectField(state, "agents");
+  const visited = new Set([agentId]);
+  let currentAgentId = agentId;
+  let directParentAgentId = "";
+  while (currentAgentId !== "main") {
+    const agentMeta = objectField(agents, currentAgentId);
+    if (!agentMeta) return null;
+    const parentAgentId = kimiCodeParentAgentId(agentMeta);
+    if ((stringField(agentMeta, "type") !== "sub" && !parentAgentId) || !parentAgentId || visited.has(parentAgentId)) {
+      return null;
+    }
+    if (!directParentAgentId) directParentAgentId = parentAgentId;
+    visited.add(parentAgentId);
+    currentAgentId = parentAgentId;
+  }
+  return kimiCodeAgentRawId(sessionId, directParentAgentId);
 }
 
 function kimiCodeTitle(state: Record<string, unknown>, question: string, rawId: string): string {
@@ -1858,30 +1907,36 @@ function kimiCodeTitle(state: Record<string, unknown>, question: string, rawId: 
 
 function loadKimiCodeSessionFile(
   filePath: string,
-  root: string,
+  identity: KimiCodeWireIdentity,
   indexEntry: KimiCodeIndexEntry | undefined,
   state: Record<string, unknown>,
   stat: VirtualSessionFileStat,
+  parentSessionId: string | null,
 ): LoadedSession | null {
-  const identity = kimiCodeMainWireIdentity(filePath, root);
-  if (!identity) return null;
+  const isSubagent = identity.agentId !== "main";
+  if (isSubagent && !parentSessionId) return null;
   const rows = readJsonl(filePath);
   const messages = kimiCodeMessages(rows);
   if (messages.length === 0) return null;
   const question = cleanTitle(firstQuestion(messages));
   const projectPath = stringField(state, "cwd") || stringField(state, "workDir") || indexEntry?.workDir || "";
-  const timestamp = parseTimestampMs(state.updatedAt) || parseTimestampMs(state.createdAt) || stat.mtimeMs;
+  const timestamp = isSubagent
+    ? stat.mtimeMs
+    : parseTimestampMs(state.updatedAt) || parseTimestampMs(state.createdAt) || stat.mtimeMs;
+  const rawId = kimiCodeAgentRawId(identity.sessionId, identity.agentId);
   return {
     session: createIndexedSession({
       keyPrefix: "kimi",
-      rawId: identity.sessionId,
+      rawId,
       source: "kimi-cli",
       projectPath,
       filePath,
-      originalTitle: kimiCodeTitle(state, question, identity.sessionId),
+      originalTitle: isSubagent ? question || identity.agentId : kimiCodeTitle(state, question, identity.sessionId),
       firstQuestion: question,
       timestamp,
       stat,
+      isSubagent,
+      parentSessionId,
     }),
     messages,
   };
@@ -1928,28 +1983,66 @@ function* loadKimiSessionsIterator(legacyRoot: string, codeRoot: string, options
 
   const indexPath = path.join(codeRoot, "session_index.jsonl");
   const sessionIndex = readKimiCodeSessionIndex(codeRoot);
-  const candidates = new Map<string, { sessionId: string; sessionDir: string; filePath: string }>();
+  const candidates = new Map<string, {
+    sessionId: string;
+    sessionDir: string;
+    agentWirePaths: Map<string, string>;
+  }>();
   for (const entry of sessionIndex.values()) {
     const filePath = path.join(entry.sessionDir, "agents", "main", "wire.jsonl");
-    if (fs.existsSync(filePath)) candidates.set(path.resolve(entry.sessionDir), { sessionId: entry.sessionId, sessionDir: entry.sessionDir, filePath });
+    if (fs.existsSync(filePath)) {
+      candidates.set(path.resolve(entry.sessionDir), {
+        sessionId: entry.sessionId,
+        sessionDir: entry.sessionDir,
+        agentWirePaths: new Map([["main", filePath]]),
+      });
+    }
   }
   for (const filePath of walkJsonlFiles(path.join(codeRoot, "sessions"))) {
-    const identity = kimiCodeMainWireIdentity(filePath, codeRoot);
-    if (identity) candidates.set(path.resolve(identity.sessionDir), { ...identity, filePath });
+    const identity = kimiCodeWireIdentity(filePath, codeRoot);
+    if (!identity) continue;
+    const candidateKey = path.resolve(identity.sessionDir);
+    const candidate = candidates.get(candidateKey) ?? {
+      sessionId: identity.sessionId,
+      sessionDir: identity.sessionDir,
+      agentWirePaths: new Map<string, string>(),
+    };
+    candidate.agentWirePaths.set(identity.agentId, filePath);
+    candidates.set(candidateKey, candidate);
   }
-  for (const candidate of [...candidates.values()].sort((left, right) => left.filePath.localeCompare(right.filePath))) {
+  for (const candidate of [...candidates.values()].sort((left, right) => left.sessionDir.localeCompare(right.sessionDir))) {
+    if (!candidate.agentWirePaths.has("main")) continue;
     const statePath = path.join(candidate.sessionDir, "state.json");
     const state = readJsonObject(statePath) ?? {};
     const custom = objectField(state, "custom");
     const importedLegacyId = stringField(custom, "kimi_cli_session_id");
     if (importedLegacyId && legacySessionIds.has(importedLegacyId)) continue;
-    const stat = safeStat(candidate.filePath);
     const dependencyMtimeMs = Math.max(safeStat(indexPath).mtimeMs, safeStat(statePath).mtimeMs);
-    if (shouldSkipFile(options, candidate.filePath, stat, dependencyMtimeMs)) continue;
     const indexed = sessionIndex.get(candidate.sessionId);
     const indexEntry = indexed && path.resolve(indexed.sessionDir) === path.resolve(candidate.sessionDir) ? indexed : undefined;
-    const loaded = loadKimiCodeSessionFile(candidate.filePath, codeRoot, indexEntry, state, stat);
-    if (loaded) yield loaded;
+    const agentWires = [...candidate.agentWirePaths]
+      .sort(([left], [right]) => {
+        if (left === "main") return right === "main" ? 0 : -1;
+        if (right === "main") return 1;
+        return left.localeCompare(right);
+      });
+    for (const [agentId, filePath] of agentWires) {
+      const stat = safeStat(filePath);
+      if (shouldSkipFile(options, filePath, stat, dependencyMtimeMs)) continue;
+      const identity = kimiCodeWireIdentity(filePath, codeRoot);
+      if (!identity) continue;
+      const loaded = loadKimiCodeSessionFile(
+        filePath,
+        identity,
+        indexEntry,
+        state,
+        stat,
+        agentId === "main"
+          ? null
+          : kimiCodeSubagentParentSessionId(state, candidate.sessionId, agentId),
+      );
+      if (loaded) yield loaded;
+    }
   }
 }
 

--- a/apps/main-2.0/src/core/session-loader-kimi.test.ts
+++ b/apps/main-2.0/src/core/session-loader-kimi.test.ts
@@ -22,6 +22,7 @@ function writeKimiCodeSession(root: string, workDirKey: string, sessionId: strin
   title?: string;
   workDir?: string;
   custom?: Record<string, unknown>;
+  agents?: Record<string, unknown>;
   indexed?: boolean;
   truncatedTail?: boolean;
 } = {}): string {
@@ -32,6 +33,7 @@ function writeKimiCodeSession(root: string, workDirKey: string, sessionId: strin
     updatedAt: 1_700_000_010_000,
     ...(options.workDir ? { workDir: options.workDir } : {}),
     ...(options.custom ? { custom: options.custom } : {}),
+    ...(options.agents ? { agents: options.agents } : {}),
   });
   write(wirePath, [
     { type: "metadata", protocol_version: "1.5", created_at: 1_700_000_000_000 },
@@ -46,6 +48,24 @@ function writeKimiCodeSession(root: string, workDirKey: string, sessionId: strin
     fs.mkdirSync(path.dirname(indexPath), { recursive: true });
     fs.appendFileSync(indexPath, `${JSON.stringify({ sessionId, sessionDir, workDir: options.workDir ?? "D:/indexed-project" })}\n`, "utf8");
   }
+  return wirePath;
+}
+
+function writeKimiCodeAgent(
+  root: string,
+  workDirKey: string,
+  sessionId: string,
+  agentId: string,
+  prompt: string,
+  response: string,
+): string {
+  const wirePath = path.join(root, "sessions", workDirKey, sessionId, "agents", agentId, "wire.jsonl");
+  write(wirePath, [
+    { type: "context.append_message", message: { role: "user", content: [{ type: "text", text: prompt }] }, time: 1_700_000_020_000 },
+    { type: "context.append_loop_event", event: { type: "step.begin", uuid: `${agentId}-step`, turnId: `${agentId}-turn`, step: 0 }, time: 1_700_000_021_000 },
+    { type: "context.append_loop_event", event: { type: "content.part", stepUuid: `${agentId}-step`, part: { type: "text", text: response } }, time: 1_700_000_022_000 },
+    { type: "context.append_loop_event", event: { type: "step.end", uuid: `${agentId}-step`, turnId: `${agentId}-turn`, step: 0 }, time: 1_700_000_023_000 },
+  ]);
   return wirePath;
 }
 
@@ -94,6 +114,80 @@ describe("Kimi Code session loading", () => {
     expect(loaded.session.originalTitle).toBe("Renamed Kimi session");
     expect(loaded.session.projectPath).toBe("D:/new-kimi-project");
     expect(loaded.messages.map((message) => message.content)).toEqual(["Hello Kimi Code", "Hello from the new engine"]);
+  });
+
+  it("indexes registered Kimi Code subagents with stable parent relationships", () => {
+    const root = home();
+    const codeRoot = path.join(root, ".kimi-code");
+    const workDirKey = "wd_subagents_123456789abc";
+    const sessionId = "session-with-subagents";
+    writeKimiCodeSession(codeRoot, workDirKey, sessionId, {
+      workDir: "D:/kimi-subagents",
+      agents: {
+        main: { type: "main" },
+        explorer: { type: "sub", parentAgentId: "main" },
+        nested: {
+          type: "sub",
+          parentAgentId: "main",
+          labels: { parentAgentId: "explorer" },
+        },
+        independent: { type: "independent" },
+        orphan: { type: "sub", parentAgentId: "missing-agent" },
+      },
+    });
+    const explorerWire = writeKimiCodeAgent(codeRoot, workDirKey, sessionId, "explorer", "Explore the parser", "Parser findings");
+    const nestedWire = writeKimiCodeAgent(codeRoot, workDirKey, sessionId, "nested", "Inspect the fixture", "Fixture findings");
+    writeKimiCodeAgent(codeRoot, workDirKey, sessionId, "independent", "Independent prompt", "Independent result");
+    writeKimiCodeAgent(codeRoot, workDirKey, sessionId, "orphan", "Orphan prompt", "Orphan result");
+
+    const loaded = loadDefaultSessions({ homeDir: root, includeKimiCli: true });
+
+    expect(loaded.map((item) => item.session.rawId)).toEqual([
+      sessionId,
+      `${sessionId}:subagent:explorer`,
+      `${sessionId}:subagent:nested`,
+    ]);
+    expect(loaded.slice(1).map((item) => ({
+      filePath: item.session.filePath,
+      isSubagent: item.session.isSubagent,
+      parentSessionId: item.session.parentSessionId,
+      messages: item.messages.map((message) => message.content),
+    }))).toEqual([
+      {
+        filePath: explorerWire,
+        isSubagent: true,
+        parentSessionId: sessionId,
+        messages: ["Explore the parser", "Parser findings"],
+      },
+      {
+        filePath: nestedWire,
+        isSubagent: true,
+        parentSessionId: `${sessionId}:subagent:explorer`,
+        messages: ["Inspect the fixture", "Fixture findings"],
+      },
+    ]);
+  });
+
+  it("applies incremental skip decisions to each Kimi Code agent wire", () => {
+    const root = home();
+    const codeRoot = path.join(root, ".kimi-code");
+    const workDirKey = "wd_incremental_123456789abc";
+    const sessionId = "incremental-session";
+    const mainWire = writeKimiCodeSession(codeRoot, workDirKey, sessionId, {
+      agents: {
+        main: { type: "main" },
+        worker: { type: "sub", parentAgentId: "main" },
+      },
+    });
+    writeKimiCodeAgent(codeRoot, workDirKey, sessionId, "worker", "Updated child", "Child result");
+
+    const loaded = loadDefaultSessions({
+      homeDir: root,
+      includeKimiCli: true,
+      shouldSkipFile: (filePath) => filePath === mainWire,
+    });
+
+    expect(loaded.map((item) => item.session.rawId)).toEqual([`${sessionId}:subagent:worker`]);
   });
 
   it("falls back to filesystem discovery and the indexed work directory", () => {

--- a/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
+++ b/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
@@ -532,10 +532,59 @@ function kimiCodeMessages(rows: unknown[]): SessionMessage[] {
     .map((draft, index) => messageFromParts(draft.role, draft.content, draft.timestamp, index));
 }
 
-function kimiCodeMainWireIdentity(filePath: string, root: string): { sessionId: string; sessionDir: string } | null {
+interface KimiCodeWireIdentity {
+  sessionId: string;
+  sessionDir: string;
+  agentId: string;
+}
+
+function kimiCodeWireIdentity(filePath: string, root: string): KimiCodeWireIdentity | null {
   const parts = path.relative(root, filePath).split(/[\\/]+/u);
-  if (parts.length !== 6 || parts[0] !== "sessions" || parts[3] !== "agents" || parts[4] !== "main" || parts[5] !== "wire.jsonl") return null;
-  return { sessionId: parts[2], sessionDir: path.dirname(path.dirname(path.dirname(filePath))) };
+  if (
+    parts.length !== 6
+    || parts[0] !== "sessions"
+    || parts[3] !== "agents"
+    || !parts[2]
+    || !parts[4]
+    || parts[5] !== "wire.jsonl"
+  ) return null;
+  return {
+    sessionId: parts[2],
+    sessionDir: path.dirname(path.dirname(path.dirname(filePath))),
+    agentId: parts[4],
+  };
+}
+
+function kimiCodeAgentRawId(sessionId: string, agentId: string): string {
+  return agentId === "main" ? sessionId : `${sessionId}:subagent:${agentId}`;
+}
+
+function kimiCodeParentAgentId(agentMeta: Record<string, unknown>): string {
+  return stringField(objectField(agentMeta, "labels"), "parentAgentId")
+    || stringField(agentMeta, "parentAgentId");
+}
+
+function kimiCodeSubagentParentSessionId(
+  state: Record<string, unknown>,
+  sessionId: string,
+  agentId: string,
+): string | null {
+  const agents = objectField(state, "agents");
+  const visited = new Set([agentId]);
+  let currentAgentId = agentId;
+  let directParentAgentId = "";
+  while (currentAgentId !== "main") {
+    const agentMeta = objectField(agents, currentAgentId);
+    if (!agentMeta) return null;
+    const parentAgentId = kimiCodeParentAgentId(agentMeta);
+    if ((stringField(agentMeta, "type") !== "sub" && !parentAgentId) || !parentAgentId || visited.has(parentAgentId)) {
+      return null;
+    }
+    if (!directParentAgentId) directParentAgentId = parentAgentId;
+    visited.add(parentAgentId);
+    currentAgentId = parentAgentId;
+  }
+  return kimiCodeAgentRawId(sessionId, directParentAgentId);
 }
 
 function kimiCodeTitle(state: Record<string, unknown>, question: string, rawId: string): string {
@@ -546,30 +595,36 @@ function kimiCodeTitle(state: Record<string, unknown>, question: string, rawId: 
 
 function loadKimiCodeSessionFile(
   filePath: string,
-  root: string,
+  identity: KimiCodeWireIdentity,
   indexEntry: KimiCodeIndexEntry | undefined,
   state: Record<string, unknown>,
   stat: VirtualSessionFileStat,
+  parentSessionId: string | null,
 ): LoadedSession | null {
-  const identity = kimiCodeMainWireIdentity(filePath, root);
-  if (!identity) return null;
+  const isSubagent = identity.agentId !== "main";
+  if (isSubagent && !parentSessionId) return null;
   const rows = readJsonl(filePath);
   const messages = kimiCodeMessages(rows);
   if (messages.length === 0) return null;
   const question = cleanTitle(firstQuestion(messages));
   const projectPath = stringField(state, "cwd") || stringField(state, "workDir") || indexEntry?.workDir || "";
-  const timestamp = timestampMs(state.updatedAt) || timestampMs(state.createdAt) || stat.mtimeMs;
+  const timestamp = isSubagent
+    ? stat.mtimeMs
+    : timestampMs(state.updatedAt) || timestampMs(state.createdAt) || stat.mtimeMs;
+  const rawId = kimiCodeAgentRawId(identity.sessionId, identity.agentId);
   return {
     session: createIndexedSession({
       keyPrefix: "kimi",
-      rawId: identity.sessionId,
+      rawId,
       source: "kimi-cli",
       projectPath,
       filePath,
-      originalTitle: kimiCodeTitle(state, question, identity.sessionId),
+      originalTitle: isSubagent ? question || identity.agentId : kimiCodeTitle(state, question, identity.sessionId),
       firstQuestion: question,
       timestamp,
       stat,
+      isSubagent,
+      parentSessionId,
     }),
     messages,
   };
@@ -620,28 +675,66 @@ export function* loadKimiSessionsIterator(
 
   const indexPath = path.join(codeRoot, "session_index.jsonl");
   const sessionIndex = readKimiCodeSessionIndex(codeRoot);
-  const candidates = new Map<string, { sessionId: string; sessionDir: string; filePath: string }>();
+  const candidates = new Map<string, {
+    sessionId: string;
+    sessionDir: string;
+    agentWirePaths: Map<string, string>;
+  }>();
   for (const entry of sessionIndex.values()) {
     const filePath = path.join(entry.sessionDir, "agents", "main", "wire.jsonl");
-    if (fs.existsSync(filePath)) candidates.set(path.resolve(entry.sessionDir), { sessionId: entry.sessionId, sessionDir: entry.sessionDir, filePath });
+    if (fs.existsSync(filePath)) {
+      candidates.set(path.resolve(entry.sessionDir), {
+        sessionId: entry.sessionId,
+        sessionDir: entry.sessionDir,
+        agentWirePaths: new Map([["main", filePath]]),
+      });
+    }
   }
   for (const filePath of walkJsonlFiles(path.join(codeRoot, "sessions"))) {
-    const identity = kimiCodeMainWireIdentity(filePath, codeRoot);
-    if (identity) candidates.set(path.resolve(identity.sessionDir), { ...identity, filePath });
+    const identity = kimiCodeWireIdentity(filePath, codeRoot);
+    if (!identity) continue;
+    const candidateKey = path.resolve(identity.sessionDir);
+    const candidate = candidates.get(candidateKey) ?? {
+      sessionId: identity.sessionId,
+      sessionDir: identity.sessionDir,
+      agentWirePaths: new Map<string, string>(),
+    };
+    candidate.agentWirePaths.set(identity.agentId, filePath);
+    candidates.set(candidateKey, candidate);
   }
-  for (const candidate of [...candidates.values()].sort((left, right) => left.filePath.localeCompare(right.filePath))) {
+  for (const candidate of [...candidates.values()].sort((left, right) => left.sessionDir.localeCompare(right.sessionDir))) {
+    if (!candidate.agentWirePaths.has("main")) continue;
     const statePath = path.join(candidate.sessionDir, "state.json");
     const state = readJsonObject(statePath) ?? {};
     const custom = objectField(state, "custom");
     const importedLegacyId = stringField(custom, "kimi_cli_session_id");
     if (importedLegacyId && legacySessionIds.has(importedLegacyId)) continue;
-    const stat = safeStat(candidate.filePath);
     const dependencyMtimeMs = Math.max(safeStat(indexPath).mtimeMs, safeStat(statePath).mtimeMs);
-    if (shouldSkipFile(options, candidate.filePath, stat, dependencyMtimeMs)) continue;
     const indexed = sessionIndex.get(candidate.sessionId);
     const indexEntry = indexed && path.resolve(indexed.sessionDir) === path.resolve(candidate.sessionDir) ? indexed : undefined;
-    const loaded = loadKimiCodeSessionFile(candidate.filePath, codeRoot, indexEntry, state, stat);
-    if (loaded) yield loaded;
+    const agentWires = [...candidate.agentWirePaths]
+      .sort(([left], [right]) => {
+        if (left === "main") return right === "main" ? 0 : -1;
+        if (right === "main") return 1;
+        return left.localeCompare(right);
+      });
+    for (const [agentId, filePath] of agentWires) {
+      const stat = safeStat(filePath);
+      if (shouldSkipFile(options, filePath, stat, dependencyMtimeMs)) continue;
+      const identity = kimiCodeWireIdentity(filePath, codeRoot);
+      if (!identity) continue;
+      const loaded = loadKimiCodeSessionFile(
+        filePath,
+        identity,
+        indexEntry,
+        state,
+        stat,
+        agentId === "main"
+          ? null
+          : kimiCodeSubagentParentSessionId(state, candidate.sessionId, agentId),
+      );
+      if (loaded) yield loaded;
+    }
   }
 }
 


### PR DESCRIPTION
## 变更概述

- 将新版 Kimi Code 会话从只索引 `agents/main/wire.jsonl` 扩展为按 Agent 独立索引已登记的子 Agent wire。
- 为子 Agent 生成稳定的 `<session-id>:subagent:<agent-id>` ID，并把一级及嵌套子 Agent 关联到对应父会话。
- 按 Kimi Code 当前元数据语义优先读取 `labels.parentAgentId`，兼容旧格式的 `parentAgentId`；仅接受父链最终到达 `main` 的关系，排除未登记、独立、孤儿和循环 Agent。
- 每个 Agent wire 独立参与增量跳过；旧版 `.kimi` 解析与只读边界保持不变。

Closes #485

## 更新说明检查

- [x] 本分支已新增且仅新增一个 `.release-notes/<branch-slug>.md`
- [x] 更新说明已在标题后显式声明 `release-target: v1`、`v2` 或 `both`，并覆盖会收到本次用户可见结果的应用；测试、文档或兼容辅助改动本身不要求 `both`
- [x] 更新说明包含面向用户的“新增功能”或“Bug 修复”列表
- [x] 更新说明已移除 MR、分支、CI、发布流程、内部服务、路径及其他不应暴露的实现或敏感信息
- [x] 已运行 `npm run release-note:check`

## 验证

- `npm exec vitest run src/core/session-loader.test.ts src/core/session-loader-kimi.test.ts src/core/session-sources.test.ts`（V1：84 tests passed；V2：87 tests passed）
- `npm exec vitest run src/core/indexer.test.ts`（V1/V2：各 33 tests passed）
- `npm run typecheck`（V1/V2；V2 source entrypoint check passed）
- `npm run release-note:check`
- `git diff --check`
