### PR TITLE
feat(sync): collect OpenCode sessions from remote environments

### DIFF
--- a/.release-notes/feat-opencode-remote-collection.md
+++ b/.release-notes/feat-opencode-remote-collection.md
@@ -1,0 +1,7 @@
+# 远程同步支持 OpenCode 会话
+
+<!-- release-target: both -->
+
+## 新增功能
+
+- 🔗 SSH 远程环境同步现在支持采集 OpenCode 会话,远程 devbox 上的会话(含子 Agent 会话及其父子关系)可同步到本机查看、搜索与统计。

--- a/apps/main-1.0/src/core/remote-session-loader.ts
+++ b/apps/main-1.0/src/core/remote-session-loader.ts
@@ -3,6 +3,7 @@ import {
   loadClaudeCliSessionRows,
   loadCodeBuddyCliSessionRows,
   loadCodeWizSessions,
+  loadOpenCodeSessions,
   loadCodexSessionRows,
   loadQoderSessionRows,
   parseCodexSessionMetaLine,
@@ -25,6 +26,7 @@ export type RemoteSessionFileKind =
   | "claude-session-index"
   | "codebuddy-project"
   | "codewiz-session"
+  | "opencode-session"
   | "qoder-project";
 
 export interface RemoteSessionFilePayload {
@@ -131,6 +133,12 @@ export function loadRemoteSessionDetailPayload(
     const [dbPath, sessionId] = payload.path.split("#", 2);
     const candidate = loadCodeWizSessions(path.dirname(dbPath)).find((item) => item.session.rawId === sessionId);
     return candidate ? scopeRemoteSession(candidate, environment, "codewiz") : null;
+  }
+
+  if (payload.kind === "opencode-session") {
+    const [dbPath, sessionId] = payload.path.split("#", 2);
+    const candidate = loadOpenCodeSessions(path.dirname(dbPath)).find((item) => item.session.rawId === sessionId);
+    return candidate ? scopeRemoteSession(candidate, environment, "opencode-cli") : null;
   }
 
   return null;

--- a/apps/main-1.0/src/core/remote-sync.test.ts
+++ b/apps/main-1.0/src/core/remote-sync.test.ts
@@ -1319,6 +1319,65 @@ db.close()
     }
   });
 
+  it("collects OpenCode summaries from the remote opencode.db including subagent relations", async () => {
+    const store = createInMemoryStore();
+    const environment = upsertSshEnvironment(store);
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "session-search-remote-opencode-"));
+    const opencodeDir = path.join(tempHome, ".local", "share", "opencode");
+    fs.mkdirSync(opencodeDir, { recursive: true });
+    const opencodeDbPath = path.join(opencodeDir, "opencode.db");
+    execFileSync(
+      "python3",
+      [
+        "-c",
+        String.raw`
+import json, sqlite3, sys
+db = sqlite3.connect(sys.argv[1])
+db.executescript('''
+CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT NOT NULL, title TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER, parent_id TEXT);
+CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, type TEXT NOT NULL, time_created INTEGER NOT NULL, data TEXT NOT NULL);
+CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, data TEXT NOT NULL);
+''')
+db.execute("INSERT INTO session (id, directory, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?)", ("opencode-root", "/repo/opencode", "OpenCode remote root", 1780560000000, 1780560600000))
+db.execute("INSERT INTO session (id, directory, title, time_created, time_updated, parent_id) VALUES (?, ?, ?, ?, ?, ?)", ("opencode-child", "/repo/opencode", "OpenCode remote child", 1780560000000, 1780560600000, "opencode-root"))
+db.execute("INSERT INTO message VALUES (?, ?, ?, ?, ?)", ("oc-user", "opencode-root", "user", 1780560060000, json.dumps({"role": "user"})))
+db.execute("INSERT INTO part VALUES (?, ?, ?, ?, ?)", ("oc-user-part", "oc-user", "opencode-root", 1780560060000, json.dumps({"type": "text", "text": "opencode remote question"})))
+db.execute("INSERT INTO message VALUES (?, ?, ?, ?, ?)", ("oc-child-user", "opencode-child", "user", 1780560060000, json.dumps({"role": "user"})))
+db.execute("INSERT INTO part VALUES (?, ?, ?, ?, ?)", ("oc-child-part", "oc-child-user", "opencode-child", 1780560060000, json.dumps({"type": "text", "text": "opencode child question"})))
+db.commit()
+db.close()
+`,
+        opencodeDbPath,
+      ],
+      { encoding: "utf8" },
+    );
+
+    try {
+      await syncRemoteEnvironment(store, environment, {
+        runSsh: async (_environment, remoteCommand) => execFileSync("python3", ["-c", decodeCollectorScript(remoteCommand)], {
+          encoding: "utf8",
+          env: { ...process.env, HOME: tempHome },
+        }),
+      });
+
+      expect(store.getSession(`ssh:${environment.id}:opencode-cli:opencode-root`)).toMatchObject({
+        rawId: "opencode-root",
+        source: "opencode-cli",
+        isSubagent: false,
+        parentSessionId: null,
+      });
+      expect(store.getSession(`ssh:${environment.id}:opencode-cli:opencode-child`)).toMatchObject({
+        rawId: "opencode-child",
+        source: "opencode-cli",
+        isSubagent: true,
+        parentSessionId: "opencode-root",
+      });
+    } finally {
+      store.close();
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
   it("fetches a remote session message page without transferring the full session payload", async () => {
     const store = createInMemoryStore();
     const environment = upsertSshEnvironment(store);

--- a/apps/main-1.0/src/core/remote-sync.ts
+++ b/apps/main-1.0/src/core/remote-sync.ts
@@ -33,7 +33,7 @@ export interface RemoteSyncOptions {
 }
 
 export interface RemoteSessionSummaryPayload {
-  kind: "codex-session" | "claude-project" | "codebuddy-project" | "codewiz-session" | "qoder-project";
+  kind: "codex-session" | "claude-project" | "codebuddy-project" | "codewiz-session" | "opencode-session" | "qoder-project";
   source?: SessionSource;
   path: string;
   mtimeMs: number;
@@ -482,7 +482,7 @@ async function syncWslEnvironment(
   const runWsl = options.runSsh ?? runSystemRemote;
   store.updateEnvironmentSyncState(environment.id, "syncing", { lastError: null });
   try {
-    const output = await runWsl(environment, buildRemoteCollectorCommand([], { includeCodeWiz: false }));
+    const output = await runWsl(environment, buildRemoteCollectorCommand([], { includeCodeWiz: false, includeOpenCode: false }));
     const { payloads, summaries } = decodeRemoteSyncOutput(output);
     const enabledSummaries = summaries.filter((summary) => isSupportedWslSource(summarySource(summary)));
     for (const summary of enabledSummaries) {
@@ -557,6 +557,7 @@ function summarySource(summary: RemoteSessionSummaryPayload): SessionSource {
   if (summary.kind === "codex-session") return "codex-cli";
   if (summary.kind === "codebuddy-project") return "codebuddy-cli";
   if (summary.kind === "codewiz-session") return "codewiz-cli";
+  if (summary.kind === "opencode-session") return "opencode-cli";
   return "claude-cli";
 }
 
@@ -565,6 +566,7 @@ function payloadSourceForPayload(payload: RemoteSessionFilePayload): SessionSour
   if (payload.kind === "codex-session" || payload.kind === "codex-index") return "codex-cli";
   if (payload.kind === "codebuddy-project") return "codebuddy-cli";
   if (payload.kind === "codewiz-session") return "codewiz-cli";
+  if (payload.kind === "opencode-session") return "opencode-cli";
   if (payload.kind === "qoder-project") return "qoder";
   return "claude-cli";
 }
@@ -711,7 +713,7 @@ async function fetchWslSessionMessagePage(
   return decodeRemoteMessagePage(output);
 }
 
-export function remoteFamilyForSource(source: SessionSource): "claude" | "codex" | "codebuddy" | "codewiz" | "qoder" {
+export function remoteFamilyForSource(source: SessionSource): "claude" | "codex" | "codebuddy" | "codewiz" | "opencode" | "qoder" {
   return sessionSourceDescriptor(source).remoteFamily ?? "codex";
 }
 
@@ -720,6 +722,7 @@ function remoteKindForSource(source: SessionSource): RemoteSessionFileKind {
   if (family === "codewiz") return "codewiz-session";
   if (family === "claude") return "claude-project";
   if (family === "codebuddy") return "codebuddy-project";
+  if (family === "opencode") return "opencode-session";
   if (family === "qoder") return "qoder-project";
   return "codex-session";
 }
@@ -745,7 +748,7 @@ print(json.dumps({
 }
 
 function buildRemoteMessagePageCommand(session: SessionSearchResult, offset: number, limit: number): string {
-  const [dbPath, codeWizSessionId] = session.source === "codewiz-cli" ? session.filePath.split("#", 2) : [session.filePath, ""];
+  const [dbPath, codeWizSessionId] = session.source === "codewiz-cli" || session.source === "opencode-cli" ? session.filePath.split("#", 2) : [session.filePath, ""];
   const request = {
     path: dbPath,
     codeWizSessionId,
@@ -764,7 +767,7 @@ end = offset + limit
 
 messages = []
 message_index = 0
-if kind == "codewiz":
+if kind in {"codewiz", "opencode"}:
   import sqlite3
   def text_from_codewiz_part(data):
     if not isinstance(data, dict):
@@ -906,7 +909,7 @@ export function formatRemoteSyncProcessError(error: unknown, stdout: string, std
 }
 
 function looksLikeRemotePayload(output: string): boolean {
-  return /^\s*\{"kind":\s*"(?:codex-session|codex-index|claude-project|claude-session-index|codebuddy-project|codewiz-session)"/.test(output);
+  return /^\s*\{"kind":\s*"(?:codex-session|codex-index|claude-project|claude-session-index|codebuddy-project|codewiz-session|opencode-session)"/.test(output);
 }
 
 function truncateRemoteError(value: string, maxChars = 1200): string {
@@ -929,6 +932,7 @@ const REMOTE_SESSION_FILE_KINDS = new Set<RemoteSessionFilePayload["kind"]>([
   "claude-project",
   "claude-session-index",
   "codewiz-session",
+  "opencode-session",
   "codebuddy-project",
   "qoder-project",
 ]);
@@ -981,7 +985,7 @@ function parseRemoteSummaryRecord(
   lineNumber: number,
   kind: RemoteSessionSummaryPayload["kind"],
 ): RemoteSessionSummaryPayload {
-  if (kind !== "codex-session" && kind !== "claude-project" && kind !== "codebuddy-project" && kind !== "codewiz-session") {
+  if (kind !== "codex-session" && kind !== "claude-project" && kind !== "codebuddy-project" && kind !== "codewiz-session" && kind !== "opencode-session") {
     throw new Error(`Invalid remote payload at line ${lineNumber}: summaries must be session files`);
   }
   const rawId = stringField(parsed, "rawId");
@@ -1461,7 +1465,7 @@ def codewiz_token_usage(session):
     session["tokens_reasoning"] if "tokens_reasoning" in session.keys() and session["tokens_reasoning"] else 0,
   )
 
-def emit_codewiz_summaries(db_path, stat):
+def emit_codewiz_summaries(db_path, stat, kind="codewiz-session", trace_source="codewiz"):
   try:
     db = sqlite3.connect(str(db_path))
     db.row_factory = sqlite3.Row
@@ -1478,7 +1482,7 @@ def emit_codewiz_summaries(db_path, stat):
       message_count = 0
       message_events = []
       rows = codewiz_message_rows(db, raw_id)
-      token_events = codewiz_token_events(rows, "codewiz")
+      token_events = codewiz_token_events(rows, trace_source)
       for row in rows:
         parsed = parse_codewiz_row(row)
         if not parsed:
@@ -1488,7 +1492,7 @@ def emit_codewiz_summaries(db_path, stat):
         if parsed["role"] == "user" and not first_question:
           first_question = parsed["content"]
       emit({
-        "kind": "codewiz-session",
+        "kind": kind,
         "path": "%s#%s" % (str(db_path), raw_id),
         "mtimeMs": int(stat.st_mtime * 1000),
         "size": stat.st_size,
@@ -1673,6 +1677,7 @@ for kind, source, root, pattern in sources:
       pass
 
 __CODEWIZ_COLLECTION__
+__OPENCODE_COLLECTION__
 codex_titles = {
   "codex-cli": load_codex_titles(".codex"),
   __OPTIONAL_CODEX_TITLE_INDEXES__
@@ -1697,7 +1702,7 @@ for _mtime, kind, source, path, _size in sorted(candidates, key=lambda item: ite
 
 function buildRemoteCollectorCommand(
   enabledOptionalSources: SessionSource[],
-  options: { includeCodeWiz?: boolean } = {},
+  options: { includeCodeWiz?: boolean; includeOpenCode?: boolean } = {},
 ): string {
   const descriptors: Record<string, string> = {
     "tclaude-cli": '("claude-project", "tclaude-cli", home / ".tclaude" / "projects", "*.jsonl")',
@@ -1720,12 +1725,21 @@ try:
     emit_codewiz_summaries(codewiz_db, codewiz_db.stat())
 except Exception:
   pass`;
+  const opencodeCollection = options.includeOpenCode === false
+    ? ""
+    : String.raw`opencode_db = home / ".local" / "share" / "opencode" / "opencode.db"
+try:
+  if opencode_db.exists():
+    emit_codewiz_summaries(opencode_db, opencode_db.stat(), kind="opencode-session", trace_source="opencode")
+except Exception:
+  pass`;
   const script = REMOTE_COLLECTOR_SCRIPT
     .replace("__ENABLED_OPTIONAL_SOURCES__", JSON.stringify(optionalSources))
     .replace("__OPTIONAL_SOURCE_DESCRIPTORS__", optionalSources.map((source) => descriptors[source]).join(",\n  "))
     .replace("__OPTIONAL_CODEX_TITLE_INDEXES__", optionalCodexTitleIndexes)
     .replace("__OPTIONAL_CLAUDE_INDEXES__", optionalClaudeIndexes)
-    .replace("__CODEWIZ_COLLECTION__", codewizCollection);
+    .replace("__CODEWIZ_COLLECTION__", codewizCollection)
+    .replace("__OPENCODE_COLLECTION__", opencodeCollection);
   return buildPythonBase64Command(script);
 }
 

--- a/apps/main-1.0/src/core/session-sources.ts
+++ b/apps/main-1.0/src/core/session-sources.ts
@@ -63,7 +63,7 @@ export interface SessionSourceDescriptor {
   liveFamily: LiveSessionFamily | null;
   migrationAgent: MigrationAgent | null;
   resumeTarget: MigrationTarget | null;
-  remoteFamily: "claude" | "codex" | "codebuddy" | "codewiz" | "qoder" | null;
+  remoteFamily: "claude" | "codex" | "codebuddy" | "codewiz" | "opencode" | "qoder" | null;
   nativeAppFamily: "claude" | "codex" | "codebuddy" | null;
   capabilities: SessionSourceCapabilities;
 }
@@ -141,7 +141,7 @@ export const SESSION_SOURCE_REGISTRY = {
   "opencode-cli": {
     id: "opencode-cli", label: "OpenCode", format: "opencode", family: "opencode", uiFamily: "other", statsGroup: null,
     optionalSetting: "includeOpenCode", pendingKey: "opencode", remoteCollectorOptional: false, liveFamily: "opencode", migrationAgent: null,
-    resumeTarget: null, remoteFamily: "codebuddy", nativeAppFamily: null,
+    resumeTarget: null, remoteFamily: "opencode", nativeAppFamily: null,
     capabilities: { live: true, resume: false, migrate: false, sessionSync: false, openApp: false },
   },
   "zcode-cli": {

--- a/apps/main-1.0/src/main/index.ts
+++ b/apps/main-1.0/src/main/index.ts
@@ -723,7 +723,7 @@ async function ensureRemoteSessionDetailsLoaded(sessionKey: string): Promise<voi
   const load = (async () => {
     const latest = store.getSession(sessionKey);
     if (!latest || isLocalSessionStorage(latest)) return;
-    if (latest.source === "codewiz-cli") return;
+    if (latest.source === "codewiz-cli" || latest.source === "opencode-cli") return;
     const environment = store.getEnvironment(latest.environmentId);
     if (environment?.kind === "wsl") {
       const payload = await fetchRemoteSessionFilePayload(environment, latest);

--- a/apps/main-2.0/src/core/remote-session-loader.ts
+++ b/apps/main-2.0/src/core/remote-session-loader.ts
@@ -3,6 +3,7 @@ import {
   loadClaudeCliSessionRows,
   loadCodeBuddyCliSessionRows,
   loadCodeWizSessions,
+  loadOpenCodeSessions,
   loadCodexSessionRows,
   loadQoderSessionRows,
   parseCodexSessionMetaLine,
@@ -25,6 +26,7 @@ export type RemoteSessionFileKind =
   | "claude-session-index"
   | "codebuddy-project"
   | "codewiz-session"
+  | "opencode-session"
   | "qoder-project";
 
 export interface RemoteSessionFilePayload {
@@ -131,6 +133,12 @@ export function loadRemoteSessionDetailPayload(
     const [dbPath, sessionId] = payload.path.split("#", 2);
     const candidate = loadCodeWizSessions(path.dirname(dbPath)).find((item) => item.session.rawId === sessionId);
     return candidate ? scopeRemoteSession(candidate, environment, "codewiz") : null;
+  }
+
+  if (payload.kind === "opencode-session") {
+    const [dbPath, sessionId] = payload.path.split("#", 2);
+    const candidate = loadOpenCodeSessions(path.dirname(dbPath)).find((item) => item.session.rawId === sessionId);
+    return candidate ? scopeRemoteSession(candidate, environment, "opencode-cli") : null;
   }
 
   return null;

--- a/apps/main-2.0/src/core/remote-sync.test.ts
+++ b/apps/main-2.0/src/core/remote-sync.test.ts
@@ -279,4 +279,81 @@ db.close()
       fs.rmSync(tempHome, { recursive: true, force: true });
     }
   }, 20_000);
+
+  it("collects OpenCode sessions from the remote opencode.db with subagent relations", async () => {
+    const store = createInMemoryStore();
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "agent-recall-v2-remote-opencode-"));
+    const opencodeDir = path.join(tempHome, ".local", "share", "opencode");
+    fs.mkdirSync(opencodeDir, { recursive: true });
+    const opencodeDbPath = path.join(opencodeDir, "opencode.db");
+    execFileSync(
+      process.platform === "win32" ? "python" : "python3",
+      [
+        "-c",
+        String.raw`
+import json, sqlite3, sys
+db = sqlite3.connect(sys.argv[1])
+db.executescript('''
+CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT NOT NULL, title TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER, parent_id TEXT);
+CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, type TEXT NOT NULL, time_created INTEGER NOT NULL, data TEXT NOT NULL);
+CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, data TEXT NOT NULL);
+''')
+db.execute("INSERT INTO session (id, directory, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?)", ("opencode-parent", "/repo/opencode", "OpenCode parent", 1780560000000, 1780560600000))
+db.execute("INSERT INTO session (id, directory, title, time_created, time_updated, parent_id) VALUES (?, ?, ?, ?, ?, ?)", ("opencode-child", "/repo/opencode", "OpenCode child", 1780560000000, 1780560600000, "opencode-parent"))
+db.execute("INSERT INTO message (id, session_id, type, time_created, data) VALUES (?, ?, ?, ?, ?)", ("oc-user", "opencode-parent", "user", 1780560060000, json.dumps({"role": "user"})))
+db.execute("INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?, ?, ?, ?, ?)", ("oc-user-part", "oc-user", "opencode-parent", 1780560060000, json.dumps({"type": "text", "text": "opencode parent question"})))
+db.execute("INSERT INTO message (id, session_id, type, time_created, data) VALUES (?, ?, ?, ?, ?)", ("oc-child-user", "opencode-child", "user", 1780560060000, json.dumps({"role": "user"})))
+db.execute("INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?, ?, ?, ?, ?)", ("oc-child-user-part", "oc-child-user", "opencode-child", 1780560060000, json.dumps({"type": "text", "text": "opencode child question"})))
+db.commit()
+db.close()
+`,
+        opencodeDbPath,
+      ],
+      { encoding: "utf8" },
+    );
+
+    try {
+      const environment = await store.upsertEnvironment({
+        id: "ssh-devbox",
+        kind: "ssh",
+        label: "devbox",
+        hostAlias: "devbox",
+        host: "devbox.example.com",
+        authMode: "none",
+        enabled: true,
+      });
+      await syncRemoteEnvironment(store, environment, {
+        runSsh: async (_environment, command) => execFileSync(
+          process.platform === "win32" ? "python" : "python3",
+          ["-c", decodeCollectorScript(command)],
+          {
+            encoding: "utf8",
+            env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+          },
+        ),
+      });
+
+      await expect(store.getSession(`ssh:${environment.id}:opencode-cli:opencode-parent`)).resolves.toMatchObject({
+        rawId: "opencode-parent",
+        source: "opencode-cli",
+        isSubagent: false,
+        parentSessionId: null,
+      });
+      await expect(store.getSession(`ssh:${environment.id}:opencode-cli:opencode-child`)).resolves.toMatchObject({
+        rawId: "opencode-child",
+        source: "opencode-cli",
+        isSubagent: true,
+        parentSessionId: "opencode-parent",
+      });
+      const rootSessions = await store.searchSessions({
+        environmentId: environment.id,
+        excludeSubagents: true,
+      });
+      expect(rootSessions).toHaveLength(1);
+      expect(rootSessions[0]?.rawId).toBe("opencode-parent");
+    } finally {
+      await store.close();
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    }
+  }, 20_000);
 });

--- a/apps/main-2.0/src/core/remote-sync.ts
+++ b/apps/main-2.0/src/core/remote-sync.ts
@@ -33,7 +33,7 @@ export interface RemoteSyncOptions {
 }
 
 export interface RemoteSessionSummaryPayload {
-  kind: "codex-session" | "claude-project" | "codebuddy-project" | "codewiz-session" | "qoder-project";
+  kind: "codex-session" | "claude-project" | "codebuddy-project" | "codewiz-session" | "opencode-session" | "qoder-project";
   source?: SessionSource;
   path: string;
   mtimeMs: number;
@@ -488,7 +488,7 @@ async function syncWslEnvironment(
   const runWsl = options.runSsh ?? runSystemRemote;
   await store.updateEnvironmentSyncState(environment.id, "syncing", { lastError: null });
   try {
-    const output = await runWsl(environment, buildRemoteCollectorCommand([], { includeCodeWiz: false }));
+    const output = await runWsl(environment, buildRemoteCollectorCommand([], { includeCodeWiz: false, includeOpenCode: false }));
     const { payloads, summaries } = decodeRemoteSyncOutput(output);
     const enabledSummaries = summaries.filter((summary) => isSupportedWslSource(summarySource(summary)));
     for (const summary of enabledSummaries) {
@@ -569,6 +569,7 @@ function summarySource(summary: RemoteSessionSummaryPayload): SessionSource {
   if (summary.kind === "codex-session") return "codex-cli";
   if (summary.kind === "codebuddy-project") return "codebuddy-cli";
   if (summary.kind === "codewiz-session") return "codewiz-cli";
+  if (summary.kind === "opencode-session") return "opencode-cli";
   return "claude-cli";
 }
 
@@ -577,6 +578,7 @@ function payloadSourceForPayload(payload: RemoteSessionFilePayload): SessionSour
   if (payload.kind === "codex-session" || payload.kind === "codex-index") return "codex-cli";
   if (payload.kind === "codebuddy-project") return "codebuddy-cli";
   if (payload.kind === "codewiz-session") return "codewiz-cli";
+  if (payload.kind === "opencode-session") return "opencode-cli";
   if (payload.kind === "qoder-project") return "qoder";
   return "claude-cli";
 }
@@ -723,7 +725,7 @@ async function fetchWslSessionMessagePage(
   return decodeRemoteMessagePage(output);
 }
 
-export function remoteFamilyForSource(source: SessionSource): "claude" | "codex" | "codebuddy" | "codewiz" | "qoder" {
+export function remoteFamilyForSource(source: SessionSource): "claude" | "codex" | "codebuddy" | "codewiz" | "opencode" | "qoder" {
   return sessionSourceDescriptor(source).remoteFamily ?? "codex";
 }
 
@@ -732,6 +734,7 @@ function remoteKindForSource(source: SessionSource): RemoteSessionFileKind {
   if (family === "codewiz") return "codewiz-session";
   if (family === "claude") return "claude-project";
   if (family === "codebuddy") return "codebuddy-project";
+  if (family === "opencode") return "opencode-session";
   if (family === "qoder") return "qoder-project";
   return "codex-session";
 }
@@ -757,7 +760,7 @@ print(json.dumps({
 }
 
 function buildRemoteMessagePageCommand(session: SessionSearchResult, offset: number, limit: number): string {
-  const [dbPath, codeWizSessionId] = session.source === "codewiz-cli" ? session.filePath.split("#", 2) : [session.filePath, ""];
+  const [dbPath, codeWizSessionId] = session.source === "codewiz-cli" || session.source === "opencode-cli" ? session.filePath.split("#", 2) : [session.filePath, ""];
   const request = {
     path: dbPath,
     codeWizSessionId,
@@ -776,7 +779,7 @@ end = offset + limit
 
 messages = []
 message_index = 0
-if kind == "codewiz":
+if kind in {"codewiz", "opencode"}:
   import sqlite3
   def text_from_codewiz_part(data):
     if not isinstance(data, dict):
@@ -918,7 +921,7 @@ export function formatRemoteSyncProcessError(error: unknown, stdout: string, std
 }
 
 function looksLikeRemotePayload(output: string): boolean {
-  return /^\s*\{"kind":\s*"(?:codex-session|codex-index|claude-project|claude-session-index|codebuddy-project|codewiz-session)"/.test(output);
+  return /^\s*\{"kind":\s*"(?:codex-session|codex-index|claude-project|claude-session-index|codebuddy-project|codewiz-session|opencode-session)"/.test(output);
 }
 
 function truncateRemoteError(value: string, maxChars = 1200): string {
@@ -941,6 +944,7 @@ const REMOTE_SESSION_FILE_KINDS = new Set<RemoteSessionFilePayload["kind"]>([
   "claude-project",
   "claude-session-index",
   "codewiz-session",
+  "opencode-session",
   "codebuddy-project",
   "qoder-project",
 ]);
@@ -993,7 +997,7 @@ function parseRemoteSummaryRecord(
   lineNumber: number,
   kind: RemoteSessionSummaryPayload["kind"],
 ): RemoteSessionSummaryPayload {
-  if (kind !== "codex-session" && kind !== "claude-project" && kind !== "codebuddy-project" && kind !== "codewiz-session") {
+  if (kind !== "codex-session" && kind !== "claude-project" && kind !== "codebuddy-project" && kind !== "codewiz-session" && kind !== "opencode-session") {
     throw new Error(`Invalid remote payload at line ${lineNumber}: summaries must be session files`);
   }
   const rawId = stringField(parsed, "rawId");
@@ -1473,7 +1477,7 @@ def codewiz_token_usage(session):
     session["tokens_reasoning"] if "tokens_reasoning" in session.keys() and session["tokens_reasoning"] else 0,
   )
 
-def emit_codewiz_summaries(db_path, stat):
+def emit_codewiz_summaries(db_path, stat, kind="codewiz-session", trace_source="codewiz"):
   try:
     db = sqlite3.connect(str(db_path))
     db.row_factory = sqlite3.Row
@@ -1490,7 +1494,7 @@ def emit_codewiz_summaries(db_path, stat):
       message_count = 0
       message_events = []
       rows = codewiz_message_rows(db, raw_id)
-      token_events = codewiz_token_events(rows, "codewiz")
+      token_events = codewiz_token_events(rows, trace_source)
       for row in rows:
         parsed = parse_codewiz_row(row)
         if not parsed:
@@ -1500,7 +1504,7 @@ def emit_codewiz_summaries(db_path, stat):
         if parsed["role"] == "user" and not first_question:
           first_question = parsed["content"]
       emit({
-        "kind": "codewiz-session",
+        "kind": kind,
         "path": "%s#%s" % (str(db_path), raw_id),
         "mtimeMs": int(stat.st_mtime * 1000),
         "size": stat.st_size,
@@ -1685,6 +1689,7 @@ for kind, source, root, pattern in sources:
       pass
 
 __CODEWIZ_COLLECTION__
+__OPENCODE_COLLECTION__
 codex_titles = {
   "codex-cli": load_codex_titles(".codex"),
   __OPTIONAL_CODEX_TITLE_INDEXES__
@@ -1709,7 +1714,7 @@ for _mtime, kind, source, path, _size in sorted(candidates, key=lambda item: ite
 
 function buildRemoteCollectorCommand(
   enabledOptionalSources: SessionSource[],
-  options: { includeCodeWiz?: boolean } = {},
+  options: { includeCodeWiz?: boolean; includeOpenCode?: boolean } = {},
 ): string {
   const descriptors: Record<string, string> = {
     "tclaude-cli": '("claude-project", "tclaude-cli", home / ".tclaude" / "projects", "*.jsonl")',
@@ -1732,12 +1737,21 @@ try:
     emit_codewiz_summaries(codewiz_db, codewiz_db.stat())
 except Exception:
   pass`;
+  const opencodeCollection = options.includeOpenCode === false
+    ? ""
+    : String.raw`opencode_db = home / ".local" / "share" / "opencode" / "opencode.db"
+try:
+  if opencode_db.exists():
+    emit_codewiz_summaries(opencode_db, opencode_db.stat(), kind="opencode-session", trace_source="opencode")
+except Exception:
+  pass`;
   const script = REMOTE_COLLECTOR_SCRIPT
     .replace("__ENABLED_OPTIONAL_SOURCES__", JSON.stringify(optionalSources))
     .replace("__OPTIONAL_SOURCE_DESCRIPTORS__", optionalSources.map((source) => descriptors[source]).join(",\n  "))
     .replace("__OPTIONAL_CODEX_TITLE_INDEXES__", optionalCodexTitleIndexes)
     .replace("__OPTIONAL_CLAUDE_INDEXES__", optionalClaudeIndexes)
-    .replace("__CODEWIZ_COLLECTION__", codewizCollection);
+    .replace("__CODEWIZ_COLLECTION__", codewizCollection)
+    .replace("__OPENCODE_COLLECTION__", opencodeCollection);
   return buildPythonBase64Command(script);
 }
 

--- a/apps/main-2.0/src/core/session-sources.ts
+++ b/apps/main-2.0/src/core/session-sources.ts
@@ -65,7 +65,7 @@ export interface SessionSourceDescriptor {
   liveFamily: LiveSessionFamily | null;
   migrationAgent: MigrationAgent | null;
   resumeTarget: MigrationTarget | null;
-  remoteFamily: "claude" | "codex" | "codebuddy" | "codewiz" | "qoder" | null;
+  remoteFamily: "claude" | "codex" | "codebuddy" | "codewiz" | "opencode" | "qoder" | null;
   nativeAppFamily: "claude" | "codex" | "codebuddy" | null;
   capabilities: SessionSourceCapabilities;
 }
@@ -155,7 +155,7 @@ export const SESSION_SOURCE_REGISTRY = {
   "opencode-cli": {
     id: "opencode-cli", label: "OpenCode", format: "opencode", family: "opencode", uiFamily: "other", statsGroup: null,
     optionalSetting: "includeOpenCode", pendingKey: "opencode", remoteCollectorOptional: false, liveFamily: "opencode", migrationAgent: null,
-    resumeTarget: null, remoteFamily: "codebuddy", nativeAppFamily: null,
+    resumeTarget: null, remoteFamily: "opencode", nativeAppFamily: null,
     capabilities: { live: true, resume: false, migrate: false, sessionSync: false, openApp: false },
   },
   "zcode-cli": {

--- a/apps/main-2.0/src/main/services/remote-session-access.ts
+++ b/apps/main-2.0/src/main/services/remote-session-access.ts
@@ -131,7 +131,7 @@ export class RemoteSessionAccess {
   private async loadDetails(sessionKey: string): Promise<void> {
     const store = this.dependencies.getStore();
     const session = await store.getSession(sessionKey);
-    if (!session || isLocalSessionEnvironment(session) || session.source === "codewiz-cli") return;
+    if (!session || isLocalSessionEnvironment(session) || session.source === "codewiz-cli" || session.source === "opencode-cli") return;
 
     const environment = await store.getEnvironment(session.environmentId);
     if (!environment) {


### PR DESCRIPTION
## 概述

Fixes #527

SSH 远程采集此前不支持 OpenCode:采集器只覆盖 Codex / Claude / TClaude / TCodex / CodeBuddy / CodeWiz / Qoder,而 CodeWiz 读取的 `opencode.db` 与 OpenCode 本体同构,属于纯遗漏(`opencode-cli` 的 descriptor 甚至已预留 `remoteCollectorOptional: false`,仅 `remoteFamily` 是 `"codebuddy"` 占位值)。

## 改动

**采集(v1/v2 `remote-sync.ts` 各一份)**

- `emit_codewiz_summaries` 参数化(`kind` / `trace_source`),新增 `__OPENCODE_COLLECTION__` 块采集 `~/.local/share/opencode/opencode.db`,emit `kind: "opencode-session"`(含 `parent_id` 派生的 `isSubagent` / `parentSessionId`,与 #490 一致);
- `includeOpenCode` 选项,WSL 路径与 CodeWiz 一致默认禁用;
- `RemoteSessionSummaryPayload` 联合类型、输出识别正则、summary kind 枚举与校验增加 `"opencode-session"`;
- `summarySource` / `payloadSourceForPayload` 映射到 `opencode-cli`;sessionKey 走通用分支(`ssh:<env>:opencode-cli:<id>`,与 codex 一致);
- 远程详情消息分页:TS 侧对 `opencode-cli` 做与 `codewiz-cli` 相同的 `db#sessionId` 路径拆分,Python 侧 SQLite 读取分支扩展为 `kind in {"codewiz", "opencode"}`(schema 同构)。

**源描述符(v1/v2 `session-sources.ts`)**

- `remoteFamily` 类型放宽,`opencode-cli` 的占位值 `"codebuddy"` 修正为 `"opencode"`,`remoteKindForSource` 增加 `opencode → opencode-session` 分支。

**详情加载**

- v1/v2 `remote-session-loader.ts`:新增 `opencode-session` payload 分支(复用 `loadOpenCodeSessions`);
- v2 `remote-session-access.ts`:`loadDetails` 对 `opencode-cli` 与 `codewiz-cli` 同样跳过整文件拉取(复合格式路径不适用,详情由消息分页通道提供)。

## 验证

- v1 `remote-sync.test.ts`:新增用例(临时 HOME + 真实 opencode.db fixture,父/子会话、`parent_id` 子会话关系断言),55/55 通过;
- v2 `remote-sync.test.ts`:新增端到端用例(同步 → store 中 `ssh:<env>:opencode-cli:<id>` 父子字段 + `excludeSubagents` 过滤),4/4 通过;
- `test:v1` 全量:1620 passed(仅 `mcp-server.test.ts` 5 例为本机路径含非 ASCII 字符的既有环境问题,此前已在未改动代码上复现);
- `test:v2` 全量:2129 passed(222 文件全绿);
- `npm run typecheck`(v1 + v2)通过。
