### PR TITLE
feat: add Qoder IDE as a separate opt-in session source

### DIFF
--- a/.release-notes/feat-qoder-ide-source.md
+++ b/.release-notes/feat-qoder-ide-source.md
@@ -1,0 +1,7 @@
+# Qoder IDE 旧版会话成为独立来源
+<!-- release-target: both -->
+
+## 新增功能
+
+- 新增「Qoder IDE」会话来源：升级到新版 Qoder 后，旧版 Qoder IDE 中未被迁移（或只迁移了一部分）的历史对话不再被自动隐藏，可以通过设置单独开启索引。
+- 设置中新增「Include Qoder IDE」开关，默认关闭；开启后旧版会话以 Qoder IDE 来源显示，并可在会话列表按该来源筛选。

--- a/apps/main-1.0/src/core/platform.test.ts
+++ b/apps/main-1.0/src/core/platform.test.ts
@@ -115,6 +115,7 @@ describe("platform application resolution", () => {
     expect(defaultSettings.includeCursorAgent).toBe(false);
     expect(defaultSettings.includeTrae).toBe(false);
     expect(defaultSettings.includeQoder).toBe(false);
+    expect(defaultSettings.includeQoderIde).toBe(false);
     expect(defaultSettings.includePi).toBe(false);
     expect(defaultSettings.includeKimiCli).toBe(false);
     expect(defaultSettings.includeQwenCode).toBe(false);

--- a/apps/main-1.0/src/core/platform.ts
+++ b/apps/main-1.0/src/core/platform.ts
@@ -90,6 +90,7 @@ export interface AppSettings {
   includeCursorAgent: boolean;
   includeTrae: boolean;
   includeQoder: boolean;
+  includeQoderIde: boolean;
   includePi: boolean;
   includeKimiCli: boolean;
   includeQwenCode: boolean;
@@ -165,6 +166,7 @@ export const defaultSettings: AppSettings = {
   includeCursorAgent: false,
   includeTrae: false,
   includeQoder: false,
+  includeQoderIde: false,
   includePi: false,
   includeKimiCli: false,
   includeQwenCode: false,

--- a/apps/main-1.0/src/core/session-loader-extra-sources.test.ts
+++ b/apps/main-1.0/src/core/session-loader-extra-sources.test.ts
@@ -12,6 +12,7 @@ import {
   loadDefaultSessions,
   loadTraeSessions,
   loadQoderSessions,
+  loadQoderIdeSessions,
 } from "./session-loader";
 
 const require = createRequire(import.meta.url);
@@ -278,7 +279,7 @@ describe("extra session sources", () => {
     }
   });
 
-  it("loads Qoder conversation history JSONL as searchable sessions", () => {
+  it("loads legacy Qoder IDE conversation history as qoder-ide sessions", () => {
     const root = tmpDir("qoder");
     const filePath = path.join(root, "cache", "projects", "demo-app-1a2b3c4d", "conversation-history", "task-fe3", "task-fe3.jsonl");
     writeJsonl(filePath, [
@@ -286,13 +287,13 @@ describe("extra session sources", () => {
       { role: "assistant", message: { content: [{ type: "text", text: "I will check the auth module." }] } },
     ]);
 
-    const loaded = loadQoderSessions(root);
+    const loaded = loadQoderIdeSessions(root);
 
     expect(loaded).toHaveLength(1);
     expect(loaded[0].session).toMatchObject({
-      sessionKey: "qoder:demo-app-1a2b3c4d/task-fe3",
+      sessionKey: "qoder-ide:demo-app-1a2b3c4d/task-fe3",
       rawId: "demo-app-1a2b3c4d/task-fe3",
-      source: "qoder",
+      source: "qoder-ide",
       projectPath: "demo-app",
       firstQuestion: "Fix the login bug",
       originalTitle: "Fix the login bug",
@@ -313,7 +314,7 @@ describe("extra session sources", () => {
       { role: "user", message: { content: [{ type: "text", text: "First part" }, { type: "text", text: "Second part" }] } },
     ]);
 
-    const loaded = loadQoderSessions(root);
+    const loaded = loadQoderIdeSessions(root);
 
     expect(loaded).toHaveLength(1);
     expect(loaded[0].session.rawId).toBe("proj-aabbccdd/task-multi");
@@ -340,7 +341,7 @@ describe("extra session sources", () => {
       { role: "assistant", message: { content: [{ type: "text", text: "明白，开始执行。" }] } },
     ]);
 
-    const loaded = loadQoderSessions(root);
+    const loaded = loadQoderIdeSessions(root);
 
     expect(loaded).toHaveLength(1);
     expect(loaded[0].session.originalTitle).toBe("我的目标在：D:\\oss-contrib\\giki\\IMPROVEMENT-LOOP.md");
@@ -370,7 +371,7 @@ describe("extra session sources", () => {
       { role: "assistant", message: { content: [{ type: "text", text: "好的。" }] } },
     ]);
 
-    const loaded = loadQoderSessions(root);
+    const loaded = loadQoderIdeSessions(root);
 
     expect(loaded).toHaveLength(1);
     expect(loaded[0].session.originalTitle).toBe("直接帮我重构这个模块");
@@ -467,7 +468,7 @@ describe("extra session sources", () => {
     fs.rmSync(root, { recursive: true, force: true });
   });
 
-  it("prefers the projects layout and skips the legacy tree once it exists", () => {
+  it("keeps legacy Qoder IDE sessions visible next to the new projects layout", () => {
     const root = tmpDir("qoder-prefer-projects");
     writeJsonl(path.join(root, "cache", "projects", "demo-app-1a2b3c4d", "conversation-history", "task-ide", "task-ide.jsonl"), [
       { role: "user", message: { content: [{ type: "text", text: "IDE question" }] } },
@@ -485,22 +486,29 @@ describe("extra session sources", () => {
       { kind: "summary", tokens: 42 },
     ]);
 
-    const loaded = loadQoderSessions(root);
+    const current = loadQoderSessions(root);
+    expect(current.map((entry) => entry.session.firstQuestion)).toEqual(["CLI question"]);
+    expect(current.map((entry) => entry.session.source)).toEqual(["qoder"]);
 
-    expect(loaded.map((entry) => entry.session.firstQuestion)).toEqual(["CLI question"]);
+    const legacy = loadQoderIdeSessions(root);
+    expect(legacy).toHaveLength(1);
+    expect(legacy[0].session).toMatchObject({
+      source: "qoder-ide",
+      sessionKey: "qoder-ide:demo-app-1a2b3c4d/task-ide",
+      firstQuestion: "IDE question",
+    });
 
     fs.rmSync(root, { recursive: true, force: true });
   });
 
-  it("falls back to the legacy conversation-history tree when the projects layout is absent", () => {
+  it("loads the legacy conversation-history tree when the projects layout is absent", () => {
     const root = tmpDir("qoder-legacy-only");
     writeJsonl(path.join(root, "cache", "projects", "demo-app-1a2b3c4d", "conversation-history", "task-ide", "task-ide.jsonl"), [
       { role: "user", message: { content: [{ type: "text", text: "IDE question" }] } },
     ]);
 
-    const loaded = loadQoderSessions(root);
-
-    expect(loaded.map((entry) => entry.session.firstQuestion)).toEqual(["IDE question"]);
+    expect(loadQoderSessions(root)).toEqual([]);
+    expect(loadQoderIdeSessions(root).map((entry) => entry.session.firstQuestion)).toEqual(["IDE question"]);
 
     fs.rmSync(root, { recursive: true, force: true });
   });

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -104,6 +104,7 @@ export interface SessionLoadOptions {
   includeCursorAgent?: boolean;
   includeTrae?: boolean;
   includeQoder?: boolean;
+  includeQoderIde?: boolean;
   includeDeepSeekCli?: boolean;
   cursorStateDbPath?: string;
   cursorWorkspacePathMap?: ReadonlyMap<string, string>;
@@ -1512,7 +1513,7 @@ function readGitBranchAt(gitPath: string): string | null {
 }
 
 function createIndexedSession(input: {
-  keyPrefix: "claude" | "codex" | "tclaude" | "tcodex" | "codebuddy" | "workbuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder" | "pi" | "deepseek" | "kimi" | "qwen";
+  keyPrefix: "claude" | "codex" | "tclaude" | "tcodex" | "codebuddy" | "workbuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder" | "qoder-ide" | "pi" | "deepseek" | "kimi" | "qwen";
   rawId: string;
   source: SessionSource;
   projectPath: string;
@@ -3481,19 +3482,37 @@ export function loadQoderSessions(qoderDir = path.join(os.homedir(), QODER_DIR))
   return [...loadQoderSessionsIterator(qoderDir)];
 }
 
+/**
+ * The new Qoder stores transcripts under `projects/<slug>/`, either directly or
+ * inside a `transcript/` subdirectory; both layouts are written concurrently,
+ * so walk the tree instead of hardcoding either shape.
+ */
 export function* loadQoderSessionsIterator(qoderDir = path.join(os.homedir(), QODER_DIR), options: SessionLoadOptions = {}): Generator<LoadedSession> {
-  // Installing the new Qoder migrates Qoder IDE's conversations from
-  // `cache/projects` into `projects`, keeping copies of the same sessions under
-  // different ids in both trees. Once the new layout exists, skip the legacy
-  // tree so migrated history is not indexed twice.
-  if (fs.existsSync(path.join(qoderDir, "projects"))) {
-    yield* loadQoderProjectsSessionsIterator(qoderDir, options);
-    return;
+  const projectsDir = path.join(qoderDir, "projects");
+  if (!fs.existsSync(projectsDir)) return;
+  const loaded: LoadedSession[] = [];
+  for (const filePath of walkJsonlFiles(projectsDir)) {
+    const stat = safeStat(filePath);
+    if (shouldSkipFile(options, filePath, stat)) continue;
+    const rows = readJsonl(filePath);
+    if (!isQoderProjectsTranscript(rows)) continue;
+    const session = loadClaudeCliSessionRows(filePath, rows, { source: "qoder", keyPrefix: "qoder", stat });
+    if (session?.messages.length) loaded.push(session);
   }
-  yield* loadQoderLegacySessionsIterator(qoderDir, options);
+  yield* dedupeQoderExecutionTranscripts(loaded);
 }
 
-function* loadQoderLegacySessionsIterator(qoderDir: string, options: SessionLoadOptions): Generator<LoadedSession> {
+export function loadQoderIdeSessions(qoderDir = path.join(os.homedir(), QODER_DIR)): LoadedSession[] {
+  return [...loadQoderIdeSessionsIterator(qoderDir)];
+}
+
+/**
+ * The legacy Qoder IDE stored conversations under
+ * `cache/projects/<slug>/conversation-history`. Installing the new Qoder copies
+ * them into `projects`; the two trees are indexed as separate sources, so
+ * conversations that were skipped or only partially migrated stay visible.
+ */
+export function* loadQoderIdeSessionsIterator(qoderDir = path.join(os.homedir(), QODER_DIR), options: SessionLoadOptions = {}): Generator<LoadedSession> {
   const projectsDir = path.join(qoderDir, "cache", "projects");
   if (!fs.existsSync(projectsDir)) return;
   for (const projectEntry of fs.readdirSync(projectsDir, { withFileTypes: true })) {
@@ -3508,26 +3527,6 @@ function* loadQoderLegacySessionsIterator(qoderDir: string, options: SessionLoad
       if (loaded) yield loaded;
     }
   }
-}
-
-/**
- * The new Qoder stores transcripts under `projects/<slug>/`, either directly or
- * inside a `transcript/` subdirectory; both layouts are written concurrently,
- * so walk the tree instead of hardcoding either shape.
- */
-function* loadQoderProjectsSessionsIterator(qoderDir: string, options: SessionLoadOptions): Generator<LoadedSession> {
-  const projectsDir = path.join(qoderDir, "projects");
-  if (!fs.existsSync(projectsDir)) return;
-  const loaded: LoadedSession[] = [];
-  for (const filePath of walkJsonlFiles(projectsDir)) {
-    const stat = safeStat(filePath);
-    if (shouldSkipFile(options, filePath, stat)) continue;
-    const rows = readJsonl(filePath);
-    if (!isQoderProjectsTranscript(rows)) continue;
-    const session = loadClaudeCliSessionRows(filePath, rows, { source: "qoder", keyPrefix: "qoder", stat });
-    if (session?.messages.length) loaded.push(session);
-  }
-  yield* dedupeQoderExecutionTranscripts(loaded);
 }
 
 /**
@@ -3600,7 +3599,7 @@ function stripQoderWrapperTags(text: string): string {
 }
 
 function loadQoderConversationFile(filePath: string, slug: string, stat: VirtualSessionFileStat): LoadedSession | null {
-  return loadQoderSessionRows(filePath, readJsonl(filePath), { stat, slug });
+  return loadQoderSessionRows(filePath, readJsonl(filePath), { stat, slug, source: "qoder-ide" });
 }
 
 function extractQoderSlugFromPath(filePath: string): string {
@@ -3608,7 +3607,11 @@ function extractQoderSlugFromPath(filePath: string): string {
   return match?.[1] ?? path.basename(filePath);
 }
 
-export function loadQoderSessionRows(filePath: string, rows: unknown[], options: { stat: VirtualSessionFileStat; slug?: string }): LoadedSession | null {
+export function loadQoderSessionRows(
+  filePath: string,
+  rows: unknown[],
+  options: { stat: VirtualSessionFileStat; slug?: string; source?: SessionSource },
+): LoadedSession | null {
   const filteredRows = rows.filter(isRecord);
   if (filteredRows.length === 0) return null;
   const slug = options.slug ?? extractQoderSlugFromPath(filePath);
@@ -3624,12 +3627,13 @@ export function loadQoderSessionRows(filePath: string, rows: unknown[], options:
     messages.push(messageFromParts(role, content, "", messages.length));
   }
   if (messages.length === 0) return null;
+  const source = options.source ?? "qoder";
   const question = firstQuestion(messages);
   return {
     session: createIndexedSession({
-      keyPrefix: "qoder",
+      keyPrefix: source === "qoder-ide" ? "qoder-ide" : "qoder",
       rawId,
-      source: "qoder",
+      source,
       projectPath,
       filePath,
       originalTitle: cleanTitle(question) || rawId,
@@ -4731,6 +4735,7 @@ export function* loadDefaultSessionsIterator(options: SessionLoadOptions = {}): 
     for (const dirName of TRAE_DIR_NAMES) yield* loadTraeSessionsIterator(path.join(homeDir, dirName), options);
   }
   if (options.includeQoder) yield* loadQoderSessionsIterator(path.join(homeDir, QODER_DIR), options);
+  if (options.includeQoderIde) yield* loadQoderIdeSessionsIterator(path.join(homeDir, QODER_DIR), options);
   if (options.includeDeepSeekCli) {
     const deepSeekDir = options.homeDir === undefined
       ? process.env.DSH_HOME?.trim() || path.join(homeDir, DEEPSEEK_HARNESS_DIR)
@@ -4772,6 +4777,7 @@ export async function* loadDefaultSessionsAsyncIterator(options: SessionLoadOpti
     for (const dirName of TRAE_DIR_NAMES) yield* loadTraeSessionsIterator(path.join(homeDir, dirName), options);
   }
   if (options.includeQoder) yield* loadQoderSessionsIterator(path.join(homeDir, QODER_DIR), options);
+  if (options.includeQoderIde) yield* loadQoderIdeSessionsIterator(path.join(homeDir, QODER_DIR), options);
   if (options.includeDeepSeekCli) {
     const deepSeekDir = options.homeDir === undefined
       ? process.env.DSH_HOME?.trim() || path.join(homeDir, DEEPSEEK_HARNESS_DIR)

--- a/apps/main-1.0/src/core/session-sources.test.ts
+++ b/apps/main-1.0/src/core/session-sources.test.ts
@@ -26,6 +26,7 @@ const ALL_SOURCES = [
   "cursor-agent",
   "trae",
   "qoder",
+  "qoder-ide",
   "pi-cli",
   "kimi-cli",
   "qwen-code",
@@ -67,6 +68,7 @@ describe("session source capability registry", () => {
       "includeCursorAgent",
       "includeTrae",
       "includeQoder",
+      "includeQoderIde",
       "includePi",
       "includeKimiCli",
       "includeQwenCode",
@@ -75,6 +77,16 @@ describe("session source capability registry", () => {
     expect(sessionSourceDescriptor("tclaude-cli")).toMatchObject({ liveFamily: "tclaude", migrationAgent: "claude" });
     expect(sessionSourceDescriptor("tcodex-cli")).toMatchObject({ liveFamily: "tcodex", migrationAgent: "codex" });
     expect(sessionSourceDescriptor("qoder")).toMatchObject({ format: "qoder", liveFamily: "qoder", remoteFamily: "qoder" });
+    expect(sessionSourceDescriptor("qoder-ide")).toMatchObject({
+      label: "Qoder IDE",
+      format: "qoder",
+      family: "qoder-ide",
+      optionalSetting: "includeQoderIde",
+      pendingKey: "qoder-ide",
+      liveFamily: null,
+      remoteFamily: null,
+      capabilities: { live: false, resume: false, migrate: false, sessionSync: false, openApp: false },
+    });
     expect(sessionSourceDescriptor("hermes")).toMatchObject({
       migrationAgent: null,
       capabilities: { live: true, resume: false, migrate: false, sessionSync: true, openApp: false },

--- a/apps/main-1.0/src/core/session-sources.ts
+++ b/apps/main-1.0/src/core/session-sources.ts
@@ -13,6 +13,7 @@ export type OptionalSessionSourceSetting =
   | "includeCursorAgent"
   | "includeTrae"
   | "includeQoder"
+  | "includeQoderIde"
   | "includePi"
   | "includeKimiCli"
   | "includeQwenCode"
@@ -33,6 +34,7 @@ export type SessionSourceFamily =
   | "cursor"
   | "trae"
   | "qoder"
+  | "qoder-ide"
   | "pi"
   | "kimi"
   | "qwen"
@@ -165,6 +167,12 @@ export const SESSION_SOURCE_REGISTRY = {
     optionalSetting: "includeQoder", pendingKey: "qoder", remoteCollectorOptional: true, liveFamily: "qoder", migrationAgent: null,
     resumeTarget: null, remoteFamily: "qoder", nativeAppFamily: null,
     capabilities: { live: true, resume: false, migrate: false, sessionSync: false, openApp: false },
+  },
+  "qoder-ide": {
+    id: "qoder-ide", label: "Qoder IDE", format: "qoder", family: "qoder-ide", uiFamily: "other", statsGroup: null,
+    optionalSetting: "includeQoderIde", pendingKey: "qoder-ide", remoteCollectorOptional: false, liveFamily: null, migrationAgent: null,
+    resumeTarget: null, remoteFamily: null, nativeAppFamily: null,
+    capabilities: { live: false, resume: false, migrate: false, sessionSync: false, openApp: false },
   },
   "pi-cli": {
     id: "pi-cli", label: "Pi", format: "pi", family: "pi", uiFamily: "other", statsGroup: null,

--- a/apps/main-1.0/src/core/types.ts
+++ b/apps/main-1.0/src/core/types.ts
@@ -15,6 +15,7 @@ export type SessionSource =
   | "cursor-agent"
   | "trae"
   | "qoder"
+  | "qoder-ide"
   | "pi-cli"
   | "deepseek-cli"
   | "kimi-cli"

--- a/apps/main-1.0/src/main/index.ts
+++ b/apps/main-1.0/src/main/index.ts
@@ -1309,6 +1309,7 @@ function runIndexSync(): Promise<IndexStatus> {
         includeCursorAgent: settings.includeCursorAgent,
         includeTrae: settings.includeTrae,
         includeQoder: settings.includeQoder,
+        includeQoderIde: settings.includeQoderIde,
         includeDeepSeekCli: settings.includeDeepSeekCli,
       },
     }, {

--- a/apps/main-1.0/src/main/session-index-worker-protocol.ts
+++ b/apps/main-1.0/src/main/session-index-worker-protocol.ts
@@ -20,6 +20,7 @@ export type SessionIndexWorkerLoadOptions = Pick<
   | "includeCursorAgent"
   | "includeTrae"
   | "includeQoder"
+  | "includeQoderIde"
   | "includeDeepSeekCli"
 >;
 

--- a/apps/main-1.0/src/renderer/src/features/settings/settings-dialog.tsx
+++ b/apps/main-1.0/src/renderer/src/features/settings/settings-dialog.tsx
@@ -718,6 +718,24 @@ export function SettingsDialog({
                 </label>
                 <label className="settings-field settings-toggle">
                   <div className="settings-field-text">
+                    <span className="settings-field-title">Include Qoder IDE</span>
+                    <span className="settings-field-sub">
+                      {l(
+                        "Indexes legacy Qoder IDE conversations from ~/.qoder/cache/projects.",
+                        "索引 ~/.qoder/cache/projects 中的旧版 Qoder IDE 对话记录。",
+                      )}
+                    </span>
+                  </div>
+                  <input
+                    type="checkbox"
+                    className="switch"
+                    checked={Boolean(settings?.includeQoderIde)}
+                    disabled={!settings}
+                    onChange={(event) => onSettingsChange({ includeQoderIde: event.currentTarget.checked })}
+                  />
+                </label>
+                <label className="settings-field settings-toggle">
+                  <div className="settings-field-text">
                     <span className="settings-field-title">Include DeepSeek Harness</span>
                     <span className="settings-field-sub">{l("Indexes local DeepSeek Harness (dsh) sessions from DSH_HOME (default: ~/.dsh).", "从 DSH_HOME（默认 ~/.dsh）索引本地 DeepSeek Harness（dsh）会话。")}</span>
                   </div>

--- a/apps/main-2.0/src/core/platform.ts
+++ b/apps/main-2.0/src/core/platform.ts
@@ -101,6 +101,7 @@ export interface AppSettings {
   includeCursorAgent: boolean;
   includeTrae: boolean;
   includeQoder: boolean;
+  includeQoderIde: boolean;
   includePi: boolean;
   includeKimiCli: boolean;
   includeQwenCode: boolean;
@@ -196,6 +197,7 @@ export const defaultSettings: AppSettings = {
   includeCursorAgent: false,
   includeTrae: false,
   includeQoder: false,
+  includeQoderIde: false,
   includePi: false,
   includeKimiCli: false,
   includeQwenCode: false,

--- a/apps/main-2.0/src/core/session-loader-qoder.test.ts
+++ b/apps/main-2.0/src/core/session-loader-qoder.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-import { loadQoderSessions } from "./session-loader";
+import { loadQoderIdeSessions, loadQoderSessions } from "./session-loader";
 
 const temporaryRoots: string[] = [];
 
@@ -104,7 +104,7 @@ describe("Qoder session loading", () => {
     expect(loadQoderSessions(root)).toEqual([]);
   });
 
-  it("prefers the projects layout and skips the legacy tree once it exists", () => {
+  it("keeps legacy Qoder IDE sessions visible next to the new projects layout", () => {
     const root = temporaryRoot("prefer-projects");
     writeJsonl(path.join(root, "cache", "projects", "demo-app-1a2b3c4d", "conversation-history", "task-ide", "task-ide.jsonl"), [
       { role: "user", message: { content: [{ type: "text", text: "IDE question" }] } },
@@ -122,20 +122,27 @@ describe("Qoder session loading", () => {
       { kind: "summary", tokens: 42 },
     ]);
 
-    const loaded = loadQoderSessions(root);
+    const current = loadQoderSessions(root);
+    expect(current.map((entry) => entry.session.firstQuestion)).toEqual(["CLI question"]);
+    expect(current.map((entry) => entry.session.source)).toEqual(["qoder"]);
 
-    expect(loaded.map((entry) => entry.session.firstQuestion)).toEqual(["CLI question"]);
+    const legacy = loadQoderIdeSessions(root);
+    expect(legacy).toHaveLength(1);
+    expect(legacy[0].session).toMatchObject({
+      source: "qoder-ide",
+      sessionKey: "qoder-ide:demo-app-1a2b3c4d/task-ide",
+      firstQuestion: "IDE question",
+    });
   });
 
-  it("falls back to the legacy conversation-history tree when the projects layout is absent", () => {
+  it("loads the legacy conversation-history tree when the projects layout is absent", () => {
     const root = temporaryRoot("legacy-only");
     writeJsonl(path.join(root, "cache", "projects", "demo-app-1a2b3c4d", "conversation-history", "task-ide", "task-ide.jsonl"), [
       { role: "user", message: { content: [{ type: "text", text: "IDE question" }] } },
     ]);
 
-    const loaded = loadQoderSessions(root);
-
-    expect(loaded.map((entry) => entry.session.firstQuestion)).toEqual(["IDE question"]);
+    expect(loadQoderSessions(root)).toEqual([]);
+    expect(loadQoderIdeSessions(root).map((entry) => entry.session.firstQuestion)).toEqual(["IDE question"]);
   });
 
   it("drops execution transcripts that duplicate a canonical session but keeps unique runs", () => {

--- a/apps/main-2.0/src/core/session-loader.ts
+++ b/apps/main-2.0/src/core/session-loader.ts
@@ -36,6 +36,7 @@ import {
   loadKimiSessionsIterator,
   loadQwenCodeSessionsIterator,
   loadQoderSessionsIterator,
+  loadQoderIdeSessionsIterator,
   loadTraeSessionsIterator,
   loadZcodeSessions,
 } from "./session-loaders/alternative-sources";
@@ -1900,6 +1901,7 @@ export function* loadDefaultSessionsIterator(options: SessionLoadOptions = {}): 
     for (const dirName of TRAE_DIR_NAMES) yield* loadTraeSessionsIterator(path.join(homeDir, dirName), options);
   }
   if (options.includeQoder) yield* loadQoderSessionsIterator(path.join(homeDir, QODER_DIR), options);
+  if (options.includeQoderIde) yield* loadQoderIdeSessionsIterator(path.join(homeDir, QODER_DIR), options);
   if (options.includeDeepSeekCli) {
     const deepSeekDir = options.homeDir === undefined
       ? process.env.DSH_HOME?.trim() || path.join(homeDir, DEEPSEEK_HARNESS_DIR)
@@ -1953,6 +1955,7 @@ export async function* loadDefaultSessionsAsyncIterator(options: SessionLoadOpti
     for (const dirName of TRAE_DIR_NAMES) yield* loadTraeSessionsIterator(path.join(homeDir, dirName), options);
   }
   if (options.includeQoder) yield* loadQoderSessionsIterator(path.join(homeDir, QODER_DIR), options);
+  if (options.includeQoderIde) yield* loadQoderIdeSessionsIterator(path.join(homeDir, QODER_DIR), options);
   if (options.includeDeepSeekCli) {
     const deepSeekDir = options.homeDir === undefined
       ? process.env.DSH_HOME?.trim() || path.join(homeDir, DEEPSEEK_HARNESS_DIR)

--- a/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
+++ b/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
@@ -20,6 +20,7 @@ import type {
   LoadedSession,
   SessionFormat,
   SessionMessage,
+  SessionSource,
   SessionTraceEvent,
   SessionTraceKind,
   TokenUsage,
@@ -1013,19 +1014,37 @@ export function loadQoderSessions(qoderDir = path.join(os.homedir(), QODER_DIR))
   return [...loadQoderSessionsIterator(qoderDir)];
 }
 
+/**
+ * The new Qoder stores transcripts under `projects/<slug>/`, either directly or
+ * inside a `transcript/` subdirectory; both layouts are written concurrently,
+ * so walk the tree instead of hardcoding either shape.
+ */
 export function* loadQoderSessionsIterator(qoderDir = path.join(os.homedir(), QODER_DIR), options: SessionLoadOptions = {}): Generator<LoadedSession> {
-  // Installing the new Qoder migrates Qoder IDE's conversations from
-  // `cache/projects` into `projects`, keeping copies of the same sessions under
-  // different ids in both trees. Once the new layout exists, skip the legacy
-  // tree so migrated history is not indexed twice.
-  if (fs.existsSync(path.join(qoderDir, "projects"))) {
-    yield* loadQoderProjectsSessionsIterator(qoderDir, options);
-    return;
+  const projectsDir = path.join(qoderDir, "projects");
+  if (!fs.existsSync(projectsDir)) return;
+  const loaded: LoadedSession[] = [];
+  for (const filePath of walkJsonlFiles(projectsDir)) {
+    const stat = safeStat(filePath);
+    if (shouldSkipFile(options, filePath, stat)) continue;
+    const rows = readJsonl(filePath);
+    if (!isQoderProjectsTranscript(rows)) continue;
+    const session = loadClaudeCliSessionRows(filePath, rows, { source: "qoder", keyPrefix: "qoder", stat });
+    if (session?.messages.length) loaded.push(session);
   }
-  yield* loadQoderLegacySessionsIterator(qoderDir, options);
+  yield* dedupeQoderExecutionTranscripts(loaded);
 }
 
-function* loadQoderLegacySessionsIterator(qoderDir: string, options: SessionLoadOptions): Generator<LoadedSession> {
+export function loadQoderIdeSessions(qoderDir = path.join(os.homedir(), QODER_DIR)): LoadedSession[] {
+  return [...loadQoderIdeSessionsIterator(qoderDir)];
+}
+
+/**
+ * The legacy Qoder IDE stored conversations under
+ * `cache/projects/<slug>/conversation-history`. Installing the new Qoder copies
+ * them into `projects`; the two trees are indexed as separate sources, so
+ * conversations that were skipped or only partially migrated stay visible.
+ */
+export function* loadQoderIdeSessionsIterator(qoderDir = path.join(os.homedir(), QODER_DIR), options: SessionLoadOptions = {}): Generator<LoadedSession> {
   const projectsDir = path.join(qoderDir, "cache", "projects");
   if (!fs.existsSync(projectsDir)) return;
   for (const projectEntry of fs.readdirSync(projectsDir, { withFileTypes: true })) {
@@ -1040,26 +1059,6 @@ function* loadQoderLegacySessionsIterator(qoderDir: string, options: SessionLoad
       if (loaded) yield loaded;
     }
   }
-}
-
-/**
- * The new Qoder stores transcripts under `projects/<slug>/`, either directly or
- * inside a `transcript/` subdirectory; both layouts are written concurrently,
- * so walk the tree instead of hardcoding either shape.
- */
-function* loadQoderProjectsSessionsIterator(qoderDir: string, options: SessionLoadOptions): Generator<LoadedSession> {
-  const projectsDir = path.join(qoderDir, "projects");
-  if (!fs.existsSync(projectsDir)) return;
-  const loaded: LoadedSession[] = [];
-  for (const filePath of walkJsonlFiles(projectsDir)) {
-    const stat = safeStat(filePath);
-    if (shouldSkipFile(options, filePath, stat)) continue;
-    const rows = readJsonl(filePath);
-    if (!isQoderProjectsTranscript(rows)) continue;
-    const session = loadClaudeCliSessionRows(filePath, rows, { source: "qoder", keyPrefix: "qoder", stat });
-    if (session?.messages.length) loaded.push(session);
-  }
-  yield* dedupeQoderExecutionTranscripts(loaded);
 }
 
 /**
@@ -1123,7 +1122,7 @@ function stripQoderWrapperTags(text: string): string {
 }
 
 function loadQoderConversationFile(filePath: string, slug: string, stat: VirtualSessionFileStat): LoadedSession | null {
-  return loadQoderSessionRows(filePath, readJsonl(filePath), { stat, slug });
+  return loadQoderSessionRows(filePath, readJsonl(filePath), { stat, slug, source: "qoder-ide" });
 }
 
 function extractQoderSlugFromPath(filePath: string): string {
@@ -1131,7 +1130,11 @@ function extractQoderSlugFromPath(filePath: string): string {
   return match?.[1] ?? path.basename(filePath);
 }
 
-export function loadQoderSessionRows(filePath: string, rows: unknown[], options: { stat: VirtualSessionFileStat; slug?: string }): LoadedSession | null {
+export function loadQoderSessionRows(
+  filePath: string,
+  rows: unknown[],
+  options: { stat: VirtualSessionFileStat; slug?: string; source?: SessionSource },
+): LoadedSession | null {
   const filteredRows = rows.filter(isRecord);
   if (filteredRows.length === 0) return null;
   const slug = options.slug ?? extractQoderSlugFromPath(filePath);
@@ -1147,12 +1150,13 @@ export function loadQoderSessionRows(filePath: string, rows: unknown[], options:
     messages.push(messageFromParts(role, content, "", messages.length));
   }
   if (messages.length === 0) return null;
+  const source = options.source ?? "qoder";
   const question = firstQuestion(messages);
   return {
     session: createIndexedSession({
-      keyPrefix: "qoder",
+      keyPrefix: source === "qoder-ide" ? "qoder-ide" : "qoder",
       rawId,
-      source: "qoder",
+      source,
       projectPath,
       filePath,
       originalTitle: cleanTitle(question) || rawId,

--- a/apps/main-2.0/src/core/session-loaders/common.ts
+++ b/apps/main-2.0/src/core/session-loaders/common.ts
@@ -32,6 +32,7 @@ export interface SessionLoadOptions {
   includeCursorAgent?: boolean;
   includeTrae?: boolean;
   includeQoder?: boolean;
+  includeQoderIde?: boolean;
   includePi?: boolean;
   includeKimiCli?: boolean;
   includeQwenCode?: boolean;
@@ -314,6 +315,7 @@ export function createIndexedSession(input: {
     | "cursor"
     | "trae"
     | "qoder"
+    | "qoder-ide"
     | "pi"
     | "kimi"
     | "qwen"

--- a/apps/main-2.0/src/core/session-sources.test.ts
+++ b/apps/main-2.0/src/core/session-sources.test.ts
@@ -21,4 +21,17 @@ describe("StepCode session source semantics", () => {
       capabilities: { live: false, resume: false, migrate: false, sessionSync: false, openApp: false },
     });
   });
+
+  it("keeps legacy Qoder IDE sessions as a separate opt-in read-only source", () => {
+    expect(sessionSourceDescriptor("qoder-ide")).toMatchObject({
+      label: "Qoder IDE",
+      format: "qoder",
+      family: "qoder-ide",
+      optionalSetting: "includeQoderIde",
+      pendingKey: "qoder-ide",
+      liveFamily: null,
+      remoteFamily: null,
+      capabilities: { live: false, resume: false, migrate: false, sessionSync: false, openApp: false },
+    });
+  });
 });

--- a/apps/main-2.0/src/core/session-sources.ts
+++ b/apps/main-2.0/src/core/session-sources.ts
@@ -14,6 +14,7 @@ export type OptionalSessionSourceSetting =
   | "includeCursorAgent"
   | "includeTrae"
   | "includeQoder"
+  | "includeQoderIde"
   | "includePi"
   | "includeKimiCli"
   | "includeQwenCode"
@@ -35,6 +36,7 @@ export type SessionSourceFamily =
   | "cursor"
   | "trae"
   | "qoder"
+  | "qoder-ide"
   | "pi"
   | "kimi"
   | "qwen"
@@ -179,6 +181,12 @@ export const SESSION_SOURCE_REGISTRY = {
     optionalSetting: "includeQoder", pendingKey: "qoder", remoteCollectorOptional: true, liveFamily: "qoder", migrationAgent: null,
     resumeTarget: null, remoteFamily: "qoder", nativeAppFamily: null,
     capabilities: { live: true, resume: false, migrate: false, sessionSync: false, openApp: false },
+  },
+  "qoder-ide": {
+    id: "qoder-ide", label: "Qoder IDE", format: "qoder", family: "qoder-ide", uiFamily: "other", statsGroup: null,
+    optionalSetting: "includeQoderIde", pendingKey: "qoder-ide", remoteCollectorOptional: false, liveFamily: null, migrationAgent: null,
+    resumeTarget: null, remoteFamily: null, nativeAppFamily: null,
+    capabilities: { live: false, resume: false, migrate: false, sessionSync: false, openApp: false },
   },
   "pi-cli": {
     id: "pi-cli", label: "Pi", format: "pi", family: "pi", uiFamily: "other", statsGroup: null,

--- a/apps/main-2.0/src/core/types.ts
+++ b/apps/main-2.0/src/core/types.ts
@@ -17,6 +17,7 @@ export type SessionSource =
   | "cursor-agent"
   | "trae"
   | "qoder"
+  | "qoder-ide"
   | "pi-cli"
   | "deepseek-cli"
   | "kimi-cli"

--- a/apps/main-2.0/src/main/index.ts
+++ b/apps/main-2.0/src/main/index.ts
@@ -1785,6 +1785,7 @@ function runIndexSync(): Promise<IndexStatus> {
         includeCursorAgent: settings.includeCursorAgent,
         includeTrae: settings.includeTrae,
         includeQoder: settings.includeQoder,
+        includeQoderIde: settings.includeQoderIde,
         includeDeepSeekCli: settings.includeDeepSeekCli,
       },
       indexFailureLogPath: indexFailureLogger.logPath,

--- a/apps/main-2.0/src/main/services/v1-session-import-service.ts
+++ b/apps/main-2.0/src/main/services/v1-session-import-service.ts
@@ -41,6 +41,7 @@ const V1_SETTINGS_KEYS = [
   "includeCursorAgent",
   "includeTrae",
   "includeQoder",
+  "includeQoderIde",
   "includePi",
   "includeKimiCli",
   "includeQwenCode",

--- a/apps/main-2.0/src/renderer/src/features/settings/settings-dialog.tsx
+++ b/apps/main-2.0/src/renderer/src/features/settings/settings-dialog.tsx
@@ -760,6 +760,24 @@ export function SettingsDialog({
                 </label>
                 <label className="settings-field settings-toggle">
                   <div className="settings-field-text">
+                    <span className="settings-field-title">Include Qoder IDE</span>
+                    <span className="settings-field-sub">
+                      {l(
+                        "Indexes legacy Qoder IDE conversations from ~/.qoder/cache/projects.",
+                        "索引 ~/.qoder/cache/projects 中的旧版 Qoder IDE 对话记录。",
+                      )}
+                    </span>
+                  </div>
+                  <input
+                    type="checkbox"
+                    className="switch"
+                    checked={Boolean(settings?.includeQoderIde)}
+                    disabled={!settings}
+                    onChange={(event) => onSettingsChange({ includeQoderIde: event.currentTarget.checked })}
+                  />
+                </label>
+                <label className="settings-field settings-toggle">
+                  <div className="settings-field-text">
                     <span className="settings-field-title">Include DeepSeek Harness</span>
                     <span className="settings-field-sub">{l("Indexes local DeepSeek Harness (dsh) sessions from DSH_HOME (default: ~/.dsh).", "从 DSH_HOME（默认 ~/.dsh）索引本地 DeepSeek Harness（dsh）会话。")}</span>
                   </div>


### PR DESCRIPTION
## 变更概述

对应 issue #506。
把这两个目录当成两个不同的平台来处理：

- Qoder loader 拆成两个独立的迭代器：projects/ 继续走 qoder 来源，cache/projects 改走新增的 qoder-ide 来源（界面显示「Qoder IDE」）
- 删掉了那个互斥开关，两棵目录树各自由自己的设置开关控制，互不影响
- 新增设置项「Include Qoder IDE」，默认关闭，和其他可选来源一致

需要说明：Qoder 的迁移是「复制」而不是「移动」，所以两个开关同时打开时，同一段对话可能出现两条（Qoder 一条、Qoder IDE 一条），这是「当成两个平台」的预期行为，不想看到重复的话关掉其中一个开关即可。

## 验证

本机已复现并回归
