### PR TITLE
feat(sessions): index ZCode workflow task sessions

### DIFF
--- a/.release-notes/feat-zcode-workflow-sessions.md
+++ b/.release-notes/feat-zcode-workflow-sessions.md
@@ -1,0 +1,7 @@
+# ZCode Workflow 任务会话修复
+
+<!-- release-target: both -->
+
+## Bug 修复
+
+- 🧩 ZCode 中由 Workflow 发起的任务会话不再作为独立会话出现在列表中,现在会正确归属到其发起会话;统计与跨设备同步也不再重复计算。旧版本数据不受影响。

--- a/apps/main-1.0/src/core/session-loader-zcode.test.ts
+++ b/apps/main-1.0/src/core/session-loader-zcode.test.ts
@@ -274,6 +274,51 @@ describe("ZCode session loader", () => {
     }
   });
 
+  it("marks workflow task sessions as subagents via session_task_link", () => {
+    const root = tempZcodeRoot("task-link");
+    const db = new DatabaseSync(databasePath(root));
+    createCoreSchema(db);
+    db.exec(`
+      CREATE TABLE session_task_link (
+        id TEXT PRIMARY KEY,
+        root_workflow_run_id TEXT,
+        parent_link_id TEXT,
+        activity_id TEXT,
+        parent_session_id TEXT,
+        child_session_id TEXT NOT NULL,
+        role TEXT NOT NULL,
+        depth INTEGER NOT NULL DEFAULT 0,
+        path TEXT NOT NULL,
+        phase TEXT,
+        label TEXT,
+        agent_type TEXT,
+        model TEXT,
+        status TEXT NOT NULL,
+        time_created INTEGER NOT NULL,
+        time_updated INTEGER NOT NULL
+      );
+    `);
+    insertSession(db, "session-root", "/work/app");
+    insertSession(db, "session-task", "/work/app");
+    insertSession(db, "session-orphan-task", "/work/app");
+    insertSession(db, "session-direct-child", "/work/app", "session-root");
+    const insertLink = db.prepare(
+      "INSERT INTO session_task_link (id, parent_session_id, child_session_id, role, depth, path, status, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    );
+    insertLink.run("link-task", "session-root", "session-task", "task", 1, "0.1", "completed", 1, 2);
+    insertLink.run("link-orphan", null, "session-orphan-task", "task", 1, "0.2", "completed", 1, 2);
+    insertMessage(db, "task-message", "session-task", Date.parse("2026-07-21T08:01:00Z"), JSON.stringify({ role: "user" }));
+    insertPart(db, "task-part", "task-message", "session-task", Date.parse("2026-07-21T08:01:00Z"), JSON.stringify({ type: "text", text: "Run the workflow task" }));
+    db.close();
+
+    const loaded = loadZcodeSessions(root);
+    const byRawId = new Map(loaded.map((item) => [item.session.rawId, item.session]));
+    expect(byRawId.get("session-root")).toMatchObject({ isSubagent: false, parentSessionId: null });
+    expect(byRawId.get("session-task")).toMatchObject({ isSubagent: true, parentSessionId: "session-root" });
+    expect(byRawId.get("session-orphan-task")).toMatchObject({ isSubagent: false, parentSessionId: null });
+    expect(byRawId.get("session-direct-child")).toMatchObject({ isSubagent: true, parentSessionId: "session-root" });
+  });
+
   it("indexes legacy sessions without usage tables with zero token usage", () => {
     const root = tempZcodeRoot("legacy");
     const db = new DatabaseSync(databasePath(root));

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -4019,18 +4019,32 @@ function zcodeTokenEventsFromModelUsage(
   }
 }
 
+function zcodeTaskLinkParentMap(db: import("node:sqlite").DatabaseSync): Map<string, string> {
+  const map = new Map<string, string>();
+  if (!sqliteTableExists(db, "session_task_link")) return map;
+  if (!sqliteHasColumns(db, "session_task_link", ["child_session_id", "parent_session_id"])) return map;
+  const rows = db.prepare("SELECT child_session_id, parent_session_id FROM session_task_link").all() as Array<Record<string, unknown>>;
+  for (const row of rows) {
+    const childSessionId = stringField(row, "child_session_id");
+    const parentSessionId = stringField(row, "parent_session_id");
+    if (childSessionId && parentSessionId) map.set(childSessionId, parentSessionId);
+  }
+  return map;
+}
+
 function loadZcodeSessionRow(
   db: import("node:sqlite").DatabaseSync,
   dbPath: string,
   stat: VirtualSessionFileStat,
   session: Record<string, unknown>,
+  taskLinkParents: Map<string, string>,
 ): LoadedSession | null {
   const rawId = stringField(session, "id");
   if (!rawId) return null;
   const { messages, traceEvents, assistantMessageIds } = zcodeMessagesFromParts(db, rawId);
   const tokenEvents = zcodeTokenEventsFromModelUsage(db, rawId, assistantMessageIds);
   const question = firstQuestion(messages);
-  const parentSessionId = stringField(session, "parent_id") || null;
+  const parentSessionId = stringField(session, "parent_id") || taskLinkParents.get(rawId) || null;
   return {
     session: createIndexedSession({
       keyPrefix: "zcode",
@@ -4061,11 +4075,12 @@ export function loadZcodeSessions(zcodeDir = path.join(os.homedir(), ".zcode")):
     if (!sqliteHasColumns(db, "message", ["id", "session_id", "time_created", "data"])) return [];
     if (!sqliteHasColumns(db, "part", ["id", "message_id", "session_id", "time_created", "data"])) return [];
     const stat = zcodeDatabaseStat(dbPath);
+    const taskLinkParents = zcodeTaskLinkParentMap(db);
     const sessions = db.prepare("SELECT * FROM session ORDER BY time_updated DESC, time_created DESC, id").all() as Array<Record<string, unknown>>;
     return sessions
       .map((session) => {
         try {
-          return loadZcodeSessionRow(db, dbPath, stat, session);
+          return loadZcodeSessionRow(db, dbPath, stat, session, taskLinkParents);
         } catch {
           return null;
         }

--- a/apps/main-2.0/src/core/session-loader-zcode.test.ts
+++ b/apps/main-2.0/src/core/session-loader-zcode.test.ts
@@ -275,6 +275,51 @@ describe("ZCode session loader", () => {
     }
   });
 
+  it("marks workflow task sessions as subagents via session_task_link", () => {
+    const root = tempZcodeRoot("task-link");
+    const db = new DatabaseSync(databasePath(root));
+    createCoreSchema(db);
+    db.exec(`
+      CREATE TABLE session_task_link (
+        id TEXT PRIMARY KEY,
+        root_workflow_run_id TEXT,
+        parent_link_id TEXT,
+        activity_id TEXT,
+        parent_session_id TEXT,
+        child_session_id TEXT NOT NULL,
+        role TEXT NOT NULL,
+        depth INTEGER NOT NULL DEFAULT 0,
+        path TEXT NOT NULL,
+        phase TEXT,
+        label TEXT,
+        agent_type TEXT,
+        model TEXT,
+        status TEXT NOT NULL,
+        time_created INTEGER NOT NULL,
+        time_updated INTEGER NOT NULL
+      );
+    `);
+    insertSession(db, "session-root", "/work/app");
+    insertSession(db, "session-task", "/work/app");
+    insertSession(db, "session-orphan-task", "/work/app");
+    insertSession(db, "session-direct-child", "/work/app", "session-root");
+    const insertLink = db.prepare(
+      "INSERT INTO session_task_link (id, parent_session_id, child_session_id, role, depth, path, status, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    );
+    insertLink.run("link-task", "session-root", "session-task", "task", 1, "0.1", "completed", 1, 2);
+    insertLink.run("link-orphan", null, "session-orphan-task", "task", 1, "0.2", "completed", 1, 2);
+    insertMessage(db, "task-message", "session-task", Date.parse("2026-07-21T08:01:00Z"), JSON.stringify({ role: "user" }));
+    insertPart(db, "task-part", "task-message", "session-task", Date.parse("2026-07-21T08:01:00Z"), JSON.stringify({ type: "text", text: "Run the workflow task" }));
+    db.close();
+
+    const loaded = loadZcodeSessions(root);
+    const byRawId = new Map(loaded.map((item) => [item.session.rawId, item.session]));
+    expect(byRawId.get("session-root")).toMatchObject({ isSubagent: false, parentSessionId: null });
+    expect(byRawId.get("session-task")).toMatchObject({ isSubagent: true, parentSessionId: "session-root" });
+    expect(byRawId.get("session-orphan-task")).toMatchObject({ isSubagent: false, parentSessionId: null });
+    expect(byRawId.get("session-direct-child")).toMatchObject({ isSubagent: true, parentSessionId: "session-root" });
+  });
+
   it("indexes legacy sessions without usage tables with zero token usage", () => {
     const root = tempZcodeRoot("legacy");
     const db = new DatabaseSync(databasePath(root));

--- a/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
+++ b/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
@@ -1594,18 +1594,32 @@ function zcodeTokenEventsFromModelUsage(
   }
 }
 
+function zcodeTaskLinkParentMap(db: import("node:sqlite").DatabaseSync): Map<string, string> {
+  const map = new Map<string, string>();
+  if (!sqliteTableExists(db, "session_task_link")) return map;
+  if (!sqliteHasColumns(db, "session_task_link", ["child_session_id", "parent_session_id"])) return map;
+  const rows = db.prepare("SELECT child_session_id, parent_session_id FROM session_task_link").all() as Array<Record<string, unknown>>;
+  for (const row of rows) {
+    const childSessionId = stringField(row, "child_session_id");
+    const parentSessionId = stringField(row, "parent_session_id");
+    if (childSessionId && parentSessionId) map.set(childSessionId, parentSessionId);
+  }
+  return map;
+}
+
 function loadZcodeSessionRow(
   db: import("node:sqlite").DatabaseSync,
   dbPath: string,
   stat: VirtualSessionFileStat,
   session: Record<string, unknown>,
+  taskLinkParents: Map<string, string>,
 ): LoadedSession | null {
   const rawId = stringField(session, "id");
   if (!rawId) return null;
   const { messages, traceEvents, assistantMessageIds } = zcodeMessagesFromParts(db, rawId);
   const tokenEvents = zcodeTokenEventsFromModelUsage(db, rawId, assistantMessageIds);
   const question = firstQuestion(messages);
-  const parentSessionId = stringField(session, "parent_id") || null;
+  const parentSessionId = stringField(session, "parent_id") || taskLinkParents.get(rawId) || null;
   return {
     session: createIndexedSession({
       keyPrefix: "zcode",
@@ -1636,11 +1650,12 @@ export function loadZcodeSessions(zcodeDir = path.join(os.homedir(), ".zcode")):
     if (!sqliteHasColumns(db, "message", ["id", "session_id", "time_created", "data"])) return [];
     if (!sqliteHasColumns(db, "part", ["id", "message_id", "session_id", "time_created", "data"])) return [];
     const stat = zcodeDatabaseStat(dbPath);
+    const taskLinkParents = zcodeTaskLinkParentMap(db);
     const sessions = db.prepare("SELECT * FROM session ORDER BY time_updated DESC, time_created DESC, id").all() as Array<Record<string, unknown>>;
     return sessions
       .map((session) => {
         try {
-          return loadZcodeSessionRow(db, dbPath, stat, session);
+          return loadZcodeSessionRow(db, dbPath, stat, session, taskLinkParents);
         } catch {
           return null;
         }


### PR DESCRIPTION
## 概述

Fixes #491

ZCode 中由 Workflow 发起的任务会话此前被索引为独立顶层会话。根因:v1 / v2 两处 ZCode loader 均只读取 `session.parent_id`,而 workflow 任务会话的父子关系仅记录在 `session_task_link` 表(`parent_session_id` / `child_session_id` 直连列)。

## 改动

- v1 `apps/main-1.0/src/core/session-loader.ts` 与 v2 `apps/main-2.0/src/core/session-loaders/alternative-sources.ts`:
  - 新增 `zcodeTaskLinkParentMap(db)`:若 `session_task_link` 表存在,构建 `child_session_id -> parent_session_id` 映射(过滤 `parent_session_id` 为空的行);表或列缺失时返回空映射,旧行为完全不变;
  - `loadZcodeSessionRow` 的 `parentSessionId` 解析改为 `session.parent_id` 优先、link 映射兜底,`isSubagent` 逻辑不变;
- 测试:v1/v2 的 `session-loader-zcode.test.ts` 各新增用例,覆盖:link 关联的任务会话被标记为子会话、`parent_session_id` 为空的孤儿 link 行回退为顶层、`parent_id` 直连路径与 link 路径并存;
- 该 child→parent 映射也可作为 #472 删除级联修复的基础(其第 2 点)。

## 验证

- `session-loader-zcode.test.ts`:v1、v2 均 6/6 通过;
- `test:v1` 全量:1617 passed(仅 `mcp-server.test.ts` 5 例为本机路径含非 ASCII 字符的既有环境问题,已在干净代码上复现);
- `test:v2` 全量:2104 passed(一次运行中 `mcp-migration` 1 例超时抖动,单文件重跑 24/24、二次全量无失败);
- `npm run typecheck`(v1 + v2)通过。
