### PR TITLE
feat(sessions): index OpenCode subagent sessions

### DIFF
--- a/.release-notes/feat-opencode-subagent-sessions.md
+++ b/.release-notes/feat-opencode-subagent-sessions.md
@@ -1,0 +1,7 @@
+# OpenCode 与 CodeWiz 子 Agent 会话修复
+
+<!-- release-target: both -->
+
+## Bug 修复
+
+- 🧩 OpenCode 与 CodeWiz 的子 Agent 会话不再作为独立会话出现在列表中,现在会正确关联到其父会话;统计与跨设备同步也不再重复计算子会话。旧版本数据不受影响。

--- a/apps/main-1.0/src/core/remote-sync.test.ts
+++ b/apps/main-1.0/src/core/remote-sync.test.ts
@@ -1193,11 +1193,12 @@ describe("remote sync", () => {
 import json, sqlite3, sys
 db = sqlite3.connect(sys.argv[1])
 db.executescript('''
-CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT NOT NULL, title TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER);
+CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT NOT NULL, title TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER, parent_id TEXT);
 CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, type TEXT NOT NULL, time_created INTEGER NOT NULL, data TEXT NOT NULL);
 CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, data TEXT NOT NULL);
 ''')
-db.execute("INSERT INTO session VALUES (?, ?, ?, ?, ?)", ("remote-codewiz-token-events", "/repo/codewiz", "CodeWiz remote tokens", 1780560000000, 1780560600000))
+db.execute("INSERT INTO session (id, directory, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?)", ("remote-codewiz-token-events", "/repo/codewiz", "CodeWiz remote tokens", 1780560000000, 1780560600000))
+db.execute("INSERT INTO session (id, directory, title, time_created, time_updated, parent_id) VALUES (?, ?, ?, ?, ?, ?)", ("remote-codewiz-child", "/repo/codewiz", "CodeWiz remote child", 1780560000000, 1780560600000, "remote-codewiz-token-events"))
 db.execute("INSERT INTO message VALUES (?, ?, ?, ?, ?)", ("cw-user", "remote-codewiz-token-events", "user", 1780560060000, json.dumps({"role": "user"})))
 db.execute("INSERT INTO part VALUES (?, ?, ?, ?, ?)", ("cw-user-part", "cw-user", "remote-codewiz-token-events", 1780560060000, json.dumps({"type": "text", "text": "codewiz remote question"})))
 db.execute("INSERT INTO message VALUES (?, ?, ?, ?, ?)", ("cw-assistant", "remote-codewiz-token-events", "assistant", 1780560120000, json.dumps({"role": "assistant", "tokens": {"input": 200, "output": 50, "reasoning": 7, "cache": {"read": 1000, "write": 9}}})))
@@ -1317,6 +1318,15 @@ db.close()
         reasoningOutputTokens: 7,
         totalTokens: 1266,
       });
+      const codewizChildSummary = output
+        .trim()
+        .split(/\r?\n/)
+        .map((line) => JSON.parse(line) as Record<string, unknown>)
+        .find((item) => item.rawId === "remote-codewiz-child");
+      expect(codewizChildSummary?.isSubagent).toBe(true);
+      expect(codewizChildSummary?.parentSessionId).toBe("remote-codewiz-token-events");
+      expect(codewizSummary?.isSubagent).toBe(false);
+      expect(codewizSummary?.parentSessionId).toBe(null);
     } finally {
       store.close();
       fs.rmSync(tempHome, { recursive: true, force: true });

--- a/apps/main-1.0/src/core/remote-sync.ts
+++ b/apps/main-1.0/src/core/remote-sync.ts
@@ -1456,6 +1456,9 @@ def emit_codewiz_summaries(db_path, stat):
   try:
     for session in sessions:
       raw_id = session["id"]
+      parent_session_id = session["parent_id"] if "parent_id" in session.keys() else None
+      if not isinstance(parent_session_id, str) or not parent_session_id:
+        parent_session_id = None
       first_question = ""
       message_count = 0
       message_events = []
@@ -1484,6 +1487,8 @@ def emit_codewiz_summaries(db_path, stat):
         "gitBranch": "",
         "tokenUsage": _tok_total(token_events) if token_events else codewiz_token_usage(session),
         "tokenEvents": token_events,
+        "isSubagent": parent_session_id is not None,
+        "parentSessionId": parent_session_id,
       })
   finally:
     try:

--- a/apps/main-1.0/src/core/session-loader-extra-sources.test.ts
+++ b/apps/main-1.0/src/core/session-loader-extra-sources.test.ts
@@ -635,6 +635,61 @@ describe("extra session sources", () => {
     fs.rmSync(root, { recursive: true, force: true });
   });
 
+  it("marks OpenCode subagent sessions via session.parent_id", () => {
+    const root = tmpDir("opencode-subagent");
+    const shareDir = path.join(root, ".local", "share", "opencode");
+    fs.mkdirSync(shareDir, { recursive: true });
+    const dbPath = path.join(shareDir, "opencode.db");
+    const db = new DatabaseSync(dbPath);
+    db.exec(`
+      CREATE TABLE session (
+        id TEXT PRIMARY KEY,
+        parent_id TEXT,
+        directory TEXT NOT NULL,
+        title TEXT NOT NULL,
+        time_created INTEGER NOT NULL,
+        time_updated INTEGER
+      );
+      CREATE TABLE message (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        type TEXT NOT NULL,
+        time_created INTEGER NOT NULL,
+        data TEXT NOT NULL
+      );
+      CREATE TABLE part (
+        id TEXT PRIMARY KEY,
+        message_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        time_created INTEGER NOT NULL,
+        data TEXT NOT NULL
+      );
+    `);
+    const insertSession = db.prepare("INSERT INTO session (id, parent_id, directory, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)");
+    insertSession.run("opencode-root", null, "/work/opencode-app", "Root session", 1_000, 2_000);
+    insertSession.run("opencode-child", "opencode-root", "/work/opencode-app", "Subagent session", 1_100, 1_900);
+    const insertMessage = db.prepare("INSERT INTO message (id, session_id, type, time_created, data) VALUES (?, ?, ?, ?, ?)");
+    const insertPart = db.prepare("INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?, ?, ?, ?, ?)");
+    insertMessage.run("msg-root-user", "opencode-root", "user", 1_100, JSON.stringify({ role: "user" }));
+    insertPart.run("part-root-user", "msg-root-user", "opencode-root", 1_100, JSON.stringify({ type: "text", text: "Audit the auth flow" }));
+    insertMessage.run("msg-child-user", "opencode-child", "user", 1_200, JSON.stringify({ role: "user" }));
+    insertPart.run("part-child-user", "msg-child-user", "opencode-child", 1_200, JSON.stringify({ type: "text", text: "Inspect middleware" }));
+    db.close();
+
+    const loaded = loadOpenCodeSessions(root);
+
+    expect(loaded).toHaveLength(2);
+    const byKey = new Map(loaded.map((item) => [item.session.sessionKey, item.session]));
+    expect(byKey.get("opencode:opencode-root")).toMatchObject({ isSubagent: false, parentSessionId: null });
+    expect(byKey.get("opencode:opencode-child")).toMatchObject({
+      sessionKey: "opencode:opencode-child",
+      isSubagent: true,
+      parentSessionId: "opencode-root",
+    });
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
   it("loads CodeWiz token usage from message and part JSON", () => {
     const root = tmpDir("codewiz-tokens");
     const dbPath = path.join(root, "opencode.db");

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -3837,6 +3837,7 @@ function loadOpenCodeSessionRow(
   const { messages, traceEvents, tokenEvents } = opencodeMessagesFromParts(db, rawId, sourceOptions.traceSource);
   const question = firstQuestion(messages);
   const stat = safeStat(dbPath);
+  const parentSessionId = stringField(session, "parent_id") || null;
   const usage = tokenEvents.length
     ? tokenUsageFromEvents(tokenEvents)
     : createSourceTokenUsage(
@@ -3857,6 +3858,8 @@ function loadOpenCodeSessionRow(
       timestamp: timestampMs(unknownField(session, "time_updated")) || timestampMs(unknownField(session, "time_created")) || stat.mtimeMs,
       tokenUsage: usage,
       stat,
+      isSubagent: parentSessionId !== null,
+      parentSessionId,
     }),
     messages,
     tokenEvents,

--- a/apps/main-2.0/src/core/remote-sync.test.ts
+++ b/apps/main-2.0/src/core/remote-sync.test.ts
@@ -168,4 +168,79 @@ describe("remote sync", () => {
       fs.rmSync(tempHome, { recursive: true, force: true });
     }
   }, 20_000);
+
+  it("keeps CodeWiz subagent sessions linked to their parent during remote collection", async () => {
+    const store = createInMemoryStore();
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-v2-remote-codewiz-"));
+    const codewizDir = path.join(tempHome, ".local", "share", "codewiz");
+    fs.mkdirSync(codewizDir, { recursive: true });
+    const codewizDbPath = path.join(codewizDir, "opencode.db");
+    execFileSync(
+      process.platform === "win32" ? "python" : "python3",
+      [
+        "-c",
+        String.raw`
+import json, sqlite3, sys
+db = sqlite3.connect(sys.argv[1])
+db.executescript('''
+CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT NOT NULL, title TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER, parent_id TEXT);
+CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, type TEXT NOT NULL, time_created INTEGER NOT NULL, data TEXT NOT NULL);
+CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, data TEXT NOT NULL);
+''')
+db.execute("INSERT INTO session (id, directory, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?)", ("codewiz-parent", "/repo/codewiz", "CodeWiz parent", 1780560000000, 1780560600000))
+db.execute("INSERT INTO session (id, directory, title, time_created, time_updated, parent_id) VALUES (?, ?, ?, ?, ?, ?)", ("codewiz-child", "/repo/codewiz", "CodeWiz child", 1780560000000, 1780560600000, "codewiz-parent"))
+db.execute("INSERT INTO message (id, session_id, type, time_created, data) VALUES (?, ?, ?, ?, ?)", ("cw-user", "codewiz-parent", "user", 1780560060000, json.dumps({"role": "user"})))
+db.execute("INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?, ?, ?, ?, ?)", ("cw-user-part", "cw-user", "codewiz-parent", 1780560060000, json.dumps({"type": "text", "text": "codewiz parent question"})))
+db.execute("INSERT INTO message (id, session_id, type, time_created, data) VALUES (?, ?, ?, ?, ?)", ("cw-child-user", "codewiz-child", "user", 1780560060000, json.dumps({"role": "user"})))
+db.execute("INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?, ?, ?, ?, ?)", ("cw-child-user-part", "cw-child-user", "codewiz-child", 1780560060000, json.dumps({"type": "text", "text": "codewiz child question"})))
+db.commit()
+db.close()
+`,
+        codewizDbPath,
+      ],
+      { encoding: "utf8" },
+    );
+
+    try {
+      const environment = await store.upsertEnvironment({
+        id: "ssh-devbox",
+        kind: "ssh",
+        label: "devbox",
+        hostAlias: "devbox",
+        host: "devbox.example.com",
+        authMode: "none",
+        enabled: true,
+      });
+      await syncRemoteEnvironment(store, environment, {
+        runSsh: async (_environment, command) => execFileSync(
+          process.platform === "win32" ? "python" : "python3",
+          ["-c", decodeCollectorScript(command)],
+          {
+            encoding: "utf8",
+            env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+          },
+        ),
+      });
+
+      await expect(store.getSession(`ssh:${environment.id}:codewiz:codewiz-parent`)).resolves.toMatchObject({
+        rawId: "codewiz-parent",
+        isSubagent: false,
+        parentSessionId: null,
+      });
+      await expect(store.getSession(`ssh:${environment.id}:codewiz:codewiz-child`)).resolves.toMatchObject({
+        rawId: "codewiz-child",
+        isSubagent: true,
+        parentSessionId: "codewiz-parent",
+      });
+      const rootSessions = await store.searchSessions({
+        environmentId: environment.id,
+        excludeSubagents: true,
+      });
+      expect(rootSessions).toHaveLength(1);
+      expect(rootSessions[0]?.rawId).toBe("codewiz-parent");
+    } finally {
+      await store.close();
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    }
+  }, 20_000);
 });

--- a/apps/main-2.0/src/core/remote-sync.ts
+++ b/apps/main-2.0/src/core/remote-sync.ts
@@ -1468,6 +1468,9 @@ def emit_codewiz_summaries(db_path, stat):
   try:
     for session in sessions:
       raw_id = session["id"]
+      parent_session_id = session["parent_id"] if "parent_id" in session.keys() else None
+      if not isinstance(parent_session_id, str) or not parent_session_id:
+        parent_session_id = None
       first_question = ""
       message_count = 0
       message_events = []
@@ -1496,6 +1499,8 @@ def emit_codewiz_summaries(db_path, stat):
         "gitBranch": "",
         "tokenUsage": _tok_total(token_events) if token_events else codewiz_token_usage(session),
         "tokenEvents": token_events,
+        "isSubagent": parent_session_id is not None,
+        "parentSessionId": parent_session_id,
       })
   finally:
     try:

--- a/apps/main-2.0/src/core/session-loader-opencode.test.ts
+++ b/apps/main-2.0/src/core/session-loader-opencode.test.ts
@@ -1,0 +1,120 @@
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadOpenCodeSessions } from "./session-loader";
+
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require("node:sqlite") as { DatabaseSync: new (path: string) => import("node:sqlite").DatabaseSync };
+
+function tmpDir(name: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `agentrecall-opencode-v2-${name}-`));
+}
+
+describe("OpenCode session loading", () => {
+  it("marks subagent sessions via session.parent_id", () => {
+    const root = tmpDir("subagent");
+    const shareDir = path.join(root, ".local", "share", "opencode");
+    fs.mkdirSync(shareDir, { recursive: true });
+    const dbPath = path.join(shareDir, "opencode.db");
+    const db = new DatabaseSync(dbPath);
+    db.exec(`
+      CREATE TABLE session (
+        id TEXT PRIMARY KEY,
+        parent_id TEXT,
+        directory TEXT NOT NULL,
+        title TEXT NOT NULL,
+        time_created INTEGER NOT NULL,
+        time_updated INTEGER
+      );
+      CREATE TABLE message (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        type TEXT NOT NULL,
+        time_created INTEGER NOT NULL,
+        data TEXT NOT NULL
+      );
+      CREATE TABLE part (
+        id TEXT PRIMARY KEY,
+        message_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        time_created INTEGER NOT NULL,
+        data TEXT NOT NULL
+      );
+    `);
+    const insertSession = db.prepare("INSERT INTO session (id, parent_id, directory, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)");
+    insertSession.run("opencode-root", null, "/work/opencode-app", "Root session", 1_000, 2_000);
+    insertSession.run("opencode-child", "opencode-root", "/work/opencode-app", "Subagent session", 1_100, 1_900);
+    const insertMessage = db.prepare("INSERT INTO message (id, session_id, type, time_created, data) VALUES (?, ?, ?, ?, ?)");
+    const insertPart = db.prepare("INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?, ?, ?, ?, ?)");
+    insertMessage.run("msg-root-user", "opencode-root", "user", 1_100, JSON.stringify({ role: "user" }));
+    insertPart.run("part-root-user", "msg-root-user", "opencode-root", 1_100, JSON.stringify({ type: "text", text: "Audit the auth flow" }));
+    insertMessage.run("msg-child-user", "opencode-child", "user", 1_200, JSON.stringify({ role: "user" }));
+    insertPart.run("part-child-user", "msg-child-user", "opencode-child", 1_200, JSON.stringify({ type: "text", text: "Inspect middleware" }));
+    db.close();
+
+    const loaded = loadOpenCodeSessions(root);
+
+    expect(loaded).toHaveLength(2);
+    const byKey = new Map(loaded.map((item) => [item.session.sessionKey, item.session]));
+    expect(byKey.get("opencode:opencode-root")).toMatchObject({ isSubagent: false, parentSessionId: null });
+    expect(byKey.get("opencode:opencode-child")).toMatchObject({
+      sessionKey: "opencode:opencode-child",
+      isSubagent: true,
+      parentSessionId: "opencode-root",
+    });
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("treats sessions as top-level when the schema has no parent_id column", () => {
+    const root = tmpDir("legacy-schema");
+    const shareDir = path.join(root, ".local", "share", "opencode");
+    fs.mkdirSync(shareDir, { recursive: true });
+    const dbPath = path.join(shareDir, "opencode.db");
+    const db = new DatabaseSync(dbPath);
+    db.exec(`
+      CREATE TABLE session (
+        id TEXT PRIMARY KEY,
+        directory TEXT NOT NULL,
+        title TEXT NOT NULL,
+        time_created INTEGER NOT NULL,
+        time_updated INTEGER
+      );
+      CREATE TABLE message (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        type TEXT NOT NULL,
+        time_created INTEGER NOT NULL,
+        data TEXT NOT NULL
+      );
+    `);
+    db.prepare("INSERT INTO session (id, directory, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?)").run(
+      "opencode-legacy",
+      "/work/opencode-app",
+      "Legacy schema session",
+      1_000,
+      2_000,
+    );
+    db.prepare("INSERT INTO message (id, session_id, type, time_created, data) VALUES (?, ?, ?, ?, ?)").run(
+      "msg-legacy-user",
+      "opencode-legacy",
+      "user",
+      1_100,
+      JSON.stringify({ role: "user" }),
+    );
+    db.close();
+
+    const loaded = loadOpenCodeSessions(root);
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].session).toMatchObject({
+      sessionKey: "opencode:opencode-legacy",
+      isSubagent: false,
+      parentSessionId: null,
+    });
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});

--- a/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
+++ b/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
@@ -1412,6 +1412,7 @@ function loadOpenCodeSessionRow(
   const { messages, traceEvents, tokenEvents } = opencodeMessagesFromParts(db, rawId, sourceOptions.traceSource);
   const question = firstQuestion(messages);
   const stat = safeStat(dbPath);
+  const parentSessionId = stringField(session, "parent_id") || null;
   const usage = tokenEvents.length
     ? tokenUsageFromEvents(tokenEvents)
     : createSourceTokenUsage(
@@ -1432,6 +1433,8 @@ function loadOpenCodeSessionRow(
       timestamp: timestampMs(unknownField(session, "time_updated")) || timestampMs(unknownField(session, "time_created")) || stat.mtimeMs,
       tokenUsage: usage,
       stat,
+      isSubagent: parentSessionId !== null,
+      parentSessionId,
     }),
     messages,
     tokenEvents,


### PR DESCRIPTION
## 概述

Fixes #489

OpenCode(及共用同一 loader 的 CodeWiz)的子 Agent 与 fork 会话此前被索引为独立顶层会话,污染会话列表与统计。根因:v1 / v2 两处 `loadOpenCodeSessionRow` 均未读取 `session.parent_id`。

## 改动

- `apps/main-1.0/src/core/session-loader.ts` 与 `apps/main-2.0/src/core/session-loaders/alternative-sources.ts` 的 `loadOpenCodeSessionRow`:读取 `parent_id` 并传入 `createIndexedSession` 的 `isSubagent` / `parentSessionId`,与 ZCode loader 及 Kimi(#486)的既有模式保持一致;
- 旧版 `opencode.db`(无 `parent_id` 列)行为不变:`SELECT *` 下字段缺失即按顶层会话处理,不做 schema 强校验;
- store 层 `is_subagent = 0` 顶层过滤、父子关系迁移、跨设备同步排除等既有逻辑自动生效,无需额外改动;
- 新增测试:v1 在 `session-loader-extra-sources.test.ts` 增加子会话用例;v2 新增 `session-loader-opencode.test.ts`(父子字段断言 + 无 `parent_id` 列的旧 schema 兼容断言);
- 按 `.release-notes` 规范补充双端 release note。

## 验证

- `test:v1`:1616 passed(仅 `mcp-server.test.ts` 5 例因本机路径含非 ASCII 字符无法加载 bundle 而失败——已在 stash 改动后的干净代码上复现同样失败,为既有环境问题);
- `test:v2`:2102 passed(`mcp-migration.test.ts` 1 例在全量运行时超时,单文件重跑 24/24 通过,为负载抖动);
- `npm run typecheck`(v1 + v2)通过。
