### PR TITLE
fix: 修复符号链接持久化后的远程会话状态

### DIFF
--- a/.release-notes/fix-remote-live-session-symlinks.md
+++ b/.release-notes/fix-remote-live-session-symlinks.md
@@ -1,0 +1,7 @@
+# 修复持久化目录下的远程会话状态
+
+<!-- release-target: both -->
+
+## Bug 修复
+
+- 使用符号链接或 NFS 持久化 Codex、Claude Code 数据目录时，AgentRecall 现在能正确识别正在运行的远程会话，不再把当前会话误显示为 Closed 或关联到旧会话。

--- a/apps/main-1.0/src/core/remote-session-activity.test.ts
+++ b/apps/main-1.0/src/core/remote-session-activity.test.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { inflateRawSync } from "node:zlib";
 import { describe, expect, it, vi } from "vitest";
 import { loadRemoteLiveSessions } from "./remote-session-activity";
 import type { SessionEnvironment } from "./types";
@@ -101,6 +102,104 @@ describe("remote live session detection", () => {
     expect(maximumActive).toBe(3);
   });
 
+  it("maps persisted Codex and Claude processes without confusing helper or historical sessions", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-remote-persisted-live-"));
+    const home = path.join(root, "home");
+    const persistedCodex = path.join(root, "persisted", "codex");
+    const persistedClaude = path.join(root, "persisted", "claude");
+    const procRoot = path.join(root, "proc");
+    const codexSessions = path.join(persistedCodex, "sessions", "2026", "08", "29");
+    const claudeMetaDir = path.join(persistedClaude, "sessions");
+    const claudeMetaProject = path.join(persistedClaude, "projects", "-work-meta");
+    const claudeFdProject = path.join(persistedClaude, "projects", "-work-fd");
+    const similarCodexRoot = path.join(root, "persisted", "codex", "sessions-evil");
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(codexSessions, { recursive: true });
+    fs.mkdirSync(claudeMetaDir, { recursive: true });
+    fs.mkdirSync(claudeMetaProject, { recursive: true });
+    fs.mkdirSync(claudeFdProject, { recursive: true });
+    fs.mkdirSync(similarCodexRoot, { recursive: true });
+    fs.symlinkSync(persistedCodex, path.join(home, ".codex"), process.platform === "win32" ? "junction" : "dir");
+    fs.symlinkSync(persistedClaude, path.join(home, ".claude"), process.platform === "win32" ? "junction" : "dir");
+
+    const activeId = "11111111-1111-4111-8111-111111111111";
+    const completedId = "22222222-2222-4222-8222-222222222222";
+    const idleOlderId = "33333333-3333-4333-8333-333333333333";
+    const idleNewestId = "44444444-4444-4444-8444-444444444444";
+    const helperId = "55555555-5555-4555-8555-555555555555";
+    const appServerId = "66666666-6666-4666-8666-666666666666";
+    const similarPrefixId = "77777777-7777-4777-8777-777777777777";
+    const activeFile = codexRollout(codexSessions, activeId, "task_started");
+    const completedFile = codexRollout(codexSessions, completedId, "task_complete");
+    const idleOlderFile = codexRollout(codexSessions, idleOlderId, "task_complete");
+    const idleNewestFile = codexRollout(codexSessions, idleNewestId, "task_complete");
+    const helperFile = codexRollout(codexSessions, helperId, "task_started");
+    const appServerFile = codexRollout(codexSessions, appServerId, "task_started");
+    const similarPrefixFile = codexRollout(similarCodexRoot, similarPrefixId, "task_started");
+    const older = new Date(Date.now() - 60_000);
+    const newer = new Date(Date.now() - 30_000);
+    fs.utimesSync(idleOlderFile, older, older);
+    fs.utimesSync(idleNewestFile, newer, newer);
+
+    const metadataClaudeId = "claude-from-pid-metadata";
+    const wrongClaudeId = "claude-wrong-time-fallback";
+    const fdClaudeId = "claude-from-canonical-fd";
+    const wrongClaudeFile = path.join(claudeMetaProject, `${wrongClaudeId}.jsonl`);
+    const fdClaudeFile = path.join(claudeFdProject, `${fdClaudeId}.jsonl`);
+    fs.writeFileSync(wrongClaudeFile, "{}\n");
+    fs.writeFileSync(fdClaudeFile, "{}\n");
+
+    writeSyntheticProcess(procRoot, 801, ["/usr/bin/codex"], [activeFile, completedFile, similarPrefixFile]);
+    writeSyntheticProcess(procRoot, 802, ["/usr/bin/codex"], [idleOlderFile, idleNewestFile]);
+    writeSyntheticProcess(procRoot, 803, ["/usr/bin/codex", "resume", "explicit-codex-resume"], [helperFile]);
+    writeSyntheticProcess(
+      procRoot,
+      804,
+      ["/opt/lib/node_modules/@openai/codex/vendor/bin/codex-code-mode-host"],
+      [helperFile],
+    );
+    writeSyntheticProcess(procRoot, 805, ["/usr/bin/claude"], [wrongClaudeFile], "/work/meta");
+    writeSyntheticProcess(procRoot, 806, ["/usr/bin/claude"], [fdClaudeFile], "/work/missing");
+    writeSyntheticProcess(procRoot, 807, ["/usr/bin/claude", "--resume", "explicit-claude-resume"], [], "/work/meta");
+    writeSyntheticProcess(
+      procRoot,
+      808,
+      ["/usr/bin/node", "/usr/bin/codex", "app-server", "--listen", "stdio://"],
+      [appServerFile, completedFile],
+    );
+    writeSyntheticProcess(procRoot, 809, ["/usr/bin/node", "/usr/bin/codex"], [helperFile]);
+    fs.writeFileSync(
+      path.join(claudeMetaDir, "805.json"),
+      JSON.stringify({ sessionId: metadataClaudeId, cwd: "/work/meta" }),
+    );
+    fs.writeFileSync(path.join(claudeMetaDir, "806.json"), "{not-json");
+    fs.writeFileSync(
+      path.join(claudeMetaDir, "807.json"),
+      JSON.stringify({ sessionId: "metadata-must-not-override-resume" }),
+    );
+
+    try {
+      const sessions = await loadRemoteLiveSessions([environment()], (_remoteEnvironment, remoteCommand) =>
+        executeRemotePayloadWithReadlinkFixtures(remoteCommand, {
+          HOME: home,
+          USERPROFILE: home,
+          AGENT_RECALL_PROC_ROOT: procRoot,
+        }));
+
+      expect(sessions).toEqual([
+        { family: "codex", rawId: activeId, pid: 801, environmentId: "ssh-devbox" },
+        { family: "codex", rawId: idleNewestId, pid: 802, environmentId: "ssh-devbox" },
+        { family: "codex", rawId: "explicit-codex-resume", pid: 803, environmentId: "ssh-devbox" },
+        { family: "claude", rawId: metadataClaudeId, pid: 805, environmentId: "ssh-devbox" },
+        { family: "claude", rawId: fdClaudeId, pid: 806, environmentId: "ssh-devbox" },
+        { family: "claude", rawId: "explicit-claude-resume", pid: 807, environmentId: "ssh-devbox" },
+        { family: "codex", rawId: appServerId, pid: 808, environmentId: "ssh-devbox" },
+      ]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it.skipIf(process.platform === "win32")("detects active Codex and Claude sessions from a synthetic remote process tree", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-remote-live-"));
     const home = path.join(root, "home");
@@ -187,6 +286,65 @@ describe("remote live session detection", () => {
 function executeRemoteCommand(remoteCommand: string, env: Record<string, string>): Promise<string> {
   return new Promise((resolve, reject) => {
     execFile("sh", ["-lc", remoteCommand], { env: { ...process.env, ...env }, maxBuffer: 1024 * 1024 }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(stderr.trim() || error.message));
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+function codexRollout(directory: string, rawId: string, eventType: "task_started" | "task_complete"): string {
+  fs.mkdirSync(directory, { recursive: true });
+  const filePath = path.join(directory, `rollout-2026-08-29T00-00-00-${rawId}.jsonl`);
+  fs.writeFileSync(filePath, JSON.stringify({ type: "event_msg", payload: { type: eventType } }) + "\n");
+  return filePath;
+}
+
+function writeSyntheticProcess(
+  procRoot: string,
+  pid: number,
+  tokens: string[],
+  openFiles: string[],
+  cwd?: string,
+): void {
+  const processRoot = path.join(procRoot, String(pid));
+  const fdRoot = path.join(processRoot, "fd");
+  fs.mkdirSync(fdRoot, { recursive: true });
+  fs.writeFileSync(path.join(processRoot, "cmdline"), Buffer.from(`${tokens.join("\0")}\0`));
+  openFiles.forEach((filePath, index) => {
+    fs.writeFileSync(path.join(fdRoot, String(index + 10)), filePath);
+  });
+  if (cwd) fs.writeFileSync(path.join(processRoot, "cwd"), cwd);
+}
+
+function executeRemotePayloadWithReadlinkFixtures(
+  remoteCommand: string,
+  env: Record<string, string>,
+): Promise<string> {
+  const payload = remoteCommand.match(/base64\.b64decode\("([A-Za-z0-9+/=]+)"\)/)?.[1];
+  if (!payload) return Promise.reject(new Error("Remote activity payload was not found."));
+  const script = inflateRawSync(Buffer.from(payload, "base64")).toString("utf8");
+  const readlinkFixture = String.raw`
+import os
+from pathlib import Path
+
+_agent_recall_real_readlink = os.readlink
+def _agent_recall_fixture_readlink(value):
+  candidate = Path(value)
+  if os.environ.get("AGENT_RECALL_PROC_ROOT") and candidate.is_file():
+    return candidate.read_text(encoding="utf-8")
+  return _agent_recall_real_readlink(value)
+os.readlink = _agent_recall_fixture_readlink
+`;
+  const executable = process.platform === "win32" ? "python" : "python3";
+  return new Promise((resolve, reject) => {
+    execFile(executable, ["-c", `${readlinkFixture}\n${script}`], {
+      env: { ...process.env, ...env },
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    }, (error, stdout, stderr) => {
       if (error) {
         reject(new Error(stderr.trim() || error.message));
         return;

--- a/apps/main-1.0/src/core/remote-session-activity.ts
+++ b/apps/main-1.0/src/core/remote-session-activity.ts
@@ -19,6 +19,25 @@ CLAUDE_SESSION_START_SKEW_MS = 2 * 60 * 1000
 READ_CHUNK_SIZE = 64 * 1024
 SESSION_ID_PATTERN = re.compile(r"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$", re.IGNORECASE)
 proc_root = Path(os.environ.get("AGENT_RECALL_PROC_ROOT", "/proc"))
+codex_sessions_root = Path.home() / ".codex" / "sessions"
+claude_projects_root = Path.home() / ".claude" / "projects"
+
+def resolved_path(value):
+  try:
+    return Path(value).resolve()
+  except Exception:
+    return None
+
+def path_is_within(value, root):
+  candidate = resolved_path(value)
+  boundary = resolved_path(root)
+  if candidate is None or boundary is None:
+    return False
+  try:
+    candidate.relative_to(boundary)
+    return True
+  except (ValueError, OSError):
+    return False
 
 def normalized_executable(token):
   name = token.replace("\\", "/").rsplit("/", 1)[-1].lower()
@@ -150,9 +169,55 @@ def process_started_at_ms(pid):
   except Exception:
     return None
 
+def codex_session_id(file_name):
+  normalized = file_name.replace("\\", "/")
+  if not normalized.lower().endswith(".jsonl") or not path_is_within(file_name, codex_sessions_root):
+    return None
+  match = SESSION_ID_PATTERN.search(normalized)
+  return match.group(1) if match else None
+
+def codex_session_candidates(pid):
+  candidates = []
+  for file_name in open_files(pid):
+    raw_id = codex_session_id(file_name)
+    if not raw_id:
+      continue
+    try:
+      modified_at = Path(file_name).stat().st_mtime
+    except Exception:
+      modified_at = 0
+    candidates.append((modified_at, file_name, raw_id))
+  return candidates
+
+def is_codex_desktop_process(token):
+  lower = token.replace("\\", "/").lower()
+  if "/.codex/computer-use/" in lower:
+    return True
+  return ".app/contents/" in lower and "/contents/resources/codex" not in lower
+
+def is_plain_codex_command(tokens, command_index, args):
+  if command_index != 0:
+    return False
+  token = tokens[command_index]
+  if normalized_executable(token) != "codex" or is_codex_desktop_process(token):
+    return False
+  if "resume" in args or "app-server" in args:
+    return False
+  return True
+
+def claude_process_session_id(pid):
+  metadata_path = Path.home() / ".claude" / "sessions" / (str(pid) + ".json")
+  try:
+    value = json.loads(metadata_path.read_text(encoding="utf-8"))
+  except Exception:
+    return None
+  raw_id = value.get("sessionId") if isinstance(value, dict) else None
+  normalized = raw_id.strip() if isinstance(raw_id, str) else ""
+  return normalized or None
+
 def claude_session_id(file_name):
   normalized = file_name.replace("\\", "/")
-  if "/.claude/projects/" not in normalized or not normalized.lower().endswith(".jsonl"):
+  if not normalized.lower().endswith(".jsonl") or not path_is_within(file_name, claude_projects_root):
     return None
   raw_id = normalized.rsplit("/", 1)[-1][:-len(".jsonl")].strip()
   if "/subagents/" in normalized:
@@ -248,12 +313,16 @@ for pid, tokens in process_rows():
         if raw_id and not raw_id.startswith("-"):
           emit_session("codex", raw_id, pid)
     if "app-server" in args:
-      for file_name in open_files(pid):
-        if "/.codex/sessions/" not in file_name.replace("\\", "/"):
-          continue
-        match = SESSION_ID_PATTERN.search(file_name)
-        if match and agent_is_working(Path(file_name)):
-          emit_session("codex", match.group(1), pid)
+      candidates = codex_session_candidates(pid)
+      for _, file_name, raw_id in candidates:
+        if agent_is_working(Path(file_name)):
+          emit_session("codex", raw_id, pid)
+    elif is_plain_codex_command(tokens, command_index, args):
+      candidates = codex_session_candidates(pid)
+      if candidates:
+        working = [candidate for candidate in candidates if agent_is_working(Path(candidate[1]))]
+        _, _, raw_id = max(working or candidates)
+        emit_session("codex", raw_id, pid)
 
   command_index = claude_command_index(tokens)
   if command_index is None:
@@ -262,6 +331,10 @@ for pid, tokens in process_rows():
   resumed_id = flag_resume_id(args)
   if resumed_id:
     emit_session("claude", resumed_id, pid)
+    continue
+  metadata_id = claude_process_session_id(pid)
+  if metadata_id:
+    emit_session("claude", metadata_id, pid)
     continue
   open_session_ids = [raw_id for raw_id in (claude_session_id(file_name) for file_name in open_files(pid)) if raw_id]
   if open_session_ids:

--- a/apps/main-2.0/src/core/remote-session-activity.test.ts
+++ b/apps/main-2.0/src/core/remote-session-activity.test.ts
@@ -1,3 +1,8 @@
+import { execFile } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { inflateRawSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
 import { loadRemoteLiveSessions } from "./remote-session-activity";
 import type { SessionEnvironment } from "./types";
@@ -83,4 +88,161 @@ describe("remote live session deletion guards", () => {
       { family: "codex", rawId: "remote-codex", pid: 42, environmentId: "ssh-1" },
     ]);
   });
+
+  it("maps persisted Codex and Claude processes without confusing helper or historical sessions", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-v2-remote-persisted-live-"));
+    const home = path.join(root, "home");
+    const persistedCodex = path.join(root, "persisted", "codex");
+    const persistedClaude = path.join(root, "persisted", "claude");
+    const procRoot = path.join(root, "proc");
+    const codexSessions = path.join(persistedCodex, "sessions", "2026", "08", "29");
+    const claudeMetaDir = path.join(persistedClaude, "sessions");
+    const claudeMetaProject = path.join(persistedClaude, "projects", "-work-meta");
+    const claudeFdProject = path.join(persistedClaude, "projects", "-work-fd");
+    const similarCodexRoot = path.join(root, "persisted", "codex", "sessions-evil");
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(codexSessions, { recursive: true });
+    fs.mkdirSync(claudeMetaDir, { recursive: true });
+    fs.mkdirSync(claudeMetaProject, { recursive: true });
+    fs.mkdirSync(claudeFdProject, { recursive: true });
+    fs.mkdirSync(similarCodexRoot, { recursive: true });
+    fs.symlinkSync(persistedCodex, path.join(home, ".codex"), process.platform === "win32" ? "junction" : "dir");
+    fs.symlinkSync(persistedClaude, path.join(home, ".claude"), process.platform === "win32" ? "junction" : "dir");
+
+    const activeId = "11111111-1111-4111-8111-111111111111";
+    const completedId = "22222222-2222-4222-8222-222222222222";
+    const idleOlderId = "33333333-3333-4333-8333-333333333333";
+    const idleNewestId = "44444444-4444-4444-8444-444444444444";
+    const helperId = "55555555-5555-4555-8555-555555555555";
+    const appServerId = "66666666-6666-4666-8666-666666666666";
+    const similarPrefixId = "77777777-7777-4777-8777-777777777777";
+    const activeFile = codexRollout(codexSessions, activeId, "task_started");
+    const completedFile = codexRollout(codexSessions, completedId, "task_complete");
+    const idleOlderFile = codexRollout(codexSessions, idleOlderId, "task_complete");
+    const idleNewestFile = codexRollout(codexSessions, idleNewestId, "task_complete");
+    const helperFile = codexRollout(codexSessions, helperId, "task_started");
+    const appServerFile = codexRollout(codexSessions, appServerId, "task_started");
+    const similarPrefixFile = codexRollout(similarCodexRoot, similarPrefixId, "task_started");
+    const older = new Date(Date.now() - 60_000);
+    const newer = new Date(Date.now() - 30_000);
+    fs.utimesSync(idleOlderFile, older, older);
+    fs.utimesSync(idleNewestFile, newer, newer);
+
+    const metadataClaudeId = "claude-from-pid-metadata";
+    const wrongClaudeId = "claude-wrong-time-fallback";
+    const fdClaudeId = "claude-from-canonical-fd";
+    const wrongClaudeFile = path.join(claudeMetaProject, `${wrongClaudeId}.jsonl`);
+    const fdClaudeFile = path.join(claudeFdProject, `${fdClaudeId}.jsonl`);
+    fs.writeFileSync(wrongClaudeFile, "{}\n");
+    fs.writeFileSync(fdClaudeFile, "{}\n");
+
+    writeSyntheticProcess(procRoot, 801, ["/usr/bin/codex"], [activeFile, completedFile, similarPrefixFile]);
+    writeSyntheticProcess(procRoot, 802, ["/usr/bin/codex"], [idleOlderFile, idleNewestFile]);
+    writeSyntheticProcess(procRoot, 803, ["/usr/bin/codex", "resume", "explicit-codex-resume"], [helperFile]);
+    writeSyntheticProcess(
+      procRoot,
+      804,
+      ["/opt/lib/node_modules/@openai/codex/vendor/bin/codex-code-mode-host"],
+      [helperFile],
+    );
+    writeSyntheticProcess(procRoot, 805, ["/usr/bin/claude"], [wrongClaudeFile], "/work/meta");
+    writeSyntheticProcess(procRoot, 806, ["/usr/bin/claude"], [fdClaudeFile], "/work/missing");
+    writeSyntheticProcess(procRoot, 807, ["/usr/bin/claude", "--resume", "explicit-claude-resume"], [], "/work/meta");
+    writeSyntheticProcess(
+      procRoot,
+      808,
+      ["/usr/bin/node", "/usr/bin/codex", "app-server", "--listen", "stdio://"],
+      [appServerFile, completedFile],
+    );
+    writeSyntheticProcess(procRoot, 809, ["/usr/bin/node", "/usr/bin/codex"], [helperFile]);
+    fs.writeFileSync(
+      path.join(claudeMetaDir, "805.json"),
+      JSON.stringify({ sessionId: metadataClaudeId, cwd: "/work/meta" }),
+    );
+    fs.writeFileSync(path.join(claudeMetaDir, "806.json"), "{not-json");
+    fs.writeFileSync(
+      path.join(claudeMetaDir, "807.json"),
+      JSON.stringify({ sessionId: "metadata-must-not-override-resume" }),
+    );
+
+    try {
+      const sessions = await loadRemoteLiveSessions([sshEnvironment(1)], (_remoteEnvironment, remoteCommand) =>
+        executeRemotePayloadWithReadlinkFixtures(remoteCommand, {
+          HOME: home,
+          USERPROFILE: home,
+          AGENT_RECALL_PROC_ROOT: procRoot,
+        }));
+
+      expect(sessions).toEqual([
+        { family: "codex", rawId: activeId, pid: 801, environmentId: "ssh-1" },
+        { family: "codex", rawId: idleNewestId, pid: 802, environmentId: "ssh-1" },
+        { family: "codex", rawId: "explicit-codex-resume", pid: 803, environmentId: "ssh-1" },
+        { family: "claude", rawId: metadataClaudeId, pid: 805, environmentId: "ssh-1" },
+        { family: "claude", rawId: fdClaudeId, pid: 806, environmentId: "ssh-1" },
+        { family: "claude", rawId: "explicit-claude-resume", pid: 807, environmentId: "ssh-1" },
+        { family: "codex", rawId: appServerId, pid: 808, environmentId: "ssh-1" },
+      ]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
+
+function codexRollout(directory: string, rawId: string, eventType: "task_started" | "task_complete"): string {
+  fs.mkdirSync(directory, { recursive: true });
+  const filePath = path.join(directory, `rollout-2026-08-29T00-00-00-${rawId}.jsonl`);
+  fs.writeFileSync(filePath, JSON.stringify({ type: "event_msg", payload: { type: eventType } }) + "\n");
+  return filePath;
+}
+
+function writeSyntheticProcess(
+  procRoot: string,
+  pid: number,
+  tokens: string[],
+  openFiles: string[],
+  cwd?: string,
+): void {
+  const processRoot = path.join(procRoot, String(pid));
+  const fdRoot = path.join(processRoot, "fd");
+  fs.mkdirSync(fdRoot, { recursive: true });
+  fs.writeFileSync(path.join(processRoot, "cmdline"), Buffer.from(`${tokens.join("\0")}\0`));
+  openFiles.forEach((filePath, index) => {
+    fs.writeFileSync(path.join(fdRoot, String(index + 10)), filePath);
+  });
+  if (cwd) fs.writeFileSync(path.join(processRoot, "cwd"), cwd);
+}
+
+function executeRemotePayloadWithReadlinkFixtures(
+  remoteCommand: string,
+  env: Record<string, string>,
+): Promise<string> {
+  const payload = remoteCommand.match(/base64\.b64decode\("([A-Za-z0-9+/=]+)"\)/)?.[1];
+  if (!payload) return Promise.reject(new Error("Remote activity payload was not found."));
+  const script = inflateRawSync(Buffer.from(payload, "base64")).toString("utf8");
+  const readlinkFixture = String.raw`
+import os
+from pathlib import Path
+
+_agent_recall_real_readlink = os.readlink
+def _agent_recall_fixture_readlink(value):
+  candidate = Path(value)
+  if os.environ.get("AGENT_RECALL_PROC_ROOT") and candidate.is_file():
+    return candidate.read_text(encoding="utf-8")
+  return _agent_recall_real_readlink(value)
+os.readlink = _agent_recall_fixture_readlink
+`;
+  const executable = process.platform === "win32" ? "python" : "python3";
+  return new Promise((resolve, reject) => {
+    execFile(executable, ["-c", `${readlinkFixture}\n${script}`], {
+      env: { ...process.env, ...env },
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(stderr.trim() || error.message));
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}

--- a/apps/main-2.0/src/core/remote-session-activity.ts
+++ b/apps/main-2.0/src/core/remote-session-activity.ts
@@ -19,6 +19,25 @@ CLAUDE_SESSION_START_SKEW_MS = 2 * 60 * 1000
 READ_CHUNK_SIZE = 64 * 1024
 SESSION_ID_PATTERN = re.compile(r"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$", re.IGNORECASE)
 proc_root = Path(os.environ.get("AGENT_RECALL_PROC_ROOT", "/proc"))
+codex_sessions_root = Path.home() / ".codex" / "sessions"
+claude_projects_root = Path.home() / ".claude" / "projects"
+
+def resolved_path(value):
+  try:
+    return Path(value).resolve()
+  except Exception:
+    return None
+
+def path_is_within(value, root):
+  candidate = resolved_path(value)
+  boundary = resolved_path(root)
+  if candidate is None or boundary is None:
+    return False
+  try:
+    candidate.relative_to(boundary)
+    return True
+  except (ValueError, OSError):
+    return False
 
 def normalized_executable(token):
   name = token.replace("\\", "/").rsplit("/", 1)[-1].lower()
@@ -150,9 +169,55 @@ def process_started_at_ms(pid):
   except Exception:
     return None
 
+def codex_session_id(file_name):
+  normalized = file_name.replace("\\", "/")
+  if not normalized.lower().endswith(".jsonl") or not path_is_within(file_name, codex_sessions_root):
+    return None
+  match = SESSION_ID_PATTERN.search(normalized)
+  return match.group(1) if match else None
+
+def codex_session_candidates(pid):
+  candidates = []
+  for file_name in open_files(pid):
+    raw_id = codex_session_id(file_name)
+    if not raw_id:
+      continue
+    try:
+      modified_at = Path(file_name).stat().st_mtime
+    except Exception:
+      modified_at = 0
+    candidates.append((modified_at, file_name, raw_id))
+  return candidates
+
+def is_codex_desktop_process(token):
+  lower = token.replace("\\", "/").lower()
+  if "/.codex/computer-use/" in lower:
+    return True
+  return ".app/contents/" in lower and "/contents/resources/codex" not in lower
+
+def is_plain_codex_command(tokens, command_index, args):
+  if command_index != 0:
+    return False
+  token = tokens[command_index]
+  if normalized_executable(token) != "codex" or is_codex_desktop_process(token):
+    return False
+  if "resume" in args or "app-server" in args:
+    return False
+  return True
+
+def claude_process_session_id(pid):
+  metadata_path = Path.home() / ".claude" / "sessions" / (str(pid) + ".json")
+  try:
+    value = json.loads(metadata_path.read_text(encoding="utf-8"))
+  except Exception:
+    return None
+  raw_id = value.get("sessionId") if isinstance(value, dict) else None
+  normalized = raw_id.strip() if isinstance(raw_id, str) else ""
+  return normalized or None
+
 def claude_session_id(file_name):
   normalized = file_name.replace("\\", "/")
-  if "/.claude/projects/" not in normalized or not normalized.lower().endswith(".jsonl"):
+  if not normalized.lower().endswith(".jsonl") or not path_is_within(file_name, claude_projects_root):
     return None
   raw_id = normalized.rsplit("/", 1)[-1][:-len(".jsonl")].strip()
   if "/subagents/" in normalized:
@@ -248,12 +313,16 @@ for pid, tokens in process_rows():
         if raw_id and not raw_id.startswith("-"):
           emit_session("codex", raw_id, pid)
     if "app-server" in args:
-      for file_name in open_files(pid):
-        if "/.codex/sessions/" not in file_name.replace("\\", "/"):
-          continue
-        match = SESSION_ID_PATTERN.search(file_name)
-        if match and agent_is_working(Path(file_name)):
-          emit_session("codex", match.group(1), pid)
+      candidates = codex_session_candidates(pid)
+      for _, file_name, raw_id in candidates:
+        if agent_is_working(Path(file_name)):
+          emit_session("codex", raw_id, pid)
+    elif is_plain_codex_command(tokens, command_index, args):
+      candidates = codex_session_candidates(pid)
+      if candidates:
+        working = [candidate for candidate in candidates if agent_is_working(Path(candidate[1]))]
+        _, _, raw_id = max(working or candidates)
+        emit_session("codex", raw_id, pid)
 
   command_index = claude_command_index(tokens)
   if command_index is None:
@@ -262,6 +331,10 @@ for pid, tokens in process_rows():
   resumed_id = flag_resume_id(args)
   if resumed_id:
     emit_session("claude", resumed_id, pid)
+    continue
+  metadata_id = claude_process_session_id(pid)
+  if metadata_id:
+    emit_session("claude", metadata_id, pid)
     continue
   open_session_ids = [raw_id for raw_id in (claude_session_id(file_name) for file_name in open_files(pid)) if raw_id]
   if open_session_ids:


### PR DESCRIPTION
## 概要

- 远程会话检测会解析 Codex 与 Claude Code 会话根目录及进程 fd 的真实路径，支持符号链接和 NFS 持久化目录。
- 普通 Codex 进程优先选择正在工作的 rollout；空闲时只选择最近打开的一个，并排除 helper、Desktop 与 Node 包装进程。
- Claude Code 优先读取进程 PID 元数据中的 sessionId，再依次降级到 fd 与现有时间候选。
- V1 与 V2 同步修复，并补充双端回归覆盖。

## 验证

- `npm exec vitest run src/core/remote-session-activity.test.ts`（V1）：通过，5 passed / 1 个既有 Windows skip
- `npm exec vitest run src/core/remote-session-activity.test.ts`（V2）：通过，6 passed
- `npm run typecheck`：通过
- `npm run release-note:check`：通过
- `npm run release:preflight`：通过；V1/V2 构建、隔离安装 smoke 与 OpenViking 三平台输入校验全部成功
- `npm test` / `npm run test:v2`：Windows 上仍有仓库既有的 FTS5、POSIX 路径/权限、命令长度和负载超时失败；本次新增回归用例在全套运行中通过，Linux 完整结果以 PR CI 为准