### PR TITLE
fix(sessions): 修复旧版 Gemini JSON 子会话漏扫

### DIFF
--- a/.release-notes/fix-gemini-legacy-subagent-json.md
+++ b/.release-notes/fix-gemini-legacy-subagent-json.md
@@ -1,0 +1,6 @@
+# Gemini CLI 历史子会话兼容性
+<!-- release-target: both -->
+
+## Bug 修复
+
+- 修复旧版 Gemini CLI 子代理会话未出现在历史记录中的问题。

--- a/apps/main-1.0/src/core/session-loader-gemini.test.ts
+++ b/apps/main-1.0/src/core/session-loader-gemini.test.ts
@@ -134,6 +134,39 @@ describe("Gemini CLI sessions", () => {
     });
   });
 
+  it.each(["json", "jsonl"])("indexes legacy .json subagents under a %s parent", (parentFormat) => {
+    const root = fixture();
+    const chats = projectChats(root, "gemini-app", "/work/gemini-app");
+    const parentId = "72d14847-09f0-4562-aa8e-f7b42bf11749";
+    const subagentId = "legacy01-cccc-dddd-eeee-ffff00001111";
+    const parentMessage = { id: "p-user", timestamp: "2026-07-29T04:55:00.000Z", type: "user", content: "Delegate the audit" };
+    const parentPath = path.join(chats, `session-2026-07-29T04-54-72d14847.${parentFormat}`);
+    if (parentFormat === "json") {
+      fs.writeFileSync(parentPath, JSON.stringify({ ...header(parentId), messages: [parentMessage] }), "utf8");
+    } else {
+      writeChat(parentPath, [header(parentId), parentMessage]);
+    }
+    const subagentPath = path.join(chats, parentId, `${subagentId}.json`);
+    fs.mkdirSync(path.dirname(subagentPath), { recursive: true });
+    fs.writeFileSync(subagentPath, JSON.stringify({
+      ...header(subagentId, { kind: "subagent" }),
+      messages: [
+        { id: "s-user", timestamp: "2026-07-29T04:56:30.000Z", type: "user", content: "Audit the legacy middleware" },
+      ],
+    }), "utf8");
+
+    const loaded = loadDefaultSessions({ homeDir: root, includeGeminiCli: true });
+    const byId = new Map(loaded.map((item) => [item.session.rawId, item]));
+
+    expect(loaded).toHaveLength(2);
+    expect(byId.get(parentId)?.session).toMatchObject({ isSubagent: false, parentSessionId: null });
+    expect(byId.get(subagentId)?.session).toMatchObject({
+      isSubagent: true,
+      parentSessionId: parentId,
+    });
+    expect(byId.get(subagentId)?.messages.map((message) => message.content)).toEqual(["Audit the legacy middleware"]);
+  });
+
   it("uses summaries as titles and ignores temp or unreadable chat files", () => {
     const root = fixture();
     const chats = projectChats(root, "gemini-app", "/work/gemini-app");

--- a/apps/main-1.0/src/core/session-loader.ts
+++ b/apps/main-1.0/src/core/session-loader.ts
@@ -2569,6 +2569,23 @@ function geminiChatFileNameUsable(name: string): boolean {
   return name.endsWith(".jsonl") || name.endsWith(".json");
 }
 
+function walkGeminiChatFiles(dir: string): string[] {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    // A missing or inaccessible subagent directory must not hide other sessions.
+    return [];
+  }
+  const files: string[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...walkGeminiChatFiles(fullPath));
+    else if (geminiChatFileNameUsable(entry.name)) files.push(fullPath);
+  }
+  return files;
+}
+
 function* loadGeminiCliSessionsIterator(root: string, options: SessionLoadOptions): Generator<LoadedSession> {
   const tmpRoot = path.join(root, "tmp");
   let projectDirs: string[] = [];
@@ -2598,7 +2615,7 @@ function* loadGeminiCliSessionsIterator(root: string, options: SessionLoadOption
       if (entry.name.startsWith(".")) continue;
       const childPath = path.join(chats, entry.name);
       if (entry.isDirectory()) {
-        for (const filePath of walkJsonlFiles(childPath)) {
+        for (const filePath of walkGeminiChatFiles(childPath)) {
           const stat = safeStat(filePath);
           if (shouldSkipFile(options, filePath, stat, dependencyMtimeMs)) continue;
           const loaded = loadGeminiCliSessionFile(filePath, projectPath, stat, entry.name);

--- a/apps/main-2.0/src/core/session-loader-gemini.test.ts
+++ b/apps/main-2.0/src/core/session-loader-gemini.test.ts
@@ -139,6 +139,39 @@ describe("Gemini CLI sessions", () => {
     });
   });
 
+  it.each(["json", "jsonl"])("indexes legacy .json subagents under a %s parent", (parentFormat) => {
+    const root = fixture();
+    const chats = projectChats(root, "gemini-app", "/work/gemini-app");
+    const parentId = "72d14847-09f0-4562-aa8e-f7b42bf11749";
+    const subagentId = "legacy01-cccc-dddd-eeee-ffff00001111";
+    const parentMessage = { id: "p-user", timestamp: "2026-07-29T04:55:00.000Z", type: "user", content: "Delegate the audit" };
+    const parentPath = path.join(chats, `session-2026-07-29T04-54-72d14847.${parentFormat}`);
+    if (parentFormat === "json") {
+      fs.writeFileSync(parentPath, JSON.stringify({ ...header(parentId), messages: [parentMessage] }), "utf8");
+    } else {
+      writeChat(parentPath, [header(parentId), parentMessage]);
+    }
+    const subagentPath = path.join(chats, parentId, `${subagentId}.json`);
+    fs.mkdirSync(path.dirname(subagentPath), { recursive: true });
+    fs.writeFileSync(subagentPath, JSON.stringify({
+      ...header(subagentId, { kind: "subagent" }),
+      messages: [
+        { id: "s-user", timestamp: "2026-07-29T04:56:30.000Z", type: "user", content: "Audit the legacy middleware" },
+      ],
+    }), "utf8");
+
+    const loaded = loadDefaultSessions({ homeDir: root, includeGeminiCli: true });
+    const byId = new Map(loaded.map((item) => [item.session.rawId, item]));
+
+    expect(loaded).toHaveLength(2);
+    expect(byId.get(parentId)?.session).toMatchObject({ isSubagent: false, parentSessionId: null });
+    expect(byId.get(subagentId)?.session).toMatchObject({
+      isSubagent: true,
+      parentSessionId: parentId,
+    });
+    expect(byId.get(subagentId)?.messages.map((message) => message.content)).toEqual(["Audit the legacy middleware"]);
+  });
+
   it("uses summaries as titles and ignores temp or unreadable chat files", () => {
     const root = fixture();
     const chats = projectChats(root, "gemini-app", "/work/gemini-app");

--- a/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
+++ b/apps/main-2.0/src/core/session-loaders/alternative-sources.ts
@@ -966,6 +966,23 @@ function geminiChatFileNameUsable(name: string): boolean {
   return name.endsWith(".jsonl") || name.endsWith(".json");
 }
 
+function walkGeminiChatFiles(dir: string): string[] {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    // A missing or inaccessible subagent directory must not hide other sessions.
+    return [];
+  }
+  const files: string[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...walkGeminiChatFiles(fullPath));
+    else if (geminiChatFileNameUsable(entry.name)) files.push(fullPath);
+  }
+  return files;
+}
+
 export function* loadGeminiCliSessionsIterator(root: string, options: SessionLoadOptions): Generator<LoadedSession> {
   const tmpRoot = path.join(root, "tmp");
   let projectDirs: string[] = [];
@@ -995,7 +1012,7 @@ export function* loadGeminiCliSessionsIterator(root: string, options: SessionLoa
       if (entry.name.startsWith(".")) continue;
       const childPath = path.join(chats, entry.name);
       if (entry.isDirectory()) {
-        for (const filePath of walkJsonlFiles(childPath)) {
+        for (const filePath of walkGeminiChatFiles(childPath)) {
           const stat = safeStat(filePath);
           if (shouldSkipFile(options, filePath, stat, dependencyMtimeMs, "gemini-cli")) continue;
           const loaded = loadGeminiCliSessionFile(filePath, projectPath, stat, entry.name);


### PR DESCRIPTION
## 概述

Closes #561

修复 V1、V2 索引旧版 Gemini CLI 子会话时的漏扫：顶层支持 JSON/JSONL，但原来的子目录遍历仅接受 JSONL，导致已存在的 JSON 子会话无法进入解析器。

## 改动

- Gemini 专用子目录遍历复用现有文件名判定，同时接受 `.json`、`.jsonl`，过滤临时/不可读备份文件名。
- 保持原有递归扫描、父会话 ID 传递、消息解析和增量跳过逻辑；不扩大其他来源的文件扫描范围，不写入或迁移原始会话文件。
- 两个应用均覆盖旧 JSON 父会话，以及 JSONL 父会话与旧 JSON 子会话并存的情况，检查完整发现、父子关系和消息内容。
- 添加面向两个版本的修复 release note。

旧文件布局已核对 [Gemini CLI 官方历史源码](https://github.com/google-gemini/gemini-cli/blob/45100f7c0e4e972555a613bb2279af385327fc01/packages/core/src/services/chatRecordingService.ts)，详见关联 Issue。

## 验证

基于 `6196927d`，macOS / Node.js 25.8.0；会话测试使用隔离 HOME、临时 npm prefix 和合成文件。

- 红绿验证：切回旧扫描调用时，V1/V2 各 2 个新增用例失败（只发现父会话）；应用修复后全部通过。
- V1 `vitest run src/core/session-loader-gemini.test.ts`：11 项通过。
- V2 同文件：12 项通过。
- V1、V2 `npm run typecheck`：通过，含 V2 源入口检查。
- `npm run release-note:check -- origin/main`、`git diff --check`：通过。

未运行全仓库测试、桌面 UI、打包或 Windows 实机验证；没有读取真实用户会话。