### PR TITLE
feat(sessions): index Gemini CLI sessions

### DIFF
--- a/.release-notes/gemini-cli-session-support.md
+++ b/.release-notes/gemini-cli-session-support.md
@@ -1,0 +1,7 @@
+# 支持 Gemini CLI 会话索引
+
+<!-- release-target: both -->
+
+## 新增功能
+
+- ✨ 新增可选数据源 Gemini CLI:在设置中开启后,可搜索、筛选、按项目查看本地 Gemini CLI 会话,查看用户/模型消息、工具调用轨迹与逐消息 Token 用量;子 Agent 会话会按父子关系归属,不会占用顶层列表。

--- a/apps/main-1.0/src/core/format-adapters.ts
+++ b/apps/main-1.0/src/core/format-adapters.ts
@@ -384,6 +384,19 @@ export const qwenAdapter: FormatAdapter = {
   },
 };
 
+function geminiPartListText(parts: unknown[]): string {
+  return parts
+    .map((part) => {
+      if (typeof part === "string") return part;
+      if (part && typeof part === "object" && typeof (part as Record<string, unknown>).text === "string") {
+        return (part as Record<string, unknown>).text as string;
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
 export const geminiAdapter: FormatAdapter = {
   format: "gemini",
   parseLine(raw) {
@@ -391,15 +404,14 @@ export const geminiAdapter: FormatAdapter = {
     const row = raw as Record<string, unknown>;
     const role = row.type === "user" ? "user" : row.type === "gemini" ? "assistant" : null;
     if (!role) return null;
-    const content = row.content;
+    const content = row.displayContent || row.content;
     const text = typeof content === "string"
       ? content
-      : Array.isArray(content)
-        ? content
-          .map((part) => part && typeof part === "object" && typeof (part as Record<string, unknown>).text === "string" ? (part as Record<string, unknown>).text as string : "")
-          .filter(Boolean)
-          .join("\n")
-        : "";
+      : content && typeof content === "object" && !Array.isArray(content)
+        ? geminiPartListText([content as Record<string, unknown>])
+        : Array.isArray(content)
+          ? geminiPartListText(content)
+          : "";
     return text ? { role, content: text, timestamp: timestampFromRaw(raw) } : null;
   },
 };

--- a/apps/main-1.0/src/core/format-adapters.ts
+++ b/apps/main-1.0/src/core/format-adapters.ts
@@ -384,6 +384,26 @@ export const qwenAdapter: FormatAdapter = {
   },
 };
 
+export const geminiAdapter: FormatAdapter = {
+  format: "gemini",
+  parseLine(raw) {
+    if (!raw || typeof raw !== "object") return null;
+    const row = raw as Record<string, unknown>;
+    const role = row.type === "user" ? "user" : row.type === "gemini" ? "assistant" : null;
+    if (!role) return null;
+    const content = row.content;
+    const text = typeof content === "string"
+      ? content
+      : Array.isArray(content)
+        ? content
+          .map((part) => part && typeof part === "object" && typeof (part as Record<string, unknown>).text === "string" ? (part as Record<string, unknown>).text as string : "")
+          .filter(Boolean)
+          .join("\n")
+        : "";
+    return text ? { role, content: text, timestamp: timestampFromRaw(raw) } : null;
+  },
+};
+
 export function getFormatForSource(source: SessionSource): SessionFormat {
   return sessionSourceDescriptor(source).format;
 }
@@ -406,6 +426,7 @@ export function getAdapter(sourceOrFormat: SessionSource | SessionFormat): Forma
   if (sourceOrFormat === "deepseek") return deepseekAdapter;
   if (sourceOrFormat === "kimi") return kimiAdapter;
   if (sourceOrFormat === "qwen") return qwenAdapter;
+  if (sourceOrFormat === "gemini") return geminiAdapter;
   const format = getFormatForSource(sourceOrFormat);
   if (format === "claude") return claudeAdapter;
   if (format === "codebuddy") return codebuddyAdapter;
@@ -422,6 +443,7 @@ export function getAdapter(sourceOrFormat: SessionSource | SessionFormat): Forma
   if (format === "deepseek") return deepseekAdapter;
   if (format === "kimi") return kimiAdapter;
   if (format === "qwen") return qwenAdapter;
+  if (format === "gemini") return geminiAdapter;
   return codexAdapter;
 }
 

--- a/apps/main-1.0/src/core/platform.ts
+++ b/apps/main-1.0/src/core/platform.ts
@@ -94,6 +94,7 @@ export interface AppSettings {
   includePi: boolean;
   includeKimiCli: boolean;
   includeQwenCode: boolean;
+  includeGeminiCli: boolean;
   includeDeepSeekCli: boolean;
   rulesSyncEnabled: boolean;
   memoriesSyncEnabled: boolean;
@@ -170,6 +171,7 @@ export const defaultSettings: AppSettings = {
   includePi: false,
   includeKimiCli: false,
   includeQwenCode: false,
+  includeGeminiCli: false,
   includeDeepSeekCli: false,
   rulesSyncEnabled: false,
   memoriesSyncEnabled: false,

--- a/apps/main-1.0/src/core/session-environment.ts
+++ b/apps/main-1.0/src/core/session-environment.ts
@@ -24,6 +24,7 @@ export function canDeleteSessionLocally(session: SessionEnvironmentIdentity): bo
   return session.source !== "workbuddy-cli"
     && session.source !== "kimi-cli"
     && session.source !== "qwen-code"
+    && session.source !== "gemini-cli"
     && (session.environmentKind !== "ssh" || session.sourceAvailable === false);
 }
 

--- a/apps/main-1.0/src/core/session-loader-gemini.test.ts
+++ b/apps/main-1.0/src/core/session-loader-gemini.test.ts
@@ -1,0 +1,163 @@
+import fs from "node:fs";
+import * as os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadDefaultSessions } from "./session-loader";
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: vi.fn(() => actual.homedir()) };
+});
+
+const roots: string[] = [];
+const defaultHomeDir = os.homedir();
+const originalGeminiDir = process.env.GEMINI_DIR;
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+beforeEach(() => {
+  delete process.env.GEMINI_DIR;
+});
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  if (originalGeminiDir === undefined) delete process.env.GEMINI_DIR;
+  else process.env.GEMINI_DIR = originalGeminiDir;
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
+  vi.restoreAllMocks();
+  vi.mocked(os.homedir).mockReset().mockReturnValue(defaultHomeDir);
+});
+
+function fixture(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "agentrecall-gemini-v1-"));
+  roots.push(root);
+  return root;
+}
+
+function projectChats(root: string, slug: string, projectPath: string): string {
+  const projectDir = path.join(root, ".gemini", "tmp", slug);
+  fs.mkdirSync(projectDir, { recursive: true });
+  fs.writeFileSync(path.join(projectDir, ".project_root"), projectPath, "utf8");
+  const chats = path.join(projectDir, "chats");
+  fs.mkdirSync(chats, { recursive: true });
+  return chats;
+}
+
+function writeChat(filePath: string, rows: unknown[]): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, rows.map((row) => JSON.stringify(row)).join("\n"), "utf8");
+}
+
+function header(sessionId: string, extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return { sessionId, projectHash: "abc123", startTime: "2026-07-29T04:54:37.634Z", lastUpdated: "2026-07-29T05:00:00.000Z", ...extra };
+}
+
+describe("Gemini CLI sessions", () => {
+  it("loads main sessions with messages, tokens, tool calls, and the project root", () => {
+    const root = fixture();
+    const chats = projectChats(root, "gemini-app", "/work/gemini-app");
+    writeChat(path.join(chats, "session-2026-07-29T04-54-72d14847.jsonl"), [
+      header("72d14847-09f0-4562-aa8e-f7b42bf11749"),
+      { id: "m-user", timestamp: "2026-07-29T04:55:00.000Z", type: "user", content: [{ text: "Fix the login flow" }] },
+      {
+        id: "m-gemini",
+        timestamp: "2026-07-29T04:56:00.000Z",
+        type: "gemini",
+        content: [{ text: "I will inspect auth.ts" }],
+        thoughts: ["Consider the auth module"],
+        tokens: { input: 100, output: 20, cached: 5, thoughts: 3, tool: 0, total: 125 },
+        model: "gemini-2.5-pro",
+        toolCalls: [{ id: "call-1", name: "read_file", displayName: "Read File", timestamp: "2026-07-29T04:56:01.000Z", args: { path: "auth.ts" }, status: "ok" }],
+      },
+    ]);
+
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeGeminiCli: true });
+
+    expect(loaded.session).toMatchObject({
+      sessionKey: "gemini:72d14847-09f0-4562-aa8e-f7b42bf11749",
+      source: "gemini-cli",
+      projectPath: "/work/gemini-app",
+      isSubagent: false,
+      parentSessionId: null,
+    });
+    expect(loaded.messages.map((message) => message.content)).toEqual(["Fix the login flow", "I will inspect auth.ts"]);
+    // AgentRecall 统计口径:total = input+output+cached+reasoning(Gemini 自身的 total 字段不含 thoughts)
+    expect(loaded.session.tokenUsage?.totalTokens).toBe(128);
+    expect(loaded.traceEvents?.some((event) => event.kind === "tool_call" && event.callId === "call-1")).toBe(true);
+    expect(loaded.traceEvents?.some((event) => event.eventType === "gemini.thought")).toBe(true);
+  });
+
+  it("rebuilds messages from checkpoints and applies rewinds", () => {
+    const root = fixture();
+    const chats = projectChats(root, "gemini-app", "/work/gemini-app");
+    writeChat(path.join(chats, "session-2026-07-29T05-10-66fcaf99.jsonl"), [
+      header("66fcaf99-1111-2222-3333-444444555555"),
+      { id: "old-user", timestamp: "2026-07-29T05:10:00.000Z", type: "user", content: "stale request" },
+      { id: "old-gemini", timestamp: "2026-07-29T05:11:00.000Z", type: "gemini", content: "stale answer", tokens: { input: 9, output: 9, cached: 0, thoughts: 0, tool: 0, total: 18 } },
+      { $set: { messages: [
+        { id: "new-user", timestamp: "2026-07-29T05:12:00.000Z", type: "user", content: "fresh request" },
+        { id: "mid-gemini", timestamp: "2026-07-29T05:13:00.000Z", type: "gemini", content: "keep me", tokens: { input: 10, output: 4, cached: 0, thoughts: 0, tool: 0, total: 14 } },
+        { id: "tail-gemini", timestamp: "2026-07-29T05:14:00.000Z", type: "gemini", content: "rewind past me", tokens: { input: 7, output: 7, cached: 0, thoughts: 0, tool: 0, total: 14 } },
+      ] } },
+      { $rewindTo: "tail-gemini" },
+    ]);
+
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeGeminiCli: true });
+
+    expect(loaded.messages.map((message) => message.content)).toEqual(["fresh request", "keep me"]);
+    expect(loaded.session.tokenUsage?.totalTokens).toBe(14);
+  });
+
+  it("indexes nested subagent sessions with parent linkage", () => {
+    const root = fixture();
+    const chats = projectChats(root, "gemini-app", "/work/gemini-app");
+    const parentId = "72d14847-09f0-4562-aa8e-f7b42bf11749";
+    writeChat(path.join(chats, `session-2026-07-29T04-54-72d14847.jsonl`), [
+      header(parentId),
+      { id: "p-user", timestamp: "2026-07-29T04:55:00.000Z", type: "user", content: "Delegate the audit" },
+    ]);
+    writeChat(path.join(chats, parentId, "aaaabbbb-cccc-dddd-eeee-ffff00001111.jsonl"), [
+      { sessionId: "aaaabbbb-cccc-dddd-eeee-ffff00001111", projectHash: "abc123", startTime: "2026-07-29T04:56:00.000Z", lastUpdated: "2026-07-29T04:57:00.000Z", kind: "subagent" },
+      { id: "s-user", timestamp: "2026-07-29T04:56:30.000Z", type: "user", content: "Audit the middleware" },
+    ]);
+
+    const loaded = loadDefaultSessions({ homeDir: root, includeGeminiCli: true });
+    const byKey = new Map(loaded.map((item) => [item.session.rawId, item.session]));
+
+    expect(byKey.get(parentId)).toMatchObject({ isSubagent: false, parentSessionId: null });
+    expect(byKey.get("aaaabbbb-cccc-dddd-eeee-ffff00001111")).toMatchObject({
+      isSubagent: true,
+      parentSessionId: parentId,
+    });
+  });
+
+  it("uses summaries as titles and ignores temp or unreadable chat files", () => {
+    const root = fixture();
+    const chats = projectChats(root, "gemini-app", "/work/gemini-app");
+    writeChat(path.join(chats, "session-2026-07-29T06-00-abcdef01.jsonl"), [
+      header("abcdef01-0000-0000-0000-000000000001"),
+      { id: "u", timestamp: "2026-07-29T06:00:30.000Z", type: "user", content: "Summarized session" },
+      { $set: { summary: "Custom summary" } },
+    ]);
+    writeChat(path.join(chats, "session-2026-07-29T06-05-deadbeef.jsonl.tmp-123"), [header("tmp-session")]);
+    writeChat(path.join(chats, "session-2026-07-29T06-06-badc0de.jsonl.unreadable-1785300000000"), [header("unreadable-session")]);
+
+    const loaded = loadDefaultSessions({ homeDir: root, includeGeminiCli: true });
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].session.originalTitle).toBe("Custom summary");
+  });
+
+  it("stays out of the default index until the optional source is enabled", () => {
+    const root = fixture();
+    const chats = projectChats(root, "gemini-app", "/work/gemini-app");
+    writeChat(path.join(chats, "session-2026-07-29T07-00-12345678.jsonl"), [
+      header("12345678-0000-0000-0000-000000000002"),
+      { id: "u", timestamp: "2026-07-29T07:00:30.000Z", type: "user", content: "Hidden until enabled" },
+    ]);
+
+    expect(loadDefaultSessions({ homeDir: root })).toHaveLength(0);
+    expect(loadDefaultSessions({ homeDir: root, includeGeminiCli: true })).toHaveLength(1);
+  });
+});

--- a/apps/main-1.0/src/core/session-loader-gemini.test.ts
+++ b/apps/main-1.0/src/core/session-loader-gemini.test.ts
@@ -65,7 +65,7 @@ describe("Gemini CLI sessions", () => {
         timestamp: "2026-07-29T04:56:00.000Z",
         type: "gemini",
         content: [{ text: "I will inspect auth.ts" }],
-        thoughts: ["Consider the auth module"],
+        thoughts: [{ subject: "Auth plan", description: "Consider the auth module", timestamp: "2026-07-29T04:55:59.000Z" }],
         tokens: { input: 100, output: 20, cached: 5, thoughts: 3, tool: 0, total: 125 },
         model: "gemini-2.5-pro",
         toolCalls: [{ id: "call-1", name: "read_file", displayName: "Read File", timestamp: "2026-07-29T04:56:01.000Z", args: { path: "auth.ts" }, status: "ok" }],
@@ -82,9 +82,9 @@ describe("Gemini CLI sessions", () => {
       parentSessionId: null,
     });
     expect(loaded.messages.map((message) => message.content)).toEqual(["Fix the login flow", "I will inspect auth.ts"]);
-    // AgentRecall 统计口径:total = input+output+cached+reasoning(Gemini 自身的 total 字段不含 thoughts)
-    expect(loaded.session.tokenUsage?.totalTokens).toBe(128);
-    expect(loaded.traceEvents?.some((event) => event.kind === "tool_call" && event.callId === "call-1")).toBe(true);
+    // Gemini 的 input 已含 cached:input 100 → 非缓存 95 + cached 5;total = 95+5+20(+tool)+3 = 123
+    expect(loaded.session.tokenUsage?.totalTokens).toBe(123);
+    expect(loaded.traceEvents?.some((event) => event.kind === "tool_call" && event.callId === "call-1" && event.status === "completed")).toBe(true);
     expect(loaded.traceEvents?.some((event) => event.eventType === "gemini.thought")).toBe(true);
   });
 
@@ -147,6 +147,79 @@ describe("Gemini CLI sessions", () => {
 
     expect(loaded).toHaveLength(1);
     expect(loaded[0].session.originalTitle).toBe("Custom summary");
+  });
+
+  it("replays enriched re-emissions under the same message id without duplication", () => {
+    const root = fixture();
+    const chats = projectChats(root, "gemini-app", "/work/gemini-app");
+    const geminiBase = { id: "dup-1", timestamp: "2026-07-29T08:00:00.000Z", type: "gemini", content: [{ text: "working on it" }] };
+    writeChat(path.join(chats, "session-2026-07-29T08-00-dup00001.jsonl"), [
+      header("dup00001-0000-0000-0000-000000000001"),
+      { id: "u", timestamp: "2026-07-29T07:59:00.000Z", type: "user", content: "Run the audit" },
+      { ...geminiBase, thoughts: [{ subject: "Plan", description: "first pass", timestamp: "2026-07-29T08:00:01.000Z" }], toolCalls: [{ id: "call-a", name: "grep", timestamp: "2026-07-29T08:00:02.000Z", args: { q: "auth" }, status: "ok" }] },
+      { ...geminiBase, tokens: { input: 50, output: 10, cached: 0, thoughts: 2, tool: 4, total: 66 } },
+    ]);
+
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeGeminiCli: true });
+
+    expect(loaded.messages.map((message) => message.content)).toEqual(["Run the audit", "working on it"]);
+    expect(loaded.session.tokenUsage?.totalTokens).toBe(66);
+    expect(loaded.traceEvents?.filter((event) => event.eventType === "gemini.thought")).toHaveLength(1);
+    expect(loaded.traceEvents?.filter((event) => event.kind === "tool_call")).toHaveLength(1);
+  });
+
+  it("resolves rewinds that target filtered tool-only messages", () => {
+    const root = fixture();
+    const chats = projectChats(root, "gemini-app", "/work/gemini-app");
+    writeChat(path.join(chats, "session-2026-07-29T09-00-aaaa0001.jsonl"), [
+      header("aaaa0001-0000-0000-0000-000000000002"),
+      { id: "keep-user", timestamp: "2026-07-29T09:00:00.000Z", type: "user", content: "Keep this request" },
+      { id: "tool-only", timestamp: "2026-07-29T09:00:10.000Z", type: "gemini", content: [], toolCalls: [{ id: "call-z", name: "bash", timestamp: "2026-07-29T09:00:11.000Z", args: { cmd: "ls" }, status: "ok" }] },
+      { id: "tail", timestamp: "2026-07-29T09:00:20.000Z", type: "gemini", content: "later answer" },
+      { $rewindTo: "tool-only" },
+    ]);
+
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeGeminiCli: true });
+
+    expect(loaded.messages.map((message) => message.content)).toEqual(["Keep this request"]);
+    expect(loaded.traceEvents?.some((event) => event.callId === "call-z")).toBe(false);
+  });
+
+  it("indexes legacy .json conversation records", () => {
+    const root = fixture();
+    const chats = projectChats(root, "gemini-app", "/work/gemini-app");
+    fs.writeFileSync(path.join(chats, "session-2026-07-29T10-00-legacy01.json"), JSON.stringify({
+      sessionId: "legacy01-0000-0000-0000-000000000003",
+      startTime: "2026-07-29T10:00:00.000Z",
+      lastUpdated: "2026-07-29T10:01:00.000Z",
+      messages: [
+        { id: "lu", timestamp: "2026-07-29T10:00:30.000Z", type: "user", content: "Legacy request" },
+        { id: "lg", timestamp: "2026-07-29T10:00:40.000Z", type: "gemini", content: "Legacy answer", tokens: { input: 8, output: 2, cached: 0, thoughts: 0, tool: 0, total: 10 } },
+      ],
+    }), "utf8");
+
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeGeminiCli: true });
+
+    expect(loaded.session).toMatchObject({ rawId: "legacy01-0000-0000-0000-000000000003", source: "gemini-cli" });
+    expect(loaded.messages.map((message) => message.content)).toEqual(["Legacy request", "Legacy answer"]);
+    expect(loaded.session.tokenUsage?.totalTokens).toBe(10);
+  });
+
+  it("resolves the root from GEMINI_CLI_HOME", () => {
+    const syntheticHome = fixture();
+    const altHome = fixture();
+    const chats = path.join(altHome, ".gemini", "tmp", "gemini-app", "chats");
+    fs.mkdirSync(chats, { recursive: true });
+    writeChat(path.join(chats, "session-2026-07-29T11-00-bbb00002.jsonl"), [
+      header("bbb00002-0000-0000-0000-000000000004"),
+      { id: "u", timestamp: "2026-07-29T11:00:30.000Z", type: "user", content: "Alternate home request" },
+    ]);
+
+    vi.mocked(os.homedir).mockReturnValue(syntheticHome);
+    process.env.GEMINI_CLI_HOME = altHome;
+    const loaded = loadDefaultSessions({ includeGeminiCli: true }).filter((item) => item.session.source === "gemini-cli");
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].session.rawId).toBe("bbb00002-0000-0000-0000-000000000004");
   });
 
   it("stays out of the default index until the optional source is enabled", () => {

--- a/apps/main-1.0/src/core/session-loader-gemini.test.ts
+++ b/apps/main-1.0/src/core/session-loader-gemini.test.ts
@@ -85,7 +85,7 @@ describe("Gemini CLI sessions", () => {
     // Gemini 的 input 已含 cached:input 100 → 非缓存 95 + cached 5;total = 95+5+20(+tool)+3 = 123
     expect(loaded.session.tokenUsage?.totalTokens).toBe(123);
     expect(loaded.traceEvents?.some((event) => event.kind === "tool_call" && event.callId === "call-1" && event.status === "completed")).toBe(true);
-    expect(loaded.traceEvents?.some((event) => event.eventType === "gemini.thought")).toBe(true);
+    expect(loaded.traceEvents?.some((event) => event.eventType === "gemini.thought" && event.timestamp === "2026-07-29T04:55:59.000Z")).toBe(true);
   });
 
   it("rebuilds messages from checkpoints and applies rewinds", () => {
@@ -190,6 +190,7 @@ describe("Gemini CLI sessions", () => {
     const chats = projectChats(root, "gemini-app", "/work/gemini-app");
     fs.writeFileSync(path.join(chats, "session-2026-07-29T10-00-legacy01.json"), JSON.stringify({
       sessionId: "legacy01-0000-0000-0000-000000000003",
+      summary: "Persisted legacy summary",
       startTime: "2026-07-29T10:00:00.000Z",
       lastUpdated: "2026-07-29T10:01:00.000Z",
       messages: [
@@ -200,7 +201,7 @@ describe("Gemini CLI sessions", () => {
 
     const [loaded] = loadDefaultSessions({ homeDir: root, includeGeminiCli: true });
 
-    expect(loaded.session).toMatchObject({ rawId: "legacy01-0000-0000-0000-000000000003", source: "gemini-cli" });
+    expect(loaded.session).toMatchObject({ rawId: "legacy01-0000-0000-0000-000000000003", source: "gemini-cli", originalTitle: "Persisted legacy summary" });
     expect(loaded.messages.map((message) => message.content)).toEqual(["Legacy request", "Legacy answer"]);
     expect(loaded.session.tokenUsage?.totalTokens).toBe(10);
   });

--- a/apps/main-1.0/src/core/session-loader-gemini.test.ts
+++ b/apps/main-1.0/src/core/session-loader-gemini.test.ts
@@ -59,7 +59,7 @@ describe("Gemini CLI sessions", () => {
     const chats = projectChats(root, "gemini-app", "/work/gemini-app");
     writeChat(path.join(chats, "session-2026-07-29T04-54-72d14847.jsonl"), [
       header("72d14847-09f0-4562-aa8e-f7b42bf11749"),
-      { id: "m-user", timestamp: "2026-07-29T04:55:00.000Z", type: "user", content: [{ text: "Fix the login flow" }] },
+      { id: "m-user", timestamp: "2026-07-29T04:55:00.000Z", type: "user", content: [{ text: "expanded @file model input" }], displayContent: "Fix the login flow" },
       {
         id: "m-gemini",
         timestamp: "2026-07-29T04:56:00.000Z",
@@ -68,7 +68,7 @@ describe("Gemini CLI sessions", () => {
         thoughts: [{ subject: "Auth plan", description: "Consider the auth module", timestamp: "2026-07-29T04:55:59.000Z" }],
         tokens: { input: 100, output: 20, cached: 5, thoughts: 3, tool: 0, total: 125 },
         model: "gemini-2.5-pro",
-        toolCalls: [{ id: "call-1", name: "read_file", displayName: "Read File", timestamp: "2026-07-29T04:56:01.000Z", args: { path: "auth.ts" }, status: "ok" }],
+        toolCalls: [{ id: "call-1", name: "read_file", displayName: "Read File", timestamp: "2026-07-29T04:56:01.000Z", args: { path: "auth.ts" }, result: [{ text: "file contents" }], status: "ok" }, { id: "call-2", name: "bash", displayName: "Shell", timestamp: "2026-07-29T04:56:02.000Z", args: { cmd: "ls" }, status: "cancelled" }],
       },
     ]);
 
@@ -84,7 +84,9 @@ describe("Gemini CLI sessions", () => {
     expect(loaded.messages.map((message) => message.content)).toEqual(["Fix the login flow", "I will inspect auth.ts"]);
     // Gemini 的 input 已含 cached:input 100 → 非缓存 95 + cached 5;total = 95+5+20(+tool)+3 = 123
     expect(loaded.session.tokenUsage?.totalTokens).toBe(123);
-    expect(loaded.traceEvents?.some((event) => event.kind === "tool_call" && event.callId === "call-1" && event.status === "completed")).toBe(true);
+    expect(loaded.traceEvents?.some((event) => event.kind === "tool_result" && event.callId === "call-1" && event.status === "completed")).toBe(true);
+    expect(loaded.traceEvents?.some((event) => event.kind === "tool_result" && event.callId === "call-2" && event.status === "aborted")).toBe(true);
+    expect(loaded.session.timestamp).toBe(Date.parse("2026-07-29T04:54:37.634Z"));
     expect(loaded.traceEvents?.some((event) => event.eventType === "gemini.thought" && event.timestamp === "2026-07-29T04:55:59.000Z")).toBe(true);
   });
 

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -2347,21 +2347,33 @@ function resolveGeminiCliRoot(homeDir: string, options: SessionLoadOptions): str
 
 function geminiContentText(content: unknown): string {
   if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  const parts: string[] = [];
-  for (const part of content) {
-    if (!isRecord(part)) continue;
-    const text = stringField(part, "text");
-    if (text) parts.push(text);
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const part of content) {
+      if (typeof part === "string") {
+        if (part) parts.push(part);
+        continue;
+      }
+      if (!isRecord(part) || Array.isArray(part)) continue;
+      const text = stringField(part, "text");
+      if (text) parts.push(text);
+    }
+    return parts.filter(Boolean).join("\n");
   }
-  return parts.filter(Boolean).join("\n");
+  if (isRecord(content)) return geminiContentText([content]);
+  return "";
 }
 
-function geminiToolStatus(value: string): "completed" | "failed" | "unknown" {
+function geminiVisibleContent(row: Record<string, unknown>): string {
+  return geminiContentText(unknownField(row, "displayContent") || unknownField(row, "content"));
+}
+
+function geminiToolStatus(value: string): "completed" | "failed" | "aborted" | "unknown" {
   const normalized = value.trim().toLowerCase();
   if (!normalized) return "unknown";
   if (normalized.includes("ok") || normalized.includes("success") || normalized.includes("complete")) return "completed";
-  if (normalized.includes("error") || normalized.includes("fail") || normalized.includes("cancel")) return "failed";
+  if (normalized.includes("cancel")) return "aborted";
+  if (normalized.includes("error") || normalized.includes("fail")) return "failed";
   return "unknown";
 }
 
@@ -2395,7 +2407,7 @@ function loadGeminiCliSessionFile(
   const activeRows: Array<{ id: string; row: Record<string, unknown> }> = [];
   const activeIndex = new Map<string, number>();
   let summary = stringField(header, "summary");
-  let lastUpdatedMs = timestampMs(unknownField(header, "lastUpdated")) || timestampMs(unknownField(header, "startTime"));
+  const createdMs = timestampMs(unknownField(header, "startTime"));
 
   const upsert = (row: Record<string, unknown>): void => {
     const type = stringField(row, "type");
@@ -2416,8 +2428,6 @@ function loadGeminiCliSessionFile(
     const setPatch = objectField(row, "$set");
     if (setPatch) {
       if ("summary" in setPatch) summary = stringField(setPatch, "summary");
-      const patchedLastUpdated = timestampMs(setPatch.lastUpdated);
-      if (patchedLastUpdated > lastUpdatedMs) lastUpdatedMs = patchedLastUpdated;
       const checkpointMessages = unknownField(setPatch, "messages");
       if (Array.isArray(checkpointMessages)) {
         activeRows.length = 0;
@@ -2449,9 +2459,8 @@ function loadGeminiCliSessionFile(
   for (const { row } of activeRows) {
     const type = stringField(row, "type");
     const timestamp = timestampMs(row.timestamp);
-    if (timestamp > lastUpdatedMs) lastUpdatedMs = timestamp;
     if (type === "user") {
-      const content = geminiContentText(unknownField(row, "content"));
+      const content = geminiVisibleContent(row);
       if (!isMeaningfulUserMessage(content)) continue;
       messages.push(messageFromParts("user", content, timestampString(timestamp), messages.length));
       continue;
@@ -2501,19 +2510,33 @@ function loadGeminiCliSessionFile(
         if (!isRecord(call)) continue;
         const name = stringField(call, "displayName") || stringField(call, "name");
         if (!name) continue;
+        const callId = stringField(call, "id") || null;
+        const callTimestamp = timestampMs(unknownField(call, "timestamp")) || timestamp;
+        const title = normalizeTraceTitle(name, firstStringField(call, ["description"]));
         traceDrafts.push({
           kind: "tool_call",
           source: "gemini",
-          title: normalizeTraceTitle(name, firstStringField(call, ["description"])),
-          detail: stringifyDetail({ args: unknownField(call, "args"), result: unknownField(call, "result") }),
-          timestamp: timestampString(timestampMs(unknownField(call, "timestamp")) || timestamp),
-          callId: stringField(call, "id") || null,
+          title,
+          detail: stringifyDetail(unknownField(call, "args")),
+          timestamp: timestampString(callTimestamp),
+          callId,
           eventType: "gemini.toolCall",
+          status: "running",
+        });
+        // Gemini 的 toolCall 自带结果与终态,补配对 result 事件供 timeline 派生层闭合 span。
+        traceDrafts.push({
+          kind: "tool_result",
+          source: "gemini",
+          title,
+          detail: stringifyDetail(unknownField(call, "result")),
+          timestamp: timestampString(callTimestamp),
+          callId,
+          eventType: "gemini.toolResult",
           status: geminiToolStatus(stringField(call, "status")),
         });
       }
     }
-    const content = geminiContentText(unknownField(row, "content"));
+    const content = geminiVisibleContent(row);
     if (!content) continue;
     messages.push(messageFromParts("assistant", content, timestampString(timestamp), messages.length));
   }
@@ -2529,7 +2552,7 @@ function loadGeminiCliSessionFile(
       filePath,
       originalTitle: summary || cleanTitle(question) || rawId,
       firstQuestion: cleanTitle(question),
-      timestamp: lastUpdatedMs || stat.mtimeMs,
+      timestamp: createdMs || stat.mtimeMs,
       tokenUsage: tokenUsageFromEvents([...tokenEntries.values()]),
       stat,
       isSubagent: parentSessionId !== null,

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -2335,14 +2335,14 @@ const GEMINI_DIR = ".gemini";
 
 function resolveGeminiCliRoot(homeDir: string, options: SessionLoadOptions): string {
   if (options.homeDir !== undefined) return path.join(homeDir, GEMINI_DIR);
-  const configured = process.env.GEMINI_DIR?.trim();
+  const configured = process.env.GEMINI_CLI_HOME?.trim();
   if (!configured) return path.join(homeDir, GEMINI_DIR);
   const expanded = configured === "~"
     ? os.homedir()
     : configured.startsWith("~/") || configured.startsWith("~\\")
       ? path.join(os.homedir(), ...configured.slice(2).split(/[\\/]+/u).filter(Boolean))
       : configured;
-  return path.resolve(expanded);
+  return path.join(path.resolve(expanded), GEMINI_DIR);
 }
 
 function geminiContentText(content: unknown): string {
@@ -2357,9 +2357,29 @@ function geminiContentText(content: unknown): string {
   return parts.filter(Boolean).join("\n");
 }
 
-interface GeminiChatMessageMeta {
-  id: string;
-  tokenKey: string | null;
+function geminiToolStatus(value: string): "completed" | "failed" | "unknown" {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return "unknown";
+  if (normalized.includes("ok") || normalized.includes("success") || normalized.includes("complete")) return "completed";
+  if (normalized.includes("error") || normalized.includes("fail") || normalized.includes("cancel")) return "failed";
+  return "unknown";
+}
+
+// Gemini CLI persists enriched re-emissions under the same message id (tokens, tool
+// results), so records must be replayed into an id-keyed log before projection.
+function geminiSessionRows(filePath: string): Record<string, unknown>[] {
+  if (filePath.endsWith(".json")) {
+    try {
+      const parsed: unknown = JSON.parse(fs.readFileSync(filePath, "utf8"));
+      if (!isRecord(parsed)) return [];
+      const messageRows = Array.isArray(parsed.messages) ? parsed.messages.filter(isRecord) : [];
+      const { messages: _messages, ...meta } = parsed;
+      return [meta, ...messageRows];
+    } catch {
+      return [];
+    }
+  }
+  return readJsonl(filePath).filter(isRecord);
 }
 
 function loadGeminiCliSessionFile(
@@ -2368,50 +2388,105 @@ function loadGeminiCliSessionFile(
   stat: VirtualSessionFileStat,
   parentSessionId: string | null,
 ): LoadedSession | null {
-  const rows = readJsonl(filePath).filter(isRecord);
+  const rows = geminiSessionRows(filePath);
   if (!rows.length) return null;
-  const header = rows.find((row) => typeof row.sessionId === "string" && typeof row.projectHash === "string") ?? rows[0];
-  const rawId = stringField(header, "sessionId") || path.basename(filePath, ".jsonl");
-  const messages: SessionMessage[] = [];
-  const messageMeta: GeminiChatMessageMeta[] = [];
-  const traceDrafts: TraceEventDraft[] = [];
-  const tokenEntries = new Map<string, TokenUsageEvent>();
+  const header = rows.find((row) => typeof row.sessionId === "string") ?? rows[0];
+  const rawId = stringField(header, "sessionId") || path.basename(filePath, path.extname(filePath));
+  const activeRows: Array<{ id: string; row: Record<string, unknown> }> = [];
+  const activeIndex = new Map<string, number>();
   let summary = "";
   let lastUpdatedMs = timestampMs(unknownField(header, "lastUpdated")) || timestampMs(unknownField(header, "startTime"));
 
-  const applyMessage = (row: Record<string, unknown>): void => {
+  const upsert = (row: Record<string, unknown>): void => {
     const type = stringField(row, "type");
     if (type !== "user" && type !== "gemini") return;
-    const timestamp = timestampMs(row.timestamp);
-    if (timestamp > lastUpdatedMs) lastUpdatedMs = timestamp;
-    const messageId = stringField(row, "id");
-    if (type === "user") {
-      const content = geminiContentText(unknownField(row, "content"));
-      if (!isMeaningfulUserMessage(content)) return;
-      messages.push(messageFromParts("user", content, timestampString(timestamp), messages.length));
-      messageMeta.push({ id: messageId, tokenKey: null });
+    const id = stringField(row, "id");
+    if (!id) return;
+    const existing = activeIndex.get(id);
+    if (existing !== undefined) {
+      activeRows[existing] = { id, row: { ...activeRows[existing].row, ...row } };
       return;
     }
+    activeIndex.set(id, activeRows.length);
+    activeRows.push({ id, row });
+  };
+
+  for (const row of rows) {
+    if (row === header) continue;
+    const setPatch = objectField(row, "$set");
+    if (setPatch) {
+      const patchedSummary = stringField(setPatch, "summary");
+      if (patchedSummary) summary = patchedSummary;
+      const patchedLastUpdated = timestampMs(setPatch.lastUpdated);
+      if (patchedLastUpdated > lastUpdatedMs) lastUpdatedMs = patchedLastUpdated;
+      const checkpointMessages = unknownField(setPatch, "messages");
+      if (Array.isArray(checkpointMessages)) {
+        activeRows.length = 0;
+        activeIndex.clear();
+        for (const checkpointRow of checkpointMessages) {
+          if (isRecord(checkpointRow)) upsert(checkpointRow);
+        }
+      }
+      continue;
+    }
+    const rewindTo = stringField(row, "$rewindTo");
+    if (rewindTo) {
+      const index = activeIndex.get(rewindTo);
+      if (index === undefined) {
+        activeRows.length = 0;
+        activeIndex.clear();
+      } else {
+        for (let cut = activeRows.length - 1; cut >= index; cut -= 1) activeIndex.delete(activeRows[cut].id);
+        activeRows.length = index;
+      }
+      continue;
+    }
+    upsert(row);
+  }
+
+  const messages: SessionMessage[] = [];
+  const traceDrafts: TraceEventDraft[] = [];
+  const tokenEntries = new Map<string, TokenUsageEvent>();
+  for (const { row } of activeRows) {
+    const type = stringField(row, "type");
+    const timestamp = timestampMs(row.timestamp);
+    if (timestamp > lastUpdatedMs) lastUpdatedMs = timestamp;
+    if (type === "user") {
+      const content = geminiContentText(unknownField(row, "content"));
+      if (!isMeaningfulUserMessage(content)) continue;
+      messages.push(messageFromParts("user", content, timestampString(timestamp), messages.length));
+      continue;
+    }
+    const messageId = stringField(row, "id");
     const tokens = objectField(row, "tokens");
-    const tokenKey = messageId ? `gemini:${messageId}` : null;
-    if (tokens && tokenKey) {
-      const input = numberField(tokens, "input");
-      const output = numberField(tokens, "output");
-      const cached = numberField(tokens, "cached");
-      const thoughts = numberField(tokens, "thoughts");
-      if (input > 0 || output > 0 || cached > 0 || thoughts > 0) {
-        putTokenEvent(tokenEntries, tokenEvent(timestamp, tokenKey, input, output, cached, thoughts));
+    if (tokens && messageId) {
+      // Gemini 的 input 已包含 cached,权威总量为 input + output + tool + thoughts。
+      const rawInput = numberField(tokens, "input");
+      const cached = Math.min(numberField(tokens, "cached"), rawInput);
+      const inputTokens = Math.max(0, rawInput - cached);
+      const outputTokens = numberField(tokens, "output") + numberField(tokens, "tool");
+      const reasoningOutputTokens = numberField(tokens, "thoughts");
+      if (rawInput > 0 || outputTokens > 0 || cached > 0 || reasoningOutputTokens > 0) {
+        putTokenEvent(tokenEntries, tokenEvent(timestamp, `gemini:${messageId}`, inputTokens, outputTokens, cached, reasoningOutputTokens));
       }
     }
     const thoughts = unknownField(row, "thoughts");
     if (Array.isArray(thoughts)) {
       for (const thought of thoughts) {
-        if (typeof thought !== "string" || !thought.trim()) continue;
+        let subject = "";
+        let description = "";
+        if (typeof thought === "string") {
+          description = thought;
+        } else if (isRecord(thought)) {
+          subject = stringField(thought, "subject");
+          description = stringField(thought, "description");
+        }
+        if (!subject && !description.trim()) continue;
         traceDrafts.push({
           kind: "event",
           source: "gemini",
-          title: normalizeTraceTitle("thought", ""),
-          detail: stringifyDetail(thought),
+          title: normalizeTraceTitle(subject || "thought", ""),
+          detail: stringifyDetail(description),
           timestamp: timestampString(timestamp),
           callId: null,
           eventType: "gemini.thought",
@@ -2433,48 +2508,13 @@ function loadGeminiCliSessionFile(
           timestamp: timestampString(timestampMs(unknownField(call, "timestamp")) || timestamp),
           callId: stringField(call, "id") || null,
           eventType: "gemini.toolCall",
-          status: "unknown",
+          status: geminiToolStatus(stringField(call, "status")),
         });
       }
     }
     const content = geminiContentText(unknownField(row, "content"));
-    if (!content) return;
+    if (!content) continue;
     messages.push(messageFromParts("assistant", content, timestampString(timestamp), messages.length));
-    messageMeta.push({ id: messageId, tokenKey });
-  };
-
-  for (const row of rows) {
-    if (row === header) continue;
-    const setPatch = objectField(row, "$set");
-    if (setPatch) {
-      const patchedSummary = stringField(setPatch, "summary");
-      if (patchedSummary) summary = patchedSummary;
-      const patchedLastUpdated = timestampMs(setPatch.lastUpdated);
-      if (patchedLastUpdated > lastUpdatedMs) lastUpdatedMs = patchedLastUpdated;
-      const checkpointMessages = unknownField(setPatch, "messages");
-      if (Array.isArray(checkpointMessages)) {
-        messages.length = 0;
-        messageMeta.length = 0;
-        traceDrafts.length = 0;
-        tokenEntries.clear();
-        for (const checkpointRow of checkpointMessages) {
-          if (isRecord(checkpointRow)) applyMessage(checkpointRow);
-        }
-      }
-      continue;
-    }
-    const rewindTo = stringField(row, "$rewindTo");
-    if (rewindTo) {
-      const index = messageMeta.findIndex((meta) => meta.id === rewindTo);
-      const cut = index >= 0 ? index : 0;
-      for (const meta of messageMeta.slice(cut)) {
-        if (meta.tokenKey) tokenEntries.delete(meta.tokenKey);
-      }
-      messages.length = cut;
-      messageMeta.length = cut;
-      continue;
-    }
-    applyMessage(row);
   }
 
   if (!messages.length) return null;
@@ -2501,7 +2541,8 @@ function loadGeminiCliSessionFile(
 }
 
 function geminiChatFileNameUsable(name: string): boolean {
-  return name.endsWith(".jsonl") && !name.includes(".tmp-") && !name.includes(".unreadable-");
+  if (name.includes(".tmp-") || name.includes(".unreadable-")) return false;
+  return name.endsWith(".jsonl") || name.endsWith(".json");
 }
 
 function* loadGeminiCliSessionsIterator(root: string, options: SessionLoadOptions): Generator<LoadedSession> {
@@ -2521,6 +2562,7 @@ function* loadGeminiCliSessionsIterator(root: string, options: SessionLoadOption
     } catch {
       projectPath = "";
     }
+    const dependencyMtimeMs = safeStat(path.join(projectDir, ".project_root")).mtimeMs;
     const chats = path.join(projectDir, "chats");
     let chatEntries: fs.Dirent[] = [];
     try {
@@ -2534,13 +2576,13 @@ function* loadGeminiCliSessionsIterator(root: string, options: SessionLoadOption
       if (entry.isDirectory()) {
         for (const filePath of walkJsonlFiles(childPath)) {
           const stat = safeStat(filePath);
-          if (shouldSkipFile(options, filePath, stat)) continue;
+          if (shouldSkipFile(options, filePath, stat, dependencyMtimeMs)) continue;
           const loaded = loadGeminiCliSessionFile(filePath, projectPath, stat, entry.name);
           if (loaded) yield loaded;
         }
       } else if (entry.isFile() && geminiChatFileNameUsable(entry.name)) {
         const stat = safeStat(childPath);
-        if (shouldSkipFile(options, childPath, stat)) continue;
+        if (shouldSkipFile(options, childPath, stat, dependencyMtimeMs)) continue;
         const loaded = loadGeminiCliSessionFile(childPath, projectPath, stat, null);
         if (loaded) yield loaded;
       }

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -2394,7 +2394,7 @@ function loadGeminiCliSessionFile(
   const rawId = stringField(header, "sessionId") || path.basename(filePath, path.extname(filePath));
   const activeRows: Array<{ id: string; row: Record<string, unknown> }> = [];
   const activeIndex = new Map<string, number>();
-  let summary = "";
+  let summary = stringField(header, "summary");
   let lastUpdatedMs = timestampMs(unknownField(header, "lastUpdated")) || timestampMs(unknownField(header, "startTime"));
 
   const upsert = (row: Record<string, unknown>): void => {
@@ -2415,8 +2415,7 @@ function loadGeminiCliSessionFile(
     if (row === header) continue;
     const setPatch = objectField(row, "$set");
     if (setPatch) {
-      const patchedSummary = stringField(setPatch, "summary");
-      if (patchedSummary) summary = patchedSummary;
+      if ("summary" in setPatch) summary = stringField(setPatch, "summary");
       const patchedLastUpdated = timestampMs(setPatch.lastUpdated);
       if (patchedLastUpdated > lastUpdatedMs) lastUpdatedMs = patchedLastUpdated;
       const checkpointMessages = unknownField(setPatch, "messages");
@@ -2475,11 +2474,13 @@ function loadGeminiCliSessionFile(
       for (const thought of thoughts) {
         let subject = "";
         let description = "";
+        let thoughtTimestamp = timestamp;
         if (typeof thought === "string") {
           description = thought;
         } else if (isRecord(thought)) {
           subject = stringField(thought, "subject");
           description = stringField(thought, "description");
+          thoughtTimestamp = timestampMs(thought.timestamp) || timestamp;
         }
         if (!subject && !description.trim()) continue;
         traceDrafts.push({
@@ -2487,7 +2488,7 @@ function loadGeminiCliSessionFile(
           source: "gemini",
           title: normalizeTraceTitle(subject || "thought", ""),
           detail: stringifyDetail(description),
-          timestamp: timestampString(timestamp),
+          timestamp: timestampString(thoughtTimestamp),
           callId: null,
           eventType: "gemini.thought",
           status: "unknown",

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -92,6 +92,7 @@ export interface SessionLoadOptions {
   includePi?: boolean;
   includeKimiCli?: boolean;
   includeQwenCode?: boolean;
+  includeGeminiCli?: boolean;
   includeTclaude?: boolean;
   includeTcodex?: boolean;
   includeCodeBuddyCli?: boolean;
@@ -1513,7 +1514,7 @@ function readGitBranchAt(gitPath: string): string | null {
 }
 
 function createIndexedSession(input: {
-  keyPrefix: "claude" | "codex" | "tclaude" | "tcodex" | "codebuddy" | "workbuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder" | "qoder-ide" | "pi" | "deepseek" | "kimi" | "qwen";
+  keyPrefix: "claude" | "codex" | "tclaude" | "tcodex" | "codebuddy" | "workbuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder" | "qoder-ide" | "pi" | "deepseek" | "kimi" | "qwen" | "gemini";
   rawId: string;
   source: SessionSource;
   projectPath: string;
@@ -2328,6 +2329,223 @@ function loadQwenCodeSessionFile(filePath: string, projectPath: string, stat: Vi
   const chainTimestamp = activeRows.map((row) => timestampMs(row.timestamp)).find((timestamp) => timestamp > 0) || stat.mtimeMs;
   const gitBranch = [...activeRows].reverse().map((row) => stringField(row, "gitBranch")).find(Boolean) || null;
   return { session: createIndexedSession({ keyPrefix: "qwen", rawId, source: "qwen-code", projectPath: stringField(leaf, "cwd") || projectPath, filePath, originalTitle: title, firstQuestion: firstQuestionText, timestamp: chainTimestamp, gitBranch, tokenUsage: tokenUsageFromEvents(tokenEvents), stat }), messages, tokenEvents, traceEvents: qwenTraceEvents(activeRows) };
+}
+
+const GEMINI_DIR = ".gemini";
+
+function resolveGeminiCliRoot(homeDir: string, options: SessionLoadOptions): string {
+  if (options.homeDir !== undefined) return path.join(homeDir, GEMINI_DIR);
+  const configured = process.env.GEMINI_DIR?.trim();
+  if (!configured) return path.join(homeDir, GEMINI_DIR);
+  const expanded = configured === "~"
+    ? os.homedir()
+    : configured.startsWith("~/") || configured.startsWith("~\\")
+      ? path.join(os.homedir(), ...configured.slice(2).split(/[\\/]+/u).filter(Boolean))
+      : configured;
+  return path.resolve(expanded);
+}
+
+function geminiContentText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const part of content) {
+    if (!isRecord(part)) continue;
+    const text = stringField(part, "text");
+    if (text) parts.push(text);
+  }
+  return parts.filter(Boolean).join("\n");
+}
+
+interface GeminiChatMessageMeta {
+  id: string;
+  tokenKey: string | null;
+}
+
+function loadGeminiCliSessionFile(
+  filePath: string,
+  projectPath: string,
+  stat: VirtualSessionFileStat,
+  parentSessionId: string | null,
+): LoadedSession | null {
+  const rows = readJsonl(filePath).filter(isRecord);
+  if (!rows.length) return null;
+  const header = rows.find((row) => typeof row.sessionId === "string" && typeof row.projectHash === "string") ?? rows[0];
+  const rawId = stringField(header, "sessionId") || path.basename(filePath, ".jsonl");
+  const messages: SessionMessage[] = [];
+  const messageMeta: GeminiChatMessageMeta[] = [];
+  const traceDrafts: TraceEventDraft[] = [];
+  const tokenEntries = new Map<string, TokenUsageEvent>();
+  let summary = "";
+  let lastUpdatedMs = timestampMs(unknownField(header, "lastUpdated")) || timestampMs(unknownField(header, "startTime"));
+
+  const applyMessage = (row: Record<string, unknown>): void => {
+    const type = stringField(row, "type");
+    if (type !== "user" && type !== "gemini") return;
+    const timestamp = timestampMs(row.timestamp);
+    if (timestamp > lastUpdatedMs) lastUpdatedMs = timestamp;
+    const messageId = stringField(row, "id");
+    if (type === "user") {
+      const content = geminiContentText(unknownField(row, "content"));
+      if (!isMeaningfulUserMessage(content)) return;
+      messages.push(messageFromParts("user", content, timestampString(timestamp), messages.length));
+      messageMeta.push({ id: messageId, tokenKey: null });
+      return;
+    }
+    const tokens = objectField(row, "tokens");
+    const tokenKey = messageId ? `gemini:${messageId}` : null;
+    if (tokens && tokenKey) {
+      const input = numberField(tokens, "input");
+      const output = numberField(tokens, "output");
+      const cached = numberField(tokens, "cached");
+      const thoughts = numberField(tokens, "thoughts");
+      if (input > 0 || output > 0 || cached > 0 || thoughts > 0) {
+        putTokenEvent(tokenEntries, tokenEvent(timestamp, tokenKey, input, output, cached, thoughts));
+      }
+    }
+    const thoughts = unknownField(row, "thoughts");
+    if (Array.isArray(thoughts)) {
+      for (const thought of thoughts) {
+        if (typeof thought !== "string" || !thought.trim()) continue;
+        traceDrafts.push({
+          kind: "event",
+          source: "gemini",
+          title: normalizeTraceTitle("thought", ""),
+          detail: stringifyDetail(thought),
+          timestamp: timestampString(timestamp),
+          callId: null,
+          eventType: "gemini.thought",
+          status: "unknown",
+        });
+      }
+    }
+    const calls = unknownField(row, "toolCalls");
+    if (Array.isArray(calls)) {
+      for (const call of calls) {
+        if (!isRecord(call)) continue;
+        const name = stringField(call, "displayName") || stringField(call, "name");
+        if (!name) continue;
+        traceDrafts.push({
+          kind: "tool_call",
+          source: "gemini",
+          title: normalizeTraceTitle(name, firstStringField(call, ["description"])),
+          detail: stringifyDetail({ args: unknownField(call, "args"), result: unknownField(call, "result") }),
+          timestamp: timestampString(timestampMs(unknownField(call, "timestamp")) || timestamp),
+          callId: stringField(call, "id") || null,
+          eventType: "gemini.toolCall",
+          status: "unknown",
+        });
+      }
+    }
+    const content = geminiContentText(unknownField(row, "content"));
+    if (!content) return;
+    messages.push(messageFromParts("assistant", content, timestampString(timestamp), messages.length));
+    messageMeta.push({ id: messageId, tokenKey });
+  };
+
+  for (const row of rows) {
+    if (row === header) continue;
+    const setPatch = objectField(row, "$set");
+    if (setPatch) {
+      const patchedSummary = stringField(setPatch, "summary");
+      if (patchedSummary) summary = patchedSummary;
+      const patchedLastUpdated = timestampMs(setPatch.lastUpdated);
+      if (patchedLastUpdated > lastUpdatedMs) lastUpdatedMs = patchedLastUpdated;
+      const checkpointMessages = unknownField(setPatch, "messages");
+      if (Array.isArray(checkpointMessages)) {
+        messages.length = 0;
+        messageMeta.length = 0;
+        traceDrafts.length = 0;
+        tokenEntries.clear();
+        for (const checkpointRow of checkpointMessages) {
+          if (isRecord(checkpointRow)) applyMessage(checkpointRow);
+        }
+      }
+      continue;
+    }
+    const rewindTo = stringField(row, "$rewindTo");
+    if (rewindTo) {
+      const index = messageMeta.findIndex((meta) => meta.id === rewindTo);
+      const cut = index >= 0 ? index : 0;
+      for (const meta of messageMeta.slice(cut)) {
+        if (meta.tokenKey) tokenEntries.delete(meta.tokenKey);
+      }
+      messages.length = cut;
+      messageMeta.length = cut;
+      continue;
+    }
+    applyMessage(row);
+  }
+
+  if (!messages.length) return null;
+  const question = firstQuestion(messages);
+  return {
+    session: createIndexedSession({
+      keyPrefix: "gemini",
+      rawId,
+      source: "gemini-cli",
+      projectPath: projectPath || filePath,
+      filePath,
+      originalTitle: summary || cleanTitle(question) || rawId,
+      firstQuestion: cleanTitle(question),
+      timestamp: lastUpdatedMs || stat.mtimeMs,
+      tokenUsage: tokenUsageFromEvents([...tokenEntries.values()]),
+      stat,
+      isSubagent: parentSessionId !== null,
+      parentSessionId,
+    }),
+    messages,
+    tokenEvents: [...tokenEntries.values()],
+    traceEvents: dedupeTraceEvents(traceDrafts),
+  };
+}
+
+function geminiChatFileNameUsable(name: string): boolean {
+  return name.endsWith(".jsonl") && !name.includes(".tmp-") && !name.includes(".unreadable-");
+}
+
+function* loadGeminiCliSessionsIterator(root: string, options: SessionLoadOptions): Generator<LoadedSession> {
+  const tmpRoot = path.join(root, "tmp");
+  let projectDirs: string[] = [];
+  try {
+    projectDirs = fs.readdirSync(tmpRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
+      .map((entry) => path.join(tmpRoot, entry.name));
+  } catch {
+    return;
+  }
+  for (const projectDir of projectDirs) {
+    let projectPath = "";
+    try {
+      projectPath = fs.readFileSync(path.join(projectDir, ".project_root"), "utf8").trim();
+    } catch {
+      projectPath = "";
+    }
+    const chats = path.join(projectDir, "chats");
+    let chatEntries: fs.Dirent[] = [];
+    try {
+      chatEntries = fs.readdirSync(chats, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of chatEntries) {
+      if (entry.name.startsWith(".")) continue;
+      const childPath = path.join(chats, entry.name);
+      if (entry.isDirectory()) {
+        for (const filePath of walkJsonlFiles(childPath)) {
+          const stat = safeStat(filePath);
+          if (shouldSkipFile(options, filePath, stat)) continue;
+          const loaded = loadGeminiCliSessionFile(filePath, projectPath, stat, entry.name);
+          if (loaded) yield loaded;
+        }
+      } else if (entry.isFile() && geminiChatFileNameUsable(entry.name)) {
+        const stat = safeStat(childPath);
+        if (shouldSkipFile(options, childPath, stat)) continue;
+        const loaded = loadGeminiCliSessionFile(childPath, projectPath, stat, null);
+        if (loaded) yield loaded;
+      }
+    }
+  }
 }
 
 function* loadQwenCodeSessionsIterator(root: string, options: SessionLoadOptions): Generator<LoadedSession> {
@@ -4722,6 +4940,9 @@ export function* loadDefaultSessionsIterator(options: SessionLoadOptions = {}): 
   if (options.includeQwenCode) {
     yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir, options), options);
   }
+  if (options.includeGeminiCli) {
+    yield* loadGeminiCliSessionsIterator(resolveGeminiCliRoot(homeDir, options), options);
+  }
   if (options.includeOpenClaw) {
     yield* loadOpenClawSessionsIterator(path.join(homeDir, ".openclaw"), options);
     yield* loadOpenClawSessionsIterator(path.join(homeDir, ".clawdbot"), options);
@@ -4763,6 +4984,9 @@ export async function* loadDefaultSessionsAsyncIterator(options: SessionLoadOpti
   if (options.includeKimiCli) yield* loadKimiSessionsIterator(path.join(homeDir, KIMI_LEGACY_DIR), resolveKimiCodeRoot(homeDir, options), options);
   if (options.includeQwenCode) {
     yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir, options), options);
+  }
+  if (options.includeGeminiCli) {
+    yield* loadGeminiCliSessionsIterator(resolveGeminiCliRoot(homeDir, options), options);
   }
   if (options.includeOpenClaw) {
     yield* loadOpenClawSessionsIterator(path.join(homeDir, ".openclaw"), options);

--- a/apps/main-1.0/src/core/session-sources.test.ts
+++ b/apps/main-1.0/src/core/session-sources.test.ts
@@ -30,6 +30,7 @@ const ALL_SOURCES = [
   "pi-cli",
   "kimi-cli",
   "qwen-code",
+  "gemini-cli",
   "deepseek-cli",
 ] as const satisfies readonly SessionSource[];
 
@@ -72,6 +73,7 @@ describe("session source capability registry", () => {
       "includePi",
       "includeKimiCli",
       "includeQwenCode",
+      "includeGeminiCli",
       "includeDeepSeekCli",
     ]);
     expect(sessionSourceDescriptor("tclaude-cli")).toMatchObject({ liveFamily: "tclaude", migrationAgent: "claude" });

--- a/apps/main-1.0/src/core/session-sources.ts
+++ b/apps/main-1.0/src/core/session-sources.ts
@@ -17,6 +17,7 @@ export type OptionalSessionSourceSetting =
   | "includePi"
   | "includeKimiCli"
   | "includeQwenCode"
+  | "includeGeminiCli"
   | "includeDeepSeekCli";
 
 export type SessionSourceFamily =
@@ -38,6 +39,7 @@ export type SessionSourceFamily =
   | "pi"
   | "kimi"
   | "qwen"
+  | "gemini"
   | "deepseek";
 
 export type SessionSourceUiFamily = "claude" | "codex" | "codebuddy" | "codewiz" | "zcode" | "other";
@@ -189,6 +191,12 @@ export const SESSION_SOURCE_REGISTRY = {
   "qwen-code": {
     id: "qwen-code", label: "Qwen Code", format: "qwen", family: "qwen", uiFamily: "other", statsGroup: null,
     optionalSetting: "includeQwenCode", pendingKey: "qwen", remoteCollectorOptional: false, liveFamily: null, migrationAgent: null,
+    resumeTarget: null, remoteFamily: null, nativeAppFamily: null,
+    capabilities: { live: false, resume: false, migrate: false, sessionSync: false, openApp: false },
+  },
+  "gemini-cli": {
+    id: "gemini-cli", label: "Gemini CLI", format: "gemini", family: "gemini", uiFamily: "other", statsGroup: null,
+    optionalSetting: "includeGeminiCli", pendingKey: "gemini", remoteCollectorOptional: false, liveFamily: null, migrationAgent: null,
     resumeTarget: null, remoteFamily: null, nativeAppFamily: null,
     capabilities: { live: false, resume: false, migrate: false, sessionSync: false, openApp: false },
   },

--- a/apps/main-1.0/src/core/store/sessions.ts
+++ b/apps/main-1.0/src/core/store/sessions.ts
@@ -731,7 +731,7 @@ export class SessionsStore {
     const targets = this.getSessionDeletionTargets([sessionKey]);
     const row = targets.find((target) => target.sessionKey === sessionKey);
     if (!row) return false;
-    if (row.source === "workbuddy-cli" || row.source === "kimi-cli" || row.source === "qwen-code") {
+    if (row.source === "workbuddy-cli" || row.source === "kimi-cli" || row.source === "qwen-code" || row.source === "gemini-cli") {
       throw new Error(`${sessionSourceDescriptor(row.source).label} session source files are read-only.`);
     }
     if (row.source === "zcode-cli") {

--- a/apps/main-1.0/src/core/trace-presentation.ts
+++ b/apps/main-1.0/src/core/trace-presentation.ts
@@ -38,7 +38,7 @@ export function tracePresentation(
   ) {
     return { category: "lifecycle", visibility: "turn_summary" };
   }
-  if (eventType === "codex.reasoning_summary" || eventType === "agent_reasoning" || eventType === "qwen.thought") {
+  if (eventType === "codex.reasoning_summary" || eventType === "agent_reasoning" || eventType === "qwen.thought" || eventType === "gemini.thought") {
     return { category: "reasoning", visibility: "timeline" };
   }
   if (

--- a/apps/main-1.0/src/core/types.ts
+++ b/apps/main-1.0/src/core/types.ts
@@ -19,8 +19,9 @@ export type SessionSource =
   | "pi-cli"
   | "deepseek-cli"
   | "kimi-cli"
-  | "qwen-code";
-export type SessionFormat = "claude" | "codex" | "codebuddy" | "workbuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder" | "pi" | "deepseek" | "kimi" | "qwen";
+  | "qwen-code"
+  | "gemini-cli";
+export type SessionFormat = "claude" | "codex" | "codebuddy" | "workbuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder" | "pi" | "deepseek" | "kimi" | "qwen" | "gemini";
 export type SessionSortBy = "smart" | "activity" | "created";
 export type EnvironmentKind = "local" | "wsl" | "ssh";
 export type EnvironmentSyncState = "idle" | "syncing" | "watching" | "disconnected" | "error";

--- a/apps/main-1.0/src/main/index.ts
+++ b/apps/main-1.0/src/main/index.ts
@@ -1310,6 +1310,7 @@ function runIndexSync(): Promise<IndexStatus> {
         includePi: settings.includePi,
         includeKimiCli: settings.includeKimiCli,
         includeQwenCode: settings.includeQwenCode,
+        includeGeminiCli: settings.includeGeminiCli,
         includeCursorAgent: settings.includeCursorAgent,
         includeTrae: settings.includeTrae,
         includeQoder: settings.includeQoder,
@@ -2273,7 +2274,7 @@ function registerIpc(): void {
     if (confirmed && !confirmationFingerprint) {
       throw new Error(SESSION_DELETE_CONFIRMATION_REQUIRED_MESSAGE);
     }
-    if (session?.source === "workbuddy-cli" || session?.source === "kimi-cli" || session?.source === "qwen-code") {
+    if (session?.source === "workbuddy-cli" || session?.source === "kimi-cli" || session?.source === "qwen-code" || session?.source === "gemini-cli") {
       throw new Error(`${sessionSourceDescriptor(session.source).label} session source files are read-only.`);
     }
     if (session && !canDeleteSessionLocally(session)) {

--- a/apps/main-1.0/src/main/services/session-bulk-delete-service.ts
+++ b/apps/main-1.0/src/main/services/session-bulk-delete-service.ts
@@ -251,7 +251,7 @@ function classifyTarget(
   if (request.inactiveBefore !== undefined && target.lastActivityAt >= request.inactiveBefore) {
     return issueFor(target.sessionKey, "recent", "Session is not older than the selected cutoff.");
   }
-  if (target.source === "workbuddy-cli" || target.source === "kimi-cli" || target.source === "qwen-code") {
+  if (target.source === "workbuddy-cli" || target.source === "kimi-cli" || target.source === "qwen-code" || target.source === "gemini-cli") {
     return issueFor(target.sessionKey, "read-only", `${sessionSourceDescriptor(target.source).label} session source files are read-only.`);
   }
   if (SHARED_DATABASE_SOURCES.has(target.source)) return issueFor(target.sessionKey, "shared-database", "This source stores multiple sessions in a shared database.");

--- a/apps/main-1.0/src/main/session-index-worker-protocol.ts
+++ b/apps/main-1.0/src/main/session-index-worker-protocol.ts
@@ -17,6 +17,7 @@ export type SessionIndexWorkerLoadOptions = Pick<
   | "includePi"
   | "includeKimiCli"
   | "includeQwenCode"
+  | "includeGeminiCli"
   | "includeCursorAgent"
   | "includeTrae"
   | "includeQoder"

--- a/apps/main-1.0/src/renderer/src/features/settings/settings-dialog.tsx
+++ b/apps/main-1.0/src/renderer/src/features/settings/settings-dialog.tsx
@@ -555,6 +555,10 @@ export function SettingsDialog({
                   <input type="checkbox" className="switch" checked={Boolean(settings?.includeQwenCode)} disabled={!settings} onChange={(event) => onSettingsChange({ includeQwenCode: event.currentTarget.checked })} />
                 </label>
                 <label className="settings-field settings-toggle">
+                  <div className="settings-field-text"><span className="settings-field-title">Include Gemini CLI</span><span className="settings-field-sub">{l("Indexes local Gemini CLI sessions read-only.", "以只读方式索引本地 Gemini CLI 会话。")}</span></div>
+                  <input type="checkbox" className="switch" checked={Boolean(settings?.includeGeminiCli)} disabled={!settings} onChange={(event) => onSettingsChange({ includeGeminiCli: event.currentTarget.checked })} />
+                </label>
+                <label className="settings-field settings-toggle">
                   <div className="settings-field-text">
                     <span className="settings-field-title">Include ~/.tclaude</span>
                     <span className="settings-field-sub">{l("Indexes TClaude CLI sessions and allows migration to that CLI.", "索引 TClaude CLI 会话，并允许迁移到该 CLI。")}</span>

--- a/apps/main-2.0/src/core/format-adapters.ts
+++ b/apps/main-2.0/src/core/format-adapters.ts
@@ -382,6 +382,26 @@ export const qwenAdapter: FormatAdapter = {
   },
 };
 
+export const geminiAdapter: FormatAdapter = {
+  format: "gemini",
+  parseLine(raw) {
+    if (!raw || typeof raw !== "object") return null;
+    const row = raw as Record<string, unknown>;
+    const role = row.type === "user" ? "user" : row.type === "gemini" ? "assistant" : null;
+    if (!role) return null;
+    const content = row.content;
+    const text = typeof content === "string"
+      ? content
+      : Array.isArray(content)
+        ? content
+          .map((part) => part && typeof part === "object" && typeof (part as Record<string, unknown>).text === "string" ? (part as Record<string, unknown>).text as string : "")
+          .filter(Boolean)
+          .join("\n")
+        : "";
+    return text ? { role, content: text, timestamp: timestampFromRaw(raw) } : null;
+  },
+};
+
 export function getFormatForSource(source: SessionSource): SessionFormat {
   return sessionSourceDescriptor(source).format;
 }
@@ -404,6 +424,7 @@ export function getAdapter(sourceOrFormat: SessionSource | SessionFormat): Forma
   if (sourceOrFormat === "deepseek") return deepseekAdapter;
   if (sourceOrFormat === "kimi") return kimiAdapter;
   if (sourceOrFormat === "qwen") return qwenAdapter;
+  if (sourceOrFormat === "gemini") return geminiAdapter;
   const format = getFormatForSource(sourceOrFormat);
   if (format === "claude") return claudeAdapter;
   if (format === "codebuddy") return codebuddyAdapter;
@@ -420,6 +441,7 @@ export function getAdapter(sourceOrFormat: SessionSource | SessionFormat): Forma
   if (format === "deepseek") return deepseekAdapter;
   if (format === "kimi") return kimiAdapter;
   if (format === "qwen") return qwenAdapter;
+  if (format === "gemini") return geminiAdapter;
   return codexAdapter;
 }
 

--- a/apps/main-2.0/src/core/format-adapters.ts
+++ b/apps/main-2.0/src/core/format-adapters.ts
@@ -382,6 +382,19 @@ export const qwenAdapter: FormatAdapter = {
   },
 };
 
+function geminiPartListText(parts: unknown[]): string {
+  return parts
+    .map((part) => {
+      if (typeof part === "string") return part;
+      if (part && typeof part === "object" && typeof (part as Record<string, unknown>).text === "string") {
+        return (part as Record<string, unknown>).text as string;
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
 export const geminiAdapter: FormatAdapter = {
   format: "gemini",
   parseLine(raw) {
@@ -389,15 +402,14 @@ export const geminiAdapter: FormatAdapter = {
     const row = raw as Record<string, unknown>;
     const role = row.type === "user" ? "user" : row.type === "gemini" ? "assistant" : null;
     if (!role) return null;
-    const content = row.content;
+    const content = row.displayContent || row.content;
     const text = typeof content === "string"
       ? content
-      : Array.isArray(content)
-        ? content
-          .map((part) => part && typeof part === "object" && typeof (part as Record<string, unknown>).text === "string" ? (part as Record<string, unknown>).text as string : "")
-          .filter(Boolean)
-          .join("\n")
-        : "";
+      : content && typeof content === "object" && !Array.isArray(content)
+        ? geminiPartListText([content as Record<string, unknown>])
+        : Array.isArray(content)
+          ? geminiPartListText(content)
+          : "";
     return text ? { role, content: text, timestamp: timestampFromRaw(raw) } : null;
   },
 };

--- a/apps/main-2.0/src/core/platform.ts
+++ b/apps/main-2.0/src/core/platform.ts
@@ -105,6 +105,7 @@ export interface AppSettings {
   includePi: boolean;
   includeKimiCli: boolean;
   includeQwenCode: boolean;
+  includeGeminiCli: boolean;
   includeDeepSeekCli: boolean;
   evalEnabled: boolean;
   openVikingMemoryEnabled: boolean;
@@ -201,6 +202,7 @@ export const defaultSettings: AppSettings = {
   includePi: false,
   includeKimiCli: false,
   includeQwenCode: false,
+  includeGeminiCli: false,
   includeDeepSeekCli: false,
   evalEnabled: false,
   openVikingMemoryEnabled: false,

--- a/apps/main-2.0/src/core/session-environment.ts
+++ b/apps/main-2.0/src/core/session-environment.ts
@@ -24,6 +24,7 @@ export function canDeleteSessionLocally(session: SessionEnvironmentIdentity): bo
   return session.source !== "workbuddy-cli"
     && session.source !== "kimi-cli"
     && session.source !== "qwen-code"
+    && session.source !== "gemini-cli"
     && (session.environmentKind !== "ssh" || session.sourceAvailable === false);
 }
 

--- a/apps/main-2.0/src/core/session-loader-gemini.test.ts
+++ b/apps/main-2.0/src/core/session-loader-gemini.test.ts
@@ -1,0 +1,163 @@
+import fs from "node:fs";
+import * as os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadDefaultSessions } from "./session-loader";
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: vi.fn(() => actual.homedir()) };
+});
+
+const roots: string[] = [];
+const defaultHomeDir = os.homedir();
+const originalGeminiDir = process.env.GEMINI_DIR;
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+beforeEach(() => {
+  delete process.env.GEMINI_DIR;
+});
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  if (originalGeminiDir === undefined) delete process.env.GEMINI_DIR;
+  else process.env.GEMINI_DIR = originalGeminiDir;
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
+  vi.restoreAllMocks();
+  vi.mocked(os.homedir).mockReset().mockReturnValue(defaultHomeDir);
+});
+
+function fixture(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "agentrecall-gemini-v2-"));
+  roots.push(root);
+  return root;
+}
+
+function projectChats(root: string, slug: string, projectPath: string): string {
+  const projectDir = path.join(root, ".gemini", "tmp", slug);
+  fs.mkdirSync(projectDir, { recursive: true });
+  fs.writeFileSync(path.join(projectDir, ".project_root"), projectPath, "utf8");
+  const chats = path.join(projectDir, "chats");
+  fs.mkdirSync(chats, { recursive: true });
+  return chats;
+}
+
+function writeChat(filePath: string, rows: unknown[]): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, rows.map((row) => JSON.stringify(row)).join("\n"), "utf8");
+}
+
+function header(sessionId: string, extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return { sessionId, projectHash: "abc123", startTime: "2026-07-29T04:54:37.634Z", lastUpdated: "2026-07-29T05:00:00.000Z", ...extra };
+}
+
+describe("Gemini CLI sessions", () => {
+  it("loads main sessions with messages, tokens, tool calls, and the project root", () => {
+    const root = fixture();
+    const chats = projectChats(root, "gemini-app", "/work/gemini-app");
+    writeChat(path.join(chats, "session-2026-07-29T04-54-72d14847.jsonl"), [
+      header("72d14847-09f0-4562-aa8e-f7b42bf11749"),
+      { id: "m-user", timestamp: "2026-07-29T04:55:00.000Z", type: "user", content: [{ text: "Fix the login flow" }] },
+      {
+        id: "m-gemini",
+        timestamp: "2026-07-29T04:56:00.000Z",
+        type: "gemini",
+        content: [{ text: "I will inspect auth.ts" }],
+        thoughts: ["Consider the auth module"],
+        tokens: { input: 100, output: 20, cached: 5, thoughts: 3, tool: 0, total: 125 },
+        model: "gemini-2.5-pro",
+        toolCalls: [{ id: "call-1", name: "read_file", displayName: "Read File", timestamp: "2026-07-29T04:56:01.000Z", args: { path: "auth.ts" }, status: "ok" }],
+      },
+    ]);
+
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeGeminiCli: true });
+
+    expect(loaded.session).toMatchObject({
+      sessionKey: "gemini:72d14847-09f0-4562-aa8e-f7b42bf11749",
+      source: "gemini-cli",
+      projectPath: "/work/gemini-app",
+      isSubagent: false,
+      parentSessionId: null,
+    });
+    expect(loaded.messages.map((message) => message.content)).toEqual(["Fix the login flow", "I will inspect auth.ts"]);
+    // AgentRecall 统计口径:total = input+output+cached+reasoning(Gemini 自身的 total 字段不含 thoughts)
+    expect(loaded.session.tokenUsage?.totalTokens).toBe(128);
+    expect(loaded.traceEvents?.some((event) => event.kind === "tool_call" && event.callId === "call-1")).toBe(true);
+    expect(loaded.traceEvents?.some((event) => event.eventType === "gemini.thought")).toBe(true);
+  });
+
+  it("rebuilds messages from checkpoints and applies rewinds", () => {
+    const root = fixture();
+    const chats = projectChats(root, "gemini-app", "/work/gemini-app");
+    writeChat(path.join(chats, "session-2026-07-29T05-10-66fcaf99.jsonl"), [
+      header("66fcaf99-1111-2222-3333-444444555555"),
+      { id: "old-user", timestamp: "2026-07-29T05:10:00.000Z", type: "user", content: "stale request" },
+      { id: "old-gemini", timestamp: "2026-07-29T05:11:00.000Z", type: "gemini", content: "stale answer", tokens: { input: 9, output: 9, cached: 0, thoughts: 0, tool: 0, total: 18 } },
+      { $set: { messages: [
+        { id: "new-user", timestamp: "2026-07-29T05:12:00.000Z", type: "user", content: "fresh request" },
+        { id: "mid-gemini", timestamp: "2026-07-29T05:13:00.000Z", type: "gemini", content: "keep me", tokens: { input: 10, output: 4, cached: 0, thoughts: 0, tool: 0, total: 14 } },
+        { id: "tail-gemini", timestamp: "2026-07-29T05:14:00.000Z", type: "gemini", content: "rewind past me", tokens: { input: 7, output: 7, cached: 0, thoughts: 0, tool: 0, total: 14 } },
+      ] } },
+      { $rewindTo: "tail-gemini" },
+    ]);
+
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeGeminiCli: true });
+
+    expect(loaded.messages.map((message) => message.content)).toEqual(["fresh request", "keep me"]);
+    expect(loaded.session.tokenUsage?.totalTokens).toBe(14);
+  });
+
+  it("indexes nested subagent sessions with parent linkage", () => {
+    const root = fixture();
+    const chats = projectChats(root, "gemini-app", "/work/gemini-app");
+    const parentId = "72d14847-09f0-4562-aa8e-f7b42bf11749";
+    writeChat(path.join(chats, `session-2026-07-29T04-54-72d14847.jsonl`), [
+      header(parentId),
+      { id: "p-user", timestamp: "2026-07-29T04:55:00.000Z", type: "user", content: "Delegate the audit" },
+    ]);
+    writeChat(path.join(chats, parentId, "aaaabbbb-cccc-dddd-eeee-ffff00001111.jsonl"), [
+      { sessionId: "aaaabbbb-cccc-dddd-eeee-ffff00001111", projectHash: "abc123", startTime: "2026-07-29T04:56:00.000Z", lastUpdated: "2026-07-29T04:57:00.000Z", kind: "subagent" },
+      { id: "s-user", timestamp: "2026-07-29T04:56:30.000Z", type: "user", content: "Audit the middleware" },
+    ]);
+
+    const loaded = loadDefaultSessions({ homeDir: root, includeGeminiCli: true });
+    const byKey = new Map(loaded.map((item) => [item.session.rawId, item.session]));
+
+    expect(byKey.get(parentId)).toMatchObject({ isSubagent: false, parentSessionId: null });
+    expect(byKey.get("aaaabbbb-cccc-dddd-eeee-ffff00001111")).toMatchObject({
+      isSubagent: true,
+      parentSessionId: parentId,
+    });
+  });
+
+  it("uses summaries as titles and ignores temp or unreadable chat files", () => {
+    const root = fixture();
+    const chats = projectChats(root, "gemini-app", "/work/gemini-app");
+    writeChat(path.join(chats, "session-2026-07-29T06-00-abcdef01.jsonl"), [
+      header("abcdef01-0000-0000-0000-000000000001"),
+      { id: "u", timestamp: "2026-07-29T06:00:30.000Z", type: "user", content: "Summarized session" },
+      { $set: { summary: "Custom summary" } },
+    ]);
+    writeChat(path.join(chats, "session-2026-07-29T06-05-deadbeef.jsonl.tmp-123"), [header("tmp-session")]);
+    writeChat(path.join(chats, "session-2026-07-29T06-06-badc0de.jsonl.unreadable-1785300000000"), [header("unreadable-session")]);
+
+    const loaded = loadDefaultSessions({ homeDir: root, includeGeminiCli: true });
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].session.originalTitle).toBe("Custom summary");
+  });
+
+  it("stays out of the default index until the optional source is enabled", () => {
+    const root = fixture();
+    const chats = projectChats(root, "gemini-app", "/work/gemini-app");
+    writeChat(path.join(chats, "session-2026-07-29T07-00-12345678.jsonl"), [
+      header("12345678-0000-0000-0000-000000000002"),
+      { id: "u", timestamp: "2026-07-29T07:00:30.000Z", type: "user", content: "Hidden until enabled" },
+    ]);
+
+    expect(loadDefaultSessions({ homeDir: root })).toHaveLength(0);
+    expect(loadDefaultSessions({ homeDir: root, includeGeminiCli: true })).toHaveLength(1);
+  });
+});

--- a/apps/main-2.0/src/core/session-loader-gemini.test.ts
+++ b/apps/main-2.0/src/core/session-loader-gemini.test.ts
@@ -3,6 +3,7 @@ import * as os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadDefaultSessions } from "./session-loader";
+import { deriveSessionTimeline } from "./turns/derive-turns";
 
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
@@ -59,7 +60,7 @@ describe("Gemini CLI sessions", () => {
     const chats = projectChats(root, "gemini-app", "/work/gemini-app");
     writeChat(path.join(chats, "session-2026-07-29T04-54-72d14847.jsonl"), [
       header("72d14847-09f0-4562-aa8e-f7b42bf11749"),
-      { id: "m-user", timestamp: "2026-07-29T04:55:00.000Z", type: "user", content: [{ text: "Fix the login flow" }] },
+      { id: "m-user", timestamp: "2026-07-29T04:55:00.000Z", type: "user", content: [{ text: "expanded @file model input" }], displayContent: "Fix the login flow" },
       {
         id: "m-gemini",
         timestamp: "2026-07-29T04:56:00.000Z",
@@ -68,7 +69,7 @@ describe("Gemini CLI sessions", () => {
         thoughts: [{ subject: "Auth plan", description: "Consider the auth module", timestamp: "2026-07-29T04:55:59.000Z" }],
         tokens: { input: 100, output: 20, cached: 5, thoughts: 3, tool: 0, total: 125 },
         model: "gemini-2.5-pro",
-        toolCalls: [{ id: "call-1", name: "read_file", displayName: "Read File", timestamp: "2026-07-29T04:56:01.000Z", args: { path: "auth.ts" }, status: "ok" }],
+        toolCalls: [{ id: "call-1", name: "read_file", displayName: "Read File", timestamp: "2026-07-29T04:56:01.000Z", args: { path: "auth.ts" }, result: [{ text: "file contents" }], status: "ok" }, { id: "call-2", name: "bash", displayName: "Shell", timestamp: "2026-07-29T04:56:02.000Z", args: { cmd: "ls" }, status: "cancelled" }],
       },
     ]);
 
@@ -84,8 +85,14 @@ describe("Gemini CLI sessions", () => {
     expect(loaded.messages.map((message) => message.content)).toEqual(["Fix the login flow", "I will inspect auth.ts"]);
     // Gemini 的 input 已含 cached:input 100 → 非缓存 95 + cached 5;total = 95+5+20(+tool)+3 = 123
     expect(loaded.session.tokenUsage?.totalTokens).toBe(123);
-    expect(loaded.traceEvents?.some((event) => event.kind === "tool_call" && event.callId === "call-1" && event.status === "completed")).toBe(true);
+    expect(loaded.traceEvents?.some((event) => event.kind === "tool_result" && event.callId === "call-1" && event.status === "completed")).toBe(true);
+    expect(loaded.traceEvents?.some((event) => event.kind === "tool_result" && event.callId === "call-2" && event.status === "aborted")).toBe(true);
+    expect(loaded.session.timestamp).toBe(Date.parse("2026-07-29T04:54:37.634Z"));
     expect(loaded.traceEvents?.some((event) => event.eventType === "gemini.thought" && event.timestamp === "2026-07-29T04:55:59.000Z")).toBe(true);
+    const timeline = deriveSessionTimeline({ sessionKey: loaded.session.sessionKey, messages: loaded.messages, tokenEvents: loaded.tokenEvents ?? [], traceEvents: loaded.traceEvents ?? [] });
+    const spans = timeline.turns.flatMap((turn) => turn.spans);
+    expect(spans.filter((span) => span.callId === "call-1")).toEqual([expect.objectContaining({ status: "completed", endedAt: expect.any(String) })]);
+    expect(spans.filter((span) => span.callId === "call-2")).toEqual([expect.objectContaining({ status: "aborted" })]);
   });
 
   it("rebuilds messages from checkpoints and applies rewinds", () => {

--- a/apps/main-2.0/src/core/session-loader-gemini.test.ts
+++ b/apps/main-2.0/src/core/session-loader-gemini.test.ts
@@ -65,7 +65,7 @@ describe("Gemini CLI sessions", () => {
         timestamp: "2026-07-29T04:56:00.000Z",
         type: "gemini",
         content: [{ text: "I will inspect auth.ts" }],
-        thoughts: ["Consider the auth module"],
+        thoughts: [{ subject: "Auth plan", description: "Consider the auth module", timestamp: "2026-07-29T04:55:59.000Z" }],
         tokens: { input: 100, output: 20, cached: 5, thoughts: 3, tool: 0, total: 125 },
         model: "gemini-2.5-pro",
         toolCalls: [{ id: "call-1", name: "read_file", displayName: "Read File", timestamp: "2026-07-29T04:56:01.000Z", args: { path: "auth.ts" }, status: "ok" }],
@@ -82,9 +82,9 @@ describe("Gemini CLI sessions", () => {
       parentSessionId: null,
     });
     expect(loaded.messages.map((message) => message.content)).toEqual(["Fix the login flow", "I will inspect auth.ts"]);
-    // AgentRecall 统计口径:total = input+output+cached+reasoning(Gemini 自身的 total 字段不含 thoughts)
-    expect(loaded.session.tokenUsage?.totalTokens).toBe(128);
-    expect(loaded.traceEvents?.some((event) => event.kind === "tool_call" && event.callId === "call-1")).toBe(true);
+    // Gemini 的 input 已含 cached:input 100 → 非缓存 95 + cached 5;total = 95+5+20(+tool)+3 = 123
+    expect(loaded.session.tokenUsage?.totalTokens).toBe(123);
+    expect(loaded.traceEvents?.some((event) => event.kind === "tool_call" && event.callId === "call-1" && event.status === "completed")).toBe(true);
     expect(loaded.traceEvents?.some((event) => event.eventType === "gemini.thought")).toBe(true);
   });
 
@@ -147,6 +147,100 @@ describe("Gemini CLI sessions", () => {
 
     expect(loaded).toHaveLength(1);
     expect(loaded[0].session.originalTitle).toBe("Custom summary");
+  });
+
+  it("replays enriched re-emissions under the same message id without duplication", () => {
+    const root = fixture();
+    const chats = projectChats(root, "gemini-app", "/work/gemini-app");
+    const geminiBase = { id: "dup-1", timestamp: "2026-07-29T08:00:00.000Z", type: "gemini", content: [{ text: "working on it" }] };
+    writeChat(path.join(chats, "session-2026-07-29T08-00-dup00001.jsonl"), [
+      header("dup00001-0000-0000-0000-000000000001"),
+      { id: "u", timestamp: "2026-07-29T07:59:00.000Z", type: "user", content: "Run the audit" },
+      { ...geminiBase, thoughts: [{ subject: "Plan", description: "first pass", timestamp: "2026-07-29T08:00:01.000Z" }], toolCalls: [{ id: "call-a", name: "grep", timestamp: "2026-07-29T08:00:02.000Z", args: { q: "auth" }, status: "ok" }] },
+      { ...geminiBase, tokens: { input: 50, output: 10, cached: 0, thoughts: 2, tool: 4, total: 66 } },
+    ]);
+
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeGeminiCli: true });
+
+    expect(loaded.messages.map((message) => message.content)).toEqual(["Run the audit", "working on it"]);
+    expect(loaded.session.tokenUsage?.totalTokens).toBe(66);
+    expect(loaded.traceEvents?.filter((event) => event.eventType === "gemini.thought")).toHaveLength(1);
+    expect(loaded.traceEvents?.filter((event) => event.kind === "tool_call")).toHaveLength(1);
+  });
+
+  it("resolves rewinds that target filtered tool-only messages", () => {
+    const root = fixture();
+    const chats = projectChats(root, "gemini-app", "/work/gemini-app");
+    writeChat(path.join(chats, "session-2026-07-29T09-00-aaaa0001.jsonl"), [
+      header("aaaa0001-0000-0000-0000-000000000002"),
+      { id: "keep-user", timestamp: "2026-07-29T09:00:00.000Z", type: "user", content: "Keep this request" },
+      { id: "tool-only", timestamp: "2026-07-29T09:00:10.000Z", type: "gemini", content: [], toolCalls: [{ id: "call-z", name: "bash", timestamp: "2026-07-29T09:00:11.000Z", args: { cmd: "ls" }, status: "ok" }] },
+      { id: "tail", timestamp: "2026-07-29T09:00:20.000Z", type: "gemini", content: "later answer" },
+      { $rewindTo: "tool-only" },
+    ]);
+
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeGeminiCli: true });
+
+    expect(loaded.messages.map((message) => message.content)).toEqual(["Keep this request"]);
+    expect(loaded.traceEvents?.some((event) => event.callId === "call-z")).toBe(false);
+  });
+
+  it("indexes legacy .json conversation records", () => {
+    const root = fixture();
+    const chats = projectChats(root, "gemini-app", "/work/gemini-app");
+    fs.writeFileSync(path.join(chats, "session-2026-07-29T10-00-legacy01.json"), JSON.stringify({
+      sessionId: "legacy01-0000-0000-0000-000000000003",
+      startTime: "2026-07-29T10:00:00.000Z",
+      lastUpdated: "2026-07-29T10:01:00.000Z",
+      messages: [
+        { id: "lu", timestamp: "2026-07-29T10:00:30.000Z", type: "user", content: "Legacy request" },
+        { id: "lg", timestamp: "2026-07-29T10:00:40.000Z", type: "gemini", content: "Legacy answer", tokens: { input: 8, output: 2, cached: 0, thoughts: 0, tool: 0, total: 10 } },
+      ],
+    }), "utf8");
+
+    const [loaded] = loadDefaultSessions({ homeDir: root, includeGeminiCli: true });
+
+    expect(loaded.session).toMatchObject({ rawId: "legacy01-0000-0000-0000-000000000003", source: "gemini-cli" });
+    expect(loaded.messages.map((message) => message.content)).toEqual(["Legacy request", "Legacy answer"]);
+    expect(loaded.session.tokenUsage?.totalTokens).toBe(10);
+  });
+
+  it("resolves the root from GEMINI_CLI_HOME", () => {
+    const syntheticHome = fixture();
+    const altHome = fixture();
+    const chats = path.join(altHome, ".gemini", "tmp", "gemini-app", "chats");
+    fs.mkdirSync(chats, { recursive: true });
+    writeChat(path.join(chats, "session-2026-07-29T11-00-bbb00002.jsonl"), [
+      header("bbb00002-0000-0000-0000-000000000004"),
+      { id: "u", timestamp: "2026-07-29T11:00:30.000Z", type: "user", content: "Alternate home request" },
+    ]);
+
+    vi.mocked(os.homedir).mockReturnValue(syntheticHome);
+    process.env.GEMINI_CLI_HOME = altHome;
+    const loaded = loadDefaultSessions({ includeGeminiCli: true }).filter((item) => item.session.source === "gemini-cli");
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].session.rawId).toBe("bbb00002-0000-0000-0000-000000000004");
+  });
+
+  it("passes the gemini source through warm-index skip checks", () => {
+    const root = fixture();
+    const chats = projectChats(root, "gemini-app", "/work/gemini-app");
+    const sessionPath = path.join(chats, "session-2026-07-29T12-00-ccc00003.jsonl");
+    writeChat(sessionPath, [
+      header("ccc00003-0000-0000-0000-000000000005"),
+      { id: "u", timestamp: "2026-07-29T12:00:30.000Z", type: "user", content: "Warm index request" },
+    ]);
+    const seenSources: Array<string | undefined> = [];
+    const loaded = loadDefaultSessions({
+      homeDir: root,
+      includeGeminiCli: true,
+      shouldSkipFile: (filePath, _stat, _dependency, source) => {
+        if (filePath === sessionPath) seenSources.push(source);
+        return false;
+      },
+    });
+    expect(loaded.filter((item) => item.session.source === "gemini-cli")).toHaveLength(1);
+    expect(seenSources).toEqual(["gemini-cli"]);
   });
 
   it("stays out of the default index until the optional source is enabled", () => {

--- a/apps/main-2.0/src/core/session-loader-gemini.test.ts
+++ b/apps/main-2.0/src/core/session-loader-gemini.test.ts
@@ -85,7 +85,7 @@ describe("Gemini CLI sessions", () => {
     // Gemini 的 input 已含 cached:input 100 → 非缓存 95 + cached 5;total = 95+5+20(+tool)+3 = 123
     expect(loaded.session.tokenUsage?.totalTokens).toBe(123);
     expect(loaded.traceEvents?.some((event) => event.kind === "tool_call" && event.callId === "call-1" && event.status === "completed")).toBe(true);
-    expect(loaded.traceEvents?.some((event) => event.eventType === "gemini.thought")).toBe(true);
+    expect(loaded.traceEvents?.some((event) => event.eventType === "gemini.thought" && event.timestamp === "2026-07-29T04:55:59.000Z")).toBe(true);
   });
 
   it("rebuilds messages from checkpoints and applies rewinds", () => {
@@ -190,6 +190,7 @@ describe("Gemini CLI sessions", () => {
     const chats = projectChats(root, "gemini-app", "/work/gemini-app");
     fs.writeFileSync(path.join(chats, "session-2026-07-29T10-00-legacy01.json"), JSON.stringify({
       sessionId: "legacy01-0000-0000-0000-000000000003",
+      summary: "Persisted legacy summary",
       startTime: "2026-07-29T10:00:00.000Z",
       lastUpdated: "2026-07-29T10:01:00.000Z",
       messages: [
@@ -200,7 +201,7 @@ describe("Gemini CLI sessions", () => {
 
     const [loaded] = loadDefaultSessions({ homeDir: root, includeGeminiCli: true });
 
-    expect(loaded.session).toMatchObject({ rawId: "legacy01-0000-0000-0000-000000000003", source: "gemini-cli" });
+    expect(loaded.session).toMatchObject({ rawId: "legacy01-0000-0000-0000-000000000003", source: "gemini-cli", originalTitle: "Persisted legacy summary" });
     expect(loaded.messages.map((message) => message.content)).toEqual(["Legacy request", "Legacy answer"]);
     expect(loaded.session.tokenUsage?.totalTokens).toBe(10);
   });

--- a/apps/main-2.0/src/core/session-loader.ts
+++ b/apps/main-2.0/src/core/session-loader.ts
@@ -24,6 +24,7 @@ import {
   KIMI_LEGACY_DIR,
   PI_SESSIONS_DIR,
   QODER_DIR,
+  GEMINI_DIR,
   QWEN_DIR,
   TRAE_DIR_NAMES,
   loadCodeWizSessions,
@@ -34,6 +35,7 @@ import {
   loadOpenCodeSessions,
   loadPiSessionsIterator,
   loadKimiSessionsIterator,
+  loadGeminiCliSessionsIterator,
   loadQwenCodeSessionsIterator,
   loadQoderSessionsIterator,
   loadQoderIdeSessionsIterator,
@@ -117,6 +119,18 @@ function resolveKimiCodeRoot(homeDir: string, options: SessionLoadOptions): stri
   return options.homeDir === undefined
     ? process.env.KIMI_CODE_HOME?.trim() || path.join(homeDir, KIMI_CODE_DIR)
     : path.join(homeDir, KIMI_CODE_DIR);
+}
+
+function resolveGeminiCliRoot(homeDir: string, options: SessionLoadOptions): string {
+  if (options.homeDir !== undefined) return path.join(homeDir, GEMINI_DIR);
+  const configured = process.env.GEMINI_DIR?.trim();
+  if (!configured) return path.join(homeDir, GEMINI_DIR);
+  const expanded = configured === "~"
+    ? os.homedir()
+    : configured.startsWith("~/") || configured.startsWith("~\\")
+      ? path.join(os.homedir(), ...configured.slice(2).split(/[\\/]+/u).filter(Boolean))
+      : configured;
+  return path.resolve(expanded);
 }
 
 function resolveQwenCodeRoot(homeDir: string, options: SessionLoadOptions): string {
@@ -1917,6 +1931,9 @@ export function* loadDefaultSessionsIterator(options: SessionLoadOptions = {}): 
   if (options.includeQwenCode) {
     yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir, options), options);
   }
+  if (options.includeGeminiCli) {
+    yield* loadGeminiCliSessionsIterator(resolveGeminiCliRoot(homeDir, options), options);
+  }
   if (options.includeTclaude) yield* loadClaudeCliSessionsIterator(path.join(homeDir, TCLAUDE_DIR), "tclaude-cli", options);
   if (options.includeTcodex) yield* loadCodexSessionsIterator(path.join(homeDir, TCODEX_DIR), "tcodex-cli", options);
   if (options.includeCodeBuddyCli) yield* loadCodeBuddyCliSessionsIterator(path.join(homeDir, CODEBUDDY_DIR), options);
@@ -1970,6 +1987,9 @@ export async function* loadDefaultSessionsAsyncIterator(options: SessionLoadOpti
   );
   if (options.includeQwenCode) {
     yield* loadQwenCodeSessionsIterator(resolveQwenCodeRoot(homeDir, options), options);
+  }
+  if (options.includeGeminiCli) {
+    yield* loadGeminiCliSessionsIterator(resolveGeminiCliRoot(homeDir, options), options);
   }
   if (options.includeTclaude) yield* loadClaudeCliSessionsIterator(path.join(homeDir, TCLAUDE_DIR), "tclaude-cli", options);
   if (options.includeTcodex) yield* loadCodexSessionsAsyncIterator(path.join(homeDir, TCODEX_DIR), "tcodex-cli", options);

--- a/apps/main-2.0/src/core/session-loader.ts
+++ b/apps/main-2.0/src/core/session-loader.ts
@@ -123,14 +123,14 @@ function resolveKimiCodeRoot(homeDir: string, options: SessionLoadOptions): stri
 
 function resolveGeminiCliRoot(homeDir: string, options: SessionLoadOptions): string {
   if (options.homeDir !== undefined) return path.join(homeDir, GEMINI_DIR);
-  const configured = process.env.GEMINI_DIR?.trim();
+  const configured = process.env.GEMINI_CLI_HOME?.trim();
   if (!configured) return path.join(homeDir, GEMINI_DIR);
   const expanded = configured === "~"
     ? os.homedir()
     : configured.startsWith("~/") || configured.startsWith("~\\")
       ? path.join(os.homedir(), ...configured.slice(2).split(/[\\/]+/u).filter(Boolean))
       : configured;
-  return path.resolve(expanded);
+  return path.join(path.resolve(expanded), GEMINI_DIR);
 }
 
 function resolveQwenCodeRoot(homeDir: string, options: SessionLoadOptions): string {

--- a/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
+++ b/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
@@ -791,7 +791,7 @@ function loadGeminiCliSessionFile(
   const rawId = stringField(header, "sessionId") || path.basename(filePath, path.extname(filePath));
   const activeRows: Array<{ id: string; row: Record<string, unknown> }> = [];
   const activeIndex = new Map<string, number>();
-  let summary = "";
+  let summary = stringField(header, "summary");
   let lastUpdatedMs = timestampMs(unknownField(header, "lastUpdated")) || timestampMs(unknownField(header, "startTime"));
 
   const upsert = (row: Record<string, unknown>): void => {
@@ -812,8 +812,7 @@ function loadGeminiCliSessionFile(
     if (row === header) continue;
     const setPatch = objectField(row, "$set");
     if (setPatch) {
-      const patchedSummary = stringField(setPatch, "summary");
-      if (patchedSummary) summary = patchedSummary;
+      if ("summary" in setPatch) summary = stringField(setPatch, "summary");
       const patchedLastUpdated = timestampMs(setPatch.lastUpdated);
       if (patchedLastUpdated > lastUpdatedMs) lastUpdatedMs = patchedLastUpdated;
       const checkpointMessages = unknownField(setPatch, "messages");
@@ -872,11 +871,13 @@ function loadGeminiCliSessionFile(
       for (const thought of thoughts) {
         let subject = "";
         let description = "";
+        let thoughtTimestamp = timestamp;
         if (typeof thought === "string") {
           description = thought;
         } else if (isRecord(thought)) {
           subject = stringField(thought, "subject");
           description = stringField(thought, "description");
+          thoughtTimestamp = timestampMs(thought.timestamp) || timestamp;
         }
         if (!subject && !description.trim()) continue;
         traceDrafts.push({
@@ -884,7 +885,7 @@ function loadGeminiCliSessionFile(
           source: "gemini",
           title: normalizeTraceTitle(subject || "thought", ""),
           detail: stringifyDetail(description),
-          timestamp: timestampString(timestamp),
+          timestamp: timestampString(thoughtTimestamp),
           callId: null,
           eventType: "gemini.thought",
           status: "unknown",

--- a/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
+++ b/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
@@ -754,9 +754,29 @@ function geminiContentText(content: unknown): string {
   return parts.filter(Boolean).join("\n");
 }
 
-interface GeminiChatMessageMeta {
-  id: string;
-  tokenKey: string | null;
+function geminiToolStatus(value: string): "completed" | "failed" | "unknown" {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return "unknown";
+  if (normalized.includes("ok") || normalized.includes("success") || normalized.includes("complete")) return "completed";
+  if (normalized.includes("error") || normalized.includes("fail") || normalized.includes("cancel")) return "failed";
+  return "unknown";
+}
+
+// Gemini CLI persists enriched re-emissions under the same message id (tokens, tool
+// results), so records must be replayed into an id-keyed log before projection.
+function geminiSessionRows(filePath: string): Record<string, unknown>[] {
+  if (filePath.endsWith(".json")) {
+    try {
+      const parsed: unknown = JSON.parse(fs.readFileSync(filePath, "utf8"));
+      if (!isRecord(parsed)) return [];
+      const messageRows = Array.isArray(parsed.messages) ? parsed.messages.filter(isRecord) : [];
+      const { messages: _messages, ...meta } = parsed;
+      return [meta, ...messageRows];
+    } catch {
+      return [];
+    }
+  }
+  return readJsonl(filePath).filter(isRecord);
 }
 
 function loadGeminiCliSessionFile(
@@ -765,50 +785,105 @@ function loadGeminiCliSessionFile(
   stat: VirtualSessionFileStat,
   parentSessionId: string | null,
 ): LoadedSession | null {
-  const rows = readJsonl(filePath).filter(isRecord);
+  const rows = geminiSessionRows(filePath);
   if (!rows.length) return null;
-  const header = rows.find((row) => typeof row.sessionId === "string" && typeof row.projectHash === "string") ?? rows[0];
-  const rawId = stringField(header, "sessionId") || path.basename(filePath, ".jsonl");
-  const messages: SessionMessage[] = [];
-  const messageMeta: GeminiChatMessageMeta[] = [];
-  const traceDrafts: TraceEventDraft[] = [];
-  const tokenEntries = new Map<string, TokenUsageEvent>();
+  const header = rows.find((row) => typeof row.sessionId === "string") ?? rows[0];
+  const rawId = stringField(header, "sessionId") || path.basename(filePath, path.extname(filePath));
+  const activeRows: Array<{ id: string; row: Record<string, unknown> }> = [];
+  const activeIndex = new Map<string, number>();
   let summary = "";
   let lastUpdatedMs = timestampMs(unknownField(header, "lastUpdated")) || timestampMs(unknownField(header, "startTime"));
 
-  const applyMessage = (row: Record<string, unknown>): void => {
+  const upsert = (row: Record<string, unknown>): void => {
     const type = stringField(row, "type");
     if (type !== "user" && type !== "gemini") return;
-    const timestamp = timestampMs(row.timestamp);
-    if (timestamp > lastUpdatedMs) lastUpdatedMs = timestamp;
-    const messageId = stringField(row, "id");
-    if (type === "user") {
-      const content = geminiContentText(unknownField(row, "content"));
-      if (!isMeaningfulUserMessage(content)) return;
-      messages.push(messageFromParts("user", content, timestampString(timestamp), messages.length));
-      messageMeta.push({ id: messageId, tokenKey: null });
+    const id = stringField(row, "id");
+    if (!id) return;
+    const existing = activeIndex.get(id);
+    if (existing !== undefined) {
+      activeRows[existing] = { id, row: { ...activeRows[existing].row, ...row } };
       return;
     }
+    activeIndex.set(id, activeRows.length);
+    activeRows.push({ id, row });
+  };
+
+  for (const row of rows) {
+    if (row === header) continue;
+    const setPatch = objectField(row, "$set");
+    if (setPatch) {
+      const patchedSummary = stringField(setPatch, "summary");
+      if (patchedSummary) summary = patchedSummary;
+      const patchedLastUpdated = timestampMs(setPatch.lastUpdated);
+      if (patchedLastUpdated > lastUpdatedMs) lastUpdatedMs = patchedLastUpdated;
+      const checkpointMessages = unknownField(setPatch, "messages");
+      if (Array.isArray(checkpointMessages)) {
+        activeRows.length = 0;
+        activeIndex.clear();
+        for (const checkpointRow of checkpointMessages) {
+          if (isRecord(checkpointRow)) upsert(checkpointRow);
+        }
+      }
+      continue;
+    }
+    const rewindTo = stringField(row, "$rewindTo");
+    if (rewindTo) {
+      const index = activeIndex.get(rewindTo);
+      if (index === undefined) {
+        activeRows.length = 0;
+        activeIndex.clear();
+      } else {
+        for (let cut = activeRows.length - 1; cut >= index; cut -= 1) activeIndex.delete(activeRows[cut].id);
+        activeRows.length = index;
+      }
+      continue;
+    }
+    upsert(row);
+  }
+
+  const messages: SessionMessage[] = [];
+  const traceDrafts: TraceEventDraft[] = [];
+  const tokenEntries = new Map<string, TokenUsageEvent>();
+  for (const { row } of activeRows) {
+    const type = stringField(row, "type");
+    const timestamp = timestampMs(row.timestamp);
+    if (timestamp > lastUpdatedMs) lastUpdatedMs = timestamp;
+    if (type === "user") {
+      const content = geminiContentText(unknownField(row, "content"));
+      if (!isMeaningfulUserMessage(content)) continue;
+      messages.push(messageFromParts("user", content, timestampString(timestamp), messages.length));
+      continue;
+    }
+    const messageId = stringField(row, "id");
     const tokens = objectField(row, "tokens");
-    const tokenKey = messageId ? `gemini:${messageId}` : null;
-    if (tokens && tokenKey) {
-      const input = numberField(tokens, "input");
-      const output = numberField(tokens, "output");
-      const cached = numberField(tokens, "cached");
-      const thoughts = numberField(tokens, "thoughts");
-      if (input > 0 || output > 0 || cached > 0 || thoughts > 0) {
-        putTokenEvent(tokenEntries, tokenEvent(timestamp, tokenKey, input, output, cached, thoughts));
+    if (tokens && messageId) {
+      // Gemini 的 input 已包含 cached,权威总量为 input + output + tool + thoughts。
+      const rawInput = numberField(tokens, "input");
+      const cached = Math.min(numberField(tokens, "cached"), rawInput);
+      const inputTokens = Math.max(0, rawInput - cached);
+      const outputTokens = numberField(tokens, "output") + numberField(tokens, "tool");
+      const reasoningOutputTokens = numberField(tokens, "thoughts");
+      if (rawInput > 0 || outputTokens > 0 || cached > 0 || reasoningOutputTokens > 0) {
+        putTokenEvent(tokenEntries, tokenEvent(timestamp, `gemini:${messageId}`, inputTokens, outputTokens, cached, reasoningOutputTokens));
       }
     }
     const thoughts = unknownField(row, "thoughts");
     if (Array.isArray(thoughts)) {
       for (const thought of thoughts) {
-        if (typeof thought !== "string" || !thought.trim()) continue;
+        let subject = "";
+        let description = "";
+        if (typeof thought === "string") {
+          description = thought;
+        } else if (isRecord(thought)) {
+          subject = stringField(thought, "subject");
+          description = stringField(thought, "description");
+        }
+        if (!subject && !description.trim()) continue;
         traceDrafts.push({
           kind: "event",
           source: "gemini",
-          title: normalizeTraceTitle("thought", ""),
-          detail: stringifyDetail(thought),
+          title: normalizeTraceTitle(subject || "thought", ""),
+          detail: stringifyDetail(description),
           timestamp: timestampString(timestamp),
           callId: null,
           eventType: "gemini.thought",
@@ -830,48 +905,13 @@ function loadGeminiCliSessionFile(
           timestamp: timestampString(timestampMs(unknownField(call, "timestamp")) || timestamp),
           callId: stringField(call, "id") || null,
           eventType: "gemini.toolCall",
-          status: "unknown",
+          status: geminiToolStatus(stringField(call, "status")),
         });
       }
     }
     const content = geminiContentText(unknownField(row, "content"));
-    if (!content) return;
+    if (!content) continue;
     messages.push(messageFromParts("assistant", content, timestampString(timestamp), messages.length));
-    messageMeta.push({ id: messageId, tokenKey });
-  };
-
-  for (const row of rows) {
-    if (row === header) continue;
-    const setPatch = objectField(row, "$set");
-    if (setPatch) {
-      const patchedSummary = stringField(setPatch, "summary");
-      if (patchedSummary) summary = patchedSummary;
-      const patchedLastUpdated = timestampMs(setPatch.lastUpdated);
-      if (patchedLastUpdated > lastUpdatedMs) lastUpdatedMs = patchedLastUpdated;
-      const checkpointMessages = unknownField(setPatch, "messages");
-      if (Array.isArray(checkpointMessages)) {
-        messages.length = 0;
-        messageMeta.length = 0;
-        traceDrafts.length = 0;
-        tokenEntries.clear();
-        for (const checkpointRow of checkpointMessages) {
-          if (isRecord(checkpointRow)) applyMessage(checkpointRow);
-        }
-      }
-      continue;
-    }
-    const rewindTo = stringField(row, "$rewindTo");
-    if (rewindTo) {
-      const index = messageMeta.findIndex((meta) => meta.id === rewindTo);
-      const cut = index >= 0 ? index : 0;
-      for (const meta of messageMeta.slice(cut)) {
-        if (meta.tokenKey) tokenEntries.delete(meta.tokenKey);
-      }
-      messages.length = cut;
-      messageMeta.length = cut;
-      continue;
-    }
-    applyMessage(row);
   }
 
   if (!messages.length) return null;
@@ -898,7 +938,8 @@ function loadGeminiCliSessionFile(
 }
 
 function geminiChatFileNameUsable(name: string): boolean {
-  return name.endsWith(".jsonl") && !name.includes(".tmp-") && !name.includes(".unreadable-");
+  if (name.includes(".tmp-") || name.includes(".unreadable-")) return false;
+  return name.endsWith(".jsonl") || name.endsWith(".json");
 }
 
 export function* loadGeminiCliSessionsIterator(root: string, options: SessionLoadOptions): Generator<LoadedSession> {
@@ -918,6 +959,7 @@ export function* loadGeminiCliSessionsIterator(root: string, options: SessionLoa
     } catch {
       projectPath = "";
     }
+    const dependencyMtimeMs = safeStat(path.join(projectDir, ".project_root")).mtimeMs;
     const chats = path.join(projectDir, "chats");
     let chatEntries: fs.Dirent[] = [];
     try {
@@ -931,13 +973,13 @@ export function* loadGeminiCliSessionsIterator(root: string, options: SessionLoa
       if (entry.isDirectory()) {
         for (const filePath of walkJsonlFiles(childPath)) {
           const stat = safeStat(filePath);
-          if (shouldSkipFile(options, filePath, stat)) continue;
+          if (shouldSkipFile(options, filePath, stat, dependencyMtimeMs, "gemini-cli")) continue;
           const loaded = loadGeminiCliSessionFile(filePath, projectPath, stat, entry.name);
           if (loaded) yield loaded;
         }
       } else if (entry.isFile() && geminiChatFileNameUsable(entry.name)) {
         const stat = safeStat(childPath);
-        if (shouldSkipFile(options, childPath, stat)) continue;
+        if (shouldSkipFile(options, childPath, stat, dependencyMtimeMs, "gemini-cli")) continue;
         const loaded = loadGeminiCliSessionFile(childPath, projectPath, stat, null);
         if (loaded) yield loaded;
       }

--- a/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
+++ b/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
@@ -744,21 +744,33 @@ export const GEMINI_DIR = ".gemini";
 
 function geminiContentText(content: unknown): string {
   if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  const parts: string[] = [];
-  for (const part of content) {
-    if (!isRecord(part)) continue;
-    const text = stringField(part, "text");
-    if (text) parts.push(text);
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const part of content) {
+      if (typeof part === "string") {
+        if (part) parts.push(part);
+        continue;
+      }
+      if (!isRecord(part) || Array.isArray(part)) continue;
+      const text = stringField(part, "text");
+      if (text) parts.push(text);
+    }
+    return parts.filter(Boolean).join("\n");
   }
-  return parts.filter(Boolean).join("\n");
+  if (isRecord(content)) return geminiContentText([content]);
+  return "";
 }
 
-function geminiToolStatus(value: string): "completed" | "failed" | "unknown" {
+function geminiVisibleContent(row: Record<string, unknown>): string {
+  return geminiContentText(unknownField(row, "displayContent") || unknownField(row, "content"));
+}
+
+function geminiToolStatus(value: string): "completed" | "failed" | "aborted" | "unknown" {
   const normalized = value.trim().toLowerCase();
   if (!normalized) return "unknown";
   if (normalized.includes("ok") || normalized.includes("success") || normalized.includes("complete")) return "completed";
-  if (normalized.includes("error") || normalized.includes("fail") || normalized.includes("cancel")) return "failed";
+  if (normalized.includes("cancel")) return "aborted";
+  if (normalized.includes("error") || normalized.includes("fail")) return "failed";
   return "unknown";
 }
 
@@ -792,7 +804,7 @@ function loadGeminiCliSessionFile(
   const activeRows: Array<{ id: string; row: Record<string, unknown> }> = [];
   const activeIndex = new Map<string, number>();
   let summary = stringField(header, "summary");
-  let lastUpdatedMs = timestampMs(unknownField(header, "lastUpdated")) || timestampMs(unknownField(header, "startTime"));
+  const createdMs = timestampMs(unknownField(header, "startTime"));
 
   const upsert = (row: Record<string, unknown>): void => {
     const type = stringField(row, "type");
@@ -813,8 +825,6 @@ function loadGeminiCliSessionFile(
     const setPatch = objectField(row, "$set");
     if (setPatch) {
       if ("summary" in setPatch) summary = stringField(setPatch, "summary");
-      const patchedLastUpdated = timestampMs(setPatch.lastUpdated);
-      if (patchedLastUpdated > lastUpdatedMs) lastUpdatedMs = patchedLastUpdated;
       const checkpointMessages = unknownField(setPatch, "messages");
       if (Array.isArray(checkpointMessages)) {
         activeRows.length = 0;
@@ -846,9 +856,8 @@ function loadGeminiCliSessionFile(
   for (const { row } of activeRows) {
     const type = stringField(row, "type");
     const timestamp = timestampMs(row.timestamp);
-    if (timestamp > lastUpdatedMs) lastUpdatedMs = timestamp;
     if (type === "user") {
-      const content = geminiContentText(unknownField(row, "content"));
+      const content = geminiVisibleContent(row);
       if (!isMeaningfulUserMessage(content)) continue;
       messages.push(messageFromParts("user", content, timestampString(timestamp), messages.length));
       continue;
@@ -898,19 +907,33 @@ function loadGeminiCliSessionFile(
         if (!isRecord(call)) continue;
         const name = stringField(call, "displayName") || stringField(call, "name");
         if (!name) continue;
+        const callId = stringField(call, "id") || null;
+        const callTimestamp = timestampMs(unknownField(call, "timestamp")) || timestamp;
+        const title = normalizeTraceTitle(name, firstStringField(call, ["description"]));
         traceDrafts.push({
           kind: "tool_call",
           source: "gemini",
-          title: normalizeTraceTitle(name, firstStringField(call, ["description"])),
-          detail: stringifyDetail({ args: unknownField(call, "args"), result: unknownField(call, "result") }),
-          timestamp: timestampString(timestampMs(unknownField(call, "timestamp")) || timestamp),
-          callId: stringField(call, "id") || null,
+          title,
+          detail: stringifyDetail(unknownField(call, "args")),
+          timestamp: timestampString(callTimestamp),
+          callId,
           eventType: "gemini.toolCall",
+          status: "running",
+        });
+        // Gemini 的 toolCall 自带结果与终态,补配对 result 事件供 timeline 派生层闭合 span。
+        traceDrafts.push({
+          kind: "tool_result",
+          source: "gemini",
+          title,
+          detail: stringifyDetail(unknownField(call, "result")),
+          timestamp: timestampString(callTimestamp),
+          callId,
+          eventType: "gemini.toolResult",
           status: geminiToolStatus(stringField(call, "status")),
         });
       }
     }
-    const content = geminiContentText(unknownField(row, "content"));
+    const content = geminiVisibleContent(row);
     if (!content) continue;
     messages.push(messageFromParts("assistant", content, timestampString(timestamp), messages.length));
   }
@@ -926,7 +949,7 @@ function loadGeminiCliSessionFile(
       filePath,
       originalTitle: summary || cleanTitle(question) || rawId,
       firstQuestion: cleanTitle(question),
-      timestamp: lastUpdatedMs || stat.mtimeMs,
+      timestamp: createdMs || stat.mtimeMs,
       tokenUsage: tokenUsageFromEvents([...tokenEntries.values()]),
       stat,
       isSubagent: parentSessionId !== null,

--- a/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
+++ b/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
@@ -740,6 +740,211 @@ export function* loadKimiSessionsIterator(
   }
 }
 
+export const GEMINI_DIR = ".gemini";
+
+function geminiContentText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const part of content) {
+    if (!isRecord(part)) continue;
+    const text = stringField(part, "text");
+    if (text) parts.push(text);
+  }
+  return parts.filter(Boolean).join("\n");
+}
+
+interface GeminiChatMessageMeta {
+  id: string;
+  tokenKey: string | null;
+}
+
+function loadGeminiCliSessionFile(
+  filePath: string,
+  projectPath: string,
+  stat: VirtualSessionFileStat,
+  parentSessionId: string | null,
+): LoadedSession | null {
+  const rows = readJsonl(filePath).filter(isRecord);
+  if (!rows.length) return null;
+  const header = rows.find((row) => typeof row.sessionId === "string" && typeof row.projectHash === "string") ?? rows[0];
+  const rawId = stringField(header, "sessionId") || path.basename(filePath, ".jsonl");
+  const messages: SessionMessage[] = [];
+  const messageMeta: GeminiChatMessageMeta[] = [];
+  const traceDrafts: TraceEventDraft[] = [];
+  const tokenEntries = new Map<string, TokenUsageEvent>();
+  let summary = "";
+  let lastUpdatedMs = timestampMs(unknownField(header, "lastUpdated")) || timestampMs(unknownField(header, "startTime"));
+
+  const applyMessage = (row: Record<string, unknown>): void => {
+    const type = stringField(row, "type");
+    if (type !== "user" && type !== "gemini") return;
+    const timestamp = timestampMs(row.timestamp);
+    if (timestamp > lastUpdatedMs) lastUpdatedMs = timestamp;
+    const messageId = stringField(row, "id");
+    if (type === "user") {
+      const content = geminiContentText(unknownField(row, "content"));
+      if (!isMeaningfulUserMessage(content)) return;
+      messages.push(messageFromParts("user", content, timestampString(timestamp), messages.length));
+      messageMeta.push({ id: messageId, tokenKey: null });
+      return;
+    }
+    const tokens = objectField(row, "tokens");
+    const tokenKey = messageId ? `gemini:${messageId}` : null;
+    if (tokens && tokenKey) {
+      const input = numberField(tokens, "input");
+      const output = numberField(tokens, "output");
+      const cached = numberField(tokens, "cached");
+      const thoughts = numberField(tokens, "thoughts");
+      if (input > 0 || output > 0 || cached > 0 || thoughts > 0) {
+        putTokenEvent(tokenEntries, tokenEvent(timestamp, tokenKey, input, output, cached, thoughts));
+      }
+    }
+    const thoughts = unknownField(row, "thoughts");
+    if (Array.isArray(thoughts)) {
+      for (const thought of thoughts) {
+        if (typeof thought !== "string" || !thought.trim()) continue;
+        traceDrafts.push({
+          kind: "event",
+          source: "gemini",
+          title: normalizeTraceTitle("thought", ""),
+          detail: stringifyDetail(thought),
+          timestamp: timestampString(timestamp),
+          callId: null,
+          eventType: "gemini.thought",
+          status: "unknown",
+        });
+      }
+    }
+    const calls = unknownField(row, "toolCalls");
+    if (Array.isArray(calls)) {
+      for (const call of calls) {
+        if (!isRecord(call)) continue;
+        const name = stringField(call, "displayName") || stringField(call, "name");
+        if (!name) continue;
+        traceDrafts.push({
+          kind: "tool_call",
+          source: "gemini",
+          title: normalizeTraceTitle(name, firstStringField(call, ["description"])),
+          detail: stringifyDetail({ args: unknownField(call, "args"), result: unknownField(call, "result") }),
+          timestamp: timestampString(timestampMs(unknownField(call, "timestamp")) || timestamp),
+          callId: stringField(call, "id") || null,
+          eventType: "gemini.toolCall",
+          status: "unknown",
+        });
+      }
+    }
+    const content = geminiContentText(unknownField(row, "content"));
+    if (!content) return;
+    messages.push(messageFromParts("assistant", content, timestampString(timestamp), messages.length));
+    messageMeta.push({ id: messageId, tokenKey });
+  };
+
+  for (const row of rows) {
+    if (row === header) continue;
+    const setPatch = objectField(row, "$set");
+    if (setPatch) {
+      const patchedSummary = stringField(setPatch, "summary");
+      if (patchedSummary) summary = patchedSummary;
+      const patchedLastUpdated = timestampMs(setPatch.lastUpdated);
+      if (patchedLastUpdated > lastUpdatedMs) lastUpdatedMs = patchedLastUpdated;
+      const checkpointMessages = unknownField(setPatch, "messages");
+      if (Array.isArray(checkpointMessages)) {
+        messages.length = 0;
+        messageMeta.length = 0;
+        traceDrafts.length = 0;
+        tokenEntries.clear();
+        for (const checkpointRow of checkpointMessages) {
+          if (isRecord(checkpointRow)) applyMessage(checkpointRow);
+        }
+      }
+      continue;
+    }
+    const rewindTo = stringField(row, "$rewindTo");
+    if (rewindTo) {
+      const index = messageMeta.findIndex((meta) => meta.id === rewindTo);
+      const cut = index >= 0 ? index : 0;
+      for (const meta of messageMeta.slice(cut)) {
+        if (meta.tokenKey) tokenEntries.delete(meta.tokenKey);
+      }
+      messages.length = cut;
+      messageMeta.length = cut;
+      continue;
+    }
+    applyMessage(row);
+  }
+
+  if (!messages.length) return null;
+  const question = firstQuestion(messages);
+  return {
+    session: createIndexedSession({
+      keyPrefix: "gemini",
+      rawId,
+      source: "gemini-cli",
+      projectPath: projectPath || filePath,
+      filePath,
+      originalTitle: summary || cleanTitle(question) || rawId,
+      firstQuestion: cleanTitle(question),
+      timestamp: lastUpdatedMs || stat.mtimeMs,
+      tokenUsage: tokenUsageFromEvents([...tokenEntries.values()]),
+      stat,
+      isSubagent: parentSessionId !== null,
+      parentSessionId,
+    }),
+    messages,
+    tokenEvents: [...tokenEntries.values()],
+    traceEvents: dedupeTraceEvents(traceDrafts),
+  };
+}
+
+function geminiChatFileNameUsable(name: string): boolean {
+  return name.endsWith(".jsonl") && !name.includes(".tmp-") && !name.includes(".unreadable-");
+}
+
+export function* loadGeminiCliSessionsIterator(root: string, options: SessionLoadOptions): Generator<LoadedSession> {
+  const tmpRoot = path.join(root, "tmp");
+  let projectDirs: string[] = [];
+  try {
+    projectDirs = fs.readdirSync(tmpRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
+      .map((entry) => path.join(tmpRoot, entry.name));
+  } catch {
+    return;
+  }
+  for (const projectDir of projectDirs) {
+    let projectPath = "";
+    try {
+      projectPath = fs.readFileSync(path.join(projectDir, ".project_root"), "utf8").trim();
+    } catch {
+      projectPath = "";
+    }
+    const chats = path.join(projectDir, "chats");
+    let chatEntries: fs.Dirent[] = [];
+    try {
+      chatEntries = fs.readdirSync(chats, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of chatEntries) {
+      if (entry.name.startsWith(".")) continue;
+      const childPath = path.join(chats, entry.name);
+      if (entry.isDirectory()) {
+        for (const filePath of walkJsonlFiles(childPath)) {
+          const stat = safeStat(filePath);
+          if (shouldSkipFile(options, filePath, stat)) continue;
+          const loaded = loadGeminiCliSessionFile(filePath, projectPath, stat, entry.name);
+          if (loaded) yield loaded;
+        }
+      } else if (entry.isFile() && geminiChatFileNameUsable(entry.name)) {
+        const stat = safeStat(childPath);
+        if (shouldSkipFile(options, childPath, stat)) continue;
+        const loaded = loadGeminiCliSessionFile(childPath, projectPath, stat, null);
+        if (loaded) yield loaded;
+      }
+    }
+  }
+}
+
 export const QWEN_DIR = ".qwen";
 
 function qwenRows(filePath: string): unknown[] {

--- a/apps/main-2.0/src/core/session-loaders/common.ts
+++ b/apps/main-2.0/src/core/session-loaders/common.ts
@@ -36,6 +36,7 @@ export interface SessionLoadOptions {
   includePi?: boolean;
   includeKimiCli?: boolean;
   includeQwenCode?: boolean;
+  includeGeminiCli?: boolean;
   includeDeepSeekCli?: boolean;
   cursorStateDbPath?: string;
   cursorWorkspacePathMap?: ReadonlyMap<string, string>;
@@ -319,6 +320,7 @@ export function createIndexedSession(input: {
     | "pi"
     | "kimi"
     | "qwen"
+    | "gemini"
     | "deepseek";
   rawId: string;
   source: SessionSource;

--- a/apps/main-2.0/src/core/session-sources.ts
+++ b/apps/main-2.0/src/core/session-sources.ts
@@ -18,6 +18,7 @@ export type OptionalSessionSourceSetting =
   | "includePi"
   | "includeKimiCli"
   | "includeQwenCode"
+  | "includeGeminiCli"
   | "includeDeepSeekCli";
 
 export type SessionSourceFamily =
@@ -40,6 +41,7 @@ export type SessionSourceFamily =
   | "pi"
   | "kimi"
   | "qwen"
+  | "gemini"
   | "deepseek";
 
 export type SessionSourceUiFamily = "claude" | "codex" | "codebuddy" | "codewiz" | "zcode" | "other";
@@ -203,6 +205,12 @@ export const SESSION_SOURCE_REGISTRY = {
   "qwen-code": {
     id: "qwen-code", label: "Qwen Code", format: "qwen", family: "qwen", uiFamily: "other", statsGroup: null,
     optionalSetting: "includeQwenCode", pendingKey: "qwen", remoteCollectorOptional: false, liveFamily: null, migrationAgent: null,
+    resumeTarget: null, remoteFamily: null, nativeAppFamily: null,
+    capabilities: { live: false, resume: false, migrate: false, sessionSync: false, openApp: false },
+  },
+  "gemini-cli": {
+    id: "gemini-cli", label: "Gemini CLI", format: "gemini", family: "gemini", uiFamily: "other", statsGroup: null,
+    optionalSetting: "includeGeminiCli", pendingKey: "gemini", remoteCollectorOptional: false, liveFamily: null, migrationAgent: null,
     resumeTarget: null, remoteFamily: null, nativeAppFamily: null,
     capabilities: { live: false, resume: false, migrate: false, sessionSync: false, openApp: false },
   },

--- a/apps/main-2.0/src/core/session-store.ts
+++ b/apps/main-2.0/src/core/session-store.ts
@@ -250,7 +250,7 @@ export class SessionStore {
     await this.ready;
     const target = targets.find((item) => item.sessionKey === requestedSessionKey);
     if (!target) return false;
-    if (target.source === "workbuddy-cli" || target.source === "kimi-cli" || target.source === "qwen-code") {
+    if (target.source === "workbuddy-cli" || target.source === "kimi-cli" || target.source === "qwen-code" || target.source === "gemini-cli") {
       throw new Error(`${sessionSourceDescriptor(target.source).label} session source files are read-only.`);
     }
     if (!canDeleteSessionLocally(target)) {

--- a/apps/main-2.0/src/core/trace-presentation.ts
+++ b/apps/main-2.0/src/core/trace-presentation.ts
@@ -38,7 +38,7 @@ export function tracePresentation(
   ) {
     return { category: "lifecycle", visibility: "turn_summary" };
   }
-  if (eventType === "codex.reasoning_summary" || eventType === "agent_reasoning" || eventType === "qwen.thought") {
+  if (eventType === "codex.reasoning_summary" || eventType === "agent_reasoning" || eventType === "qwen.thought" || eventType === "gemini.thought") {
     return { category: "reasoning", visibility: "timeline" };
   }
   if (

--- a/apps/main-2.0/src/core/types.ts
+++ b/apps/main-2.0/src/core/types.ts
@@ -21,8 +21,9 @@ export type SessionSource =
   | "pi-cli"
   | "deepseek-cli"
   | "kimi-cli"
-  | "qwen-code";
-export type SessionFormat = "claude" | "codex" | "codebuddy" | "workbuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder" | "pi" | "deepseek" | "kimi" | "qwen";
+  | "qwen-code"
+  | "gemini-cli";
+export type SessionFormat = "claude" | "codex" | "codebuddy" | "workbuddy" | "codewiz" | "openclaw" | "hermes" | "opencode" | "zcode" | "cursor" | "trae" | "qoder" | "pi" | "deepseek" | "kimi" | "qwen" | "gemini";
 export type SessionSortBy = "smart" | "activity" | "created";
 export type EnvironmentKind = "local" | "wsl" | "ssh";
 export type EnvironmentSyncState = "idle" | "syncing" | "watching" | "disconnected" | "error";

--- a/apps/main-2.0/src/main/index.ts
+++ b/apps/main-2.0/src/main/index.ts
@@ -1782,6 +1782,7 @@ function runIndexSync(): Promise<IndexStatus> {
         includePi: settings.includePi,
         includeKimiCli: settings.includeKimiCli,
         includeQwenCode: settings.includeQwenCode,
+        includeGeminiCli: settings.includeGeminiCli,
         includeCursorAgent: settings.includeCursorAgent,
         includeTrae: settings.includeTrae,
         includeQoder: settings.includeQoder,

--- a/apps/main-2.0/src/main/services/session-bulk-delete-service.ts
+++ b/apps/main-2.0/src/main/services/session-bulk-delete-service.ts
@@ -286,7 +286,7 @@ function classifyTarget(
   if (request.inactiveBefore !== undefined && target.lastActivityAt >= request.inactiveBefore) {
     return issueFor(target.sessionKey, "recent", "Session is not older than the selected cutoff.");
   }
-  if (target.source === "workbuddy-cli" || target.source === "kimi-cli" || target.source === "qwen-code") {
+  if (target.source === "workbuddy-cli" || target.source === "kimi-cli" || target.source === "qwen-code" || target.source === "gemini-cli") {
     return issueFor(target.sessionKey, "read-only", `${sessionSourceDescriptor(target.source).label} session source files are read-only.`);
   }
   if (SHARED_DATABASE_SOURCES.has(target.source)) return issueFor(target.sessionKey, "shared-database", "This source stores multiple sessions in a shared database.");

--- a/apps/main-2.0/src/main/services/session-catalog-service.ts
+++ b/apps/main-2.0/src/main/services/session-catalog-service.ts
@@ -201,8 +201,8 @@ export class SessionCatalogService {
   async delete(sessionKey: string, options?: unknown): Promise<boolean> {
     const normalizedOptions = normalizeSessionDeleteOptions(options);
     const session = await this.dependencies.store.getSession(sessionKey);
-    if (session?.source === "workbuddy-cli" || session?.source === "kimi-cli" || session?.source === "qwen-code") {
-      const label = session.source === "workbuddy-cli" ? "WorkBuddy" : session.source === "kimi-cli" ? "Kimi Code" : "Qwen Code";
+    if (session?.source === "workbuddy-cli" || session?.source === "kimi-cli" || session?.source === "qwen-code" || session?.source === "gemini-cli") {
+      const label = session.source === "workbuddy-cli" ? "WorkBuddy" : session.source === "kimi-cli" ? "Kimi Code" : session.source === "qwen-code" ? "Qwen Code" : "Gemini CLI";
       throw new Error(`${label} session source files are read-only.`);
     }
     if (session && !canDeleteSessionLocally(session)) {

--- a/apps/main-2.0/src/main/services/v1-session-import-service.ts
+++ b/apps/main-2.0/src/main/services/v1-session-import-service.ts
@@ -45,6 +45,7 @@ const V1_SETTINGS_KEYS = [
   "includePi",
   "includeKimiCli",
   "includeQwenCode",
+  "includeGeminiCli",
   "summaryAutoBackfill",
   "summaryMaxAgeDays",
   "compressionConcurrency",
@@ -70,7 +71,7 @@ const V1_SETTINGS_KEYS = [
 const SESSION_SOURCES = new Set<SessionSource>([
   "claude-cli", "claude-app", "codex-cli", "codex-app", "tclaude-cli", "tcodex-cli",
   "codebuddy-cli", "workbuddy-cli", "codewiz-cli", "openclaw", "hermes", "opencode-cli", "zcode-cli",
-  "cursor-agent", "trae", "qoder", "pi-cli", "kimi-cli", "qwen-code", "deepseek-cli",
+  "cursor-agent", "trae", "qoder", "pi-cli", "kimi-cli", "qwen-code", "gemini-cli", "deepseek-cli",
 ]);
 
 interface V1SessionRow {

--- a/apps/main-2.0/src/renderer/src/features/settings/settings-dialog.tsx
+++ b/apps/main-2.0/src/renderer/src/features/settings/settings-dialog.tsx
@@ -584,6 +584,10 @@ export function SettingsDialog({
                   <input type="checkbox" className="switch" checked={Boolean(settings?.includeQwenCode)} disabled={!settings} onChange={(event) => onSettingsChange({ includeQwenCode: event.currentTarget.checked })} />
                 </label>
                 <label className="settings-field settings-toggle">
+                  <div className="settings-field-text"><span className="settings-field-title">Include Gemini CLI</span><span className="settings-field-sub">{l("Indexes local Gemini CLI sessions read-only.", "以只读方式索引本地 Gemini CLI 会话。")}</span></div>
+                  <input type="checkbox" className="switch" checked={Boolean(settings?.includeGeminiCli)} disabled={!settings} onChange={(event) => onSettingsChange({ includeGeminiCli: event.currentTarget.checked })} />
+                </label>
+                <label className="settings-field settings-toggle">
                   <div className="settings-field-text">
                     <span className="settings-field-title">Include CodeWiz</span>
                     <span className="settings-field-sub">{l("Indexes CodeWiz sessions from ~/.local/share/codewiz.", "索引 ~/.local/share/codewiz 中的 CodeWiz 会话。")}</span>


### PR DESCRIPTION
## 概述

Fixes #529

新增可选数据源 Gemini CLI(v1 + v2)。此前 20+ 支持源中不包含 Gemini CLI;本 PR 的格式规格已在 issue #529 中基于 gemini-cli 源码(`chatRecordingService.ts` / `chatRecordingTypes.ts` / `projectRegistry.ts`)与本机真实数据核实。

## 实现

**loader(v1 `session-loader.ts` / v2 `session-loaders/alternative-sources.ts`,结构一致)**

- 遍历 `~/.gemini/tmp/<slug>/chats/`;`<slug>/.project_root` 提供项目路径(gemini-cli 的项目注册表机制);
- 完整解析记录流:消息(`user`/`gemini`,`content` 为字符串或 Part 数组)、`$set` 元数据(含 `summary` 标题与 `lastUpdated`)、**`$set.messages` 检查点(清空重建)**、**`$rewindTo` 截断(连带清理对应 token 事件)**;
- `gemini` 消息的 `tokens`(input/output/cached/thoughts)→ 逐消息 token 事件,口径与既有源一致(total 含 reasoning);`toolCalls` → 工具调用轨迹;`thoughts` → `gemini.thought` 思考轨迹;
- **子 agent 会话**(`chats/<parentSessionId>/<sessionId>.jsonl` 嵌套目录)→ `isSubagent` / `parentSessionId`,复用 #486/#490/#492 建立的父子会话机制,不占用顶层列表;
- 跳过 `.tmp-<pid>` 临时文件与 `.unreadable-*` 备份;支持 `GEMINI_DIR` 环境变量与 `homeDir` 隔离;
- 源默认关闭(`includeGeminiCli`),与其他可选源一致。

**接入面**(v1/v2 各自镜像):`types.ts`(SessionSource/SessionFormat)、`session-sources.ts`(descriptor + 联合)、`platform.ts`(设置)、`common.ts`(v2)、`format-adapters.ts`(`geminiAdapter`)、`trace-presentation.ts`(`gemini.thought`)、`session-environment.ts`、store / bulk-delete / catalog / v1-import 的只读源清单、`session-index-worker-protocol.ts`(v1)、设置界面开关、`createIndexedSession` keyPrefix 联合。

## 验证

- 新增 `session-loader-gemini.test.ts`(v1/v2 各 5 例):主会话(消息/token/工具轨迹/项目路径)、检查点重建 + rewind 截断(token 联动清理)、嵌套子会话父子关系、summary 标题 + 临时/损坏文件跳过、默认关闭;
- `test:v1` 全量:1625 passed(仅 `mcp-server.test.ts` 5 例为本机路径含非 ASCII 字符的既有环境问题,此前的 PR 中已在未改动代码上复现);
- `test:v2` 全量:2134 passed(223 文件全绿);
- `npm run typecheck`(v1 + v2)通过;按 `.release-notes` 规范补充双端 release note。
