### PR TITLE
fix: resolve migration CLI through the user shell PATH

### DIFF
--- a/.release-notes/fix-session-migration-cli-path.md
+++ b/.release-notes/fix-session-migration-cli-path.md
@@ -1,0 +1,6 @@
+# Session 迁移使用终端中的 CLI
+<!-- release-target: both -->
+
+## Bug 修复
+
+- 修复应用与用户终端的命令路径不一致时，Session 迁移可能错误提示 Claude 或其他目标 CLI 版本检查失败的问题。

--- a/apps/main-1.0/src/core/platform.test.ts
+++ b/apps/main-1.0/src/core/platform.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { mergeApiConfigWithProfileDefaults, mergeClaudeApiConfigWithProfileDefaults } from "./api-config";
@@ -1165,6 +1165,46 @@ describe("migration cli process specs", () => {
     expect(getRemoteMigrationCliVersionCommand("codex", ["--version"])).toBe(
       'bash -lc \'if [ -s "$HOME/.nvm/nvm.sh" ]; then . "$HOME/.nvm/nvm.sh"; fi; codex --version\'',
     );
+  });
+
+  it.skipIf(process.platform === "win32")("probes bare migration CLI names through the user shell PATH", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "agent-recall-migration-cli-"));
+    const appBin = path.join(root, "app-bin");
+    const userBin = path.join(root, "user-bin");
+    const shell = path.join(root, "test-shell");
+    const previous = {
+      path: process.env.PATH,
+      shell: process.env.SHELL,
+      userBin: process.env.AGENT_RECALL_TEST_CLI_BIN,
+    };
+    try {
+      mkdirSync(appBin);
+      mkdirSync(userBin);
+      writeFileSync(path.join(appBin, "claude"), "#!/bin/sh\nexit 9\n");
+      writeFileSync(path.join(userBin, "claude"), "#!/bin/sh\nprintf '2.1.233 (Claude Code)\\n'\n");
+      // Startup files print unrelated paths around the lookup result.
+      writeFileSync(
+        shell,
+        "#!/bin/sh\nprintf 'Restored session from /Users/example/.zsh_history\\n'\n"
+          + "printf '%s/claude\\n' \"$AGENT_RECALL_TEST_CLI_BIN\"\nprintf '/opt/homebrew/bin/node\\n'\n",
+      );
+      chmodSync(path.join(appBin, "claude"), 0o755);
+      chmodSync(path.join(userBin, "claude"), 0o755);
+      chmodSync(shell, 0o755);
+      process.env.PATH = appBin;
+      process.env.SHELL = shell;
+      process.env.AGENT_RECALL_TEST_CLI_BIN = userBin;
+
+      await expect(inspectMigrationCli("claude", defaultSettings)).resolves.toBeUndefined();
+    } finally {
+      if (previous.path === undefined) delete process.env.PATH;
+      else process.env.PATH = previous.path;
+      if (previous.shell === undefined) delete process.env.SHELL;
+      else process.env.SHELL = previous.shell;
+      if (previous.userBin === undefined) delete process.env.AGENT_RECALL_TEST_CLI_BIN;
+      else process.env.AGENT_RECALL_TEST_CLI_BIN = previous.userBin;
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("does not echo potentially sensitive unparseable version output", async () => {

--- a/apps/main-1.0/src/core/platform.ts
+++ b/apps/main-1.0/src/core/platform.ts
@@ -1327,7 +1327,39 @@ export function mergeProcessEnvOverrides(overrides?: Record<string, string>): No
   return { ...process.env, ...(overrides ?? {}) };
 }
 
-function runCliVersion(command: string, args: string[], env?: Record<string, string>): Promise<string> {
+function runCliVersionProcess(
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  timeoutMs = 0,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, { env, timeout: timeoutMs }, (error, stdout, stderr) => {
+      if (!error) {
+        resolve(stdout);
+        return;
+      }
+      const failure = error instanceof Error ? error : new Error(String(error));
+      reject(Object.assign(failure, { stdout, stderr }));
+    });
+  });
+}
+
+// Startup files often print banners around the lookup result, so accept only a
+// line that names the requested binary instead of the first path that appears.
+function absoluteCliFromShellOutput(output: string, command: string): string | null {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => path.isAbsolute(line) && path.basename(line) === command)
+    .at(-1) ?? null;
+}
+
+// Login and interactive startup files are where users put the PATH entries their
+// terminal relies on, but reading them means running arbitrary startup code.
+const SHELL_CLI_LOOKUP_TIMEOUT_MS = 5_000;
+
+async function runCliVersion(command: string, args: string[], env?: Record<string, string>): Promise<string> {
   if (process.platform === "win32") {
     // npm installs Windows CLI shims as .cmd files. PowerShell invokes those
     // shims, while single-quoted arguments keep paths and values literal.
@@ -1365,16 +1397,24 @@ function runCliVersion(command: string, args: string[], env?: Record<string, str
     );
   }
 
-  return new Promise((resolve, reject) => {
-    execFile(command, args, { env: mergeProcessEnvOverrides(env) }, (error, stdout, stderr) => {
-      if (!error) {
-        resolve(stdout);
-        return;
-      }
-      const failure = error instanceof Error ? error : new Error(String(error));
-      reject(Object.assign(failure, { stdout, stderr }));
-    });
-  });
+  const childEnv = mergeProcessEnvOverrides(env);
+  if (!path.isAbsolute(command) && !/[\\/]/.test(command)) {
+    const shell = childEnv.SHELL?.trim() || "/bin/sh";
+    try {
+      const resolvedOutput = await runCliVersionProcess(
+        shell,
+        ["-lic", 'command -v -- "$0"', command],
+        childEnv,
+        SHELL_CLI_LOOKUP_TIMEOUT_MS,
+      );
+      command = absoluteCliFromShellOutput(resolvedOutput, command) ?? command;
+    } catch {
+      // A custom shell may not support login/interactive flags, and a slow
+      // startup file can exhaust the lookup timeout. The inherited application
+      // PATH is still a valid fallback for directly installed CLIs.
+    }
+  }
+  return runCliVersionProcess(command, args, childEnv);
 }
 
 function quotePowerShellCliArg(value: string): string {

--- a/apps/main-2.0/src/core/platform.test.ts
+++ b/apps/main-2.0/src/core/platform.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import type { SessionSearchResult } from "./types";
 import {
   defaultSettings,
   getRemoteMigrationCliVersionCommand,
   getResumeCommand,
+  inspectMigrationCli,
   mergeAppSettings,
 } from "./platform";
 
@@ -12,6 +16,46 @@ describe("app settings", () => {
     expect(getRemoteMigrationCliVersionCommand("codex", ["--version"])).toBe(
       'bash -lc \'if [ -s "$HOME/.nvm/nvm.sh" ]; then . "$HOME/.nvm/nvm.sh"; fi; codex --version\'',
     );
+  });
+
+  it.skipIf(process.platform === "win32")("probes bare migration CLI names through the user shell PATH", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "agent-recall-migration-cli-"));
+    const appBin = path.join(root, "app-bin");
+    const userBin = path.join(root, "user-bin");
+    const shell = path.join(root, "test-shell");
+    const previous = {
+      path: process.env.PATH,
+      shell: process.env.SHELL,
+      userBin: process.env.AGENT_RECALL_TEST_CLI_BIN,
+    };
+    try {
+      mkdirSync(appBin);
+      mkdirSync(userBin);
+      writeFileSync(path.join(appBin, "claude"), "#!/bin/sh\nexit 9\n");
+      writeFileSync(path.join(userBin, "claude"), "#!/bin/sh\nprintf '2.1.233 (Claude Code)\\n'\n");
+      // Startup files print unrelated paths around the lookup result.
+      writeFileSync(
+        shell,
+        "#!/bin/sh\nprintf 'Restored session from /Users/example/.zsh_history\\n'\n"
+          + "printf '%s/claude\\n' \"$AGENT_RECALL_TEST_CLI_BIN\"\nprintf '/opt/homebrew/bin/node\\n'\n",
+      );
+      chmodSync(path.join(appBin, "claude"), 0o755);
+      chmodSync(path.join(userBin, "claude"), 0o755);
+      chmodSync(shell, 0o755);
+      process.env.PATH = appBin;
+      process.env.SHELL = shell;
+      process.env.AGENT_RECALL_TEST_CLI_BIN = userBin;
+
+      await expect(inspectMigrationCli("claude", defaultSettings)).resolves.toBeUndefined();
+    } finally {
+      if (previous.path === undefined) delete process.env.PATH;
+      else process.env.PATH = previous.path;
+      if (previous.shell === undefined) delete process.env.SHELL;
+      else process.env.SHELL = previous.shell;
+      if (previous.userBin === undefined) delete process.env.AGENT_RECALL_TEST_CLI_BIN;
+      else process.env.AGENT_RECALL_TEST_CLI_BIN = previous.userBin;
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("keeps WorkBuddy indexing opt-in while accepting an explicit enable", () => {

--- a/apps/main-2.0/src/core/platform.ts
+++ b/apps/main-2.0/src/core/platform.ts
@@ -1406,7 +1406,39 @@ export function mergeProcessEnvOverrides(overrides?: Record<string, string>): No
   return { ...process.env, ...(overrides ?? {}) };
 }
 
-function runCliVersion(command: string, args: string[], env?: Record<string, string>): Promise<string> {
+function runCliVersionProcess(
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  timeoutMs = 0,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, { env, timeout: timeoutMs }, (error, stdout, stderr) => {
+      if (!error) {
+        resolve(stdout);
+        return;
+      }
+      const failure = error instanceof Error ? error : new Error(String(error));
+      reject(Object.assign(failure, { stdout, stderr }));
+    });
+  });
+}
+
+// Startup files often print banners around the lookup result, so accept only a
+// line that names the requested binary instead of the first path that appears.
+function absoluteCliFromShellOutput(output: string, command: string): string | null {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => path.isAbsolute(line) && path.basename(line) === command)
+    .at(-1) ?? null;
+}
+
+// Login and interactive startup files are where users put the PATH entries their
+// terminal relies on, but reading them means running arbitrary startup code.
+const SHELL_CLI_LOOKUP_TIMEOUT_MS = 5_000;
+
+async function runCliVersion(command: string, args: string[], env?: Record<string, string>): Promise<string> {
   if (process.platform === "win32") {
     // npm installs Windows CLI shims as .cmd files. PowerShell invokes those
     // shims, while single-quoted arguments keep paths and values literal.
@@ -1444,16 +1476,24 @@ function runCliVersion(command: string, args: string[], env?: Record<string, str
     );
   }
 
-  return new Promise((resolve, reject) => {
-    execFile(command, args, { env: mergeProcessEnvOverrides(env) }, (error, stdout, stderr) => {
-      if (!error) {
-        resolve(stdout);
-        return;
-      }
-      const failure = error instanceof Error ? error : new Error(String(error));
-      reject(Object.assign(failure, { stdout, stderr }));
-    });
-  });
+  const childEnv = mergeProcessEnvOverrides(env);
+  if (!path.isAbsolute(command) && !/[\\/]/.test(command)) {
+    const shell = childEnv.SHELL?.trim() || "/bin/sh";
+    try {
+      const resolvedOutput = await runCliVersionProcess(
+        shell,
+        ["-lic", 'command -v -- "$0"', command],
+        childEnv,
+        SHELL_CLI_LOOKUP_TIMEOUT_MS,
+      );
+      command = absoluteCliFromShellOutput(resolvedOutput, command) ?? command;
+    } catch {
+      // A custom shell may not support login/interactive flags, and a slow
+      // startup file can exhaust the lookup timeout. The inherited application
+      // PATH is still a valid fallback for directly installed CLIs.
+    }
+  }
+  return runCliVersionProcess(command, args, childEnv);
 }
 
 function quotePowerShellCliArg(value: string): string {


### PR DESCRIPTION
## Problem

Session migration verifies the target CLI's version before it writes anything. That probe ran with the PATH the application itself inherited, which is not the PATH the user's terminal has:

- A GUI-launched app never reads the shell startup files that put a directly-installed CLI (for example `~/.local/bin/claude`) on PATH.
- A development launch resolves a project-local `node_modules/.bin` shim before the user's own install.

The result was `Claude CLI --version failed for claude` (or `binary not found`) for a CLI that the user's terminal runs fine — and migration writes files that the user later resumes *from that terminal*, so the probe was checking the wrong binary.

## Fix

`runCliVersion` now resolves bare command names through the user's login shell (`$SHELL -lic 'command -v -- "$0"'`) before probing, matching the environment resume actually uses. Explicit absolute paths and the Windows PowerShell branch are untouched.

Three guards on the new path:

- Falls back to the inherited PATH when the shell cannot report a path (custom shell without `-l`/`-i`, function/alias instead of a binary).
- 5s cap on the lookup, so a slow or blocking startup file cannot stall the precheck.
- Accepts only an output line naming the requested binary, so startup banners that print unrelated absolute paths cannot redirect the probe.

This mirrors what the remote probe in the same file already does — `getRemoteMigrationCliVersionCommand` wraps the SSH version check in `bash -lc`.

Applied to V1 and V2 identically; the migration precheck behavior is shared, and the V2 standalone MCP migration entry benefits for the same reason.

## Verification

- `apps/main-1.0` `src/core/platform.test.ts` — 97 passed, 1 pre-existing skip
- `apps/main-2.0` `src/core/platform.test.ts` — 10 passed
- New regression in both apps: a fake `claude` that exits 9 on the application PATH, the working one reachable only through the user shell, plus banner noise and a decoy absolute path in the shell output. Verified it fails against the pre-fix parsing.
- `npm run typecheck` — both apps clean (V2 also passes its dead-code entrypoint check)
- `npm run release-note:check` — passes (1 fix, 0 features)
- Real-machine check: the login-shell lookup resolves the user's install in 0.04–0.09s, well inside the 5s cap.

Not run: full `npm test` and `package:smoke:all` (CI covers those).

🤖 Generated with [Claude Code](https://claude.com/claude-code)