### PR TITLE
fix(v2): stop MCP stdio servers from outliving their host

### DIFF
--- a/.release-notes/fix-issue-499-mcp-stdio-process-leak.md
+++ b/.release-notes/fix-issue-499-mcp-stdio-process-leak.md
@@ -4,4 +4,4 @@
 
 ## Bug 修复
 
-- 修复宿主客户端退出后 Gateway / Workflow stdio MCP 进程残留的问题：stdin 关闭或管道中断时，服务会在给在途请求留出有限的收尾窗口（默认 5 秒，可用 `AGENT_RECALL_MCP_SHUTDOWN_DRAIN_MS` 调整）后自行退出，并响应 SIGTERM / SIGINT 信号（#499 问题 2）。
+- 修复宿主客户端(如 Codex、Claude Code)退出后 Gateway / Workflow MCP 进程残留、随时间不断累积的问题:这些进程现在会在收尾后自行退出,不再长期占用系统资源。

--- a/.release-notes/fix-issue-499-mcp-stdio-process-leak.md
+++ b/.release-notes/fix-issue-499-mcp-stdio-process-leak.md
@@ -1,0 +1,7 @@
+# 修复 MCP Gateway 进程泄漏
+
+<!-- release-target: v2 -->
+
+## Bug 修复
+
+- 修复宿主客户端退出后 Gateway / Workflow stdio MCP 进程残留的问题：stdin 关闭或管道中断时，服务会在给在途请求留出有限的收尾窗口（默认 5 秒，可用 `AGENT_RECALL_MCP_SHUTDOWN_DRAIN_MS` 调整）后自行退出，并响应 SIGTERM / SIGINT 信号（#499 问题 2）。

--- a/apps/main-2.0/src/automation/engine/mcp/server.test.ts
+++ b/apps/main-2.0/src/automation/engine/mcp/server.test.ts
@@ -25,16 +25,26 @@ async function killAndWaitForExit(child: ReturnType<typeof spawn>): Promise<void
   if (child.exitCode === null && child.signalCode === null && !child.killed) child.kill();
   if (child.exitCode !== null || child.signalCode !== null) return;
   await new Promise<void>((resolve) => {
-    // Bounded so a stubborn child cannot hang the suite on top of a failure.
-    const timer = setTimeout(resolve, 2_000);
-    child.once("close", () => {
-      clearTimeout(timer);
+    let settled = false;
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(escalate);
+      clearTimeout(backstop);
       resolve();
-    });
-    child.once("error", () => {
-      clearTimeout(timer);
-      resolve();
-    });
+    };
+    // SIGTERM may be ignored or stuck; escalate to SIGKILL and drop our ends
+    // of the pipes so nothing can hold the suite open on top of a failure.
+    const escalate = setTimeout(() => {
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+      child.stdout?.destroy();
+      child.stderr?.destroy();
+      child.stdin?.destroy();
+    }, 2_000);
+    // Absolute backstop: even a child that refuses to die cannot hang here.
+    const backstop = setTimeout(settle, 5_000);
+    child.once("close", settle);
+    child.once("error", settle);
   });
 }
 describe("MCP server tools", () => {

--- a/apps/main-2.0/src/automation/engine/mcp/server.test.ts
+++ b/apps/main-2.0/src/automation/engine/mcp/server.test.ts
@@ -20,6 +20,23 @@ const originalExecutionId = process.env.AGENT_RECALL_WORKFLOW_NODE_EXECUTION_ID;
 const originalReviewRevision = process.env.AGENT_RECALL_WORKFLOW_REVIEW_REVISION;
 const originalScope = process.env.AGENT_RECALL_WORKFLOW_MCP_SCOPE;
 const originalMode = process.env.AGENT_RECALL_MCP_MODE;
+
+async function killAndWaitForExit(child: ReturnType<typeof spawn>): Promise<void> {
+  if (child.exitCode === null && child.signalCode === null && !child.killed) child.kill();
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await new Promise<void>((resolve) => {
+    // Bounded so a stubborn child cannot hang the suite on top of a failure.
+    const timer = setTimeout(resolve, 2_000);
+    child.once("close", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    child.once("error", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
 describe("MCP server tools", () => {
   afterEach(() => {
     if (originalEnv === undefined) delete process.env.AGENT_RECALL_WORKFLOW_MCP_BRIDGE;
@@ -342,32 +359,36 @@ describe("MCP server tools", () => {
       env: { ...process.env, AGENT_RECALL_WORKFLOW_MCP_BRIDGE: path.join(os.tmpdir(), "missing-mcp-bridge.json"), AGENT_RECALL_WORKFLOW_MCP_TOKEN: "" },
       stdio: ["pipe", "pipe", "pipe"],
     });
-    const response = await new Promise<Record<string, any>>((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error("MCP stdio response timed out")), 5_000);
-      let output = "";
-      child.stdout.setEncoding("utf8");
-      child.stdout.on("data", (chunk: string) => {
-        output += chunk;
-        const newlineIndex = output.indexOf("\n");
-        if (newlineIndex < 0) return;
-        clearTimeout(timer);
-        resolve(JSON.parse(output.slice(0, newlineIndex)));
+    try {
+      const response = await new Promise<Record<string, any>>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("MCP stdio response timed out")), 5_000);
+        let output = "";
+        child.stdout.setEncoding("utf8");
+        child.stdout.on("data", (chunk: string) => {
+          output += chunk;
+          const newlineIndex = output.indexOf("\n");
+          if (newlineIndex < 0) return;
+          clearTimeout(timer);
+          resolve(JSON.parse(output.slice(0, newlineIndex)));
+        });
+        child.once("error", reject);
+        child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} })}\n`);
       });
-      child.once("error", reject);
-      child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} })}\n`);
-    });
-    expect(response.result.tools.length).toBeGreaterThan(0);
+      expect(response.result.tools.length).toBeGreaterThan(0);
 
-    child.stdin.end();
-    const exitCode = await new Promise<number | null>((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error("MCP stdio server outlived closed stdin")), 5_000);
-      child.once("exit", (code) => {
-        clearTimeout(timer);
-        resolve(code);
+      child.stdin.end();
+      const exitCode = await new Promise<number | null>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("MCP stdio server outlived closed stdin")), 5_000);
+        child.once("exit", (code) => {
+          clearTimeout(timer);
+          resolve(code);
+        });
+        child.once("error", reject);
       });
-      child.once("error", reject);
-    });
-    expect(exitCode).toBe(0);
+      expect(exitCode).toBe(0);
+    } finally {
+      await killAndWaitForExit(child);
+    }
   });
 
   test("gateway stdio server exits after the host closes stdin", async () => {
@@ -378,32 +399,36 @@ describe("MCP server tools", () => {
       env: { ...process.env, AGENT_RECALL_MCP_BRIDGE: path.join(os.tmpdir(), "missing-mcp-bridge.json") },
       stdio: ["pipe", "pipe", "pipe"],
     });
-    const response = await new Promise<Record<string, any>>((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error("Gateway stdio response timed out")), 5_000);
-      let output = "";
-      child.stdout.setEncoding("utf8");
-      child.stdout.on("data", (chunk: string) => {
-        output += chunk;
-        const newlineIndex = output.indexOf("\n");
-        if (newlineIndex < 0) return;
-        clearTimeout(timer);
-        resolve(JSON.parse(output.slice(0, newlineIndex)));
+    try {
+      const response = await new Promise<Record<string, any>>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("Gateway stdio response timed out")), 5_000);
+        let output = "";
+        child.stdout.setEncoding("utf8");
+        child.stdout.on("data", (chunk: string) => {
+          output += chunk;
+          const newlineIndex = output.indexOf("\n");
+          if (newlineIndex < 0) return;
+          clearTimeout(timer);
+          resolve(JSON.parse(output.slice(0, newlineIndex)));
+        });
+        child.once("error", reject);
+        child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} })}\n`);
       });
-      child.once("error", reject);
-      child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} })}\n`);
-    });
-    expect(response.result.tools.length).toBeGreaterThan(0);
+      expect(response.result.tools.length).toBeGreaterThan(0);
 
-    child.stdin.end();
-    const exitCode = await new Promise<number | null>((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error("Gateway stdio server outlived closed stdin")), 5_000);
-      child.once("exit", (code) => {
-        clearTimeout(timer);
-        resolve(code);
+      child.stdin.end();
+      const exitCode = await new Promise<number | null>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("Gateway stdio server outlived closed stdin")), 5_000);
+        child.once("exit", (code) => {
+          clearTimeout(timer);
+          resolve(code);
+        });
+        child.once("error", reject);
       });
-      child.once("error", reject);
-    });
-    expect(exitCode).toBe(0);
+      expect(exitCode).toBe(0);
+    } finally {
+      await killAndWaitForExit(child);
+    }
   });
 
   test("drains in-flight requests before exiting on stdin close", async () => {
@@ -583,7 +608,7 @@ describe("MCP server tools", () => {
       });
       expect(exitCode).toBe(0);
     } finally {
-      child.kill();
+      await killAndWaitForExit(child);
       // The blackhole never ends its accepted sockets, so plain close() would
       // wait forever for the half-open connection; drop them explicitly.
       for (const socket of blackholeSockets) socket.destroy();

--- a/apps/main-2.0/src/automation/engine/mcp/server.test.ts
+++ b/apps/main-2.0/src/automation/engine/mcp/server.test.ts
@@ -419,7 +419,15 @@ describe("MCP server tools", () => {
       await fetchGate;
       return { ok: true, status: 200, json: async () => ({ ok: true, workflowId: "wf_1" }) } as Response;
     });
-    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(process.stdout, "write").mockImplementation(((
+      _chunk: unknown,
+      encodingOrCallback?: BufferEncoding | (() => void),
+      maybeCallback?: () => void,
+    ) => {
+      const callback = typeof encodingOrCallback === "function" ? encodingOrCallback : maybeCallback;
+      if (callback) setImmediate(callback);
+      return true;
+    }) as typeof process.stdout.write);
     const exitCodes: number[] = [];
     const stdin = new PassThrough();
 
@@ -432,6 +440,35 @@ describe("MCP server tools", () => {
     expect(exitCodes).toEqual([]);
 
     releaseFetch();
+    await vi.waitFor(() => expect(exitCodes).toEqual([0]));
+  });
+
+  test("waits for the last response to flush before exiting on stdin close", async () => {
+    let releaseFlush!: () => void;
+    const flushGate = new Promise<void>((resolve) => {
+      releaseFlush = resolve;
+    });
+    vi.spyOn(process.stdout, "write").mockImplementation(((
+      _chunk: unknown,
+      encodingOrCallback?: BufferEncoding | (() => void),
+      maybeCallback?: () => void,
+    ) => {
+      const callback = typeof encodingOrCallback === "function" ? encodingOrCallback : maybeCallback;
+      if (callback) void flushGate.then(callback);
+      return true;
+    }) as typeof process.stdout.write);
+    const exitCodes: number[] = [];
+    const stdin = new PassThrough();
+
+    startStdioMcpServer({ stdin, signalTarget: { on: () => undefined }, exit: (code) => exitCodes.push(code) });
+
+    stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 11, method: "tools/list", params: {} })}\n`);
+    await new Promise((resolve) => setImmediate(resolve));
+    stdin.end();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(exitCodes).toEqual([]);
+
+    releaseFlush();
     await vi.waitFor(() => expect(exitCodes).toEqual([0]));
   });
 

--- a/apps/main-2.0/src/automation/engine/mcp/server.test.ts
+++ b/apps/main-2.0/src/automation/engine/mcp/server.test.ts
@@ -1,11 +1,13 @@
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import http from "node:http";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { RUNTIME_IDS } from "../shared/runtime-catalog";
-import { callMcpTool, mcpToolDefinitions, resolveBridgeDiscoveryPath } from "./server";
+import { callMcpTool, mcpToolDefinitions, resolveBridgeDiscoveryPath, startStdioMcpServer } from "./server";
 
 const originalEnv = process.env.AGENT_RECALL_WORKFLOW_MCP_BRIDGE;
 const originalBridgeEnv = process.env.AGENT_RECALL_MCP_BRIDGE;
@@ -331,6 +333,226 @@ describe("MCP server tools", () => {
       await new Promise<void>((resolve, reject) => bridge.close((error) => error ? reject(error) : resolve()));
     }
   });
+
+  test("workflow stdio server exits after the host closes stdin", async () => {
+    const tsxCli = path.resolve("node_modules", "tsx", "dist", "cli.mjs");
+    const serverPath = path.resolve("src", "mcp", "workflow-entry.ts");
+    const child = spawn(process.execPath, [tsxCli, serverPath], {
+      cwd: process.cwd(),
+      env: { ...process.env, AGENT_RECALL_WORKFLOW_MCP_BRIDGE: path.join(os.tmpdir(), "missing-mcp-bridge.json"), AGENT_RECALL_WORKFLOW_MCP_TOKEN: "" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const response = await new Promise<Record<string, any>>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("MCP stdio response timed out")), 5_000);
+      let output = "";
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", (chunk: string) => {
+        output += chunk;
+        const newlineIndex = output.indexOf("\n");
+        if (newlineIndex < 0) return;
+        clearTimeout(timer);
+        resolve(JSON.parse(output.slice(0, newlineIndex)));
+      });
+      child.once("error", reject);
+      child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} })}\n`);
+    });
+    expect(response.result.tools.length).toBeGreaterThan(0);
+
+    child.stdin.end();
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("MCP stdio server outlived closed stdin")), 5_000);
+      child.once("exit", (code) => {
+        clearTimeout(timer);
+        resolve(code);
+      });
+      child.once("error", reject);
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("gateway stdio server exits after the host closes stdin", async () => {
+    const tsxCli = path.resolve("node_modules", "tsx", "dist", "cli.mjs");
+    const serverPath = path.resolve("src", "mcp", "gateway-entry.ts");
+    const child = spawn(process.execPath, [tsxCli, serverPath], {
+      cwd: process.cwd(),
+      env: { ...process.env, AGENT_RECALL_MCP_BRIDGE: path.join(os.tmpdir(), "missing-mcp-bridge.json") },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const response = await new Promise<Record<string, any>>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("Gateway stdio response timed out")), 5_000);
+      let output = "";
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", (chunk: string) => {
+        output += chunk;
+        const newlineIndex = output.indexOf("\n");
+        if (newlineIndex < 0) return;
+        clearTimeout(timer);
+        resolve(JSON.parse(output.slice(0, newlineIndex)));
+      });
+      child.once("error", reject);
+      child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} })}\n`);
+    });
+    expect(response.result.tools.length).toBeGreaterThan(0);
+
+    child.stdin.end();
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("Gateway stdio server outlived closed stdin")), 5_000);
+      child.once("exit", (code) => {
+        clearTimeout(timer);
+        resolve(code);
+      });
+      child.once("error", reject);
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("drains in-flight requests before exiting on stdin close", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "agent-recall-stdio-drain-"));
+    const discoveryPath = path.join(dir, "bridge.json");
+    process.env.AGENT_RECALL_WORKFLOW_MCP_BRIDGE = discoveryPath;
+    await writeFile(discoveryPath, JSON.stringify({ host: "127.0.0.1", port: 48123, token: "secret" }), "utf8");
+    let releaseFetch!: () => void;
+    const fetchGate = new Promise<void>((resolve) => {
+      releaseFetch = resolve;
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      await fetchGate;
+      return { ok: true, status: 200, json: async () => ({ ok: true, workflowId: "wf_1" }) } as Response;
+    });
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const exitCodes: number[] = [];
+    const stdin = new PassThrough();
+
+    startStdioMcpServer({ stdin, signalTarget: { on: () => undefined }, exit: (code) => exitCodes.push(code) });
+
+    stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 7, method: "tools/call", params: { name: "workflow_run_list", arguments: {} } })}\n`);
+    await new Promise((resolve) => setImmediate(resolve));
+    stdin.end();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(exitCodes).toEqual([]);
+
+    releaseFetch();
+    await vi.waitFor(() => expect(exitCodes).toEqual([0]));
+  });
+
+  test("stops waiting for in-flight requests after the drain window", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "agent-recall-stdio-drain-cap-"));
+    const discoveryPath = path.join(dir, "bridge.json");
+    process.env.AGENT_RECALL_WORKFLOW_MCP_BRIDGE = discoveryPath;
+    await writeFile(discoveryPath, JSON.stringify({ host: "127.0.0.1", port: 48123, token: "secret" }), "utf8");
+    vi.spyOn(globalThis, "fetch").mockImplementation(() => new Promise<Response>(() => undefined));
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const exitCodes: number[] = [];
+    const stdin = new PassThrough();
+
+    startStdioMcpServer({ stdin, signalTarget: { on: () => undefined }, exit: (code) => exitCodes.push(code), drainMs: 20 });
+
+    stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 8, method: "tools/call", params: { name: "workflow_run_list", arguments: {} } })}\n`);
+    await new Promise((resolve) => setImmediate(resolve));
+    stdin.end();
+    await vi.waitFor(() => expect(exitCodes).toEqual([0]));
+  });
+
+  test("exits on termination signals and broken stream pipes", async () => {
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const signalListeners = new Map<string, (() => void)[]>();
+    const signalTarget = {
+      on(signal: string, listener: () => void) {
+        signalListeners.set(signal, [...(signalListeners.get(signal) ?? []), listener]);
+        return this;
+      },
+    };
+    const exitCodes: number[] = [];
+
+    startStdioMcpServer({
+      stdin,
+      stdout,
+      signalTarget,
+      exit: (code) => exitCodes.push(code),
+    });
+
+    for (const listener of signalListeners.get("SIGTERM") ?? []) listener();
+    expect(exitCodes).toEqual([0]);
+
+    const stdinAlreadyClosed = new PassThrough();
+    stdinAlreadyClosed.destroy();
+    await new Promise((resolve) => setImmediate(resolve));
+    startStdioMcpServer({
+      stdin: stdinAlreadyClosed,
+      stdout,
+      signalTarget,
+      exit: (code) => exitCodes.push(code),
+    });
+    expect(exitCodes).toEqual([0, 0]);
+
+    const stdoutForPipeError = new PassThrough();
+    startStdioMcpServer({
+      stdin: new PassThrough(),
+      stdout: stdoutForPipeError,
+      signalTarget,
+      exit: (code) => exitCodes.push(code),
+    });
+    stdoutForPipeError.emit("error", new Error("EPIPE"));
+    expect(exitCodes).toEqual([0, 0, 0]);
+  });
+
+  test("stdio server stops instead of leaking when stdin closes mid-request", async () => {
+    const blackholeSockets = new Set<net.Socket>();
+    const blackhole = net.createServer((socket) => {
+      // Accept the TCP connection but never respond, so the tool call hangs
+      // the same way a gateway request in flight while its host dies does.
+      blackholeSockets.add(socket);
+      socket.once("close", () => blackholeSockets.delete(socket));
+    });
+    await new Promise<void>((resolve, reject) => {
+      blackhole.once("error", reject);
+      blackhole.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = blackhole.address();
+    if (!address || typeof address === "string") throw new Error("Test bridge did not bind to TCP.");
+    const dir = await mkdtemp(path.join(os.tmpdir(), "agent-recall-stdio-leak-"));
+    const discoveryPath = path.join(dir, "bridge.json");
+    await writeFile(discoveryPath, JSON.stringify({ host: "127.0.0.1", port: address.port, token: "secret" }), "utf8");
+    const tsxCli = path.resolve("node_modules", "tsx", "dist", "cli.mjs");
+    const serverPath = path.resolve("src", "mcp", "workflow-entry.ts");
+    const child = spawn(process.execPath, [tsxCli, serverPath], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        AGENT_RECALL_WORKFLOW_MCP_BRIDGE: discoveryPath,
+        AGENT_RECALL_WORKFLOW_MCP_TOKEN: "",
+        AGENT_RECALL_MCP_SHUTDOWN_DRAIN_MS: "300",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    try {
+      child.stdin.write(`${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 9,
+        method: "tools/call",
+        params: { name: "workflow_run_list", arguments: {} },
+      })}\n`);
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      child.stdin.end();
+      const exitCode = await new Promise<number | null>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("MCP stdio server leaked after stdin closed mid-request")), 5_000);
+        child.once("exit", (code) => {
+          clearTimeout(timer);
+          resolve(code);
+        });
+        child.once("error", reject);
+      });
+      expect(exitCode).toBe(0);
+    } finally {
+      child.kill();
+      // The blackhole never ends its accepted sockets, so plain close() would
+      // wait forever for the half-open connection; drop them explicitly.
+      for (const socket of blackholeSockets) socket.destroy();
+      await new Promise<void>((resolve, reject) => blackhole.close((error) => error ? reject(error) : resolve()));
+    }
+  }, 15_000);
 
   test("calls bridge endpoints with discovery token", async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), "multi-agent-chat-mcp-server-"));

--- a/apps/main-2.0/src/automation/engine/mcp/server.ts
+++ b/apps/main-2.0/src/automation/engine/mcp/server.ts
@@ -866,10 +866,54 @@ async function handleJsonRpc(request: JsonRpcRequest): Promise<void> {
   }
 }
 
-export function startStdioMcpServer(): void {
+const STDIO_MCP_SHUTDOWN_DRAIN_MS = 5_000;
+
+export interface StdioMcpServerOptions {
+  stdin?: NodeJS.ReadableStream & { readableEnded: boolean; destroyed: boolean };
+  stdout?: NodeJS.WritableStream;
+  signalTarget?: { on(signal: NodeJS.Signals, listener: () => void): unknown };
+  exit?: (code: number) => void;
+  drainMs?: number;
+}
+
+function shutdownDrainMsFromEnvironment(): number {
+  const raw = process.env.AGENT_RECALL_MCP_SHUTDOWN_DRAIN_MS?.trim();
+  if (!raw) return STDIO_MCP_SHUTDOWN_DRAIN_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : STDIO_MCP_SHUTDOWN_DRAIN_MS;
+}
+
+export function startStdioMcpServer(options: StdioMcpServerOptions = {}): void {
+  const stdin = options.stdin ?? process.stdin;
+  const stdout = options.stdout ?? process.stdout;
+  const signalTarget = options.signalTarget ?? process;
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+  const drainMs = options.drainMs ?? shutdownDrainMsFromEnvironment();
   let buffer = "";
-  process.stdin.setEncoding("utf8");
-  process.stdin.on("data", (chunk: string) => {
+  let inFlightRequests = 0;
+  let shutdownReason: string | null = null;
+  let exited = false;
+  const exitOnce = (code: number) => {
+    if (exited) return;
+    exited = true;
+    exit(code);
+  };
+  const shutdown = (reason: string) => {
+    if (shutdownReason !== null) return;
+    shutdownReason = reason;
+    if (inFlightRequests <= 0) {
+      exitOnce(0);
+      return;
+    }
+    // The host is already gone; give in-flight requests a bounded window to
+    // write their last responses, then stop instead of leaking the process.
+    const drainTimer = setTimeout(() => exitOnce(0), drainMs);
+    drainTimer.unref();
+  };
+
+  stdin.setEncoding("utf8");
+  stdin.on("data", (chunk: string) => {
+    if (shutdownReason !== null) return;
     buffer += chunk;
     while (true) {
       const newlineIndex = buffer.indexOf("\n");
@@ -877,7 +921,20 @@ export function startStdioMcpServer(): void {
       const line = buffer.slice(0, newlineIndex).trim();
       buffer = buffer.slice(newlineIndex + 1);
       if (!line) continue;
-      void handleJsonRpc(JSON.parse(line) as JsonRpcRequest);
+      inFlightRequests += 1;
+      void handleJsonRpc(JSON.parse(line) as JsonRpcRequest).finally(() => {
+        inFlightRequests -= 1;
+        if (shutdownReason !== null && inFlightRequests <= 0) exitOnce(0);
+      });
     }
   });
+  // Hosts release stdio MCP servers by closing the pipes; without these
+  // handlers the gateway/workflow entries outlive their client (issue #499).
+  stdin.on("end", () => shutdown("stdin end"));
+  stdin.on("close", () => shutdown("stdin close"));
+  stdin.on("error", () => shutdown("stdin error"));
+  stdout.on("error", () => shutdown("stdout error"));
+  signalTarget.on("SIGTERM", () => shutdown("SIGTERM"));
+  signalTarget.on("SIGINT", () => shutdown("SIGINT"));
+  if (stdin.readableEnded || stdin.destroyed) shutdown("stdin already closed");
 }

--- a/apps/main-2.0/src/automation/engine/mcp/server.ts
+++ b/apps/main-2.0/src/automation/engine/mcp/server.ts
@@ -807,8 +807,21 @@ export async function callMcpTool(name: string, args: unknown): Promise<unknown>
   return payload;
 }
 
+interface StdioServerLifecycle {
+  beginRequest(): void;
+  endRequest(): void;
+  beginStdoutWrite(): (() => void) | null;
+}
+
+let activeStdioServer: StdioServerLifecycle | null = null;
+
 function writeJsonRpc(payload: unknown): void {
-  process.stdout.write(`${JSON.stringify(payload)}\n`);
+  const line = `${JSON.stringify(payload)}\n`;
+  // Pipe writes are asynchronous; only count a response as delivered once its
+  // write callback fires, so shutdown never truncates the last response.
+  const finishWrite = activeStdioServer?.beginStdoutWrite();
+  if (finishWrite) process.stdout.write(line, finishWrite);
+  else process.stdout.write(line);
 }
 
 async function handleJsonRpc(request: JsonRpcRequest): Promise<void> {
@@ -891,6 +904,7 @@ export function startStdioMcpServer(options: StdioMcpServerOptions = {}): void {
   const drainMs = options.drainMs ?? shutdownDrainMsFromEnvironment();
   let buffer = "";
   let inFlightRequests = 0;
+  let pendingStdoutWrites = 0;
   let shutdownReason: string | null = null;
   let exited = false;
   const exitOnce = (code: number) => {
@@ -898,18 +912,38 @@ export function startStdioMcpServer(options: StdioMcpServerOptions = {}): void {
     exited = true;
     exit(code);
   };
+  const settle = () => {
+    if (shutdownReason !== null && inFlightRequests <= 0 && pendingStdoutWrites <= 0) exitOnce(0);
+  };
   const shutdown = (reason: string) => {
     if (shutdownReason !== null) return;
     shutdownReason = reason;
-    if (inFlightRequests <= 0) {
+    if (inFlightRequests <= 0 && pendingStdoutWrites <= 0) {
       exitOnce(0);
       return;
     }
     // The host is already gone; give in-flight requests a bounded window to
-    // write their last responses, then stop instead of leaking the process.
+    // flush their last responses, then stop instead of leaking the process.
     const drainTimer = setTimeout(() => exitOnce(0), drainMs);
     drainTimer.unref();
   };
+  const lifecycle: StdioServerLifecycle = {
+    beginRequest: () => {
+      inFlightRequests += 1;
+    },
+    endRequest: () => {
+      inFlightRequests -= 1;
+      settle();
+    },
+    beginStdoutWrite: () => {
+      pendingStdoutWrites += 1;
+      return () => {
+        pendingStdoutWrites -= 1;
+        settle();
+      };
+    },
+  };
+  activeStdioServer = lifecycle;
 
   stdin.setEncoding("utf8");
   stdin.on("data", (chunk: string) => {
@@ -921,11 +955,8 @@ export function startStdioMcpServer(options: StdioMcpServerOptions = {}): void {
       const line = buffer.slice(0, newlineIndex).trim();
       buffer = buffer.slice(newlineIndex + 1);
       if (!line) continue;
-      inFlightRequests += 1;
-      void handleJsonRpc(JSON.parse(line) as JsonRpcRequest).finally(() => {
-        inFlightRequests -= 1;
-        if (shutdownReason !== null && inFlightRequests <= 0) exitOnce(0);
-      });
+      lifecycle.beginRequest();
+      void handleJsonRpc(JSON.parse(line) as JsonRpcRequest).finally(() => lifecycle.endRequest());
     }
   });
   // Hosts release stdio MCP servers by closing the pipes; without these


### PR DESCRIPTION
Refs #499(问题 2:MCP gateway 进程泄漏)

## 问题

`#499` 报告了宿主客户端退出后 `out/mcp/gateway-entry.js` 进程残留、数小时内累积 12 个孤儿进程的问题。

## 根因

`startStdioMcpServer()`(gateway-entry 与 workflow-entry 共用)只挂了 stdin 的 `data` 监听,没有任何生命周期处理:

- 宿主退出、管道关闭后,若无其他活跃句柄,进程虽会自然退出;但**只要存在在途请求(如正在等待 MCP bridge 响应的 fetch),事件循环就被 socket 挂住,进程在宿主死后仍长期存活**——我已用最小脚本独立复现:仅含 `data` 监听 + 一个挂起的 fetch 的进程,在 stdin EOF 后 4 秒仍然存活。
- 同时也没有 SIGTERM / SIGINT / EPIPE 处理,与仓库内基于官方 SDK 的 `agent-recall-mcp.mjs`(自带信号退出)行为不一致。

## 修复

`startStdioMcpServer` 现在统一走一条 shutdown 路径,触发源:

- stdin `end` / `close` / `error`(宿主关闭管道,主要泄漏路径)
- stdout `error`(EPIPE,宿主异常死亡)
- SIGTERM / SIGINT

关停语义:

- 无在途请求时立即 `exit(0)`;
- 有在途 JSON-RPC 请求时给一个有界收尾窗口(默认 5s,可用 `AGENT_RECALL_MCP_SHUTDOWN_DRAIN_MS` 调整,便于测试与特殊环境),窗口内请求写完最后响应即退出,超时强制退出,保证进程不再泄漏。

不引入 idle timeout:空闲服务器可能正被宿主持有长期待命,按空闲杀进程会误伤;关闭管道才是宿主释放 stdio MCP server 的规范信号。

## 测试

- 新增集成回归测试 `stdio server stops instead of leaking when stdin closes mid-request`:用黑洞 TCP bridge 挂住在途请求后关闭 stdin,断言进程有界退出。**在修复前的代码上该测试稳定失败**(报 "MCP stdio server leaked after stdin closed mid-request"),修复后通过。
- 新增两个集成测试:gateway / workflow 入口在宿主关闭 stdin 后退出码为 0。
- 新增单测:stdin 关闭时在途请求可正常排空后退出、收尾窗口超时后强制退出、SIGTERM/SIGINT 与管道错误触发退出、stdin 已关闭时启动立即退出。
- `apps/main-2.0` 全量测试(vitest + scripts 166 项)与 `typecheck`(`tsc --noEmit` + dead-code + entrypoint 检查)全部通过。

## 说明

#499 的其余子问题(问题 3:macOS shim 版本漂移;问题 4:幽灵 `--manifest` 参数)不在本 PR 范围内,建议保持 issue 开放。