### PR TITLE
fix: 禁用 CodeWiz 会话摘要

### DIFF
--- a/.release-notes/disable-codewiz-summaries.md
+++ b/.release-notes/disable-codewiz-summaries.md
@@ -1,0 +1,7 @@
+# CodeWiz 会话不再触发 AI 摘要
+
+<!-- release-target: both -->
+
+## Bug 修复
+
+- AgentRecall 不再为 CodeWiz 会话自动、批量或手动生成 AI 摘要，避免产生与主会话无关的后台模型请求；已有摘要仍会保留显示。

--- a/apps/main-1.0/src/core/session-sources.test.ts
+++ b/apps/main-1.0/src/core/session-sources.test.ts
@@ -6,6 +6,7 @@ import {
   SESSION_SOURCE_DESCRIPTORS,
   SESSION_SOURCE_REGISTRY,
   sessionSourceDescriptor,
+  supportsAiSummarySource,
 } from "./session-sources";
 import type { SessionSource } from "./types";
 
@@ -154,5 +155,11 @@ describe("session source capability registry", () => {
     expect(isSessionSource("qoder")).toBe(true);
     expect(isSessionSource("unknown-agent")).toBe(false);
     expect(isSessionSource(null)).toBe(false);
+  });
+
+  it("disables AI summaries only for CodeWiz sessions", () => {
+    for (const source of ALL_SOURCES) {
+      expect(supportsAiSummarySource(source)).toBe(source !== "codewiz-cli");
+    }
   });
 });

--- a/apps/main-1.0/src/core/session-sources.ts
+++ b/apps/main-1.0/src/core/session-sources.ts
@@ -229,6 +229,10 @@ export function sessionSourceLabel(source: SessionSource): string {
   return sessionSourceDescriptor(source).label;
 }
 
+export function supportsAiSummarySource(source: SessionSource): boolean {
+  return source !== "codewiz-cli";
+}
+
 export function remoteSessionAgentForSource(source: SessionSource): RemoteSessionAgent | null {
   if (source === "hermes") return "hermes";
   if (source === "pi-cli") return "pi";

--- a/apps/main-1.0/src/core/session-store.test.ts
+++ b/apps/main-1.0/src/core/session-store.test.ts
@@ -140,6 +140,34 @@ const traceEvents: SessionTraceEvent[] = [
 ];
 
 describe("SessionStore", () => {
+  it("excludes CodeWiz sessions from summary backfill while keeping other sources eligible", () => {
+    const store = createInMemoryStore();
+    const now = 1_000;
+    store.upsertIndexedSession(
+      sampleSession({
+        sessionKey: "codex:summary-candidate",
+        rawId: "summary-candidate",
+        filePath: "/tmp/codex-summary.jsonl",
+        fileMtimeMs: 900,
+      }),
+      messages,
+    );
+    store.upsertIndexedSession(
+      sampleSession({
+        sessionKey: "codewiz:summary-candidate",
+        rawId: "summary-candidate",
+        source: "codewiz-cli",
+        filePath: "/tmp/codewiz-opencode.db#summary-candidate",
+        fileMtimeMs: 950,
+      }),
+      messages,
+    );
+
+    expect(store.listSessionsNeedingSummary(now, 500, 10).map(({ sessionKey }) => sessionKey)).toEqual([
+      "codex:summary-candidate",
+    ]);
+  });
+
   it("atomically migrates a legacy key with all dependent data and migration history", () => {
     const store = createInMemoryStore();
     const legacyKey = "ssh:ssh-devbox:codex:legacy-all-data";

--- a/apps/main-1.0/src/core/store/sessions.ts
+++ b/apps/main-1.0/src/core/store/sessions.ts
@@ -1338,6 +1338,7 @@ export class SessionsStore {
       .prepare(
         `SELECT * FROM sessions
          WHERE file_mtime_ms >= ?
+           AND source <> 'codewiz-cli'
            AND (ai_summary IS NULL OR file_mtime_ms > COALESCE(ai_summary_basis, 0))
          ORDER BY file_mtime_ms DESC
          LIMIT ?`,

--- a/apps/main-1.0/src/main/index.ts
+++ b/apps/main-1.0/src/main/index.ts
@@ -136,7 +136,11 @@ import {
   isSharedSessionSourceDatabase,
   remoteSessionKey,
 } from "../core/session-environment";
-import { OPTIONAL_SESSION_SOURCE_DESCRIPTORS, sessionSourceDescriptor } from "../core/session-sources";
+import {
+  OPTIONAL_SESSION_SOURCE_DESCRIPTORS,
+  sessionSourceDescriptor,
+  supportsAiSummarySource,
+} from "../core/session-sources";
 import type { AppSettings, AppSettingsUpdate } from "../core/platform";
 import { APP_UPDATE_EVENTS } from "../shared/ipc/app-update";
 import { QUOTA_EVENTS } from "../shared/ipc/quota";
@@ -1431,6 +1435,10 @@ const SUMMARY_FULL_THRESHOLD = SUMMARY_HEAD_MESSAGES + SUMMARY_TAIL_MESSAGES;
 // Short sessions are summarized in full; long ones use a head + tail excerpt so the
 // original problem and the final resolution both survive, fetching only a bounded slice.
 async function summarizeOneSession(sessionKey: string, endpoint: SummaryEndpoint): Promise<void> {
+  const source = store.getSession(sessionKey)?.source;
+  if (source && !supportsAiSummarySource(source)) {
+    throw new Error("AI summaries are disabled for CodeWiz sessions.");
+  }
   const count = store.getMessageCount(sessionKey);
   let excerpt;
   if (count <= SUMMARY_FULL_THRESHOLD) {
@@ -2035,6 +2043,10 @@ function registerIpc(): void {
   ipcMain.handle("sessions:live", (_event, fresh = false) => loadConfiguredLiveSessions(fresh));
   ipcMain.handle("session:summarize", async (_event, sessionKey: string) => {
     await ensureRemoteSessionDetailsLoaded(sessionKey);
+    const session = store.getSession(sessionKey);
+    if (session && !supportsAiSummarySource(session.source)) {
+      throw new Error("AI summaries are disabled for CodeWiz sessions.");
+    }
     const endpoint = await resolveSummaryEndpointFromSettings();
     if (!endpoint) {
       throw new Error(SUMMARY_PROVIDER_ERROR);

--- a/apps/main-1.0/src/main/main-startup-wiring.test.ts
+++ b/apps/main-1.0/src/main/main-startup-wiring.test.ts
@@ -65,4 +65,28 @@ describe("main process startup wiring", () => {
     expect(source).toContain("fetch: electronSummaryFetch");
     expect(source).toContain("net.fetch(input, init)");
   });
+
+  it("checks summary source support before reading messages or invoking the provider", () => {
+    const source = readFileSync(new URL("./index.ts", import.meta.url), "utf8");
+    const summarizeOneSession = source.match(
+      /async function summarizeOneSession[\s\S]*?\n}\n\nasync function pathExists/,
+    )?.[0];
+    const manualSummaryHandler = source.match(
+      /ipcMain\.handle\("session:summarize",[\s\S]*?\n\s*}\);/,
+    )?.[0];
+
+    expect(summarizeOneSession).toBeDefined();
+    expect(summarizeOneSession).toContain("supportsAiSummarySource");
+    expect(summarizeOneSession!.indexOf("supportsAiSummarySource")).toBeLessThan(
+      summarizeOneSession!.indexOf("store.getMessageCount"),
+    );
+    expect(summarizeOneSession!.indexOf("supportsAiSummarySource")).toBeLessThan(
+      summarizeOneSession!.indexOf("await summarizeSession"),
+    );
+    expect(manualSummaryHandler).toBeDefined();
+    expect(manualSummaryHandler).toContain("supportsAiSummarySource");
+    expect(manualSummaryHandler!.indexOf("supportsAiSummarySource")).toBeLessThan(
+      manualSummaryHandler!.indexOf("resolveSummaryEndpointFromSettings"),
+    );
+  });
 });

--- a/apps/main-1.0/src/renderer/src/features/session-detail/detail-panel.test.tsx
+++ b/apps/main-1.0/src/renderer/src/features/session-detail/detail-panel.test.tsx
@@ -25,7 +25,10 @@ describe("DetailPanel Code Mode tool groups", () => {
     container.remove();
   });
 
-  async function renderTraceEvents(traceEvents: SessionTraceEvent[]): Promise<void> {
+  async function renderTraceEvents(
+    traceEvents: SessionTraceEvent[],
+    sessionOverrides: Partial<SessionSearchResult> = {},
+  ): Promise<void> {
     await act(async () => {
       root.render(createElement(DetailPanel, {
         session: {
@@ -63,6 +66,7 @@ describe("DetailPanel Code Mode tool groups", () => {
           messageCount: 0,
           aiSummary: null,
           aiSummaryStale: false,
+          ...sessionOverrides,
         } satisfies SessionSearchResult,
         messages: [],
         matchedMessageIndex: null,
@@ -103,6 +107,20 @@ describe("DetailPanel Code Mode tool groups", () => {
       }));
     });
   }
+
+  it("keeps an existing CodeWiz summary visible without offering a summary action", async () => {
+    await renderTraceEvents([], {
+      sessionKey: "codewiz:existing-summary",
+      rawId: "existing-summary",
+      source: "codewiz-cli",
+      aiSummary: "Previously generated summary",
+    });
+
+    expect(container.querySelector(".detail-summary")?.textContent).toContain("Previously generated summary");
+    expect(
+      [...container.querySelectorAll("button")].some((button) => button.textContent?.includes("重新摘要")),
+    ).toBe(false);
+  });
 
   it("shows each parsed tool after its runtime result inside exec", async () => {
     const commands = [

--- a/apps/main-1.0/src/renderer/src/features/session-detail/detail-panel.tsx
+++ b/apps/main-1.0/src/renderer/src/features/session-detail/detail-panel.tsx
@@ -25,7 +25,11 @@ import {
 import { readInitialToolEventsVisibility, storeToolEventsVisibility } from "../../tool-events-visibility";
 import type { SessionFamily } from "../../../../core/session-family";
 import { canDeleteSessionLocally } from "../../../../core/session-environment";
-import { isSessionSource, sessionSourceDescriptor } from "../../../../core/session-sources";
+import {
+  isSessionSource,
+  sessionSourceDescriptor,
+  supportsAiSummarySource,
+} from "../../../../core/session-sources";
 import { SubagentSessionTree } from "./subagent-session-tree";
 import { SessionContextComponentsPanel } from "./session-context-components-panel";
 import { collaborationMessageMetadata } from "./collaboration-message";
@@ -554,14 +558,16 @@ export function DetailPanel({
             <button onClick={onAddTag} disabled={actionRunning}>
               <Tag size={15} /> {l("Add Tag", "添加标签")}
             </button>
-            <button onClick={onSummarize} disabled={actionRunning || summarizing}>
-              <Sparkles size={15} />{" "}
-              {summarizing
-                ? l("Summarizing...", "摘要中...")
-                : session.aiSummary
-                  ? l("Re-summarize", "重新摘要")
-                  : l("AI Summary", "AI 摘要")}
-            </button>
+            {supportsAiSummarySource(session.source) ? (
+              <button onClick={onSummarize} disabled={actionRunning || summarizing}>
+                <Sparkles size={15} />{" "}
+                {summarizing
+                  ? l("Summarizing...", "摘要中...")
+                  : session.aiSummary
+                    ? l("Re-summarize", "重新摘要")
+                    : l("AI Summary", "AI 摘要")}
+              </button>
+            ) : null}
             <button onClick={onMigrate} disabled={actionRunning || !canMigrate} title={migrationTitle}>
               <ArrowRightLeft size={15} /> {l("Migrate to…", "迁移到…")}
             </button>

--- a/apps/main-2.0/src/core/postgres/session-repository.test.ts
+++ b/apps/main-2.0/src/core/postgres/session-repository.test.ts
@@ -127,6 +127,35 @@ describe("PostgresSessionRepository", () => {
     expect(Number(result.rows[0]?.ai_summary_basis)).toBe(fileMtimeMs);
   });
 
+  it("excludes CodeWiz sessions from batch and automatic summary candidates", async () => {
+    await repository.upsertIndexedSession(
+      session({
+        sessionKey: "codex:summary-candidate",
+        rawId: "summary-candidate",
+        source: "codex-cli",
+        fileMtimeMs: 900,
+      }),
+      messages,
+    );
+    await repository.upsertIndexedSession(
+      session({
+        sessionKey: "codewiz:summary-candidate",
+        rawId: "summary-candidate",
+        source: "codewiz-cli",
+        fileMtimeMs: 950,
+      }),
+      messages,
+    );
+
+    await expect(repository.listSessionsNeedingSummary(1_000, 1_000, 25))
+      .resolves.toEqual([
+        expect.objectContaining({
+          sessionKey: "codex:summary-candidate",
+          source: "codex-cli",
+        }),
+      ]);
+  });
+
   it("preserves paginated Codex history when migrating to a new Session key", async () => {
     const legacyKey = "ssh:dev:codex:legacy-paginated";
     const targetKey = "ssh:dev:codex-cli:legacy-paginated";

--- a/apps/main-2.0/src/core/postgres/session-repository.ts
+++ b/apps/main-2.0/src/core/postgres/session-repository.ts
@@ -2034,6 +2034,7 @@ export class PostgresSessionRepository {
         from agent_recall.sessions sessions
         join agent_recall.environments environments on environments.id = sessions.environment_id
         where sessions.file_mtime_ms >= $1
+          and sessions.source <> 'codewiz-cli'
           and (
             sessions.ai_summary is null
             or sessions.file_mtime_ms > coalesce(sessions.ai_summary_basis, 0)

--- a/apps/main-2.0/src/core/session-sources.test.ts
+++ b/apps/main-2.0/src/core/session-sources.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { sessionSourceDescriptor } from "./session-sources";
+import { sessionSourceDescriptor, supportsAiSummarySource } from "./session-sources";
 
 describe("StepCode session source semantics", () => {
   it("keeps StepCode sources in their native Claude/Codex families", () => {
@@ -33,5 +33,10 @@ describe("StepCode session source semantics", () => {
       remoteFamily: null,
       capabilities: { live: false, resume: false, migrate: false, sessionSync: false, openApp: false },
     });
+  });
+
+  it("disables AI summaries only for CodeWiz sessions", () => {
+    expect(supportsAiSummarySource("codewiz-cli")).toBe(false);
+    expect(supportsAiSummarySource("codex-cli")).toBe(true);
   });
 });

--- a/apps/main-2.0/src/core/session-sources.ts
+++ b/apps/main-2.0/src/core/session-sources.ts
@@ -254,6 +254,10 @@ export function sessionSourceLabel(source: SessionSource): string {
   return sessionSourceDescriptor(source).label;
 }
 
+export function supportsAiSummarySource(source: SessionSource): boolean {
+  return source !== "codewiz-cli";
+}
+
 export function remoteSessionAgentForSource(source: SessionSource): RemoteSessionAgent | null {
   if (source === "hermes") return "hermes";
   if (source === "pi-cli") return "pi";

--- a/apps/main-2.0/src/main/index.ts
+++ b/apps/main-2.0/src/main/index.ts
@@ -119,6 +119,7 @@ import { remoteSessionKey } from "../core/session-environment";
 import {
   OPTIONAL_SESSION_SOURCE_DESCRIPTORS,
   sessionSourcesForOptionalSetting,
+  supportsAiSummarySource,
 } from "../core/session-sources";
 import type { AppSettings, AppSettingsUpdate } from "../core/platform";
 import { APP_UPDATE_EVENTS } from "../shared/ipc/app-update";
@@ -2114,6 +2115,10 @@ const SUMMARY_FULL_THRESHOLD = SUMMARY_HEAD_MESSAGES + SUMMARY_TAIL_MESSAGES;
 // Short sessions are summarized in full; long ones use a head + tail excerpt so the
 // original problem and the final resolution both survive, fetching only a bounded slice.
 async function summarizeOneSession(sessionKey: string, endpoint: SummaryEndpoint): Promise<void> {
+  const session = await store.getSession(sessionKey);
+  if (session && !supportsAiSummarySource(session.source)) {
+    throw new Error("AI summaries are disabled for CodeWiz sessions.");
+  }
   const count = await store.getMessageCount(sessionKey);
   let excerpt;
   if (count <= SUMMARY_FULL_THRESHOLD) {
@@ -2769,6 +2774,10 @@ function registerIpc(): void {
   });
   ipcMain.handle("session:summarize", async (_event, sessionKey: string) => {
     await remoteSessionAccess.ensureDetails(sessionKey);
+    const session = await store.getSession(sessionKey);
+    if (session && !supportsAiSummarySource(session.source)) {
+      throw new Error("AI summaries are disabled for CodeWiz sessions.");
+    }
     const endpoint = await resolveSummaryEndpointFromSettings();
     if (!endpoint) {
       throw new Error(SUMMARY_PROVIDER_ERROR);

--- a/apps/main-2.0/src/renderer/src/features/session-detail/detail-panel.test.tsx
+++ b/apps/main-2.0/src/renderer/src/features/session-detail/detail-panel.test.tsx
@@ -191,4 +191,62 @@ describe("DetailPanel Turn controls", () => {
     });
     expect(document.activeElement).toBe(container.querySelector(".panel-search-input"));
   });
+
+  it("keeps an existing CodeWiz summary visible without offering summary actions", async () => {
+    await act(async () => {
+      root.render(
+        <DetailPanel
+          session={{
+            ...session,
+            sessionKey: "codewiz:test-session",
+            source: "codewiz-cli",
+            aiSummary: "Existing CodeWiz summary",
+          }}
+          turns={null}
+          turnsLoading={false}
+          matchedTurnId={null}
+          onLoadTurn={async () => null}
+          messages={[]}
+          matchedContextMessages={[]}
+          matchedMessageIndex={null}
+          traceEvents={[]}
+          loading={false}
+          actionStatus={null}
+          query=""
+          liveState="closed"
+          language="en"
+          revealLabel="Explorer"
+          showItermAction={false}
+          messagePageSize={100}
+          olderMessageCount={0}
+          onClose={vi.fn()}
+          onShowMore={vi.fn()}
+          onRename={vi.fn()}
+          onAddTag={vi.fn()}
+          onRemoveTag={vi.fn()}
+          onFavorite={vi.fn()}
+          onSummarize={vi.fn()}
+          summarizing={false}
+          canResume={false}
+          canMigrate={false}
+          migrationTitle=""
+          onResume={vi.fn()}
+          onResumeIterm={vi.fn()}
+          onMigrate={vi.fn()}
+          onCopyResume={vi.fn()}
+          onCopyMarkdown={vi.fn()}
+          onExportMarkdown={vi.fn()}
+          onExportJson={vi.fn()}
+          onCopyPlain={vi.fn()}
+          onDelete={vi.fn()}
+          onReveal={vi.fn()}
+          sessionFamily={{ parent: null, children: [], truncated: false }}
+        />,
+      );
+    });
+
+    expect(container.querySelector(".detail-summary")?.textContent).toContain("Existing CodeWiz summary");
+    const buttonLabels = [...container.querySelectorAll("button")].map((button) => button.textContent);
+    expect(buttonLabels.some((label) => label?.includes("Re-summarize"))).toBe(false);
+  });
 });

--- a/apps/main-2.0/src/renderer/src/features/session-detail/detail-panel.tsx
+++ b/apps/main-2.0/src/renderer/src/features/session-detail/detail-panel.tsx
@@ -35,7 +35,11 @@ import { TurnAccordion, type TurnMessageRoleFilter } from "./turn-accordion";
 import { MessageHead } from "./message-shell";
 import type { SessionFamily } from "../../../../core/session-family";
 import { canDeleteSessionLocally } from "../../../../core/session-environment";
-import { isSessionSource, sessionSourceDescriptor } from "../../../../core/session-sources";
+import {
+  isSessionSource,
+  sessionSourceDescriptor,
+  supportsAiSummarySource,
+} from "../../../../core/session-sources";
 import { SubagentSessionTree } from "./subagent-session-tree";
 import { SessionContextComponentsPanel } from "./session-context-components-panel";
 import { collaborationMessageMetadata } from "./collaboration-message";
@@ -666,14 +670,16 @@ export function DetailPanel({
             <button onClick={onAddTag} disabled={actionRunning}>
               <Tag size={15} /> {l("Add Tag", "添加标签")}
             </button>
-            <button onClick={onSummarize} disabled={actionRunning || summarizing}>
-              <Sparkles size={15} />{" "}
-              {summarizing
-                ? l("Summarizing...", "摘要中...")
-                : session.aiSummary
-                  ? l("Re-summarize", "重新摘要")
-                  : l("AI Summary", "AI 摘要")}
-            </button>
+            {supportsAiSummarySource(session.source) ? (
+              <button onClick={onSummarize} disabled={actionRunning || summarizing}>
+                <Sparkles size={15} />{" "}
+                {summarizing
+                  ? l("Summarizing...", "摘要中...")
+                  : session.aiSummary
+                    ? l("Re-summarize", "重新摘要")
+                    : l("AI Summary", "AI 摘要")}
+              </button>
+            ) : null}
             <button onClick={onMigrate} disabled={actionRunning || !canMigrate} title={migrationTitle}>
               <ArrowRightLeft size={15} /> {l("Migrate to…", "迁移到…")}
             </button>

--- a/docs/superpowers/specs/sessions/2026-09-08-disable-codewiz-summaries-design.md
+++ b/docs/superpowers/specs/sessions/2026-09-08-disable-codewiz-summaries-design.md
@@ -1,0 +1,19 @@
+# Disable AI summaries for CodeWiz sessions
+
+## Scope
+
+AgentRecall must never generate AI summaries for sessions whose source is `codewiz-cli`. Existing stored summaries remain visible and are not deleted. All other session sources keep their current behavior.
+
+## Design
+
+- Define the source-level eligibility rule in the session-source domain module.
+- Exclude `codewiz-cli` in both V1 SQLite and V2 PostgreSQL missing-summary queries so automatic and batch backfills do not select those sessions or let them consume batch limits.
+- Enforce the same rule in the single-session summary operation so manual and future callers cannot bypass it.
+- Hide the manual summary action for CodeWiz sessions while continuing to display any existing summary.
+
+## Verification
+
+- V1 and V2 repository tests prove CodeWiz is excluded while an eligible session remains selected.
+- Source-rule tests prove only `codewiz-cli` is ineligible.
+- V1 and V2 renderer tests prove the manual summary action is absent for CodeWiz.
+- Focused tests and both-app typechecking must pass.


### PR DESCRIPTION
## 变更概述

AgentRecall 不再为 CodeWiz 会话触发自动、批量或手动 AI 摘要，同时保留已有摘要的展示。V1 与 V2 均在候选查询、执行入口和界面操作层实施相同约束。

## 更新说明检查

- [x] 本分支已新增且仅新增一个 `.release-notes/<branch-slug>.md`
- [x] 更新说明已声明 `release-target: both`
- [x] 更新说明包含面向用户的 Bug 修复列表
- [x] 更新说明未包含内部服务、路径或敏感信息
- [x] 已运行 `npm run release-note:check`

## 验证

- V1 聚焦测试：125/125 通过
- V2 聚焦测试：24/24 通过
- `npm run typecheck` 通过
- `npm run release-note:check` 通过
- `git diff --check` 通过

全量测试中的既有 `claude-profile.test.ts` 默认模型断言失败与本次改动无关；本次涉及的测试均通过。